### PR TITLE
Bump ipython-cluster-helper to 0.5.1.

### DIFF
--- a/recipes/ipython-cluster-helper/meta.yaml
+++ b/recipes/ipython-cluster-helper/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: ipython-cluster-helper
-  version: 0.5.0
+  version: 0.5.1
 
 source:
-  fn: ipython-cluster-helper-0.5.0.tar.gz
-  url: https://pypi.python.org/packages/source/i/ipython-cluster-helper/ipython-cluster-helper-0.5.0.tar.gz
+  fn: ipython-cluster-helper-0.5.1.tar.gz
+  url: https://pypi.python.org/packages/source/i/ipython-cluster-helper/ipython-cluster-helper-0.5.1.tar.gz
 
 build:
   skip: True # [not py27]


### PR DESCRIPTION
Adds support for UGE schedulers.