### PR TITLE
Add ucsc command line utilities

### DIFF
--- a/recipes/ucsc-utilities/build.sh
+++ b/recipes/ucsc-utilities/build.sh
@@ -1,0 +1,7 @@
+#! /bin/bash
+
+pushd $SRC_DIR
+mkdir -p $PREFIX/bin
+rsync -aP $PREFIX/include/openssl $SRC_DIR/kent/src/inc/
+make
+rsync -aP bin/ $PREFIX/bin/

--- a/recipes/ucsc-utilities/meta.yaml
+++ b/recipes/ucsc-utilities/meta.yaml
@@ -1,0 +1,23 @@
+about:
+  home: http://genome.cse.ucsc.edu/index.html
+  license: Academic Free License
+  summary: UCSC genome browser command line bioinformatic utilities
+package:
+  name: ucsc-utilities
+  version: 3.2.2
+requirements:
+  build:
+    - openssl
+    - mysql
+    - libpng
+    - zlib
+  run:
+test:
+  commands:
+    - bigWigToBedGraph 2>&1 | grep bigWigToBedGraph > /dev/null
+    - faToNib 2>&1 | grep faToNib > /dev/null
+source:
+  fn: userApps.v322.src.tgz
+  url: http://hgdownload.cse.ucsc.edu/admin/exe/userApps.v322.src.tgz
+  md5: eabbb7e1aceb4426a4360af66cb55e54
+


### PR DESCRIPTION
Add ucsc command line utilities, including blat, bigwigtools etc.
Note that there was a problem in setting up the build in that despite
setting SSLDIR to $PREFIX/include/openssl, the openssl header files
could not be found. A workaround was to copy openssl header files to a
directory that was included in compilation commands, namely
kent/src/inc/.