### PR TITLE
Feature/homer

### DIFF
--- a/recipes/homer/build.sh
+++ b/recipes/homer/build.sh
@@ -146,24 +146,24 @@ mkdir -p $PREFIX/bin
 chmod +x configureHomer.pl
 cp configureHomer.pl $outdir/
 
-cd $PREFIX/bin
-# Add helper script to configureHomer.pl so that configureHomer.pl
-# -install really installs in $outdir
-configureHomer=$PREFIX/bin/configureHomer.pl
-echo "#! /bin/bash" > $configureHomer;
-echo 'DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )' >>  $configureHomer;
-echo '$DIR/../share/'$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM/configureHomer.pl $@ >> $configureHomer;
-chmod +x $configureHomer;
-
 # Note that homer cannot be built as a package since the installation
 # script *hard-codes* the paths in the perl scripts. Nevertheless,
 # create symlinks to $outdir/bin as this is where configureHomer.pl
 # -install will put the binaries
 
-# For all binaries, wrap configureHomer
+# For all binaries, wrap configureHomer.pl; not the ideal way to go
 for i in $binaries; do
     echo "#! /bin/bash" > $outdir/bin/$i;
     echo configureHomer.pl >> $outdir/bin/$i;
     chmod +x $outdir/bin/$i;
     ln -s $outdir/bin/$i $PREFIX/bin/$i; 
 done
+
+# Add helper script to configureHomer.pl so that configureHomer.pl
+# -install really installs in $outdir
+configureHomer=$PREFIX/bin/configureHomer.pl
+echo "#! /bin/bash" > $configureHomer;
+echo 'DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )' >>  $configureHomer;
+echo '$DIR/../share/'$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM/configureHomer.pl '$@' >> $configureHomer;
+chmod +x $configureHomer;
+

--- a/recipes/homer/build.sh
+++ b/recipes/homer/build.sh
@@ -152,7 +152,7 @@ cd $PREFIX/bin
 configureHomer=$PREFIX/bin/configureHomer.pl
 echo "#! /bin/bash" > $configureHomer;
 echo 'DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )' >>  $configureHomer;
-echo '$DIR/../share/'$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM/configureHomer.pl >> $configureHomer;
+echo '$DIR/../share/'$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM/configureHomer.pl $@ >> $configureHomer;
 chmod +x $configureHomer;
 
 # Note that homer cannot be built as a package since the installation

--- a/recipes/homer/build.sh
+++ b/recipes/homer/build.sh
@@ -159,4 +159,11 @@ chmod +x $configureHomer;
 # script *hard-codes* the paths in the perl scripts. Nevertheless,
 # create symlinks to $outdir/bin as this is where configureHomer.pl
 # -install will put the binaries
-for i in $binaries; do ln -s $outdir/bin/$i $PREFIX/bin/$i; done
+
+# For all binaries, wrap configureHomer
+for i in $binaries; do
+    echo "#! /bin/bash" > $outdir/bin/$i;
+    echo configureHomer.pl >> $outdir/bin/$i;
+    chmod +x $outdir/bin/$i;
+    ln -s $outdir/bin/$i $PREFIX/bin/$i; 
+done

--- a/recipes/homer/build.sh
+++ b/recipes/homer/build.sh
@@ -1,0 +1,162 @@
+#! /bin/bash
+
+# ls -1 bin/ | grep -v old | sed -e "s/\*/ \\\/g"
+binaries="\
+GenomeOntology.pl \
+HomerConfig.pm \
+SIMA.pl \
+Statistics.pm
+addData.pl \
+addDataHeader.pl \
+addGeneAnnotation.pl \
+addInternalData.pl \
+addOligos.pl \
+adjustPeakFile.pl \
+adjustRedunGroupFile.pl \
+analyzeChIP-Seq.pl \
+analyzeHiC \
+analyzeRNA.pl \
+analyzeRepeats.pl \
+annotateInteractions.pl \
+annotatePeaks.pl \
+annotateRelativePosition.pl \
+annotateTranscripts.pl \
+assignGeneWeights.pl \
+assignGenomeAnnotation \
+assignTSStoGene.pl \
+batchAnnotatePeaksHistogram.pl \
+batchFindMotifs.pl \
+batchFindMotifsGenome.pl \
+batchMakeTagDirectory.pl \
+batchParallel.pl \
+bed2pos.pl \
+bed2tag.pl \
+changeNewLine.pl \
+checkPeakFile.pl \
+checkTagBias.pl \
+chopUpBackground.pl \
+chopUpPeakFile.pl \
+chopify.pl \
+cleanUpPeakFile.pl \
+cleanUpSequences.pl \
+cluster2bed.pl \
+cluster2bedgraph.pl \
+compareMotifs.pl \
+condenseBedGraph.pl \
+cons2fasta.pl \
+conservationAverage.pl \
+conservationPerLocus.pl \
+convertCoordinates.pl \
+convertIDs.pl \
+convertOrganismID.pl \
+duplicateCol.pl \
+eland2tags.pl \
+fasta2tab.pl \
+fastq2fasta.pl \
+filterListBy.pl \
+findGO.pl \
+findGOtxt.pl \
+findHiCCompartments.pl \
+findHiCDomains.pl \
+findHiCInteractionsByChr.pl \
+findKnownMotifs.pl \
+findMotifs.pl \
+findMotifsGenome.pl \
+findPeaks \
+findRedundantBLAT.pl \
+findTopMotifs.pl \
+freq2group.pl \
+genericConvertIDs.pl \
+genomeOntology \
+getChrLengths.pl \
+getConservedRegions.pl \
+getDiffExpression.pl \
+getDifferentialBedGraph.pl \
+getDifferentialPeaks \
+getDistalPeaks.pl \
+getFocalPeaks.pl \
+getGWASoverlap.pl \
+getGenesInCategory.pl \
+getGenomeTilingPeaks \
+getHiCcorrDiff.pl \
+getMappableRegions \
+getPartOfPromoter.pl \
+getPeakTags \
+getPos.pl \
+getRandomReads.pl \
+getSiteConservation.pl \
+getTopPeaks.pl \
+gff2pos.pl \
+go2cytoscape.pl \
+groupSequences.pl \
+homer \
+homer2 \
+homerTools \
+joinFiles.pl \
+loadGenome.pl \
+loadPromoters.pl \
+makeBigBedMotifTrack.pl \
+makeBigWig.pl \
+makeBinaryFile.pl \
+makeHiCWashUfile.pl \
+makeMultiWigHub.pl \
+makeTagDirectory \
+makeUCSCfile \
+map-bowtie2.pl \
+map-star.pl \
+mergeData.pl \
+mergePeaks \
+motif2Jaspar.pl \
+motif2Logo.pl \
+parseGTF.pl \
+pos2bed.pl \
+prepForR.pl \
+preparseGenome.pl \
+profile2seq.pl \
+qseq2fastq.pl \
+randRemoveBackground.pl \
+randomizeGroupFile.pl \
+randomizeMotifs.pl \
+removeAccVersion.pl \
+removeBadSeq.pl \
+removeOutOfBoundsReads.pl \
+removePoorSeq.pl \
+removeRedundantPeaks.pl \
+renamePeaks.pl \
+resizePosFile.pl \
+revoppMotif.pl \
+runHiCpca.pl \
+scanMotifGenomeWide.pl \
+scrambleFasta.pl \
+seq2profile.pl \
+tab2fasta.pl \
+tag2bed.pl \
+tag2pos.pl \
+tagDir2HiCsummary.pl \
+tagDir2bed.pl \
+zipHomerResults.pl \
+"
+
+
+
+outdir=$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM
+mkdir -p $outdir
+mkdir -p $outdir/bin
+mkdir -p $PREFIX/bin
+chmod +x configureHomer.pl
+cp configureHomer.pl $outdir/
+
+cd $PREFIX/bin
+# Add helper script to configureHomer.pl so that configureHomer.pl
+# -install really installs in $outdir
+configureHomer=$PREFIX/bin/configureHomer.pl
+echo "#! /bin/bash" > $configureHomer;
+echo 'DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )' >>  $configureHomer;
+echo '$DIR/../share/'$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM/configureHomer.pl >> $configureHomer;
+chmod +x $configureHomer;
+
+# Note that homer cannot be built as a package since the installation
+# script *hard-codes* the paths in the perl scripts. Nevertheless,
+# create symlinks to $outdir/bin as this is where configureHomer.pl
+# -install will put the binaries
+for i in $binaries; do ln -s $outdir/bin/$i $PREFIX/bin/$i; done

--- a/recipes/homer/build.sh
+++ b/recipes/homer/build.sh
@@ -154,7 +154,7 @@ cp configureHomer.pl $outdir/
 # For all binaries, wrap configureHomer.pl; not the ideal way to go
 for i in $binaries; do
     echo "#! /bin/bash" > $outdir/bin/$i;
-    echo configureHomer.pl >> $outdir/bin/$i;
+    echo "echo $i not installed - please run configureHomer.pl -install to install" >> $outdir/bin/$i;
     chmod +x $outdir/bin/$i;
     ln -s $outdir/bin/$i $PREFIX/bin/$i; 
 done

--- a/recipes/homer/meta.yaml
+++ b/recipes/homer/meta.yaml
@@ -1,0 +1,20 @@
+about:
+  home: 'http://homer.salk.edu/homer/'
+  license: GPLv3
+  summary:  Software for motif discovery and next generation sequencing analysis
+
+package:
+  name: homer
+  version: '4.7'
+source:
+  fn: configureHomer.pl
+  md5: 50a9013dfcba9b950e571e83ebf48fe9
+  url: http://homer.salk.edu/homer/configureHomer.pl
+requirements:
+  run:
+    - perl
+test:
+  requires:
+    - perl
+  commands:
+    - configureHomer.pl 2>&1 | grep "share" > /dev/null

--- a/recipes/homer/meta.yaml
+++ b/recipes/homer/meta.yaml
@@ -11,6 +11,9 @@ source:
   md5: 50a9013dfcba9b950e571e83ebf48fe9
   url: http://homer.salk.edu/homer/configureHomer.pl
 requirements:
+  build:
+    # See https://www.biostars.org/p/113042/#113616 for this requirement
+    - weblogo==2.8.2
   run:
     - perl
 test:
@@ -18,3 +21,5 @@ test:
     - perl
   commands:
     - configureHomer.pl 2>&1 | grep "share" > /dev/null
+    - findMotifs.pl 2>&1 | grep "share" > /dev/null
+    - findMotifs.pl 2>&1 | grep "Current base directory for HOMER" > /dev/null

--- a/recipes/homer/meta.yaml
+++ b/recipes/homer/meta.yaml
@@ -11,9 +11,6 @@ source:
   md5: 50a9013dfcba9b950e571e83ebf48fe9
   url: http://homer.salk.edu/homer/configureHomer.pl
 requirements:
-  build:
-    # See https://www.biostars.org/p/113042/#113616 for this requirement
-    - weblogo==2.8.2
   run:
     - perl
 test:

--- a/recipes/homer/meta.yaml
+++ b/recipes/homer/meta.yaml
@@ -18,5 +18,5 @@ test:
     - perl
   commands:
     - configureHomer.pl 2>&1 | grep "share" > /dev/null
-    - findMotifs.pl 2>&1 | grep "share" > /dev/null
-    - findMotifs.pl 2>&1 | grep "Current base directory for HOMER" > /dev/null
+    - findMotifs.pl 2>&1 | grep "findMotifs.pl" > /dev/null
+    - findMotifs.pl 2>&1 | grep "please run configureHomer.pl" > /dev/null


### PR DESCRIPTION
Add homer, software for motif discovery and next-gen sequencing analysis.

Here is another unusual package where advice/input would be appreciated. I provide some details of the recipe rationale here for future reference.

 Homer is installed by downloading a script, configureHomer.pl, which then is invoked with parameter -install to install some ~130 scripts. Upon installation, the configure script _hard codes_ the path to the installation directory, which means building the scripts in the recipe is out of the question. My current solution is to place the install script in $PREFIX/share/homer and link it to $PREFIX/bin. Furthermore, in $PREFIX/share/homer, for all ~130 as-of-yet uninstalled scripts, the recipe creates a corresponding script wrapper which is linked to $PREFIX/bin. When run, the script produces an error message with information on how to actually install homer using configureHomer.pl. The links need to be present prior to running the configuration script.

That's the best I could think of now. 
