### PR TITLE
Add java-jdk dependency to all packages that need it.

### DIFF
--- a/recipes/bcbio-prioritize/meta.yaml
+++ b/recipes/bcbio-prioritize/meta.yaml
@@ -7,17 +7,15 @@ source:
   url: https://github.com/chapmanb/bcbio.prioritize/releases/download/v0.0.5/bcbio-prioritize
 
 build:
-  number: 0
+  number: 1
 
 requirements:
-  build:
   run:
+    - java-jdk
 
 test:
   commands:
     - bcbio-prioritize version
-  requires:
-    - java-jdk
 
 about:
   home: https://github.com/chapmanb/bcbio.prioritize

--- a/recipes/bcbio-variation-recall/meta.yaml
+++ b/recipes/bcbio-variation-recall/meta.yaml
@@ -7,19 +7,17 @@ source:
   url: https://github.com/chapmanb/bcbio.variation.recall/releases/download/v0.1.4/bcbio-variation-recall
 
 build:
-  number: 0
+  number: 1
 
 requirements:
-  build:
   run:
+    - java-jdk
 
 test:
   commands:
     - bcbio-variation-recall version
-  requires:
-    - java-jdk
 
 about:
   home: https://github.com/chapmanb/bcbio.variation.recall
   license: MIT
-  summary: Parallel merging, squaring off and ensemble calling for genomic variants 
+  summary: Parallel merging, squaring off and ensemble calling for genomic variants

--- a/recipes/cramtools/meta.yaml
+++ b/recipes/cramtools/meta.yaml
@@ -7,13 +7,15 @@ source:
   url: https://github.com/enasequence/cramtools/raw/9f0569da1753ebcfd8410142cbd0dd7021b36db5/cramtools-3.0.jar
 
 build:
-  number: 1
+  number: 2
+
+requirements:
+  run:
+    - java-jdk
 
 test:
   commands:
     - cramtools -h
-  requires:
-    - java-jdk
 
 about:
   home: http://www.ebi.ac.uk/ena/software/cram-toolkit

--- a/recipes/fastqc/meta.yaml
+++ b/recipes/fastqc/meta.yaml
@@ -3,18 +3,23 @@ about:
   home: 'http://www.bioinformatics.babraham.ac.uk/projects/fastqc/'
   license: GPL
   summary: 'A quality control tool for high throughput sequence data.'
+
 build:
   detect_binary_files_with_prefix: true
   number: 1
+
 requirements:
   run:
     - java-jdk
+
 package:
   name: fastqc
   version: 0.11.4
+
 source:
   fn: fastqc_v0.11.4.zip
   url: http://www.bioinformatics.babraham.ac.uk/projects/fastqc/fastqc_v0.11.4.zip
+
 test:
   commands:
     - "fastqc -h"

--- a/recipes/gatk-framework/meta.yaml
+++ b/recipes/gatk-framework/meta.yaml
@@ -16,7 +16,7 @@ source:
 
 requirements:
   run:
-    - java-jdk
+    - java-jdk >=7,<8
 
 test:
     commands:

--- a/recipes/gatk-framework/meta.yaml
+++ b/recipes/gatk-framework/meta.yaml
@@ -2,19 +2,22 @@ about:
   home: https://github.com/chapmanb/gatk
   license: MIT
   summary: The core MIT-licensed Genome Analysis Toolkit (GATK) framework, free for all uses
+
 package:
   name: gatk-framework
   version: '3.4.46'
+
 build:
-  number: 0
+  number: 1
+
 source:
   fn: gatk-framework-3.4-46.tar.gz
   url: https://github.com/chapmanb/gatk/releases/download/v3.4-46-framework/gatk-framework-3.4-46.tar.gz
+
 requirements:
-  build:
   run:
+    - java-jdk
+
 test:
     commands:
       - gatk-framework --version
-    requires:
-      - java-jdk

--- a/recipes/oncofuse/meta.yaml
+++ b/recipes/oncofuse/meta.yaml
@@ -7,13 +7,15 @@ source:
   url: https://github.com/mikessh/oncofuse/releases/download/1.1.0/oncofuse-1.1.0.zip
 
 build:
-  number: 0
+  number: 1
+
+requirements:
+  run:
+    - java-jdk
 
 test:
   commands:
     - "oncofuse -h 2>&1 | grep '^usage: Oncofuse'"
-  requires:
-    - java-jdk
 
 about:
   home: https://github.com/mikessh/oncofuse

--- a/recipes/picard/meta.yaml
+++ b/recipes/picard/meta.yaml
@@ -10,13 +10,15 @@ source:
   url: https://github.com/broadinstitute/picard/releases/download/1.126/picard-tools-1.126.zip
 
 build:
-  number: 2
+  number: 3
+
+requirements:
+  run:
+    - java-jdk
 
 test:
   commands:
     - "picard 2>&1 | grep 'USAGE: PicardCommandLine'"
-  requires:
-    - java-jdk
 
 about:
   home: "http://broadinstitute.github.io/picard/"

--- a/recipes/qsignature/meta.yaml
+++ b/recipes/qsignature/meta.yaml
@@ -7,15 +7,17 @@ source:
   url: http://downloads.sourceforge.net/project/adamajava/qsignature.tar.bz2
 
 build:
-  number: 1
+  number: 2
+
+requirements:
+  run:
+    - java-jdk
 
 test:
   commands:
     - qsignature org.qcmg.sig.SignatureGenerator -h
-  requires:
-    - java-jdk
 
 about:
   home: http://sourceforge.net/p/adamajava/wiki/Home/
   license: GPLv3
-  summary: qsignature is a simple and highly effective method for detecting potential sample mix-ups using distance measurements between SNP 
+  summary: qsignature is a simple and highly effective method for detecting potential sample mix-ups using distance measurements between SNP

--- a/recipes/qualimap/meta.yaml
+++ b/recipes/qualimap/meta.yaml
@@ -1,16 +1,22 @@
 package:
   name: qualimap
   version: "2.1.3"
+
 source:
   fn: qualimap_v2.1.3.zip
   url: https://bitbucket.org/kokonech/qualimap/downloads/qualimap_v2.1.3.zip
+
 build:
-  number: 0
+  number: 1
+
+requirements:
+  run:
+    - java-jdk
+
 test:
   commands:
     - qualimap -h
-  requires:
-    - java-jdk
+
 about:
   home: http://qualimap.bioinfo.cipf.es/
   license: GPLv2

--- a/recipes/snpeff/meta.yaml
+++ b/recipes/snpeff/meta.yaml
@@ -2,20 +2,23 @@ about:
   home: 'http://snpeff.sourceforge.net/'
   license: "LGPLv3"
   summary: "Genetic variant annotation and effect prediction toolbox"
-package: 
+
+package:
   name: snpeff
   version: '4.1l'
+
 build:
   number: 2
+
 source:
   fn: snpEff_v4_1l_core.zip
   md5: 43dd4b41f3223bbb4cc094ec5c5e2aac
   url: http://downloads.sourceforge.net/project/snpeff/snpEff_v4_1l_core.zip
+
 requirements:
-  build:
-      - java-jdk
   run:
       - java-jdk
+
 test:
     commands:
       - snpEff -version

--- a/recipes/trimmomatic/meta.yaml
+++ b/recipes/trimmomatic/meta.yaml
@@ -2,20 +2,23 @@ about:
   home: 'http://www.usadellab.org/cms/?page=trimmomatic'
   license: "GPLv3"
   summary: "A flexible read trimming tool for Illumina NGS data"
-package: 
+
+package:
   name: trimmomatic
   version: '0.35'
+
 build:
   number: 2
+
 source:
   fn: Trimmomatic-0.35.zip
   md5: 564e62f4f0f9f56d22762b237d4c69c4
   url: http://www.usadellab.org/cms/uploads/supplementary/Trimmomatic/Trimmomatic-0.35.zip
+
 requirements:
-  build:
-      - java-jdk
   run:
       - java-jdk
+
 test:
     commands:
       #- trimmomatic -version # trimmomatic currently lacks a simple argument that gives

--- a/recipes/vardict-java/meta.yaml
+++ b/recipes/vardict-java/meta.yaml
@@ -7,17 +7,15 @@ source:
   url: https://github.com/AstraZeneca-NGS/VarDictJava/releases/download/v1.4.3/VarDict-1.4.3.zip
 
 build:
-  number: 0
+  number: 1
 
 requirements:
-  build:
   run:
+    - java-jdk
 
 test:
   commands:
     - vardict-java -h
-  requires:
-    - java-jdk
 
 about:
   home: https://github.com/AstraZeneca-NGS/VarDictJava


### PR DESCRIPTION
Now that we can support multiple Java versions, there is no need anymore to keep packages that depend on the system java. People that want to use GATK (which seemingly only supports java 7) can install java=7 from bioconda. The rest can just use the most up to date java from bioconda (currently java 8).

@chapmanb I think my changes are mostly on your packages. Any objections? Also, does the gatk-framework package need java=7 as well or is it only the full GATK?