### PR TITLE
add older Trinity

### DIFF
--- a/recipes/trinity/2011_11_26/RunButterfly.cc.patch
+++ b/recipes/trinity/2011_11_26/RunButterfly.cc.patch
@@ -1,0 +1,7 @@
+--- Chrysalis/analysis/RunButterfly.cc	2011-11-28 09:14:40.000000000 -0500
++++ Chrysalis/analysis/RunButterfly.cc	2015-12-15 16:54:00.000000000 -0500
+@@ -1,3 +1,4 @@
++#include <unistd.h>
+ #include <string>
+ #include "base/CommandLineParser.h"
+ #include "base/FileParser.h"

--- a/recipes/trinity/2011_11_26/Trinity.pl.patch
+++ b/recipes/trinity/2011_11_26/Trinity.pl.patch
@@ -1,0 +1,12 @@
+--- Trinity.pl	2011-11-28 09:14:58.000000000 -0500
++++ Trinity.pl	2015-12-15 16:54:00.000000000 -0500
+@@ -208,7 +208,8 @@
+ 
+ ## Check Java version:
+ my $java_version = `java -version 2>&1 `;
+-unless ($java_version =~ /java version \"1\.6\./) {
++$java_version =~ /java version "1\.(\d+)\./;
++unless ($1 >= 6) {
+     die "Error, Trinity requires access to Java version 1.6.  Currently installed version is: $java_version";
+ }
+ 

--- a/recipes/trinity/2011_11_26/build.sh
+++ b/recipes/trinity/2011_11_26/build.sh
@@ -1,17 +1,12 @@
 #!/bin/bash
 
-#mkdir -p $PREFIX/bin
-#cp -R $SRC_DIR/* $PREFIX/bin/
-
-# ===========================
-
 BINARY=Trinity
 BINARY_HOME=$PREFIX/bin
 TRINITY_HOME=$PREFIX/bin/trinity-$PKG_VERSION
 
 cd $SRC_DIR
 
-#make
+make
 
 # remove the sample data
 rm -rf $SRC_DIR/sample_data
@@ -20,5 +15,5 @@ rm -rf $SRC_DIR/sample_data
 mkdir -p $PREFIX/bin
 mkdir -p $TRINITY_HOME
 cp -R $SRC_DIR/* $TRINITY_HOME/
-cd $TRINITY_HOME && chmod +x Trinity
-cd $BINARY_HOME && ln -s trinity-$PKG_VERSION/Trinity $BINARY
+cd $TRINITY_HOME && chmod +x Trinity.pl
+cd $BINARY_HOME && ln -s trinity-$PKG_VERSION/Trinity.pl $BINARY

--- a/recipes/trinity/2011_11_26/meta.yaml
+++ b/recipes/trinity/2011_11_26/meta.yaml
@@ -1,0 +1,30 @@
+about:
+    home: 'https://github.com/trinityrnaseq/trinityrnaseq'
+    license: "https://raw.githubusercontent.com/trinityrnaseq/trinityrnaseq/master/LICENSE.txt"
+    summary: "Trinity assembles transcript sequences from Illumina RNA-Seq data"
+build:
+  number: 0
+package: 
+  name: trinity
+  version: '2011_11_26'
+source:
+  fn: trinityrnaseq_r2011-11-26.tgz
+  md5: 3a4c4691908d37042ca63ca469c75fd3
+  url: http://sourceforge.net/projects/trinityrnaseq/files/trinityrnaseq_r2011-11-26.tgz
+  patches:
+    - RunButterfly.cc.patch # this file is missing a header include
+    - Trinity.pl.patch # Trinity requires exactly Java 1.6, but works fine >1.6, so adjust to be more permissive
+requirements:
+  build:
+    - perl-threaded
+    - gcc
+    - java # [not osx]
+  run:
+    - perl-threaded
+    - libgcc
+    - java # [not osx]
+test:
+    commands:
+        # This version of Trinity does not have a quick function to exit 0
+        # So at least check that we can compile the file
+        - "perl -c $PREFIX/bin/Trinity &> /dev/null"

--- a/recipes/trinity/2011_11_26/meta.yaml
+++ b/recipes/trinity/2011_11_26/meta.yaml
@@ -18,11 +18,11 @@ requirements:
   build:
     - perl-threaded
     - gcc
-    - java # [not osx]
+    - java-jdk # [not osx]
   run:
     - perl-threaded
     - libgcc
-    - java # [not osx]
+    - java-jdk # [not osx]
 test:
     commands:
         # This version of Trinity does not have a quick function to exit 0

--- a/recipes/trinity/meta.yaml
+++ b/recipes/trinity/meta.yaml
@@ -3,7 +3,7 @@ about:
     license: "https://raw.githubusercontent.com/trinityrnaseq/trinityrnaseq/master/LICENSE.txt"
     summary: "Trinity assembles transcript sequences from Illumina RNA-Seq data"
 build:
-  number: 1
+  number: 2
 package: 
   name: trinity
   version: '2.1.1'
@@ -18,4 +18,4 @@ requirements:
     - perl-threaded
 test:
     commands:
-        - Trinity --cite
+        - "Trinity --cite &> /dev/null"

--- a/recipes/trinity/meta.yaml
+++ b/recipes/trinity/meta.yaml
@@ -14,8 +14,10 @@ source:
 requirements:
   build:
     - perl-threaded
+    - java-jdk
   run:
     - perl-threaded
+    - java-jdk
 test:
     commands:
         - "Trinity --cite &> /dev/null"


### PR DESCRIPTION
This adds a recipe for an older version of Trinity (2011-11-26) that
uses an older assembly algorithm that works better with highly diverse
viral genomes. It also restructures the regular trinity build script a
bit to have the Trinity files in a subdir of $BIN to reduce likelihood
of conflicts