### PR TITLE
Ucsc recipe builder improvements

### DIFF
--- a/scripts/ucsc/create-ucsc-packages.py
+++ b/scripts/ucsc/create-ucsc-packages.py
@@ -94,6 +94,9 @@ for program, summary in parse_footer('FOOTER'):
     program = program.split()[0]
 
     program = problematic.get(program, program)
+custom_build_scripts = {
+    'fetchChromSizes': 'template-build-fetchChromSizes.sh',
+}
 
     # conda package names must be lowercase
     package = 'ucsc-' + program.lower()
@@ -119,8 +122,12 @@ for program, summary in parse_footer('FOOTER'):
         )
 
     with open(os.path.join(recipe_dir, 'build.sh'), 'w') as fout:
+        _template = open(
+            custom_build_scripts.get(program, 'template-build.sh')
+        ).read()
+
         fout.write(
-            build_template.format(
+            _template.format(
                 program=program,
                 program_source_dir=program_subdir(program, names),
             )

--- a/scripts/ucsc/create-ucsc-packages.py
+++ b/scripts/ucsc/create-ucsc-packages.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import os
 import re
+from textwrap import dedent
 import tarfile
 from conda.fetch import download
 
@@ -49,9 +50,15 @@ def parse_footer(fn):
 # http://hgdownload.cse.ucsc.edu/admin/exe/
 VERSION = "324"
 
-tarball = 'http://hgdownload.cse.ucsc.edu/admin/exe/userApps.v{0}.src.tgz'.format(VERSION)
+# Download tarball if it doesn't exist. Always download FOOTER.
+tarball = (
+    'http://hgdownload.cse.ucsc.edu/admin/exe/userApps.v{0}.src.tgz'
+    .format(VERSION))
 if not os.path.exists(os.path.basename(tarball)):
     download(tarball, os.path.basename(tarball))
+download(
+    'http://hgdownload.cse.ucsc.edu/admin/exe/linux.x86_64/FOOTER',
+    'FOOTER')
 
 # Different programs are built under different subdirectories in the source. So
 # get a directory listing of the tarball
@@ -59,8 +66,12 @@ t = tarfile.open(os.path.basename(tarball))
 names = [i for i in t.getnames()
          if i.startswith('./userApps/kent/src')]
 
+
 def program_subdir(program, names):
-    hits = [i for i in names if program in i and t.getmember(i).isdir() ]
+    """
+    Identify the source directory for a program.
+    """
+    hits = [i for i in names if program in i and t.getmember(i).isdir()]
     if len(hits) == 0:
         return
     top = sorted(hits)[0]

--- a/scripts/ucsc/template-build-fetchChromSizes.sh
+++ b/scripts/ucsc/template-build-fetchChromSizes.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+mkdir -p $PREFIX/bin
+cp kent/src/utils/userApps/fetchChromSizes $PREFIX/bin
+chmod +x $PREFIX/bin/fetchChromSizes


### PR DESCRIPTION

- combined improvements make recipes for another 8 programs that were
not handled before
- look for and correctly handle cases where the header program name
doesn't match the description, and then resolve the correct source dir
- handle programs with no description (and give them a description
copied from FOOTER)
- support for skipping otherwise problematic programs (currently just
sizeof)
- support for custom build scripts (currently just fetchChromSizes)

This PR also includes fetchChromSizes