### PR TITLE
Add pgbzip to osx whitelist

### DIFF
--- a/osx-whitelist.txt
+++ b/osx-whitelist.txt
@@ -304,3 +304,4 @@ voluptuous
 vphaser2
 ws4py
 xmltodict
+pgbzip

--- a/osx-whitelist.txt
+++ b/osx-whitelist.txt
@@ -304,4 +304,4 @@ voluptuous
 vphaser2
 ws4py
 xmltodict
-pgbzip
+pbgzip


### PR DESCRIPTION
It builds (locally, tested) correctly and it is needed to index compressed VCF files with tabix.