### PR TITLE
Re-activate 3.4 builds.

### DIFF
--- a/scripts/build-packages.py
+++ b/scripts/build-packages.py
@@ -10,7 +10,7 @@ import nose
 from conda_build.metadata import MetaData
 from toposort import toposort_flatten
 
-PYTHON_VERSIONS = ["27", "35"]
+PYTHON_VERSIONS = ["27", "34", "35"]
 CONDA_NPY = "110"
 CONDA_PERL = "5.22.0"
 


### PR DESCRIPTION
In order to avoid inconsistencies with Python 3.4 builds no longer being updated, this is a try to also build for Python 3.4. In the future, we could always keep the last two Python version for convenience.

When we deactivate a Python version, we should maybe remove the builds from anaconda... 