### PR TITLE
Perl: move to threaded libraries, dependencies 2

### DIFF
--- a/recipes/perl-dbd-mysql/meta.yaml
+++ b/recipes/perl-dbd-mysql/meta.yaml
@@ -7,17 +7,17 @@ source:
   url: https://cpan.metacpan.org/authors/id/C/CA/CAPTTOFU/DBD-mysql-4.033.tar.gz
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
-    - perl
+    - perl-threaded
     - perl-app-cpanminus
     - perl-module-build
     - perl-dbi
     - mysqlclient
   run:
-    - perl
+    - perl-threaded
     - perl-dbi
     - mysqlclient
 

--- a/recipes/perl-gdgraph/meta.yaml
+++ b/recipes/perl-gdgraph/meta.yaml
@@ -10,19 +10,17 @@ source:
    # List any patch files here
    # - fix.patch
 
-# build:
-  # If this is a new build for the same version, increment the build
-  # number. If you do not include this key, it defaults to 0.
-  # number: 1
+build:
+  number: 1
 
 requirements:
   build:
-    - perl >=5.22.0
+    - perl-threaded >=5.22.0
     - perl-gdtextutil
     - perl-gd
 
   run:
-    - perl >=5.22.0
+    - perl-threaded >=5.22.0
     - perl-gd
     - perl-gdtextutil
 

--- a/recipes/perl-math-cdf/meta.yaml
+++ b/recipes/perl-math-cdf/meta.yaml
@@ -8,15 +8,14 @@ source:
   md5: 7866c7b6b9d27f0ce4b7637334478ab7
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
-    - perl
-    - gcc
+    - perl-threaded
 
   run:
-    - perl
+    - perl-threaded
 
 test:
   # Perl 'use' tests

--- a/recipes/perl-pdf-api2/meta.yaml
+++ b/recipes/perl-pdf-api2/meta.yaml
@@ -7,15 +7,15 @@ source:
   url: https://cpan.metacpan.org/authors/id/S/SS/SSIMMS/PDF-API2-2.025.tar.gz
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
-    - perl
+    - perl-threaded
     - perl-app-cpanminus
     - perl-module-build
   run:
-    - perl
+    - perl-threaded
 
 test:
   imports:

--- a/recipes/perl-scalar-list-utils/meta.yaml
+++ b/recipes/perl-scalar-list-utils/meta.yaml
@@ -10,17 +10,15 @@ source:
    # List any patch files here
    # - fix.patch
 
-# build:
-  # If this is a new build for the same version, increment the build
-  # number. If you do not include this key, it defaults to 0.
-  # number: 1
+build:
+  number: 1
 
 requirements:
   build:
-    - perl
+    - perl-threaded
 
   run:
-    - perl
+    - perl-threaded
 
 test:
   # Perl 'use' tests

--- a/recipes/perl-set-intervaltree/meta.yaml
+++ b/recipes/perl-set-intervaltree/meta.yaml
@@ -5,12 +5,12 @@ source:
   fn: Set-IntervalTree-0.10.tar.gz
   url: http://search.cpan.org/CPAN/authors/id/B/BE/BENBOOTH/Set-IntervalTree-0.10.tar.gz
 build:
-  number: 1
+  number: 2
 requirements:
   build:
-    - perl
+    - perl-threaded
   run:
-    - perl
+    - perl-threaded
 test:
   imports:
     - Set::IntervalTree

--- a/recipes/perl-statistics-descriptive/meta.yaml
+++ b/recipes/perl-statistics-descriptive/meta.yaml
@@ -7,15 +7,15 @@ source:
   url: https://cpan.metacpan.org/authors/id/S/SH/SHLOMIF/Statistics-Descriptive-3.0609.tar.gz
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
-    - perl
+    - perl-threaded
     - perl-app-cpanminus
     - perl-module-build
   run:
-    - perl
+    - perl-threaded
 
 about:
   home: https://metacpan.org/pod/Statistics::Descriptive

--- a/recipes/perl-sub-uplevel/meta.yaml
+++ b/recipes/perl-sub-uplevel/meta.yaml
@@ -8,14 +8,14 @@ source:
   md5: 5d0752dbfa94d0c91b25a264f47f5675
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
-    - perl
+    - perl-threaded
 
   run:
-    - perl
+    - perl-threaded
 
 test:
   # Perl 'use' tests

--- a/recipes/perl-time-hires/meta.yaml
+++ b/recipes/perl-time-hires/meta.yaml
@@ -7,15 +7,15 @@ source:
   url: https://cpan.metacpan.org/authors/id/R/RJ/RJBS/Time-HiRes-1.9728.tar.gz
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
-    - perl
+    - perl-threaded
     - perl-app-cpanminus
     - perl-module-build
   run:
-    - perl
+    - perl-threaded
 
 test:
   imports:

--- a/recipes/perl-uri/meta.yaml
+++ b/recipes/perl-uri/meta.yaml
@@ -10,18 +10,16 @@ source:
    # List any patch files here
    # - fix.patch
 
-# build:
-  # If this is a new build for the same version, increment the build
-  # number. If you do not include this key, it defaults to 0.
-  # number: 1
+build:
+  number: 1
 
 requirements:
   build:
-    - perl
+    - perl-threaded
     - perl-scalar-list-utils
 
   run:
-    - perl
+    - perl-threaded
     - perl-scalar-list-utils
 
 test:


### PR DESCRIPTION
Second and final rounds of perl dependencies moving to perl-threaded.
Final step in transition is a upcoming PR with high level packages
using Perl.