### PR TITLE
Add python requirement for levenshtein

### DIFF
--- a/recipes/python-levenshtein/meta.yaml
+++ b/recipes/python-levenshtein/meta.yaml
@@ -26,7 +26,6 @@ requirements:
     - nose
     - python
 
-
 test:
   requires:
     - nose

--- a/recipes/python-levenshtein/meta.yaml
+++ b/recipes/python-levenshtein/meta.yaml
@@ -13,16 +13,19 @@ source:
 
 build:
   preserve_egg_dir: True
-  number: 0
+  number: 1
 
 requirements:
   build:
     - cython
     - nose
+    - python
 
   run:
     - cython
     - nose
+    - python
+
 
 test:
   requires:


### PR DESCRIPTION
Has some C extensions, so should have explicit python dependency.