### PR TITLE
add note to README.md to mention how to enter a bash shell within the build container

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,11 @@ Then test a recipe with:
 docker run -v `pwd`:/bioconda-recipes bioconda/bioconda-builder --packages your_package
 ```
 
+If you wish the open a bash shell in the Docker container for manual debugging:
+
+```bash
+docker run -i -t --entrypoint /bin/bash bioconda/bioconda-builder
+```
 
 ## The bioconda build system
 This repository is set up on [Travis CI](https://travis-ci.org) such that on


### PR DESCRIPTION
add note to README.md to mention how to enter a bash shell within the build container

Sometimes it is helpful to debug build issues within the docker container by manually calling conda build within a bash shell for the container. This PR adds a note to the readme instructing how to do this, since the default container entrypoint is overridden by the bioconda build script.