### PR TITLE
Add recipe for NPY 1.10 build of scikit-bio 0.2.3

### DIFF
--- a/recipes/scikit-bio/build.sh
+++ b/recipes/scikit-bio/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$PYTHON setup.py install

--- a/recipes/scikit-bio/meta.yaml
+++ b/recipes/scikit-bio/meta.yaml
@@ -1,0 +1,78 @@
+package:
+  name: scikit-bio
+  version: "0.2.3"
+
+source:
+  fn: scikit-bio-0.2.3.tar.gz
+  url: https://pypi.python.org/packages/source/s/scikit-bio/scikit-bio-0.2.3.tar.gz
+  md5: 2bb1148468d3e5129fa8ff5b29cbeaa3
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - numpy
+    - matplotlib >=1.1.0
+    - scipy >=0.13.0
+    - pandas
+    - future
+    - six
+    - natsort
+    - ipython
+
+  run:
+    - python
+    - numpy
+    - matplotlib >=1.1.0
+    - scipy >=0.13.0
+    - pandas
+    - future
+    - six
+    - natsort
+    - ipython
+
+test:
+  # Python imports
+  imports:
+    - skbio
+    - skbio.alignment
+    - skbio.alignment._lib
+    - skbio.alignment.tests
+    - skbio.diversity
+    - skbio.diversity.alpha
+    - skbio.diversity.alpha.tests
+    - skbio.diversity.beta
+    - skbio.diversity.beta.tests
+    - skbio.draw
+    - skbio.draw.tests
+    - skbio.format
+    - skbio.format.sequences
+    - skbio.format.sequences.tests
+    - skbio.io
+    - skbio.io.tests
+    - skbio.parse
+    - skbio.parse.sequences
+    - skbio.parse.sequences.tests
+    - skbio.parse.tests
+    - skbio.sequence
+    - skbio.sequence.tests
+    - skbio.stats
+    - skbio.stats.distance
+    - skbio.stats.distance.tests
+    - skbio.stats.ordination
+    - skbio.stats.ordination.tests
+    - skbio.stats.tests
+    - skbio.tests
+    - skbio.tree
+    - skbio.tree.tests
+    - skbio.util
+    - skbio.util.tests
+
+about:
+  home: http://scikit-bio.org
+  license: BSD License
+  summary: 'Data structures, algorithms and educational resources for bioinformatics.'
+  license_file: COPYING.txt


### PR DESCRIPTION
The 0.2.3 version of scikit-bio from the default channel
only includes up to NumPy 1.9.