### PR TITLE
Update: biocinstaller and gatk

### DIFF
--- a/recipes/bioconductor-biocinstaller/meta.yaml
+++ b/recipes/bioconductor-biocinstaller/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: bioconductor-biocinstaller
-  version: 1.20.0
+  version: 1.20.1
 source:
-  fn: BiocInstaller_1.20.0.tar.gz
-  url: http://bioconductor.org/packages/release/bioc/src/contrib/BiocInstaller_1.20.0.tar.gz
-  md5: bee40d0d2272bff06310e6a8a0dce855
+  fn: BiocInstaller_1.20.1.tar.gz
+  url: http://bioconductor.org/packages/release/bioc/src/contrib/BiocInstaller_1.20.1.tar.gz
+  md5: d6758faae696c9bbed2c5c43fcefdb00
 build:
   number: 0
   rpaths:

--- a/recipes/gatk-framework/meta.yaml
+++ b/recipes/gatk-framework/meta.yaml
@@ -8,7 +8,7 @@ package:
   version: '3.4.46'
 
 build:
-  number: 2
+  number: 3
 
 source:
   fn: gatk-framework-3.4-46.tar.gz
@@ -16,12 +16,8 @@ source:
 
 requirements:
   run:
-    # Java 7 currently broken, shared libraries cannot find each other
-    # /anaconda/envs/_test/jre/lib/amd64/libnio.so: libnet.so: cannot open shared object file: No such file or directory
-    #- java-jdk >=7,<8
+    - java-jdk >=7,<8
 
 test:
     commands:
       - gatk-framework --version
-    requires:
-      - java-jdk


### PR DESCRIPTION
- Bump biocinstaller to latest point release to avoid in-progress
  updates when using it.
- gatk-framework -- use fixed Java 7