### PR TITLE
updated MUSCLE to latest

### DIFF
--- a/recipes/muscle/build.sh
+++ b/recipes/muscle/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # cd to location of Makefile and source
-cd $SRC_DIR/src
+cd $SRC_DIR
 
 export PRFX=$PREFIX
 make
@@ -11,4 +11,4 @@ muscle \
 "
 
 mkdir -p $PREFIX/bin
-for i in $binaries; do cp $SRC_DIR/src/$i $PREFIX/bin && chmod +x $PREFIX/bin/$i; done
+for i in $binaries; do cp $SRC_DIR/$i $PREFIX/bin && chmod +x $PREFIX/bin/$i; done

--- a/recipes/muscle/meta.yaml
+++ b/recipes/muscle/meta.yaml
@@ -10,7 +10,7 @@ source:
   md5: 1b7c9661f275a82d3cf708f923736bf8
   url: http://www.drive5.com/muscle/muscle_src_3.8.1551.tar.gz
   patches:
-    - osx-makefile.patch
+    - osx-makefile.patch # [osx]
 build:
   number: 1
 test:

--- a/recipes/muscle/meta.yaml
+++ b/recipes/muscle/meta.yaml
@@ -4,11 +4,15 @@ about:
     summary: "MUSCLE: multiple sequence alignment with high accuracy and high throughput"
 package: 
   name: muscle
-  version: '3.8.31'
+  version: '3.8.1551'
 source:
-  fn: muscle3.8.31_src.tar.gz
-  md5: f767f00fd15f0c5db944d41936779e10
-  url: http://www.drive5.com/muscle/downloads3.8.31/muscle3.8.31_src.tar.gz
+  fn: muscle_src_3.8.1551.tar.gz
+  md5: 1b7c9661f275a82d3cf708f923736bf8
+  url: http://www.drive5.com/muscle/muscle_src_3.8.1551.tar.gz
+  patches:
+    - osx-makefile.patch
+build:
+  number: 1
 test:
     commands:
         - muscle -version

--- a/recipes/muscle/osx-makefile.patch
+++ b/recipes/muscle/osx-makefile.patch
@@ -1,0 +1,11 @@
+--- Makefile 2014-07-12 12:42:52.000000000 -0400
++++ osx-makefile.patch 2015-12-07 11:26:20.000000000 -0500
+@@ -10,7 +10,7 @@
+ # this is fixed by deleting "-static" from the LDLIBS line.
+
+ CFLAGS = -O3 -funroll-loops -Winline -DNDEBUG=1
+-LDLIBS = -lm -static
++LDLIBS = -lm
+ # LDLIBS = -lm
+
+ OBJ = .o


### PR DESCRIPTION
Mac version needs its makefile to be patched to remove flag for static linking