### PR TITLE
Fix fastqc memory; additional bcbio python deps

### DIFF
--- a/osx-whitelist.txt
+++ b/osx-whitelist.txt
@@ -1,5 +1,6 @@
 appdirs
 argh
+arrow
 bamtools
 bcbio-prioritize
 bcbio-variation-recall
@@ -12,6 +13,7 @@ bleach
 bmfilter
 bmtagger
 bmtool
+botocore
 bottle
 bwa
 bx-python
@@ -76,6 +78,7 @@ pythonpy
 pyvcf
 qsignature
 qualimap
+requests-toolbelt
 rsa
 rtg-tools
 s3gof3r

--- a/recipes/arrow/build.sh
+++ b/recipes/arrow/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+$PYTHON setup.py install

--- a/recipes/arrow/meta.yaml
+++ b/recipes/arrow/meta.yaml
@@ -1,0 +1,30 @@
+package:
+  name: arrow
+  version: '0.7.0'
+
+source:
+  fn: arrow-0.7.0.tar.gz
+  url: https://pypi.python.org/packages/source/a/arrow/arrow-0.7.0.tar.gz
+  md5: 1597108362c5fa675dc5e0524ece4451
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - python-dateutil
+
+  run:
+    - python
+    - python-dateutil
+
+test:
+  imports:
+    - arrow
+
+about:
+  home: https://github.com/crsmithdev/arrow/
+  license: Apache License 2.0
+  summary: Better dates and times for Python

--- a/recipes/botocore/build.sh
+++ b/recipes/botocore/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+$PYTHON setup.py install

--- a/recipes/botocore/meta.yaml
+++ b/recipes/botocore/meta.yaml
@@ -1,0 +1,33 @@
+package:
+  name: botocore
+  version: '1.3.6'
+
+source:
+  fn: botocore-1.3.6.tar.gz
+  url: https://pypi.python.org/packages/source/b/botocore/botocore-1.3.6.tar.gz
+  md5: 0d88c01a33f278db51e23ff9b8223bb6
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - jmespath
+    - python-dateutil
+    - docutils
+
+  run:
+    - python
+    - jmespath
+    - python-dateutil
+    - docutils
+
+test:
+  imports:
+    - botocore
+
+about:
+  home: https://github.com/boto/botocore
+  license: Apache License 2.0

--- a/recipes/fastqc/java_xms.patch
+++ b/recipes/fastqc/java_xms.patch
@@ -1,0 +1,18 @@
+*** fastqc.orig	2015-10-09 11:59:24.000000000 -0400
+--- fastqc	2015-12-16 13:27:53.953520316 -0500
+***************
+*** 158,167 ****
+--- 158,170 ----
+  	
+  	push @java_args ,"-Dfastqc.threads=$threads";
+  	my $memory = 250 * $threads;
++ 	my $stack = 200 * $threads;
+  	unshift @java_args,"-Xmx${memory}m";
++ 	unshift @java_args,"-Xms${memory}m";
+  }
+  else {
+  	unshift @java_args,'-Xmx250m';
++ 	unshift @java_args,'-Xms200m';
+  }
+  
+  if ($kmer_size) {

--- a/recipes/fastqc/meta.yaml
+++ b/recipes/fastqc/meta.yaml
@@ -6,7 +6,7 @@ about:
 
 build:
   detect_binary_files_with_prefix: true
-  number: 1
+  number: 2
 
 requirements:
   run:
@@ -19,6 +19,8 @@ package:
 source:
   fn: fastqc_v0.11.4.zip
   url: http://www.bioinformatics.babraham.ac.uk/projects/fastqc/fastqc_v0.11.4.zip
+  patches:
+    - java_xms.patch
 
 test:
   commands:

--- a/recipes/requests-toolbelt/build.sh
+++ b/recipes/requests-toolbelt/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+$PYTHON setup.py install

--- a/recipes/requests-toolbelt/meta.yaml
+++ b/recipes/requests-toolbelt/meta.yaml
@@ -1,0 +1,31 @@
+package:
+  name: requests-toolbelt
+  version: '0.5.0'
+
+source:
+  fn: requests-toolbelt-0.5.0.tar.gz
+  url: https://pypi.python.org/packages/source/r/requests-toolbelt/requests-toolbelt-0.5.0.tar.gz
+  md5: 317a788caa4eec4e3b8f2433c646eaa8
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - requests
+
+  run:
+    - python
+    - requests
+
+test:
+  imports:
+    - requests_toolbelt.multipart
+    - requests_toolbelt.downloadutils
+
+about:
+  home: https://github.com/sigmavirus24/requests-toolbelt
+  license: Apache License 2.0
+  summary: A toolbelt of useful classes and functions to be used with python-requests 


### PR DESCRIPTION
- Set heap (Xms) for fastqc runs. Fixes chapmanb/bcbio-nextgen#1163
- Additional python deps for bcbio, awscli and bioblend