### PR TITLE
jellyfish1-1.1.11

### DIFF
--- a/recipes/jellyfish/1.1.11/build.sh
+++ b/recipes/jellyfish/1.1.11/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+pushd $SRC_DIR
+
+sed -i 's/AM_CXXFLAGS = -g -O3/AM_CXXFLAGS = -g -O3 -Wno-maybe-uninitialized/' Makefile.am
+autoreconf -i -I /usr/share/aclocal
+./configure --prefix=$PREFIX
+make
+make install

--- a/recipes/jellyfish/1.1.11/meta.yaml
+++ b/recipes/jellyfish/1.1.11/meta.yaml
@@ -1,0 +1,18 @@
+package:
+  name: jellyfish
+  version: "1.1.11"
+source:
+  fn: v1.1.11.zip
+  url: https://github.com/gmarcais/Jellyfish/archive/43fc99e4d44d11f115dc6741ff705cf7e113f251.zip
+  md5: 618afc01dd54305689f4deab656e482e
+requirements:
+  build:
+    - yaggo >=1.5.8
+  run:
+test:
+  commands:
+    - jellyfish --version 2>&1 > /dev/null
+about:
+  home: http://www.genome.umd.edu/jellyfish.html
+  license: GPLv3
+  summary: Jellyfish is a tool for fast, memory-efficient counting of k-mers in DNA. A k-mer is a substring of length k, and counting the occurrences of all such substrings is a central step in many analyses of DNA sequence


### PR DESCRIPTION
The current version of jellyfish (2) is not backwards compatible with jellyfish1.