### PR TITLE
Add placeholder prefix in JAMM.sh

### DIFF
--- a/recipes/jamm/meta.yaml
+++ b/recipes/jamm/meta.yaml
@@ -6,9 +6,11 @@ source:
   fn: v1.0.7.2.zip
   url: https://github.com/mahmoudibrahim/JAMM/archive/v1.0.7.2.zip
   md5: 0902ea81e0559a8804c49dd7b1f02efd
+  patches:
+    - setpath.patch
 
 build:
-  number: 0
+  number: 1
 
 requirements:
 

--- a/recipes/jamm/setpath.patch
+++ b/recipes/jamm/setpath.patch
@@ -1,0 +1,12 @@
+--- JAMM.sh	2015-08-04 07:05:25.000000000 +0000
++++ JAMM.sh.new	2015-12-14 18:00:49.468599990 +0000
+@@ -20,8 +20,7 @@
+ 
+ 
+ ##Finding out the path
+-sPath="`dirname \"$0\"`"
+-sPath="`( cd \"$sPath\" && pwd )`"
++sPath=/opt/anaconda1anaconda2anaconda3/bin
+ 
+ 
+ 


### PR DESCRIPTION
By default JAMM.sh uses the CWD to search for R/Perl scripts.
Change to using placehold prefix so the search path is set to
${PREFIX}/bin at install time.