### PR TITLE
Fix builds failing on py3 (#498). More R packages

### DIFF
--- a/recipes/bcbio_monitor/meta.yaml
+++ b/recipes/bcbio_monitor/meta.yaml
@@ -11,6 +11,7 @@ source:
    # - fix.patch
 
 build:
+  skip: True # [not py27]
   # noarch_python: True
   # preserve_egg_dir: True
   entry_points:

--- a/recipes/bioconductor-degreport/meta.yaml
+++ b/recipes/bioconductor-degreport/meta.yaml
@@ -4,7 +4,7 @@ package:
 source:
   git_url: https://github.com/Bioconductor-mirror/DEGreport
 build:
-  number: 0
+  number: 1
   rpaths:
     - lib/R/lib/
     - lib/
@@ -14,6 +14,7 @@ requirements:
     - 'bioconductor-biocgenerics >=0.7.5'
     - r
     - r-ggplot2
+    - r-nozzle.r1
     - r-plyr
     - bioconductor-edger
   run:
@@ -21,6 +22,7 @@ requirements:
     - 'bioconductor-biocgenerics >=0.7.5'
     - r
     - r-ggplot2
+    - r-nozzle.r1
     - r-plyr
     - bioconductor-edger
 test:

--- a/recipes/bx-python/meta.yaml
+++ b/recipes/bx-python/meta.yaml
@@ -10,6 +10,7 @@ source:
 
 build:
   number: 0
+  skip: True # [not py27]
 
 requirements:
   build:

--- a/recipes/geneimpacts/meta.yaml
+++ b/recipes/geneimpacts/meta.yaml
@@ -9,6 +9,7 @@ source:
 
 build:
   number: 0
+  skip: True # [not py27]
 
 requirements:
   build:

--- a/recipes/hall-lab-svtools/meta.yaml
+++ b/recipes/hall-lab-svtools/meta.yaml
@@ -7,6 +7,9 @@ source:
   url: https://github.com/hall-lab/svtools/archive/3731a7c6e19.tar.gz
   md5: c6ba71cd3a7f02b0c58d1d13a48c02db
 
+build:
+  skip: True # [not py27]
+
 requirements:
   build:
     - python

--- a/recipes/htseq/meta.yaml
+++ b/recipes/htseq/meta.yaml
@@ -10,6 +10,7 @@ source:
 build:
   preserve_egg_dir: True
   number: 0
+  skip: True # [not py27]
 
 requirements:
   build:

--- a/recipes/ipython-cluster-helper/meta.yaml
+++ b/recipes/ipython-cluster-helper/meta.yaml
@@ -6,6 +6,9 @@ source:
   fn: ipython-cluster-helper-0.5.0.tar.gz
   url: https://pypi.python.org/packages/source/i/ipython-cluster-helper/ipython-cluster-helper-0.5.0.tar.gz
 
+build:
+  skip: True # [not py27]
+
 requirements:
   build:
     - python

--- a/recipes/pyutilib/meta.yaml
+++ b/recipes/pyutilib/meta.yaml
@@ -9,6 +9,9 @@ source:
   url: https://pypi.python.org/packages/source/P/PyUtilib/PyUtilib-5.1.3556.tar.gz
   md5: fa6b4fba1e8c817d431e9c2aac8a27b5
 
+build:
+  skip: True # [not py27]
+
 requirements:
   build:
     - python

--- a/recipes/r-ks/bld.bat
+++ b/recipes/r-ks/bld.bat
@@ -1,0 +1,8 @@
+"%R%" CMD INSTALL --build .
+if errorlevel 1 exit 1
+
+@rem Add more build steps here, if they are necessary.
+
+@rem See
+@rem http://docs.continuum.io/conda/build.html
+@rem for a list of environment variables that are set during the build process.

--- a/recipes/r-ks/build.sh
+++ b/recipes/r-ks/build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# R refuses to build packages that mark themselves as Priority: Recommended
+mv DESCRIPTION DESCRIPTION.old
+grep -v '^Priority: ' DESCRIPTION.old > DESCRIPTION
+
+$R CMD INSTALL --build --no-test-load .
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/recipes/r-ks/meta.yaml
+++ b/recipes/r-ks/meta.yaml
@@ -1,0 +1,89 @@
+package:
+  name: r-ks
+  # Note that conda versions cannot contain -, so any -'s in the version have
+  # been replaced with _'s.
+  version: "1.10.0"
+
+source:
+  fn: ks_1.10.0.tar.gz
+  url:
+    - http://cran.r-project.org/src/contrib/ks_1.10.0.tar.gz
+    - http://cran.r-project.org/src/contrib/Archive/ks/ks_1.10.0.tar.gz
+
+
+  # You can add a hash for the file here, like md5 or sha1
+  # md5: 49448ba4863157652311cc5ea4fea3ea
+  # sha1: 3bcfbee008276084cbb37a2b453963c61176a322
+  # patches:
+   # List any patch files here
+   # - fix.patch
+
+build:
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+  # This is required to make R link correctly on Linux.
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+# Suggests: MASS
+requirements:
+  build:
+    - r
+    - r-kernsmooth >=2.22 # [not win]
+    - r-misc3d >=0.4_0
+    - r-multicool
+    - r-mvtnorm >=1.0_0
+    - r-rgl >=0.66
+
+  run:
+    - r
+    - r-kernsmooth >=2.22 # [not win]
+    - r-misc3d >=0.4_0
+    - r-multicool
+    - r-mvtnorm >=1.0_0
+    - r-rgl >=0.66
+
+test:
+  commands:
+    # You can put additional test commands to be run here.
+    - $R -e "library('ks')" # [not win]
+    - "\"%R%\" -e \"library('ks')\"" # [win]
+
+  # You can also put a file called run_test.py, run_test.sh, or run_test.bat
+  # in the recipe that will be run at test time.
+
+  # requires:
+    # Put any additional test requirements here.
+
+about:
+  home: !!python/unicode 'http://www.mvstat.net/tduong'
+
+  license: GPL-2 | GPL-3
+  summary: !!python/unicode 'Kernel smoothers for univariate and multivariate data.'
+
+
+# The original CRAN metadata for this package was:
+
+# Package: ks
+# Version: 1.10.0
+# Date: 2015-10-22
+# Title: Kernel Smoothing
+# Author: Tarn Duong <tarn.duong@gmail.com>
+# Maintainer: Tarn Duong <tarn.duong@gmail.com>
+# Depends: R (>= 1.4.0), KernSmooth (>= 2.22), misc3d (>= 0.4-0), mvtnorm (>= 1.0-0), rgl (>= 0.66)
+# Imports: grDevices, graphics, multicool, stats, utils
+# Suggests: MASS
+# Description: Kernel smoothers for univariate and multivariate data.
+# License: GPL-2 | GPL-3
+# URL: http://www.mvstat.net/tduong
+# NeedsCompilation: yes
+# Packaged: 2015-10-22 20:15:26 UTC; duongt
+# Repository: CRAN
+# Date/Publication: 2015-10-23 01:29:22
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/recipes/r-pscbs/bld.bat
+++ b/recipes/r-pscbs/bld.bat
@@ -1,0 +1,8 @@
+"%R%" CMD INSTALL --build .
+if errorlevel 1 exit 1
+
+@rem Add more build steps here, if they are necessary.
+
+@rem See
+@rem http://docs.continuum.io/conda/build.html
+@rem for a list of environment variables that are set during the build process.

--- a/recipes/r-pscbs/build.sh
+++ b/recipes/r-pscbs/build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# R refuses to build packages that mark themselves as Priority: Recommended
+mv DESCRIPTION DESCRIPTION.old
+grep -v '^Priority: ' DESCRIPTION.old > DESCRIPTION
+
+$R CMD INSTALL --build .
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/recipes/r-pscbs/meta.yaml
+++ b/recipes/r-pscbs/meta.yaml
@@ -1,0 +1,104 @@
+package:
+  name: r-pscbs
+  # Note that conda versions cannot contain -, so any -'s in the version have
+  # been replaced with _'s.
+  version: "0.60.0"
+
+source:
+  fn: PSCBS_0.60.0.tar.gz
+  url:
+    - http://cran.r-project.org/src/contrib/PSCBS_0.60.0.tar.gz
+    - http://cran.r-project.org/src/contrib/Archive/PSCBS/PSCBS_0.60.0.tar.gz
+
+
+  # You can add a hash for the file here, like md5 or sha1
+  # md5: 49448ba4863157652311cc5ea4fea3ea
+  # sha1: 3bcfbee008276084cbb37a2b453963c61176a322
+  # patches:
+   # List any patch files here
+   # - fix.patch
+
+build:
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+  # This is required to make R link correctly on Linux.
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+# Suggests: Hmisc (>= 3.16-0), R.rsp (>= 0.20.0), R.devices (>= 2.13.1), ggplot2 (>= 1.0.1), aroma.light (>= 2.2.1)
+requirements:
+  build:
+    - r
+    - bioconductor-dnacopy
+    - r-r.cache >=0.12.0
+    - r-r.methodss3 >=1.7.0
+    - r-r.oo >=1.19.0
+    - r-r.utils >=2.1.0
+    - r-future >=0.8.2
+    - r-listenv >=0.5.0
+    - r-matrixstats >=0.15.0
+
+  run:
+    - r
+    - bioconductor-dnacopy
+    - r-r.cache >=0.12.0
+    - r-r.methodss3 >=1.7.0
+    - r-r.oo >=1.19.0
+    - r-r.utils >=2.1.0
+    - r-future >=0.8.2
+    - r-listenv >=0.5.0
+    - r-matrixstats >=0.15.0
+
+test:
+  commands:
+    # You can put additional test commands to be run here.
+    - $R -e "library('PSCBS')" # [not win]
+    - "\"%R%\" -e \"library('PSCBS')\"" # [win]
+
+  # You can also put a file called run_test.py, run_test.sh, or run_test.bat
+  # in the recipe that will be run at test time.
+
+  # requires:
+    # Put any additional test requirements here.
+
+about:
+  home: !!python/unicode 'https://github.com/HenrikBengtsson/PSCBS'
+
+  license: GPL (>= 2)
+  summary: !!python/unicode 'Segmentation of allele-specific DNA copy number data and detection
+    of regions with abnormal copy number within each parental chromosome.  Both tumor-normal
+    paired and tumor-only analyses are supported.'
+
+
+# The original CRAN metadata for this package was:
+
+# Package: PSCBS
+# Version: 0.60.0
+# Depends: R (>= 3.1.1), utils
+# Imports: R.methodsS3 (>= 1.7.0), R.oo (>= 1.19.0), R.utils (>= 2.1.0), R.cache (>= 0.12.0), matrixStats (>= 0.15.0), DNAcopy (>= 1.40.0), listenv (>= 0.5.0), future (>= 0.8.2), parallel
+# Suggests: Hmisc (>= 3.16-0), R.rsp (>= 0.20.0), R.devices (>= 2.13.1), ggplot2 (>= 1.0.1), aroma.light (>= 2.2.1)
+# SuggestsNote: BioC (>= 3.0), Recommended: Hmisc, aroma.light
+# VignetteBuilder: R.rsp
+# Date: 2015-11-17
+# Title: Analysis of Parent-Specific DNA Copy Numbers
+# Authors@R: c( person("Henrik", "Bengtsson", role=c("aut", "cre", "cph"), email="henrikb@braju.com"), person("Pierre", "Neuvial", role="aut"), person("Venkatraman E.", "Seshan", role="aut"), person("Adam B.", "Olshen", role="aut"), person("Paul T.", "Spellman", role="aut"), person("Richard A.", "Olshen", role="aut"))
+# Description: Segmentation of allele-specific DNA copy number data and detection of regions with abnormal copy number within each parental chromosome.  Both tumor-normal paired and tumor-only analyses are supported.
+# License: GPL (>= 2)
+# LazyLoad: TRUE
+# ByteCompile: TRUE
+# biocViews: aCGH, CopyNumberVariants, SNP, Microarray, OneChannel, TwoChannel, Genetics
+# URL: https://github.com/HenrikBengtsson/PSCBS
+# BugReports: https://github.com/HenrikBengtsson/PSCBS/issues
+# NeedsCompilation: no
+# Packaged: 2015-11-17 17:52:13 UTC; hb
+# Author: Henrik Bengtsson [aut, cre, cph], Pierre Neuvial [aut], Venkatraman E. Seshan [aut], Adam B. Olshen [aut], Paul T. Spellman [aut], Richard A. Olshen [aut]
+# Maintainer: Henrik Bengtsson <henrikb@braju.com>
+# Repository: CRAN
+# Date/Publication: 2015-11-18 09:31:06
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/recipes/vawk/meta.yaml
+++ b/recipes/vawk/meta.yaml
@@ -8,6 +8,7 @@ source:
 
 build:
   number: 0
+  skip: True # [not py27]
 
 requirements:
   build:


### PR DESCRIPTION
- Skips py3 builds for packages that don't work correctly there. Thanks
  to @daler for detecting problem in #498
- Add PSCBS and ks packages for R
- Add nozzle dependency to degreport