### PR TITLE
Rename bioconda curl

### DIFF
--- a/osx-whitelist.txt
+++ b/osx-whitelist.txt
@@ -49,6 +49,7 @@ chromhmm
 cnvkit
 cpat
 cramtools
+curl
 cutadapt
 cyordereddict
 cyvcf2
@@ -109,6 +110,7 @@ py-graphviz
 pyaml
 pyasn1-modules
 pybedtools
+pybigwig
 pycli
 pyfaidx
 pysam

--- a/recipes/curl/build.sh
+++ b/recipes/curl/build.sh
@@ -3,7 +3,8 @@
 
 mkdir -p $PREFIX/etc/pki/tls/certs
 #use system curl, or whatever comes with anaconda to get the CA certificates
-curl http://curl.haxx.se/ca/cacert.pem -o $PREFIX/etc/pki/tls/certs/cacert.pem
+#curl http://curl.haxx.se/ca/cacert.pem -o $PREFIX/etc/pki/tls/certs/cacert.pem
+wget -O $PREFIX/etc/pki/tls/certs/cacert.pem http://curl.haxx.se/ca/cacert.pem
 
 #Actually install curl over the broken anaconda version
 ./configure --prefix=$PREFIX --disable-ldap --with-ssl=$PREFIX --with-zlib=$PREFIX --with-ca-bundle=$PREFIX/etc/pki/tls/certs/cacert.pem

--- a/recipes/curl/build.sh
+++ b/recipes/curl/build.sh
@@ -7,7 +7,7 @@ curl http://curl.haxx.se/ca/cacert.pem -o $PREFIX/etc/pki/tls/certs/cacert.pem
 #wget -O $PREFIX/etc/pki/tls/certs/cacert.pem http://curl.haxx.se/ca/cacert.pem
 
 #This won't build on OSX without this
-export DYLD_LIBRARY_PATH=$PREFIX
+export DYLD_LIBRARY_PATH=$PREFIX/lib
 
 #Actually install curl over the broken anaconda version
 ./configure --prefix=$PREFIX --disable-ldap --with-ssl=$PREFIX --with-zlib=$PREFIX --with-ca-bundle=$PREFIX/etc/pki/tls/certs/cacert.pem

--- a/recipes/curl/build.sh
+++ b/recipes/curl/build.sh
@@ -6,6 +6,9 @@ mkdir -p $PREFIX/etc/pki/tls/certs
 curl http://curl.haxx.se/ca/cacert.pem -o $PREFIX/etc/pki/tls/certs/cacert.pem
 #wget -O $PREFIX/etc/pki/tls/certs/cacert.pem http://curl.haxx.se/ca/cacert.pem
 
+#This won't build on OSX without this
+export DYLD_LIBRARY_PATH=$PREFIX
+
 #Actually install curl over the broken anaconda version
 ./configure --prefix=$PREFIX --disable-ldap --with-ssl=$PREFIX --with-zlib=$PREFIX --with-ca-bundle=$PREFIX/etc/pki/tls/certs/cacert.pem
 make

--- a/recipes/curl/build.sh
+++ b/recipes/curl/build.sh
@@ -3,8 +3,8 @@
 
 mkdir -p $PREFIX/etc/pki/tls/certs
 #use system curl, or whatever comes with anaconda to get the CA certificates
-#curl http://curl.haxx.se/ca/cacert.pem -o $PREFIX/etc/pki/tls/certs/cacert.pem
-wget -O $PREFIX/etc/pki/tls/certs/cacert.pem http://curl.haxx.se/ca/cacert.pem
+curl http://curl.haxx.se/ca/cacert.pem -o $PREFIX/etc/pki/tls/certs/cacert.pem
+#wget -O $PREFIX/etc/pki/tls/certs/cacert.pem http://curl.haxx.se/ca/cacert.pem
 
 #Actually install curl over the broken anaconda version
 ./configure --prefix=$PREFIX --disable-ldap --with-ssl=$PREFIX --with-zlib=$PREFIX --with-ca-bundle=$PREFIX/etc/pki/tls/certs/cacert.pem

--- a/recipes/curl/meta.yaml
+++ b/recipes/curl/meta.yaml
@@ -4,25 +4,21 @@ about:
   summary: curl is an open source command line tool and library for transferring data with URL syntax
 
 build:
-  number: 0
-  always_include_files:
-    - bin/curl-config
-    - include/curl/*.h
-    - lib/pkgconfig/libcurl.pc
-    - lib/libcurl.*
+  number: 1
   binary_has_prefix_files:
-    - lib/libcurl.so.4.4.0
+    - lib/libcurl.so.4.4.0 # [not osx]
+    - lib/libcurl.4.dylib # [not linux]
 
 package:
   name: curl
-  version: 7.46.0
+  version: 7.45.0
 
 test:
   commands:
     - (curl --version 2>&1) > /dev/null
 
 source:
-  fn: curl-7.46.0.tar.gz
-  sha256: df9e7d4883abdd2703ee758fe0e3ae74cec759b26ec2b70e5d1c40239eea06ec
-  url: http://curl.haxx.se/download/curl-7.46.0.tar.gz
+  fn: curl-7.45.0.tar.gz
+  sha256: 02c78c8060d587422e2826f622c729189b56084bba365140f13af3d402b6cb6b
+  url: http://curl.haxx.se/download/curl-7.45.0.tar.gz
 

--- a/recipes/curl/meta.yaml
+++ b/recipes/curl/meta.yaml
@@ -9,6 +9,14 @@ build:
     - lib/libcurl.so.4.4.0 # [not osx]
     - lib/libcurl.4.dylib # [not linux]
 
+requirements:
+  build:
+    - openssl
+    - zlib
+  run:
+    - openssl
+    - zlib
+
 package:
   name: curl
   version: 7.45.0

--- a/recipes/curl/meta.yaml
+++ b/recipes/curl/meta.yaml
@@ -14,12 +14,12 @@ build:
     - lib/libcurl.so.4.4.0
 
 package:
-  name: bioconda_curl
+  name: curl
   version: 7.46.0
 
-requirements:
-  build:
-    - curl
+test:
+  commands:
+    - (curl --version 2>&1) > /dev/null
 
 source:
   fn: curl-7.46.0.tar.gz

--- a/recipes/pybigwig/0.1.11/meta.yaml
+++ b/recipes/pybigwig/0.1.11/meta.yaml
@@ -13,6 +13,7 @@ build:
 
 requirements:
   build:
+    skip: True # [osx]
     - python
     - curl
   run:

--- a/recipes/pybigwig/0.1.11/meta.yaml
+++ b/recipes/pybigwig/0.1.11/meta.yaml
@@ -10,10 +10,10 @@ source:
 
 build:
   number: 0
+  skip: True # [osx]
 
 requirements:
   build:
-    skip: True # [osx]
     - python
     - curl
   run:

--- a/recipes/pybigwig/build.sh
+++ b/recipes/pybigwig/build.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 
 export C_INCLUDE_PATH=$PREFIX/include
-curl-config --ca
 $PYTHON setup.py install

--- a/recipes/pybigwig/build.sh
+++ b/recipes/pybigwig/build.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 
 export C_INCLUDE_PATH=$PREFIX/include
+curl-config --ca
 $PYTHON setup.py install

--- a/recipes/pybigwig/meta.yaml
+++ b/recipes/pybigwig/meta.yaml
@@ -23,7 +23,6 @@ test:
     - pyBigWig
 
   commands:
-    - curl-config --ca
     - nosetests pyBigWigTest -s -v
 
   requires:

--- a/recipes/pybigwig/meta.yaml
+++ b/recipes/pybigwig/meta.yaml
@@ -9,15 +9,15 @@ source:
   url: https://pypi.python.org/packages/source/p/pyBigWig/pyBigWig-0.2.1b.tar.gz
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
     - python
-    - bioconda_curl
+    - curl
   run:
     - python
-    - bioconda_curl
+    - curl
 test:
   imports:
     - pyBigWig

--- a/recipes/pybigwig/meta.yaml
+++ b/recipes/pybigwig/meta.yaml
@@ -23,6 +23,7 @@ test:
     - pyBigWig
 
   commands:
+    - curl-config --ca
     - nosetests pyBigWigTest -s -v
 
   requires:


### PR DESCRIPTION
@johanneskoester Can you have a look? This will hopefully work and is now using the same version of curl that comes with the most recent version of anaconda (this will hopefully avoid other issues).