### PR TITLE
Add kraken-all metapackage that includes jellyfish dep.

### DIFF
--- a/recipes/kraken-all/meta.yaml
+++ b/recipes/kraken-all/meta.yaml
@@ -1,0 +1,11 @@
+package:
+  name: kraken-all
+  version: "0.10.5beta"
+requirements:
+  run:
+    - kraken ==0.10.5beta
+    - jellyfish >=1.1.11,<2
+about:
+  home: http://ccb.jhu.edu/software/kraken/
+  license: GPLv3
+  summary: This metapackage installs kraken with optional dependency jellyfish for building kraken databases.


### PR DESCRIPTION
Adds jellyfish1 dep for kraken-all to support building databases.

This is based off of #389, since `jellyfish` is an optional dependency - the best way to go about this seems to be a metapackage that installs it.