### PR TITLE
Additional python dependencies for bcbio porting

### DIFF
--- a/osx-whitelist.txt
+++ b/osx-whitelist.txt
@@ -1,6 +1,7 @@
 appdirs
 argh
 arrow
+awscli
 bamtools
 bcbio-prioritize
 bcbio-rnaseq
@@ -9,6 +10,7 @@ bcbio_monitor
 bcdoc
 bcftools
 bedtools
+bioblend
 bioconductor-biocgenerics
 bioconductor-biocinstaller
 bioconductor-limma
@@ -31,6 +33,7 @@ cutadapt
 cyordereddict
 cyvcf2
 extract_fullseq
+fadapa
 fastq-join
 fastq-multx
 fastqc
@@ -52,6 +55,7 @@ jmespath
 joblib
 last
 lofreq
+logbook
 lumpy-sv
 mafft
 mageck
@@ -117,6 +121,7 @@ spades
 srprism
 subread
 sure
+tabulate
 tbb
 toposort
 trackhub

--- a/recipes/awscli/build.sh
+++ b/recipes/awscli/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+$PYTHON setup.py install --single-version-externally-managed --record=record.txt

--- a/recipes/awscli/meta.yaml
+++ b/recipes/awscli/meta.yaml
@@ -1,0 +1,39 @@
+package:
+  name: awscli
+  version: '1.8.3'
+
+source:
+  fn: awscli-1.8.3.tar.gz
+  url: https://pypi.python.org/packages/source/a/awscli/awscli-1.8.3.tar.gz
+  md5: 9a603bcfe54afdb9184babe182e2cc54
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - botocore
+    - jmespath
+    - bcdoc
+    - colorama
+    - docutils
+    - rsa
+  run:
+    - python
+    - botocore
+    - jmespath
+    - bcdoc
+    - colorama
+    - docutils
+    - rsa
+
+test:
+  imports:
+    - awscli
+
+about:
+  home: http://aws.amazon.com/cli/
+  license: Apache License 2.0
+  summary: Universal Command Line Environment for AWS

--- a/recipes/bioblend/build.sh
+++ b/recipes/bioblend/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+$PYTHON setup.py install

--- a/recipes/bioblend/meta.yaml
+++ b/recipes/bioblend/meta.yaml
@@ -1,0 +1,39 @@
+package:
+  name: bioblend
+  version: '0.7.0'
+
+source:
+  fn: bioblend-0.7.0.tar.gz
+  url: https://pypi.python.org/packages/source/b/bioblend/bioblend-0.7.0.tar.gz
+  md5: 9b91e764de795e81ae7d136218b3b07e
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - requests
+    - requests-toolbelt
+    - boto
+    - pyyaml
+    - six
+
+  run:
+    - python
+    - requests
+    - requests-toolbelt
+    - boto
+    - pyyaml
+    - six
+
+test:
+  imports:
+    - bioblend
+    - bioblend.galaxy
+
+about:
+  home: https://github.com/galaxy/bioblend
+  license: Academic Free License 3.0
+  summary:  A Python library for interacting with CloudMan and the Galaxy API 

--- a/recipes/fadapa/build.sh
+++ b/recipes/fadapa/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+$PYTHON setup.py install

--- a/recipes/fadapa/meta.yaml
+++ b/recipes/fadapa/meta.yaml
@@ -1,0 +1,27 @@
+package:
+  name: fadapa
+  version: "0.3.1"
+
+source:
+  fn: fadapa-0.3.1.tar.gz
+  url: https://pypi.python.org/packages/source/f/fadapa/fadapa-0.3.1.tar.gz
+  md5: 4924717f0a02c1fa9fb8985970d59bf0
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+
+test:
+  imports:
+    - fadapa
+
+about:
+  home: https://github.com/fadapa/fadapa
+  license: uncopyrighted
+  summary: FAstqc DAta PArser - A minimal parser to parse FastQC output data

--- a/recipes/logbook/build.sh
+++ b/recipes/logbook/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+$PYTHON setup.py install

--- a/recipes/logbook/meta.yaml
+++ b/recipes/logbook/meta.yaml
@@ -1,0 +1,29 @@
+# migrated from https://anaconda.org/asmeurer/logbook
+
+package:
+  name: logbook
+  version: "0.12.2"
+
+source:
+  fn: Logbook-0.12.2.tar.gz
+  url: https://pypi.python.org/packages/source/L/Logbook/Logbook-0.12.2.tar.gz
+  md5: aec29d6ea167f9d4e7edcb951a24c86c
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+
+test:
+  imports:
+    - logbook
+
+about:
+  home: http://logbook.pocoo.org/
+  license: BSD
+  summary: 'A logging replacement for Python'

--- a/recipes/tabulate/build.sh
+++ b/recipes/tabulate/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+$PYTHON setup.py install

--- a/recipes/tabulate/meta.yaml
+++ b/recipes/tabulate/meta.yaml
@@ -1,0 +1,27 @@
+package:
+  name: tabulate
+  version: "0.7.5"
+
+source:
+  fn: tabulate-0.7.5.tar.gz
+  url: https://pypi.python.org/packages/source/t/tabulate/tabulate-0.7.5.tar.gz
+  md5: 576e1f063b8e74dbfeda02d978564987
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+
+test:
+  imports:
+    - tabulate
+
+about:
+  home: https://bitbucket.org/astanin/python-tabulate
+  license: MIT
+  summary: Pretty-print tabular data


### PR DESCRIPTION
- Includes awscli, bioblend, fadapa, logbook and tabulate