### PR TITLE
Add recipe for oligotyping

### DIFF
--- a/recipes/oligotyping/bld.bat
+++ b/recipes/oligotyping/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/recipes/oligotyping/build.sh
+++ b/recipes/oligotyping/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/recipes/oligotyping/meta.yaml
+++ b/recipes/oligotyping/meta.yaml
@@ -1,0 +1,84 @@
+package:
+  name: oligotyping
+  version: "2.0"
+
+source:
+  fn: oligotyping-2.0.tar.gz
+  url: https://pypi.python.org/packages/source/o/oligotyping/oligotyping-2.0.tar.gz
+  md5: 2159126a355bf3429418224ab17d5a56
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+build:
+  skip: True # [not py27]
+  # noarch_python: True
+  # preserve_egg_dir: True
+  # entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - oligotyping = oligotyping:main
+    #
+    # Would create an entry point called oligotyping that calls oligotyping.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - matplotlib
+    - biopython
+    - scipy
+    - django
+
+  run:
+    - python
+    - matplotlib
+    - biopython
+    - scipy
+    - django
+    - blast
+    - r-vegan
+    - r-ggplot2
+    - r-gplots
+    - r-gtools
+    - r-reshape
+    - r-optparse
+    - r-pheatmap
+    - r-rcolorbrewer
+    - r-compute.es
+
+test :
+  # Python imports
+  imports:
+    - Oligotyping
+    - Oligotyping.lib
+    - Oligotyping.utils
+    - Oligotyping.utils.html
+    - Oligotyping.visualization
+
+  # commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: http://oligotyping.org
+  license: GNU General Public License v3 or later (GPLv3+)
+  summary: 'The oligotyping and minimum entropy decomposition (MED) pipeline for the analysis of marker gene amplicons'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml


### PR DESCRIPTION
Oligotyping is a computational method that helps microbial ecologists to investigate concealed diversity within their operational taxonomic units at an extremely precise level. 

The recipe is created using the pypi skeleton with added non-python dependancies.