### PR TITLE
Specify glimmer license as "Custom".

### DIFF
--- a/recipes/glimmer/meta.yaml
+++ b/recipes/glimmer/meta.yaml
@@ -1,14 +1,21 @@
 package:
   name: glimmer
   version: 3.02
+
 about:
   home: https://ccb.jhu.edu/software/glimmer/index.shtml
+  license: Custom
   license_file: LICENSE
   summary: Glimmer is a system for finding genes in microbial DNA
+
 source:
   fn: glimmer302b.tar.gz
   url: https://ccb.jhu.edu/software/glimmer/glimmer302b.tar.gz
   md5: 344d012ae12596de905866fe9eb7f16c
+
+build:
+  number: 1
+
 test:
   commands:
     - glimmer3 | cat


### PR DESCRIPTION
So far the recipe had only a license_file, but this is not sufficient for a proper display of the license in anaconda.org.