### PR TITLE
Changed from pre-compiled binaries to compiled code

### DIFF
--- a/recipes/p7zip/build.sh
+++ b/recipes/p7zip/build.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+mkdir -p $PREFIX/bin
+mkdir -p $PREFIX/lib
+
+make all_test
+
+sed -i "s|#! /bin/sh|#!/bin/bash|" install.sh
 sed -i "s|DEST_HOME=.*|DEST_HOME=$PREFIX|" install.sh
 ./install.sh
 

--- a/recipes/p7zip/meta.yaml
+++ b/recipes/p7zip/meta.yaml
@@ -3,12 +3,12 @@ package:
   version: "15.09"
 
 build:
-  number: 2
+  number: 3
 
 source:
-  fn: p7zip_15.09_x86_linux_bin.tar.bz2
-  url: http://iweb.dl.sourceforge.net/project/p7zip/p7zip/15.09/p7zip_15.09_x86_linux_bin.tar.bz2 
-  md5: 5bf52de80afe61aaf2607d94178f148e
+  fn: p7zip_15.09_src_all.tar.bz2
+  url: http://iweb.dl.sourceforge.net/project/p7zip/p7zip/15.09/p7zip_15.09_src_all.tar.bz2 
+  md5: ab69f4f13ba0ec57eca2cf4c9edd9678
 
 test:
   commands:


### PR DESCRIPTION
For some reason precompiled 7z was crashing on travis-ci, to chaged to compiling it ourselves.