### PR TITLE
Osx bioconductor graph

### DIFF
--- a/osx-whitelist.txt
+++ b/osx-whitelist.txt
@@ -11,6 +11,7 @@ bcftools
 bedtools
 bioconductor-biocgenerics
 bioconductor-biocinstaller
+bioconductor-graph
 bioconductor-limma
 bioconductor-preprocesscore
 bioconductor-zlibbioc

--- a/recipes/bioconductor-graph/Makevars.patch
+++ b/recipes/bioconductor-graph/Makevars.patch
@@ -1,0 +1,13 @@
+diff --git a/src/Makevars b/src/Makevars
+index 5ddfd10..77759f9 100644
+--- src/Makevars
++++ src/Makevars
+@@ -1,6 +1,6 @@
+ after: $(SHLIB)
+-	mv $(SHLIB) BioC_graph$(SHLIB_EXT)
+-
++	cp $(SHLIB) BioC_graph$(SHLIB_EXT)
++#
+ # By default, 'R CMD build' won't remove that file so it will end up in the
+ # source tarball (observed with R 2.12.0).
+ clean:

--- a/recipes/bioconductor-graph/meta.yaml
+++ b/recipes/bioconductor-graph/meta.yaml
@@ -7,6 +7,7 @@ source:
   md5: 7933ce72bc5014060316b81035ef8273
 build:
   number: 1
+  detect_binary_files_with_prefix: True
   rpaths:
     - lib/R/lib/
     - lib/

--- a/recipes/bioconductor-graph/meta.yaml
+++ b/recipes/bioconductor-graph/meta.yaml
@@ -5,9 +5,10 @@ source:
   fn: graph_1.48.0.tar.gz
   url: https://bioarchive.galaxyproject.org/graph_1.48.0.tar.gz
   md5: 7933ce72bc5014060316b81035ef8273
+  patches:            # [osx]
+    - Makevars.patch  # [osx]
 build:
   number: 1
-  detect_binary_files_with_prefix: True
   rpaths:
     - lib/R/lib/
     - lib/


### PR DESCRIPTION
I was getting errors building `bioconductor-graph` on OSX.  The problem was that during the build, the R installer moves `graph.so`. Somehow conda knew about the original `graph.so` and tried to fix the prefix of that file, but couldn't find it. Patching `src/Makevars` on OSX to copy instead of move fixed the problem.

The official Bioconductor build reports for OSX look fine; I think this is a conda-specific issue. I'm not sure how to handle special cases like this in the bioconductor helper scripts.

