### PR TITLE
Prefix builds with travis_wait to avoid timeouts.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ sudo: required
 services:
   - docker
 install: scripts/travis-setup.sh
-script: scripts/travis-run.sh
+script: travis_wait scripts/travis-run.sh

--- a/scripts/travis-run.sh
+++ b/scripts/travis-run.sh
@@ -4,9 +4,9 @@ set -e
 if [[ $TRAVIS_OS_NAME = "linux" ]]
 then
     # run CentOS5 based docker container
-    docker run -e TRAVIS_BRANCH -e TRAVIS_PULL_REQUEST -e ANACONDA_TOKEN -v `pwd`:/bioconda-recipes bioconda/bioconda-builder
+    travis_wait docker run -e TRAVIS_BRANCH -e TRAVIS_PULL_REQUEST -e ANACONDA_TOKEN -v `pwd`:/bioconda-recipes bioconda/bioconda-builder
 else
     export PATH=/anaconda/bin:$PATH
     # build packages
-    scripts/build-packages.py --repository . --packages `cat osx-whitelist.txt`
+    travis_wait scripts/build-packages.py --repository . --packages `cat osx-whitelist.txt`
 fi

--- a/scripts/travis-run.sh
+++ b/scripts/travis-run.sh
@@ -4,9 +4,9 @@ set -e
 if [[ $TRAVIS_OS_NAME = "linux" ]]
 then
     # run CentOS5 based docker container
-    travis_wait docker run -e TRAVIS_BRANCH -e TRAVIS_PULL_REQUEST -e ANACONDA_TOKEN -v `pwd`:/bioconda-recipes bioconda/bioconda-builder
+    docker run -e TRAVIS_BRANCH -e TRAVIS_PULL_REQUEST -e ANACONDA_TOKEN -v `pwd`:/bioconda-recipes bioconda/bioconda-builder
 else
     export PATH=/anaconda/bin:$PATH
     # build packages
-    travis_wait scripts/build-packages.py --repository . --packages `cat osx-whitelist.txt`
+    scripts/build-packages.py --repository . --packages `cat osx-whitelist.txt`
 fi


### PR DESCRIPTION
This was asked by Sebastian:

> So my recipe passes the tests locally with Docker but it takes 15 minutes to complete. 
> However, Travis considers as "errored" builds those that do not output something after 10 minutes.
> Has anybody found this problem? Any advice?

I think for now travis_wait will solve the issue, as it posts an output before the timeout expires (see [here](https://docs.travis-ci.com/user/build-timeouts/#Build-times-out-because-no-output-was-received)).