### PR TITLE
Perl: move to threaded, top level tools (step 3)

### DIFF
--- a/recipes/fastq-screen/meta.yaml
+++ b/recipes/fastq-screen/meta.yaml
@@ -4,18 +4,18 @@ about:
   summary: 'FastQ Screen allows you to screen a library of sequences in FastQ format against a set of sequence databases so you can see if the composition of the library matches with what you expect'
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
     - bowtie
     - bowtie2
-    - perl >=5.22.0
+    - perl-threaded >=5.22.0
     - perl-gdgraph
   run:
     - bowtie
     - bowtie2
-    - perl >=5.22.0
+    - perl-threaded >=5.22.0
     - perl-gdgraph
 package:
   name: fastq-screen

--- a/recipes/igblast/meta.yaml
+++ b/recipes/igblast/meta.yaml
@@ -9,10 +9,10 @@ about:
   license: Public Domain
   summary: A tool for analyzing immunoglobulin (IG) and T cell receptor (TR) sequences.
 build: 
-  number: 4
+  number: 5
 requirements:
   run:
-    - perl >=5.8.8
+    - perl-threaded >=5.8.8
 test:
   commands:
     - igblastn -h

--- a/recipes/jamm/meta.yaml
+++ b/recipes/jamm/meta.yaml
@@ -10,13 +10,13 @@ source:
     - setpath.patch
 
 build:
-  number: 1
+  number: 2
 
 requirements:
 
   run:
     - r >=3
-    - perl
+    - perl-threaded
     - r-signal
     - r-mclust >=4
  

--- a/recipes/mirdeep2/meta.yaml
+++ b/recipes/mirdeep2/meta.yaml
@@ -7,11 +7,11 @@ source:
   git_rev: e875953
 
 build:
-  number: 2
+  number: 3
 
 requirements:
   run:
-    - perl
+    - perl-threaded
     - perl-pdf-api2
 
 about:

--- a/recipes/mugsy/meta.yaml
+++ b/recipes/mugsy/meta.yaml
@@ -10,11 +10,11 @@ source:
     - perl-env.patch
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   run:
-    - perl
+    - perl-threaded
 
 about:
   home: http://mugsy.sourceforge.net

--- a/recipes/perl-sanger-cgp-battenberg/build.sh
+++ b/recipes/perl-sanger-cgp-battenberg/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd perl
+cpanm -i --notest .

--- a/recipes/perl-sanger-cgp-battenberg/meta.yaml
+++ b/recipes/perl-sanger-cgp-battenberg/meta.yaml
@@ -1,0 +1,39 @@
+package:
+  name: perl-sanger-cgp-battenberg
+  version: '1.4.1'
+
+source:
+  fn: cgpBattenberg-1.4.1_1.tar.gz
+  url: https://github.com/cancerit/cgpBattenberg/archive/ef74823.tar.gz
+
+build:
+  number: 1
+
+requirements:
+  build:
+    - perl-threaded
+    - perl-app-cpanminus
+    - perl-module-build
+    - perl-file-sharedir
+    - perl-file-sharedir-install
+    - perl-pcap
+    - perl-sanger-cgp-allelecount
+    - cancerit-allelecount
+  run:
+    - perl-threaded
+    - perl-file-sharedir
+    - perl-file-sharedir-install
+    - perl-pcap
+    - perl-sanger-cgp-allelecount
+    - cancerit-allelecount
+
+test:
+  imports:
+    - Sanger::CGP::Battenberg
+  commands:
+    - "battenberg.pl 2>&1 | grep battenberg.pl"
+
+about:
+  home: https://github.com/cancerit/cgpBattenberg
+  license: GPLv3
+  summary: detect subclonality and copy number in matched NGS data

--- a/recipes/perl-threaded/build.sh
+++ b/recipes/perl-threaded/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 # Build perl
-sh Configure -de -Dprefix=$PREFIX -Duserelocatableinc -Dusethreads
+sh Configure -de -Dprefix=$PREFIX -Duserelocatableinc -Dusethreads -Dcc=${PREFIX}/bin/gcc
 make
 make install

--- a/recipes/perl-threaded/meta.yaml
+++ b/recipes/perl-threaded/meta.yaml
@@ -9,7 +9,11 @@ source:
   md5: e32cb6a8dda0084f2a43dac76318d68d
 
 build:
-  number: 8
+  number: 9
+
+requirements:
+  build:
+    - gcc
 
 test:
   commands:

--- a/recipes/prinseq/meta.yaml
+++ b/recipes/prinseq/meta.yaml
@@ -5,13 +5,15 @@ about:
 package: 
   name: prinseq
   version: '0.20.4'
+build:
+  number: 1
 source:
   fn: prinseq-lite-0.20.4.tar.gz
   md5: 3be1a572073ebbbecfeba42a42853ff5
   url: http://iweb.dl.sourceforge.net/project/prinseq/standalone/prinseq-lite-0.20.4.tar.gz
 requirements:
   run:
-      - perl # [not osx]
+      - perl-threaded # [not osx]
 test:
     commands:
         - prinseq-lite.pl -version

--- a/recipes/protrac/meta.yaml
+++ b/recipes/protrac/meta.yaml
@@ -7,11 +7,11 @@ source:
   url: http://www.smallrnagroup.uni-mainz.de/software/proTRAC_2.1.pl
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   run:
-    - perl >=5.22.0
+    - perl-threaded >=5.22.0
     - perl-gd
 test:
   commands:

--- a/recipes/snippy/meta.yaml
+++ b/recipes/snippy/meta.yaml
@@ -8,11 +8,11 @@ source:
   url: https://github.com/tseemann/snippy/archive/v2.9.zip
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
-    - perl
+    - perl-threaded
     - perl-bioperl
     - perl-app-cpanminus
     - perl-module-build
@@ -24,7 +24,7 @@ requirements:
     - vcftools
     - snpeff
   run:
-    - perl
+    - perl-threaded
     - perl-bioperl
     - bwa
     - samtools

--- a/recipes/star-fusion/meta.yaml
+++ b/recipes/star-fusion/meta.yaml
@@ -5,11 +5,13 @@ package:
 source:
   fn: STAR-Fusion_v0.5.4.FULL.tar.gz
   url: https://github.com/STAR-Fusion/STAR-Fusion/releases/download/v0.5.4/STAR-Fusion_v0.5.4.FULL.tar.gz
+build:
+  number: 1
 
 requirements:
   run:
       - blast
-      - perl
+      - perl-threaded
       - perl-set-intervaltree
       - perl-db-file
       - perl-uri

--- a/recipes/variant-effect-predictor/meta.yaml
+++ b/recipes/variant-effect-predictor/meta.yaml
@@ -7,17 +7,17 @@ source:
   url: https://github.com/Ensembl/ensembl-tools/archive/release/83.zip
 
 build:
-  number: 2
+  number: 3
 
 requirements:
   build:
-    - perl
+    - perl-threaded
     - perl-archive-extract
     - perl-archive-zip
     - perl-lwp-simple
     - perl-lwp-protocol-https
   run:
-    - perl
+    - perl-threaded
     - perl-bioperl
     - perl-encode-locale
     - perl-archive-extract

--- a/recipes/variant-effect-predictor/meta.yaml
+++ b/recipes/variant-effect-predictor/meta.yaml
@@ -11,6 +11,7 @@ build:
 
 requirements:
   build:
+    - gcc
     - perl-threaded
     - perl-archive-extract
     - perl-archive-zip

--- a/recipes/vcftools/meta.yaml
+++ b/recipes/vcftools/meta.yaml
@@ -7,16 +7,16 @@ source:
   url: https://github.com/vcftools/vcftools/releases/download/v0.1.14/vcftools-0.1.14.tar.gz
 
 build:
-  number: 2
+  number: 3
 
 requirements:
   build:
-    - perl
+    - perl-threaded
     - zlib
     - perl-vcftools-vcf ==0.953
 
   run:
-    - perl
+    - perl-threaded
     - zlib
     - perl-vcftools-vcf ==0.953
 


### PR DESCRIPTION
- Finalizes move of packages to use perl-threaded instead of perl,
  adding all final top level tools that use perl and libraries. (#722)
- Use conda gcc with perl-threaded to enable use for module library
  builds (#735). Requires one final upcoming PR to re-build library
  dependencies including gcc.