### PR TITLE
Update STAR to 2.5.0c.

### DIFF
--- a/recipes/star/meta.yaml
+++ b/recipes/star/meta.yaml
@@ -1,9 +1,9 @@
 package:
   name: star
-  version: "2.5.0b"
+  version: "2.5.0c"
 source:
-  fn: 2.5.0b.tar.gz
-  url: https://github.com/alexdobin/STAR/archive/2.5.0b.tar.gz
+  fn: 2.5.0c.tar.gz
+  url: https://github.com/alexdobin/STAR/archive/2.5.0c.tar.gz
 about:
   home: https://github.com/alexdobin/STAR
   license: GPLv3


### PR DESCRIPTION
2.5.0a and b hang during genome generation on some genomes.