### PR TITLE
New: bcbio-nextgen-vm, update bcbio to conda install

### DIFF
--- a/osx-whitelist.txt
+++ b/osx-whitelist.txt
@@ -4,8 +4,6 @@ argh
 arrow
 awscli
 bamtools
-bcbio-nextgen
-bcbio-nextgen-vm
 bcbio-prioritize
 bcbio-rnaseq
 bcbio-variation-recall

--- a/osx-whitelist.txt
+++ b/osx-whitelist.txt
@@ -5,6 +5,7 @@ arrow
 awscli
 bamtools
 bcbio-nextgen
+bcbio-nextgen-vm
 bcbio-prioritize
 bcbio-rnaseq
 bcbio-variation-recall

--- a/recipes/bcbio-nextgen-vm/build.sh
+++ b/recipes/bcbio-nextgen-vm/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+#cp -r $RECIPE_DIR/.. .
+$PYTHON setup.py install --record=/dev/null

--- a/recipes/bcbio-nextgen-vm/meta.yaml
+++ b/recipes/bcbio-nextgen-vm/meta.yaml
@@ -1,0 +1,35 @@
+package:
+  name: bcbio-nextgen-vm
+  version: '0.1.0a'
+
+build:
+  number: 69
+  skip: True # [not py27]
+
+source:
+  fn: bcbio-nextgen-vm-8e55cc1.tar.gz
+  url: https://github.com/chapmanb/bcbio-nextgen-vm/archive/8e55cc1.tar.gz
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+    - setuptools
+    - bcbio-nextgen
+    - elasticluster
+    - nose
+    - six
+
+test:
+  imports:
+    - bcbiovm.version
+  commands:
+    - bcbio_vm.py -h
+
+about:
+  home: https://github.com/chapmanb/bcbio-nextgen-vm
+  license: MIT
+  summary: Run bcbio-nextgen genomic sequencing analyses using isolated containers and virtual machines

--- a/recipes/bcbio-nextgen/build.sh
+++ b/recipes/bcbio-nextgen/build.sh
@@ -1,3 +1,2 @@
 #!/bin/bash
-#cp -r $RECIPE_DIR/.. .
-$PYTHON setup.py install --record=/dev/null
+$PYTHON setup.py install

--- a/recipes/bcbio-nextgen/meta.yaml
+++ b/recipes/bcbio-nextgen/meta.yaml
@@ -1,16 +1,16 @@
 package:
   name: bcbio-nextgen
-  version: '0.9.5'
+  version: '0.9.6a'
 
 build:
-  number: 1
+  number: 0
   skip: True # [not py27]
 
 source:
-  fn: bcbio-nextgen-0.9.5.tar.gz
-  url: https://pypi.python.org/packages/source/b/bcbio-nextgen/bcbio-nextgen-0.9.5.tar.gz
-  #fn: bcbio-nextgen-acd79b4.tar.gz
-  #url: https://github.com/chapmanb/bcbio-nextgen/archive/acd79b4.tar.gz
+  #fn: bcbio-nextgen-0.9.5.tar.gz
+  #url: https://pypi.python.org/packages/source/b/bcbio-nextgen/bcbio-nextgen-0.9.5.tar.gz
+  fn: bcbio-nextgen-c3d4c82.tar.gz
+  url: https://github.com/chapmanb/bcbio-nextgen/archive/c3d4c82.tar.gz
 
 requirements:
   build:
@@ -73,6 +73,10 @@ test:
     - bcbio.distributed.multi
     - bcbio.pipeline.main
     - bcbio.provenance.do
+  commands:
+    - bcbio_nextgen.py -h
+    - bcbio_setup_genome.py -h
+    - bcbio_prepare_samples.py -h
 
 about:
   home: https://github.com/chapmanb/bcbio-nextgen


### PR DESCRIPTION
Migrates bcbio and bcbio-vm installation to be conda only
with all packages supplied via bioconda.