### PR TITLE
Also skip recipe if a certain configuration has been marked as skip in the meta.yaml.

### DIFF
--- a/scripts/build-packages.py
+++ b/scripts/build-packages.py
@@ -101,12 +101,13 @@ def filter_recipes(recipes):
         ).stdout.split("\n")
         if "Ignoring non-recipe" not in msg
     ][1:-1]
+    skip = lambda msg: "already built, skipping" in msg or "defines build/skip" in msg
 
     for item in zip(recipes, *map(msgs, PYTHON_VERSIONS)):
         recipe = item[0]
         msg = item[1:]
 
-        if all("already built, skipping" in m for m in msg):
+        if all(map(skip, msg)):
             print("Skipping recipe", recipe, file=sys.stderr)
         else:
             yield recipe


### PR DESCRIPTION
Currently, all recipes that have a skip instruction for a certain python version are build over and over because the message from conda build is not parsed correctly. This PR should provide a significant speed up by skipping them as well.