### PR TITLE
Update: pindel, New: arvados-cli

### DIFF
--- a/recipes/arvados-cli/build.sh
+++ b/recipes/arvados-cli/build.sh
@@ -1,0 +1,5 @@
+#! /bin/bash
+set -eu -o pipefail
+
+gem source -a https://rubygems.org/
+gem install --install-dir=$PREFIX/lib/ruby/gems/2.2.0 --bindir=$PREFIX/bin arvados-cli-*.gem

--- a/recipes/arvados-cli/meta.yaml
+++ b/recipes/arvados-cli/meta.yaml
@@ -1,0 +1,22 @@
+package:
+  name: arvados-cli
+  version: "0.1.20151207150126"
+build:
+  number: 0
+source:
+  fn: arvados-cli-0.1.20151207150126.gem
+  url: https://rubygems.org/downloads/arvados-cli-0.1.20151207150126.gem
+requirements:
+  build:
+    - ruby
+    - curl
+  run:
+    - ruby
+    - curl
+test:
+  commands:
+    - "arv --help 2>&1 | grep 'ARVADOS'"
+about:
+  home: http://doc.arvados.org/sdk/cli/index.html
+  license: Apache v2
+  summary: Command line interface to Arvados, a free and open source platform for big data science

--- a/recipes/pindel/build.sh
+++ b/recipes/pindel/build.sh
@@ -1,15 +1,8 @@
 #!/bin/bash
 set -eu
 
-
-# samtools dependency
-wget -O samtools-0.1.19.tar.bz2 https://downloads.sourceforge.net/project/samtools/samtools/0.1.19/samtools-0.1.19.tar.bz2
-tar -xjvpf samtools-0.1.19.tar.bz2
-cd samtools-0.1.19
-make
-cd ..
-
-echo 'SAMTOOLS=samtools-0.1.19' > Makefile.local
-./INSTALL samtools-0.1.19
+echo "HTSLIB_CPPFLAGS=-I$PREFIX/include" > Makefile.local
+echo "HTSLIB_LDFLAGS=-L$PREFIX/lib -Wl,-rpath $PREFIX/lib" >> Makefile.local
+./INSTALL $PREFIX
 mkdir -p $PREFIX/bin
-cp pindel pindel2vcf sam2pindel $PREFIX/bin
+cp pindel pindel2vcf pindel2vcf4tcga sam2pindel $PREFIX/bin

--- a/recipes/pindel/meta.yaml
+++ b/recipes/pindel/meta.yaml
@@ -1,19 +1,22 @@
 package:
   name: pindel
-  version: '0.2.5a7'
+  version: '0.2.5b8'
 build:
   number: 0
 source:
-  fn: pindel-0.2.5a7.tar.gz
-  url: https://github.com/genome/pindel/archive/bcbio.tar.gz
+  fn: pindel-0.2.5b8.tar.gz
+  url: https://github.com/genome/pindel/archive/v0.2.5b8.tar.gz
 
 requirements:
   build:
+    - htslib
   run:
+    - htslib
 
 test:
   commands:
     - "pindel -h 2>&1 | grep 'Pindel version'"
+    - "pindel2vcf  --help | grep Example:"
 
 about:
   home: http://gmt.genome.wustl.edu/packages/pindel/index.html


### PR DESCRIPTION
- Update pindel to latest release, which uses htslib instead of older
  samtools. New version has better support for complex alleles:
  http://www.nature.com/nm/journal/v22/n1/full/nm.4002.html
- Add support for Arvados command line interface