### PR TITLE
diamond 0.7.10

### DIFF
--- a/recipes/diamond/build.sh
+++ b/recipes/diamond/build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+mkdir build
+cd build
+
+cmake .. \
+      -DCMAKE_INSTALL_PREFIX=$PREFIX \
+      -DCMAKE_PREFIX_PATH=$PREFIX \
+      -DBOOST_NO_SYSTEM_PATHS=on
+
+cmake --build . --config Release --target install
+
+# Reference link:
+# https://github.com/conda/conda-recipes/blob/master/boost/build.sh

--- a/recipes/diamond/cmake_patch
+++ b/recipes/diamond/cmake_patch
@@ -1,0 +1,19 @@
+--- CMakeLists_orig.txt	2015-11-12 17:48:32.078758260 -0700
++++ CMakeLists.txt	2015-11-12 17:48:14.434581321 -0700
+@@ -1,6 +1,8 @@
+ cmake_minimum_required (VERSION 2.6)
+ project (DIAMOND)
+
++
++FIND_PACKAGE(Threads REQUIRED)
+ find_package(Boost
+   1.53.0 REQUIRED
+   COMPONENTS program_options timer iostreams thread
+@@ -18,6 +20,6 @@
+   src/basic/options.cpp
+   src/util/tinythread.cpp)
+
+-target_link_libraries(diamond blast_core ${Boost_LIBRARIES})
++target_link_libraries(diamond blast_core ${Boost_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+
+ install(TARGETS diamond DESTINATION bin)

--- a/recipes/diamond/meta.yaml
+++ b/recipes/diamond/meta.yaml
@@ -1,0 +1,24 @@
+package:
+  name: diamond
+  version: "0.7.10"
+source:
+  git_url: https://github.com/bbuchfink/diamond/
+  git_tag: v0.7.10
+  patches:
+    - cmake_patch
+# We pin on gcc version to avoid gcc-5 dual ABI issues depending on boost.
+requirements:
+  build:
+    - gcc >=4.8.5,<5 # [unix]
+    - boost >=1.53.0
+    - cmake
+  run:
+    - libgcc >=4.8.5,<5 # [unix]
+    - boost >=1.53.0
+test:
+  commands:
+    - diamond --help 2>&1 > /dev/null
+about:
+  home: http://ab.inf.uni-tuebingen.de/software/diamond/
+  license: BSD
+  summary: Accelerated BLAST compatible local sequence aligner


### PR DESCRIPTION
Accelerated BLAST compatible local sequence aligner.

Includes patch from https://github.com/bbuchfink/diamond/issues/24.

Also includes a general workaround for GCC 5 dual ABI incompatibility. The situation is not great since the gcc-5/clang incompatibility bug has not been solved yet, but I'm hoping that the anaconda team will do a full rebuild of C++ pkgs with GCC 5 dual ABI and assume everything in conda is gcc.