### PR TITLE
Fix strange permission errors in CrossMap eggs

### DIFF
--- a/recipes/crossmap/build.sh
+++ b/recipes/crossmap/build.sh
@@ -7,3 +7,5 @@ rm -rf lib/samtools
 rm -rf lib/tabix
 rm -rf lib/src
 $PYTHON setup.py install
+# Fix strange permission issue in egg-info
+find $PREFIX/lib/python*/site-packages/CrossMap*egg -type f -execdir chmod 664 {} \;

--- a/recipes/crossmap/meta.yaml
+++ b/recipes/crossmap/meta.yaml
@@ -8,7 +8,7 @@ source:
     - setup_remove_deps.diff
 
 build:
-    number: 0
+    number: 1
 
     # CrossMap is very particular about Python version.
     skip: True # [not py27]

--- a/recipes/r-r.utils/bld.bat
+++ b/recipes/r-r.utils/bld.bat
@@ -1,0 +1,8 @@
+"%R%" CMD INSTALL --build .
+if errorlevel 1 exit 1
+
+@rem Add more build steps here, if they are necessary.
+
+@rem See
+@rem http://docs.continuum.io/conda/build.html
+@rem for a list of environment variables that are set during the build process.

--- a/recipes/r-r.utils/build.sh
+++ b/recipes/r-r.utils/build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# R refuses to build packages that mark themselves as Priority: Recommended
+mv DESCRIPTION DESCRIPTION.old
+grep -v '^Priority: ' DESCRIPTION.old > DESCRIPTION
+
+$R CMD INSTALL --build .
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/recipes/r-r.utils/meta.yaml
+++ b/recipes/r-r.utils/meta.yaml
@@ -1,0 +1,86 @@
+package:
+  name: r-r.utils
+  # Note that conda versions cannot contain -, so any -'s in the version have
+  # been replaced with _'s.
+  version: "2.2.0"
+
+source:
+  fn: R.utils_2.2.0.tar.gz
+  url:
+    - http://cran.r-project.org/src/contrib/R.utils_2.2.0.tar.gz
+    - http://cran.r-project.org/src/contrib/Archive/R.utils/R.utils_2.2.0.tar.gz
+
+
+  # You can add a hash for the file here, like md5 or sha1
+  # md5: 49448ba4863157652311cc5ea4fea3ea
+  # sha1: 3bcfbee008276084cbb37a2b453963c61176a322
+  # patches:
+   # List any patch files here
+   # - fix.patch
+
+build:
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+  # This is required to make R link correctly on Linux.
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+# Suggests: digest (>= 0.6.8)
+requirements:
+  build:
+    - r
+    - r-r.methodss3 >=1.7.0
+    - r-r.oo >=1.19.0
+
+  run:
+    - r
+    - r-r.methodss3 >=1.7.0
+    - r-r.oo >=1.19.0
+
+test:
+  commands:
+    # You can put additional test commands to be run here.
+    - $R -e "library('R.utils')" # [not win]
+    - "\"%R%\" -e \"library('R.utils')\"" # [win]
+
+  # You can also put a file called run_test.py, run_test.sh, or run_test.bat
+  # in the recipe that will be run at test time.
+
+  # requires:
+    # Put any additional test requirements here.
+
+about:
+  home: !!python/unicode 'https://github.com/HenrikBengtsson/R.utils'
+
+  license: LGPL (>= 2.1)
+  summary: !!python/unicode 'Utility functions useful when programming and developing R packages.'
+
+
+# The original CRAN metadata for this package was:
+
+# Package: R.utils
+# Version: 2.2.0
+# Depends: R (>= 2.5.0), R.oo (>= 1.19.0)
+# Imports: methods, utils, tools, R.methodsS3 (>= 1.7.0)
+# Suggests: digest (>= 0.6.8)
+# Date: 2015-12-09
+# Title: Various Programming Utilities
+# Authors@R: c(person("Henrik", "Bengtsson", role=c("aut", "cre", "cph"), email = "henrikb@braju.com"))
+# Author: Henrik Bengtsson [aut, cre, cph]
+# Maintainer: Henrik Bengtsson <henrikb@braju.com>
+# Description: Utility functions useful when programming and developing R packages.
+# License: LGPL (>= 2.1)
+# LazyLoad: TRUE
+# URL: https://github.com/HenrikBengtsson/R.utils
+# BugReports: https://github.com/HenrikBengtsson/R.utils/issues
+# NeedsCompilation: no
+# Packaged: 2015-12-09 22:41:20 UTC; hb
+# Repository: CRAN
+# Date/Publication: 2015-12-11 13:30:47
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml


### PR DESCRIPTION
CrossMap egg PKG-INFO file was not readable by non-install users
causing errors when installed by root. Additional R package dependency
trees for bcbio.