### PR TITLE
Change Perl build to use Conda gcc

### DIFF
--- a/recipes/perl/build.sh
+++ b/recipes/perl/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 # Build perl
-sh Configure -de -Dprefix=$PREFIX -Duserelocatableinc
+sh Configure -de -Dprefix=$PREFIX -Duserelocatableinc -Dcc=${PREFIX}/bin/gcc
 make
 make install

--- a/recipes/perl/meta.yaml
+++ b/recipes/perl/meta.yaml
@@ -9,7 +9,11 @@ source:
   md5: e32cb6a8dda0084f2a43dac76318d68d
 
 build:
-  number: 8
+  number: 9
+
+requirements:
+  build:
+    - gcc
 
 test:
   commands:


### PR DESCRIPTION
The gcc 4.8.5 via the devtoolset-2 RPMs used previously to build Perl
has backports from RH from the GCC 4.9 series.  This includes the
`-fstack-protector-strong` option introduced in 4.9.  The Perl `Configure`
sees this option as supported and adds it to the default compiler options.
When building Perl modules with shared libraries, specifying `gcc` in the
build requirements pulls in the gcc from the default channel.  The build
then fails as this is an unpatched version and that option is not
supported. Using the conda gcc, `Configure` uses `-fstack-protector`
instead and avoids the issue.