### PR TITLE
All builds must pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,15 +19,27 @@ Bioconda team.  Please post in the [team thread on
 GitHub](https://github.com/bioconda/recipes/issues/1) to ask for permission.
 
 We build Linux packages inside a CentOS 5 docker container to maintain
-compatibility across multiple systems. The steps below describe how to
-contribute a new package. It is assumed you have
-[docker](https://www.docker.com/) and [git](https://git-scm.com/) installed.
+compatibility across multiple systems. OSX packages are built using the [OSX
+build environment](https://docs.travis-ci.com/user/osx-ci-environment/) on
+[Travis CI](https://travis-ci.org/).
+
+The steps below describe how to contribute a new package. The following
+prerequisites are assumed:
+
+- The [`conda`](http://anaconda.org) command line tool. This comes with the
+  full [Anaconda scientific Python stack](https://www.continuum.io/downloads)
+  installation, or the slimmed-down
+  [Miniconda](http://conda.pydata.org/miniconda.html). The Python 3 version is
+  recommended.
+- [`docker`](https://www.docker.com/)
+- [`git`](https://git-scm.com/)
 
 ### Step 1: Create a new recipe
 
 Fork this repository or create a new branch to work in. Within the new branch,
 [create a recipe](http://conda.pydata.org/docs/building/build.html)
-(`your_package` in this example) in the `recipes` directory.
+(`your_package` in this example) in the `recipes` directory. See the "bioconda
+build system" section below for further details.
 
 ### Step 2: Test the recipe
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 [![Build Status](https://travis-ci.org/bioconda/bioconda-recipes.svg?branch=master)](https://travis-ci.org/bioconda/bioconda-recipes)
 
-[Conda](http://anaconda.org) is a platform and language independent package manager, that sports easy distribution, installation and version management of software.
-The [bioconda channel](https://anaconda.org/bioconda) is a Conda channel providing bioinformatics related packages.
-This repository hosts the corresponding recipes.
+[Conda](http://anaconda.org) is a platform- and language-independent package
+manager that sports easy distribution, installation and version management of
+software.  The [bioconda channel](https://anaconda.org/bioconda) is a Conda
+channel providing bioinformatics related packages.  This repository hosts the
+corresponding recipes.
 
 ## User guide
 
@@ -12,10 +14,9 @@ Please visit https://bioconda.github.io for details.
 
 ## Developer guide
 
-If you want to contribute new packages to Bioconda, you are invited to join the Bioconda team.
-Please post in the
-[team thread on GitHub](https://github.com/bioconda/recipes/issues/1) to ask for
-permission.
+If you want to contribute new packages to Bioconda, you are invited to join the
+Bioconda team.  Please post in the [team thread on
+GitHub](https://github.com/bioconda/recipes/issues/1) to ask for permission.
 
 We build Linux packages inside a CentOS 5 docker container to maintain
 compatibility across multiple systems. The steps below describe how to
@@ -30,8 +31,7 @@ Fork this repository or create a new branch to work in. Within the new branch,
 
 ### Step 2: Test the recipe
 
-When the recipe
-is ready first test it with your local conda installation via
+When the recipe is ready, first test it with your local conda installation via
 
     conda build recipes/your_package
 
@@ -49,7 +49,9 @@ package name:
 
     docker run -v `pwd`:/tmp/conda-recipes bioconda/bioconda-builder
 
-If rebuilding a previously-built package and the version number hasn't changed, be sure to increment the build number in `meta.yaml` (the default build number is 0):
+If rebuilding a previously-built package and the version number hasn't changed,
+be sure to increment the build number in `meta.yaml` (the default build number
+is 0):
 
     build:
       number: 1
@@ -72,21 +74,26 @@ using:
 
 ### Step 4:
 
-If you want to promote the Bioconda installation of your package, we recommend to add the following badge to your homepage:
+If you want to promote the Bioconda installation of your package, we recommend
+to add the following badge to your homepage:
 
     [![bioconda-badge](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg?style=flat-square)](http://bioconda.github.io)
 
-This will display as [![bioconda-badge](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg?style=flat-square)](https://bioconda.github.io). For other styles, replace ``?style=flat-square`` with ``?style=flat`` or ``?style=plastic``.
+This will display as
+[![bioconda-badge](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg?style=flat-square)](https://bioconda.github.io).
+For other styles, replace ``?style=flat-square`` with ``?style=flat`` or
+``?style=plastic``.
 
 ### Building packages for Mac OSX
 
-If you want your package to be built for Mac OSX as well, you have to add it to
-the ``osx-whitelist.txt`` file in the root of this repository.
+If you want your package to be built for Mac OSX as well, add the recipe name
+to the ``osx-whitelist.txt`` file in the root of this repository.
 
 To set up a local machine for building and testing OSX recipes, run
 ``scripts/travis-setup.sh``. Several commands in this script will prompt for
 sudo privileges, but the script itself should be run as a regular user. This
-script will set up a conda environment in ``/anaconda`` and install necessary prerequisites.
+script will set up a conda environment in ``/anaconda`` and install necessary
+prerequisites.
 
 To test all recipes in the ``osx-whitelist``, use:
 
@@ -97,8 +104,9 @@ scripts/build-packages.py --repository . --packages `cat osx-whitelist.txt`
 
 ### Managing multiple versions of a package
 
-If there is interest to keep multiple versions of a package or to explicitly build an older version of a package,
-you can store those versions in subdirectories of the corresponding recipe, e.g.:
+If there is interest to keep multiple versions of a package or to explicitly
+build an older version of a package, you can store those versions in
+subdirectories of the corresponding recipe, e.g.:
 
 ```
 java-jdk/
@@ -109,7 +117,8 @@ java-jdk/
 └── meta.yaml
 ```
 
-There should always be a primary in the root directory of a package that is updated when new releases are made.
+There should always be a primary in the root directory of a package that is
+updated when new releases are made.
 
 ### Other notes
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ When the recipe is ready, first test it with your local conda installation via
 
     conda build recipes/your_package
 
+If the recipe has dependencies in the bioconda channel (this is often the
+case), you will need to add `--channel bioconda` to the command. If the recipe
+is an R package, you will also need to add `--channel r`. For example many
+Bioconductor packages will be built using:
+
+    conda build recipes/your_package --channel bioconda --channel r
+
 Then, you can test it in the docker container with:
 
     docker run -v `pwd`:/bioconda-recipes bioconda/bioconda-builder --packages your_package

--- a/README.md
+++ b/README.md
@@ -144,8 +144,16 @@ updated when new releases are made.
 We use a pre-built CentOS 5 image with compilers installed as part of the
 standard build. To build this yourself, you can do:
 
-    docker login
-    cd scripts && docker build -t bicoonda/bioconda-builder .
+```bash
+docker login
+(cd scripts && docker build -t bicoonda/bioconda-builder .)
+```
+
+Then test a recipe with:
+
+```bash
+docker run -v `pwd`:/bioconda-recipes bioconda/bioconda-builder --packages your_package
+```
 
 ### Creating Bioconductor recipes
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,9 @@ using:
 If you want to promote the Bioconda installation of your package, we recommend
 to add the following badge to your homepage:
 
-    [![bioconda-badge](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg?style=flat-square)](http://bioconda.github.io)
+```
+[![bioconda-badge](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg?style=flat-square)](http://bioconda.github.io)
+```
 
 This will display as
 [![bioconda-badge](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg?style=flat-square)](https://bioconda.github.io).
@@ -118,10 +120,9 @@ prerequisites.
 
 To test all recipes in the ``osx-whitelist``, use:
 
-```
+```bash
 scripts/build-packages.py --repository . --packages `cat osx-whitelist.txt`
 ```
-
 
 ### Managing multiple versions of a package
 
@@ -219,6 +220,12 @@ Or a package that only runs on Python 3.4 and 3.5:
 ```yaml
 build:
   skip: True # [py27]
+```
+
+Alternatively, for straightforward compatibility fixes you can apply a [patch
+in the
+meta.yaml](http://conda.pydata.org/docs/building/meta-yaml.html#patches).
+
 ### Creating Bioconductor recipes
 
 See [`scripts/bioconductor/README.md`](scripts/bioconductor/README.md) for

--- a/osx-whitelist.txt
+++ b/osx-whitelist.txt
@@ -152,7 +152,6 @@ rtg-tools
 s3gof3r
 sambamba
 samtools
-seqcluster
 simple_sv_annotation
 simplejson
 snakemake

--- a/recipes/google-api-python-client/meta.yaml
+++ b/recipes/google-api-python-client/meta.yaml
@@ -8,6 +8,7 @@ source:
   md5: d17fc4919724b0da29651086f5b72458
 
 build:
+  skip: True #[not py27]
   number: 0
 
 requirements:

--- a/scripts/build-packages.py
+++ b/scripts/build-packages.py
@@ -84,7 +84,7 @@ def build_recipe(recipe):
         success = build()
     else:
         # use list to enforce all builds
-        success = any(list(map(build, PYTHON_VERSIONS)))
+        success = all(list(map(build, PYTHON_VERSIONS)))
 
     if not success:
         # fail if all builds result in an error

--- a/scripts/build-packages.py
+++ b/scripts/build-packages.py
@@ -84,11 +84,11 @@ def build_recipe(recipe):
         success = build()
     else:
         # use list to enforce all builds
-        success = any(list(map(build, PYTHON_VERSIONS)))
+        success = all(list(map(build, PYTHON_VERSIONS)))
 
     if not success:
         # fail if all builds result in an error
-        assert False, "All builds of recipe {} failed.".format(recipe)
+        assert False, "At least one build of recipe {} failed.".format(recipe)
 
 
 def filter_recipes(recipes):

--- a/scripts/build-packages.py
+++ b/scripts/build-packages.py
@@ -84,7 +84,7 @@ def build_recipe(recipe):
         success = build()
     else:
         # use list to enforce all builds
-        success = all(list(map(build, PYTHON_VERSIONS)))
+        success = any(list(map(build, PYTHON_VERSIONS)))
 
     if not success:
         # fail if all builds result in an error


### PR DESCRIPTION
As discussed in #498, this is a simple change to build-packages.py to require all non-skipped recipes to successfully build. I added a fix to google-api-python-client to only build on py27 so that it passes. 

I updated the readme to reflect these changes. While I was there, added more info about the build system, more details on prerequisites, examples of skipping Python versions, and some cosmetic tweaks.