### PR TITLE
Add svgwrite and pyparsing to osx-whitelist.

### DIFF
--- a/osx-whitelist.txt
+++ b/osx-whitelist.txt
@@ -27,9 +27,9 @@ bioconductor-biostrings
 bioconductor-complexheatmap
 bioconductor-dada2
 bioconductor-dnacopy
+bioconductor-genomeinfodb
 bioconductor-genomicalignments
 bioconductor-genomicranges
-bioconductor-genomeinfodb
 bioconductor-geoquery
 bioconductor-graph
 bioconductor-iranges
@@ -107,6 +107,7 @@ netifaces
 novoalign
 oauth2client
 oncofuse
+pbgzip
 peakzilla
 perl
 perl-app-cpanminus
@@ -125,9 +126,9 @@ pycli
 pyfaidx
 pysam
 pysan1-modules
-python-magic
 python-dateutil
 python-levenshtein
+python-magic
 python-wget
 pythonpy
 pyvcf
@@ -193,6 +194,7 @@ srprism
 star
 subread
 sure
+svgwrite
 tabulate
 tbb
 toposort
@@ -320,4 +322,3 @@ voluptuous
 vphaser2
 ws4py
 xmltodict
-pbgzip


### PR DESCRIPTION
Also resort the osx-whitelist file, resulting in minor changes.

Both svgwrite and pyparsing are pure-python modules so there should be no problems with OSX compatibility.

