### PR TITLE
Use prebuilt binary for Rapmap.

### DIFF
--- a/recipes/rapmap/build.sh
+++ b/recipes/rapmap/build.sh
@@ -1,8 +1,3 @@
 #!/bin/bash
 mkdir -p $PREFIX/bin
-mkdir -p build
-cd build
-cmake ..
-make
-make install
-cp ../bin/rapmap $PREFIX/bin
+cp bin/rapmap $PREFIX/bin

--- a/recipes/rapmap/meta.yaml
+++ b/recipes/rapmap/meta.yaml
@@ -3,13 +3,10 @@ package:
   version: "v0.1.0pre"
 source:
   fn: v0.1.0-pre.tar.gz
-  url: https://github.com/COMBINE-lab/RapMap/archive/v0.1.0-pre.tar.gz
-  sha256: 3c4c16191c32804c4aa3a4ce633884c5eeb62e82065bcb57a05bebf5223c1900
-requirements:
-  build:
-  - cmake
+  url: https://github.com/COMBINE-lab/RapMap/releases/download/v0.1.0-pre/RapMap-0.1.0-pre_CentOS5.tar.gz
+  sha256: 9ec27f9c85db49fd605d80a78b084c9b5bb72d8bac408bfd90bca8137c05ca77
 build:
-  number: 1
+  number: 2
 about:
   home: https://github.com/COMBINE-lab/RapMap
   license: GPL


### PR DESCRIPTION
The build results in a broken binary when you try to do anything real with it, so for now use the prebuilt one.