### PR TITLE
Perl: move dependencies to perl-threaded

### DIFF
--- a/osx-whitelist.txt
+++ b/osx-whitelist.txt
@@ -113,7 +113,6 @@ oncofuse
 pbgzip
 peakzilla
 perl
-perl-app-cpanminus
 perl-module-build
 perl-threaded
 perl-vcftools-vcf

--- a/osx-whitelist.txt
+++ b/osx-whitelist.txt
@@ -113,9 +113,7 @@ oncofuse
 pbgzip
 peakzilla
 perl
-perl-module-build
 perl-threaded
-perl-vcftools-vcf
 phonenumbers
 picard
 prinseq

--- a/recipes/perl-app-cpanminus/meta.yaml
+++ b/recipes/perl-app-cpanminus/meta.yaml
@@ -9,14 +9,14 @@ source:
   url: https://cpan.metacpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7039.tar.gz
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
-    - perl
+    - perl-threaded
 
   run:
-    - perl
+    - perl-threaded
 
 test:
   imports:

--- a/recipes/perl-bio-db-sam/meta.yaml
+++ b/recipes/perl-bio-db-sam/meta.yaml
@@ -7,16 +7,16 @@ source:
   url: https://cpan.metacpan.org/authors/id/L/LD/LDS/Bio-SamTools-1.41.tar.gz
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
-    - perl
+    - perl-threaded
     - perl-app-cpanminus
     - perl-module-build
     - perl-bioperl
   run:
-    - perl
+    - perl-threaded
     - perl-bioperl
 
 test:

--- a/recipes/perl-bioperl/meta.yaml
+++ b/recipes/perl-bioperl/meta.yaml
@@ -7,15 +7,15 @@ source:
   url: https://cpan.metacpan.org/authors/id/C/CJ/CJFIELDS/BioPerl-1.6.924.tar.gz
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
-    - perl
+    - perl-threaded
     - perl-app-cpanminus
     - perl-module-build
   run:
-    - perl
+    - perl-threaded
 
 about:
   home: https://metacpan.org/pod/distribution/BioPerl/BioPerl.pm

--- a/recipes/perl-data-uuid/meta.yaml
+++ b/recipes/perl-data-uuid/meta.yaml
@@ -7,16 +7,15 @@ source:
   url: https://cpan.metacpan.org/authors/id/R/RJ/RJBS/Data-UUID-1.221.tar.gz
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
-    - gcc
-    - perl
+    - perl-threaded
     - perl-app-cpanminus
     - perl-module-build
   run:
-    - perl
+    - perl-threaded
 
 test:
   imports:

--- a/recipes/perl-encode-locale/meta.yaml
+++ b/recipes/perl-encode-locale/meta.yaml
@@ -7,14 +7,14 @@ source:
   url: https://cpan.metacpan.org/authors/id/G/GA/GAAS/Encode-Locale-1.05.tar.gz
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
-    - perl
+    - perl-threaded
     - perl-app-cpanminus
   run:
-    - perl
+    - perl-threaded
 
 about:
   home: https://metacpan.org/pod/Encode::Locale

--- a/recipes/perl-file-sharedir-install/meta.yaml
+++ b/recipes/perl-file-sharedir-install/meta.yaml
@@ -7,15 +7,15 @@ source:
   url: https://cpan.metacpan.org/authors/id/G/GW/GWYN/File-ShareDir-Install-0.10.tar.gz
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
-    - perl
+    - perl-threaded
     - perl-app-cpanminus
     - perl-module-build
   run:
-    - perl
+    - perl-threaded
 
 test:
   imports:

--- a/recipes/perl-file-sharedir/meta.yaml
+++ b/recipes/perl-file-sharedir/meta.yaml
@@ -7,15 +7,15 @@ source:
   url: https://cpan.metacpan.org/authors/id/R/RE/REHSACK/File-ShareDir-1.102.tar.gz
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
-    - perl
+    - perl-threaded
     - perl-app-cpanminus
     - perl-module-build
   run:
-    - perl
+    - perl-threaded
 
 test:
   imports:

--- a/recipes/perl-gd/meta.yaml
+++ b/recipes/perl-gd/meta.yaml
@@ -5,13 +5,15 @@ source:
   fn: GD-2.56.tar.gz
   url: https://cpan.metacpan.org/authors/id/L/LD/LDS/GD-2.56.tar.gz
   md5: c4b3afd98b2c4ce3c2e1027d101a8f1e
+build:
+  number: 1
 requirements:
   build:
-    - perl >=5.22.0
+    - perl-threaded >=5.22.0
     - libgd
     - perl-module-build
   run:
-    - perl >=5.22.0
+    - perl-threaded >=5.22.0
     - libgd
 test:
   imports:

--- a/recipes/perl-ipc-system-simple/meta.yaml
+++ b/recipes/perl-ipc-system-simple/meta.yaml
@@ -7,15 +7,15 @@ source:
   url: https://cpan.metacpan.org/authors/id/P/PJ/PJF/IPC-System-Simple-1.25.tar.gz
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
-    - perl
+    - perl-threaded
     - perl-app-cpanminus
     - perl-module-build
   run:
-    - perl
+    - perl-threaded
 
 test:
   imports:

--- a/recipes/perl-lwp-simple/meta.yaml
+++ b/recipes/perl-lwp-simple/meta.yaml
@@ -7,16 +7,16 @@ source:
   url: https://cpan.metacpan.org/authors/id/E/ET/ETHER/libwww-perl-6.15.tar.gz
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
-    - perl
+    - perl-threaded
     - perl-app-cpanminus
     - perl-encode-locale
     - perl-module-build
   run:
-    - perl
+    - perl-threaded
     - perl-encode-locale
 
 test:

--- a/recipes/perl-module-build/meta.yaml
+++ b/recipes/perl-module-build/meta.yaml
@@ -10,17 +10,15 @@ source:
    # List any patch files here
    # - fix.patch
 
-# build:
-  # If this is a new build for the same version, increment the build
-  # number. If you do not include this key, it defaults to 0.
-  # number: 1
+build:
+  number: 1
 
 requirements:
   build:
-    - perl >=5.22.0
+    - perl-threaded >=5.22.0
 
   run:
-    - perl >=5.22.0
+    - perl-threaded >=5.22.0
 
 test:
   # Perl 'use' tests

--- a/recipes/perl-vcftools-vcf/meta.yaml
+++ b/recipes/perl-vcftools-vcf/meta.yaml
@@ -7,15 +7,15 @@ source:
   url: https://github.com/vcftools/vcftools/releases/download/v0.1.14/vcftools-0.1.14.tar.gz
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
-    - perl
+    - perl-threaded
     - perl-app-cpanminus
     - perl-module-build
   run:
-    - perl
+    - perl-threaded
 
 test:
   imports:

--- a/recipes/perl-xml-parser/meta.yaml
+++ b/recipes/perl-xml-parser/meta.yaml
@@ -7,17 +7,16 @@ source:
   url: https://cpan.metacpan.org/authors/id/T/TO/TODDR/XML-Parser-2.44.tar.gz
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
-    - gcc
-    - perl
+    - perl-threaded
     - perl-app-cpanminus
     - perl-module-build
     - expat
   run:
-    - perl
+    - perl-threaded
     - expat
 
 test:


### PR DESCRIPTION
Battenberg perl requires threaded perl but libraries not built
for it. Move to perl-threaded as default.