### PR TITLE
Fix java libs

### DIFF
--- a/recipes/java-jdk/7.0.91/build.sh
+++ b/recipes/java-jdk/7.0.91/build.sh
@@ -17,19 +17,6 @@ mv $NAME/* .
 rm -r $NAME
 
 # clean up
-rm -rf release README readme.txt Welcome.html *jli.* demo sample *.zip
+rm -rf release README readme.txt Welcome.html *jli.* demo sample *.zip DISCLAIMER LICENSE THIRD_PARTY_README ASSEMBLY_EXCEPTION
 
-if [[ `uname` == "Linux" ]]
-then
-    mv lib/amd64/jli/*.so lib
-    mv jre/lib/amd64/*.so lib
-    rm -r lib/amd64
-fi
 cp -r * $PREFIX
-
-# more clean up
-rm -rf $PREFIX/release $PREFIX/README $PREFIX/Welcome.html
-rm -f $PREFIX/DISCLAIMER
-rm -f $PREFIX/LICENSE
-rm -f $PREFIX/THIRD_PARTY_README
-rm -f $PREFIX/ASSEMBLY_EXCEPTION

--- a/recipes/java-jdk/7.0.91/build.sh
+++ b/recipes/java-jdk/7.0.91/build.sh
@@ -22,6 +22,7 @@ rm -rf release README readme.txt Welcome.html *jli.* demo sample *.zip
 if [[ `uname` == "Linux" ]]
 then
     mv lib/amd64/jli/*.so lib
+    mv jre/lib/amd64/*.so lib
     rm -r lib/amd64
 fi
 cp -r * $PREFIX

--- a/recipes/java-jdk/7.0.91/meta.yaml
+++ b/recipes/java-jdk/7.0.91/meta.yaml
@@ -6,6 +6,7 @@ package:
 
 build:
   number: 1
+  binary_relocation: False
 
 test:
   commands:

--- a/recipes/java-jdk/7.0.91/meta.yaml
+++ b/recipes/java-jdk/7.0.91/meta.yaml
@@ -4,6 +4,9 @@ package:
   name: java-jdk
   version: 7.0.91
 
+build:
+  number: 1
+
 test:
   commands:
     - java -version


### PR DESCRIPTION
The Zulu java distribution is already relocatable. Conda trying to make some internal .so files relocatable actually broke hardcoded relative paths. This pull request deactivates the relocation fixes done by conda.