### PR TITLE
Add ropebwt2

### DIFF
--- a/recipes/ropebwt2/build.sh
+++ b/recipes/ropebwt2/build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+#strictly use anaconda build environment
+CC=${PREFIX}/bin/gcc
+CXX=${PREFIX}/bin/g++
+
+mkdir -p $PREFIX/bin
+
+make 
+mv ropebwt2  $PREFIX/bin
+
+

--- a/recipes/ropebwt2/meta.yaml
+++ b/recipes/ropebwt2/meta.yaml
@@ -1,0 +1,29 @@
+package:
+  name: ropebwt2
+  version: "r187"
+
+build:
+  number: 0
+
+source:
+  fn: ropebwt2_r187.tar.gz
+  url: https://github.com/lh3/ropebwt2/archive/e23a7df263571c02aa0c0434e623108482097e3d.tar.gz
+  md5: fc23f90727e28eef748304a12583a585
+
+requirements:
+  build:
+  - gcc
+
+  run:
+  - libgcc
+
+test:
+  commands:
+    - ropebwt2  2>&1 | grep ropebwt2 > /dev/null
+
+about:
+  home: https://github.com/lh3/ropebwt2
+  license: MIT
+  license_file: LICENSE.txt
+  summary: Incremental construction of FM-index for DNA sequences
+


### PR DESCRIPTION
RopeBWT2 is an tool for constructing the FM-index for a collection of DNA sequences.