### PR TITLE
add trimmomatic

### DIFF
--- a/recipes/trimmomatic/build.sh
+++ b/recipes/trimmomatic/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+outdir=$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM
+mkdir -p $outdir
+mkdir -p $PREFIX/bin
+cp -R ./* $outdir/
+cp $RECIPE_DIR/trimmomatic.sh $outdir/trimmomatic
+chmod +x $outdir/trimmomatic
+
+ln -s $outdir/trimmomatic $PREFIX/bin

--- a/recipes/trimmomatic/build.sh
+++ b/recipes/trimmomatic/build.sh
@@ -4,6 +4,7 @@ outdir=$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM
 mkdir -p $outdir
 mkdir -p $PREFIX/bin
 cp -R ./* $outdir/
+mv $outdir/trimmomatic-$PKG_VERSION.jar $outdir/trimmomatic.jar
 cp $RECIPE_DIR/trimmomatic.sh $outdir/trimmomatic
 chmod +x $outdir/trimmomatic
 

--- a/recipes/trimmomatic/meta.yaml
+++ b/recipes/trimmomatic/meta.yaml
@@ -21,4 +21,4 @@ test:
       #- trimmomatic -version # trimmomatic currently lacks a simple argument that gives
       # a zero exit code, so...
       # check if the jar file (as a zip file) is valid instead:
-      - "unzip -t $PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM/trimmomatic-$PKG_VERSION.jar &> /dev/null"
+      - "unzip -t $PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM/trimmomatic.jar &> /dev/null"

--- a/recipes/trimmomatic/meta.yaml
+++ b/recipes/trimmomatic/meta.yaml
@@ -1,0 +1,24 @@
+about:
+  home: 'http://www.usadellab.org/cms/?page=trimmomatic'
+  license: "GPLv3"
+  summary: "Genetic variant annotation and effect prediction toolbox"
+package: 
+  name: trimmomatic
+  version: '0.35'
+build:
+  number: 1
+source:
+  fn: Trimmomatic-0.35.zip
+  md5: 564e62f4f0f9f56d22762b237d4c69c4
+  url: http://www.usadellab.org/cms/uploads/supplementary/Trimmomatic/Trimmomatic-0.35.zip
+requirements:
+  build:
+      - java-jdk
+  run:
+      - java-jdk
+test:
+    commands:
+      #- trimmomatic -version # trimmomatic currently lacks a simple argument that gives
+      # a zero exit code, so...
+      # check if the jar file (as a zip file) is valid instead:
+      - "unzip -t $PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM/trimmomatic-$PKG_VERSION.jar &> /dev/null"

--- a/recipes/trimmomatic/trimmomatic.sh
+++ b/recipes/trimmomatic/trimmomatic.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# trimmomatic executable shell script, adapted from VarScan shell script
+set -eu -o pipefail
+
+set -o pipefail
+export LC_ALL=en_US.UTF-8
+
+# Find original directory of bash script, resovling symlinks
+# http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in/246128#246128
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+    DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+    SOURCE="$(readlink "$SOURCE")"
+    [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+
+JAR_DIR=$DIR
+
+java=java
+
+if [ -z "${JAVA_HOME:=}" ]; then
+  if [ -e "$JAVA_HOME/bin/java" ]; then
+      java="$JAVA_HOME/bin/java"
+  fi
+fi
+
+# extract memory and system property Java arguments from the list of provided arguments
+# http://java.dzone.com/articles/better-java-shell-script
+default_jvm_mem_opts="-Xms512m -Xmx1g"
+jvm_mem_opts=""
+jvm_prop_opts=""
+pass_args=""
+for arg in "$@"; do
+    case $arg in
+        '-D'*)
+            jvm_prop_opts="$jvm_prop_opts $arg"
+            ;;
+        '-XX'*)
+            jvm_prop_opts="$jvm_prop_opts $arg"
+            ;;
+         '-Xm'*)
+            jvm_mem_opts="$jvm_mem_opts $arg"
+            ;;
+         *)
+            pass_args="$pass_args $arg"
+            ;;
+    esac
+done
+
+if [ "$jvm_mem_opts" == "" ]; then
+    jvm_mem_opts="$default_jvm_mem_opts"
+fi
+
+pass_arr=($pass_args)
+if [[ ${pass_arr[0]:=} == org* ]]
+then
+    eval "$java" $jvm_mem_opts $jvm_prop_opts -cp "$JAR_DIR/trimmomatic.jar" $pass_args
+else
+    eval "$java" $jvm_mem_opts $jvm_prop_opts -jar "$JAR_DIR/trimmomatic.jar" $pass_args
+fi
+exit


### PR DESCRIPTION
assumes presence of “unzip” to test. trimmomatic currently lacks a
simple argument that gives a zero exit code (email is out to author
requesting one) so the recipe checks if the jar file (as a zip file) is
valid