### PR TITLE
Use conda-build from master to solve issue #597 until a new version is released.

### DIFF
--- a/scripts/build-packages.py
+++ b/scripts/build-packages.py
@@ -174,6 +174,9 @@ if __name__ == "__main__":
     global args
     args = p.parse_args()
 
+    # Install conda-build with fixes to skipping mechanism (PR #726)
+    sp.run(["pip", "install", "git+https://https://github.com/conda/conda-build.git@237e8fd2643863b6c1df6a4fd413dba8c24119b5"], check=True)
+
     sp.run(["gcc", "--version"], check=True)
     try:
         sp.run(["ldd", "--version"], check=True)

--- a/scripts/build-packages.py
+++ b/scripts/build-packages.py
@@ -175,7 +175,7 @@ if __name__ == "__main__":
     args = p.parse_args()
 
     # Install conda-build with fixes to skipping mechanism (PR #726)
-    sp.run(["pip", "install", "git+https://https://github.com/conda/conda-build.git@237e8fd2643863b6c1df6a4fd413dba8c24119b5"], check=True)
+    sp.run(["pip", "install", "git+https://github.com/conda/conda-build.git@237e8fd2643863b6c1df6a4fd413dba8c24119b5"], check=True)
 
     sp.run(["gcc", "--version"], check=True)
     try:


### PR DESCRIPTION
This should fix issue #597. The overhead for already existing and skipped packages plus download of the docker container is about a minute now. The rest will be only compile time of the new recipe/version.