### PR TITLE
Bioconda_curl + pyBigWig-0.2.1b

### DIFF
--- a/recipes/bioconda_curl/build.sh
+++ b/recipes/bioconda_curl/build.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 
+
 mkdir -p $PREFIX/etc/pki/tls/certs
 #use system curl, or whatever comes with anaconda to get the CA certificates
 curl http://curl.haxx.se/ca/cacert.pem -o $PREFIX/etc/pki/tls/certs/cacert.pem
 
 #Actually install curl over the broken anaconda version
-./configure --prefix=$PREFIX --disable-ldap --with-ssl=$PREFIX --with-zlib=$PREFIX --with-ca-path=$PREFIX/etc/pki/tls/certs --with-ca-bundle=$PREFIX/etc/pki/tls/certs/cacert.pem
+./configure --prefix=$PREFIX --disable-ldap --with-ssl=$PREFIX --with-zlib=$PREFIX --with-ca-bundle=$PREFIX/etc/pki/tls/certs/cacert.pem
 make
 make install

--- a/recipes/bioconda_curl/build.sh
+++ b/recipes/bioconda_curl/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+mkdir -p $PREFIX/etc/pki/tls/certs
+#use system curl, or whatever comes with anaconda to get the CA certificates
+curl http://curl.haxx.se/ca/cacert.pem -o $PREFIX/etc/pki/tls/certs/cacert.pem
+
+#Actually install curl over the broken anaconda version
+./configure --prefix=$PREFIX --disable-ldap --with-ssl=$PREFIX --with-zlib=$PREFIX --with-ca-path=$PREFIX/etc/pki/tls/certs --with-ca-bundle=$PREFIX/etc/pki/tls/certs/cacert.pem
+make
+make install

--- a/recipes/bioconda_curl/meta.yaml
+++ b/recipes/bioconda_curl/meta.yaml
@@ -5,6 +5,12 @@ about:
 
 build:
   number: 0
+  always_include_files:
+    - bin/curl-config
+    - include/curl/*.h
+    - lib/pkgconfig/libcurl.pc
+    - lib/libcurl.*
+
 
 package:
   name: bioconda_curl

--- a/recipes/bioconda_curl/meta.yaml
+++ b/recipes/bioconda_curl/meta.yaml
@@ -1,0 +1,21 @@
+about:
+  home: http://www.curl.haxx.se/
+  license: MIT
+  summary: curl is an open source command line tool and library for transferring data with URL syntax
+
+build:
+  number: 0
+
+package:
+  name: bioconda_curl
+  version: 7.46.0
+
+requirements:
+  build:
+    - curl
+
+source:
+  fn: curl-7.46.0.tar.gz
+  sha256: df9e7d4883abdd2703ee758fe0e3ae74cec759b26ec2b70e5d1c40239eea06ec
+  url: http://curl.haxx.se/download/curl-7.46.0.tar.gz
+

--- a/recipes/bioconda_curl/meta.yaml
+++ b/recipes/bioconda_curl/meta.yaml
@@ -10,7 +10,8 @@ build:
     - include/curl/*.h
     - lib/pkgconfig/libcurl.pc
     - lib/libcurl.*
-
+  binary_has_prefix_files:
+    - lib/libcurl.so.4.4.0
 
 package:
   name: bioconda_curl

--- a/recipes/pybigwig/0.1.11/build.sh
+++ b/recipes/pybigwig/0.1.11/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+export C_INCLUDE_PATH=$PREFIX/include
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/recipes/pybigwig/0.1.11/meta.yaml
+++ b/recipes/pybigwig/0.1.11/meta.yaml
@@ -1,12 +1,12 @@
 package:
   name: pybigwig
-  version: '0.2.1b'
+  version: '0.1.11'
 
 source:
   #git_url: https://github.com/dpryan79/pyBigWig
-  fn: pyBigWig-0.2.1b.tar.gz
-  sha256: 8927da11cc0f46499e828070ce7812a23b755cb133d6911e262752a440c61563
-  url: https://pypi.python.org/packages/source/p/pyBigWig/pyBigWig-0.2.1b.tar.gz
+  fn: pyBigWig-0.1.11.tar.gz
+  url: https://github.com/dpryan79/pyBigWig/archive/0.1.11.tar.gz
+  sha256: 7b2d5897da5761b125e6a6efbaebe60ee81996546689ecd4b1493cc5ee14ae07
 
 build:
   number: 0
@@ -14,16 +14,16 @@ build:
 requirements:
   build:
     - python
-    - bioconda_curl
+    - curl
   run:
     - python
-    - bioconda_curl
+    - curl
 test:
   imports:
     - pyBigWig
 
   commands:
-    - nosetests pyBigWigTest -s -v
+    - nosetests
 
   requires:
     - nose

--- a/recipes/pybigwig/build.sh
+++ b/recipes/pybigwig/build.sh
@@ -2,9 +2,3 @@
 
 export C_INCLUDE_PATH=$PREFIX/include
 $PYTHON setup.py install
-
-# Add more build steps here, if they are necessary.
-
-# See
-# http://docs.continuum.io/conda/build.html
-# for a list of environment variables that are set during the build process.


### PR DESCRIPTION
Update pyBigWig to version 0.2.1. Additionally, add "bioconda_curl", which replaces the problematic version of curl that comes with anaconda (as best as I can tell, this fixes https://github.com/ContinuumIO/anaconda-issues/issues/72, at least under Ubuntu).