### PR TITLE
Add tbl2asn

### DIFF
--- a/recipes/tbl2asn/build.sh
+++ b/recipes/tbl2asn/build.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -e -x -o pipefail
+
+
+for i in $SRC_DIR/*tbl2asn.gz ; do gunzip "$i"; done
+#for i in $SRC_DIR/*_tbl2asn ; do mv "$i" "${i/[a-zA-Z0-9]*.tbl2asn/tbl2asn}" ; done
+
+cd $SRC_DIR/
+
+binaries="\
+tbl2asn \
+"
+
+mkdir -p $PREFIX/bin
+
+for i in $binaries; do cp $SRC_DIR/$i $PREFIX/bin/ && chmod +x $PREFIX/bin/$i; done
+
+# if [ "$(uname)" == "Darwin" ]; then
+#     echo "Platform: Mac"
+
+#     for i in $binaries; do cp $SRC_DIR/$i $PREFIX/bin/ && chmod +x $PREFIX/bin/$i; done
+
+# elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+#     echo "Platform: Linux"
+
+#     # cd to location of Makefile and source
+#     cd $SRC_DIR/
+#     make    
+
+#     for i in $binaries; do cp $SRC_DIR/bmtagger/$i $PREFIX/bin/ && chmod +x $PREFIX/bin/$i; done
+# fi
+
+# chmod +x $PREFIX/bin/*

--- a/recipes/tbl2asn/meta.yaml
+++ b/recipes/tbl2asn/meta.yaml
@@ -1,0 +1,28 @@
+package:
+    name: tbl2asn
+    version: 24.3
+source:
+    fn: tbl2asn.gz # [osx]
+    url: ftp://ftp.ncbi.nih.gov/toolbox/ncbi_tools/converters/by_program/tbl2asn/mac.tbl2asn.gz # [osx]
+    md5: 2a92d2021a0838659f606822197f60ee # [osx]
+    # Currently only the binaries are posted for Linux, and they use GLIBC_2.7, making them incompatible with the
+    # GLIBC_2.5-based CentOS 5 test environment used by bioconda.
+    # 
+    # fn: tbl2asn.gz # [linux]
+    # url: ftp://ftp.ncbi.nih.gov/toolbox/ncbi_tools/converters/by_program/tbl2asn/linux.tbl2asn.gz # [linux]
+    # md5: dbd2144e8a34465d567e2e05135ee567 # [linux]
+    # fn: tbl2asn.gz # [linux64]
+    # url: ftp://ftp.ncbi.nih.gov/toolbox/ncbi_tools/converters/by_program/tbl2asn/linux64.tbl2asn.gz # [linux64]
+    # md5: 4d86a86fb10f35d72866a73e73b94724 # [linux64]
+build:
+    number: 1
+requirements:
+  build:
+  run:
+test:
+    commands:
+        - "tbl2asn --help &> /dev/null"
+about:
+    home: ftp://ftp.ncbi.nih.gov/toolbox/ncbi_tools/converters/by_program/tbl2asn/
+    license: Public Domain
+    summary: "tbl2asn is a program that automates the submission of sequence records to GenBank"


### PR DESCRIPTION
mac only for now since only binaries are available and the Linux
ones rely on GLIBC_2.7, which is incompatible with the current
GLIBC_2.5-based CentOS 5 test environment used by bioconda. An email is
out to Jonathan Kans at NCBI to see if the source is available.