### PR TITLE
Fixes `prodigal`

### DIFF
--- a/osx-whitelist.txt
+++ b/osx-whitelist.txt
@@ -74,6 +74,7 @@ perl-app-cpanminus
 perl-threaded
 picard
 prinseq
+prodigal
 py-graphviz
 pybedtools
 pyfaidx

--- a/recipes/prodigal/build.sh
+++ b/recipes/prodigal/build.sh
@@ -1,2 +1,8 @@
 #!/bin/sh
-make install prefix=$PREFIX
+
+# the executable is not installed in $PREFIX though
+# make install prefix=$PREFIX
+
+make
+mkdir -p $PREFIX/bin
+cp $PKG_NAME $PREFIX/bin

--- a/recipes/prodigal/meta.yaml
+++ b/recipes/prodigal/meta.yaml
@@ -6,7 +6,7 @@ source:
   url: https://github.com/hyattpd/Prodigal/archive/v2.6.2.zip
   sha256: 8fb270872a144bbf60dbf4035339183c0771379ecc8749f494993ce9c7235306
 build:
-    number: 1
+    number: 2
 requirements:
   build:
   run:


### PR DESCRIPTION
The executable was not being moved to `$PREFIX/bin` despite passing tests.