### PR TITLE
New: theta2, bcbio-variation-recall. Fix: java shell scripts

### DIFF
--- a/osx-whitelist.txt
+++ b/osx-whitelist.txt
@@ -98,3 +98,4 @@ qualimap
 cramtools
 srprism
 spades
+bcbio-variation-recall

--- a/recipes/bcbio-variation-recall/build.sh
+++ b/recipes/bcbio-variation-recall/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+mkdir -p $PREFIX/bin
+cp bcbio-variation-recall $PREFIX/bin
+chmod a+x $PREFIX/bin/bcbio-variation-recall

--- a/recipes/bcbio-variation-recall/meta.yaml
+++ b/recipes/bcbio-variation-recall/meta.yaml
@@ -1,0 +1,25 @@
+package:
+  name: bcbio-variation-recall
+  version: 0.1.4
+
+source:
+  fn: bcbio-variation-recall
+  url: https://github.com/chapmanb/bcbio.variation.recall/releases/download/v0.1.4/bcbio-variation-recall
+
+build:
+  number: 0
+
+requirements:
+  build:
+  run:
+
+test:
+  commands:
+    - bcbio-variation-recall version
+  requires:
+    - java-jdk
+
+about:
+  home: https://github.com/chapmanb/bcbio.variation.recall
+  license: MIT
+  summary: Parallel merging, squaring off and ensemble calling for genomic variants 

--- a/recipes/cramtools/cramtools.sh
+++ b/recipes/cramtools/cramtools.sh
@@ -19,7 +19,7 @@ JAR_DIR=$DIR
 
 java=java
 
-if [ -z "${JAVA_HOME:=}"]; then
+if [ -z "${JAVA_HOME:=}" ]; then
   if [ -e "$JAVA_HOME/bin/java" ]; then
       java="$JAVA_HOME/bin/java"
   fi

--- a/recipes/cramtools/meta.yaml
+++ b/recipes/cramtools/meta.yaml
@@ -7,7 +7,7 @@ source:
   url: https://github.com/enasequence/cramtools/raw/9f0569da1753ebcfd8410142cbd0dd7021b36db5/cramtools-3.0.jar
 
 build:
-  number: 0
+  number: 1
 
 test:
   commands:

--- a/recipes/picard/meta.yaml
+++ b/recipes/picard/meta.yaml
@@ -10,7 +10,7 @@ source:
   url: https://github.com/broadinstitute/picard/releases/download/1.141/picard-tools-1.141.zip
 
 build:
-  number: 0
+  number: 1
 
 test:
   commands:

--- a/recipes/picard/picard.sh
+++ b/recipes/picard/picard.sh
@@ -19,7 +19,7 @@ JAR_DIR=$DIR
 
 java=java
 
-if [ -z "${JAVA_HOME:=}"]; then
+if [ -z "${JAVA_HOME:=}" ]; then
   if [ -e "$JAVA_HOME/bin/java" ]; then
       java="$JAVA_HOME/bin/java"
   fi

--- a/recipes/snpeff/meta.yaml
+++ b/recipes/snpeff/meta.yaml
@@ -6,7 +6,7 @@ package:
   name: snpeff
   version: '4.1l'
 build:
-  number: 1
+  number: 2
 source:
   fn: snpEff_v4_1l_core.zip
   md5: 43dd4b41f3223bbb4cc094ec5c5e2aac

--- a/recipes/snpeff/snpeff.sh
+++ b/recipes/snpeff/snpeff.sh
@@ -19,7 +19,7 @@ JAR_DIR=$DIR
 
 java=java
 
-if [ -z "${JAVA_HOME:=}"]; then
+if [ -z "${JAVA_HOME:=}" ]; then
   if [ -e "$JAVA_HOME/bin/java" ]; then
       java="$JAVA_HOME/bin/java"
   fi

--- a/recipes/theta2/build.sh
+++ b/recipes/theta2/build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -eu
+# Only installs the parts for running THetA not pre-prearation
+outdir=$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM
+mkdir -p $outdir
+mkdir -p $PREFIX/bin
+cp -r python $outdir
+
+# bnpy dependency
+wget -O bnpy-dev.zip https://bitbucket.org/michaelchughes/bnpy-dev/get/590663f97f93.zip
+unzip bnpy-dev.zip
+mv michaelchughes-bnpy-dev-590663f97f93/bnpy $outdir/python
+
+maincmd=$outdir/python/RunTHetA.py
+sed -i.bak '1i#!/opt/anaconda1anaconda2anaconda3/bin/python' $maincmd
+sed -i.bak '2iimport os\nthis_dir = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(os.path.realpath(__file__))))\nimport sys\nsys.path.append(this_dir)' $maincmd
+chmod a+x $maincmd
+ln -s $maincmd $PREFIX/bin

--- a/recipes/theta2/meta.yaml
+++ b/recipes/theta2/meta.yaml
@@ -1,0 +1,34 @@
+package:
+  name: theta2
+  version: '0.7'
+build:
+  number: 0
+  skip: True # [not py27]
+source:
+  fn: theta-0.7.tar.gz
+  url: https://github.com/raphael-group/THetA/archive/v0.7.tar.gz
+
+requirements:
+  build:
+    - python
+    - numpy
+    - scipy
+    - matplotlib
+    - joblib
+    - numexpr
+  run:
+    - python
+    - numpy
+    - scipy
+    - matplotlib
+    - joblib
+    - numexpr
+
+test:
+  commands:
+    - RunTHetA.py -h
+
+about:
+  home: https://github.com/raphael-group/THetA
+  license: MIT
+  summary: Estimate tumor purity and clonal/subclonal copy number aberrations directly from high-throughput DNA sequencing data

--- a/recipes/varscan/meta.yaml
+++ b/recipes/varscan/meta.yaml
@@ -5,6 +5,8 @@ about:
 package:
     name: varscan
     version: 2.4.0
+build:
+  number: 1
 source:
     fn: VarScan-2.4.0.jar
     url: https://github.com/dkoboldt/varscan/raw/master/VarScan.v2.4.0.jar

--- a/recipes/varscan/varscan.sh
+++ b/recipes/varscan/varscan.sh
@@ -19,7 +19,7 @@ JAR_DIR=$DIR
 
 java=java
 
-if [ -z "${JAVA_HOME:=}"]; then
+if [ -z "${JAVA_HOME:=}" ]; then
   if [ -e "$JAVA_HOME/bin/java" ]; then
       java="$JAVA_HOME/bin/java"
   fi


### PR DESCRIPTION
- Fixes closing bracket spacing typo in java wrappers for
  cramtools, picard, snpeff and varscan
- Adds new recipes for THetA2 and bcbio.variation.recall, migrated
  from homebrew recipes.