### PR TITLE
Perl: update all libraries with conda gcc

### DIFF
--- a/osx-whitelist.txt
+++ b/osx-whitelist.txt
@@ -116,7 +116,10 @@ oncofuse
 pbgzip
 peakzilla
 perl
+perl-app-cpanminus
+perl-module-build
 perl-threaded
+perl-vcftools-vcf
 phonenumbers
 picard
 prinseq

--- a/recipes/perl-app-cpanminus/meta.yaml
+++ b/recipes/perl-app-cpanminus/meta.yaml
@@ -9,13 +9,15 @@ source:
   url: https://cpan.metacpan.org/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7039.tar.gz
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
+    - gcc
     - perl-threaded
 
   run:
+    - libgcc
     - perl-threaded
 
 test:

--- a/recipes/perl-archive-extract/meta.yaml
+++ b/recipes/perl-archive-extract/meta.yaml
@@ -7,13 +7,15 @@ source:
   url: https://cpan.metacpan.org/authors/id/B/BI/BINGOS/Archive-Extract-0.76.tar.gz
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
+    - gcc
     - perl-threaded
     - perl-app-cpanminus
   run:
+    - libgcc
     - perl-threaded
 
 about:

--- a/recipes/perl-archive-zip/meta.yaml
+++ b/recipes/perl-archive-zip/meta.yaml
@@ -7,14 +7,16 @@ source:
   url: https://cpan.metacpan.org/authors/id/P/PH/PHRED/Archive-Zip-1.55.tar.gz
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
+    - gcc
     - perl-threaded
     - perl-app-cpanminus
     - perl-module-build
   run:
+    - libgcc
     - perl-threaded
 
 about:

--- a/recipes/perl-bio-db-sam/meta.yaml
+++ b/recipes/perl-bio-db-sam/meta.yaml
@@ -7,15 +7,17 @@ source:
   url: https://cpan.metacpan.org/authors/id/L/LD/LDS/Bio-SamTools-1.41.tar.gz
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
+    - gcc
     - perl-threaded
     - perl-app-cpanminus
     - perl-module-build
     - perl-bioperl
   run:
+    - libgcc
     - perl-threaded
     - perl-bioperl
 

--- a/recipes/perl-bioperl/meta.yaml
+++ b/recipes/perl-bioperl/meta.yaml
@@ -7,14 +7,16 @@ source:
   url: https://cpan.metacpan.org/authors/id/C/CJ/CJFIELDS/BioPerl-1.6.924.tar.gz
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
+    - gcc
     - perl-threaded
     - perl-app-cpanminus
     - perl-module-build
   run:
+    - libgcc
     - perl-threaded
 
 about:

--- a/recipes/perl-cgi/meta.yaml
+++ b/recipes/perl-cgi/meta.yaml
@@ -7,14 +7,16 @@ source:
   url: https://cpan.metacpan.org/authors/id/L/LE/LEEJO/CGI-4.22.tar.gz
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
+    - gcc
     - perl-threaded
     - perl-app-cpanminus
     - perl-module-build
   run:
+    - libgcc
     - perl-threaded
 
 test:

--- a/recipes/perl-compress-raw-zlib/meta.yaml
+++ b/recipes/perl-compress-raw-zlib/meta.yaml
@@ -7,14 +7,16 @@ source:
   url: https://cpan.metacpan.org/authors/id/P/PM/PMQS/Compress-Raw-Zlib-2.069.tar.gz
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
+    - gcc
     - perl-threaded
     - perl-app-cpanminus
     - perl-module-build
   run:
+    - libgcc
     - perl-threaded
 
 about:

--- a/recipes/perl-data-uuid/meta.yaml
+++ b/recipes/perl-data-uuid/meta.yaml
@@ -7,14 +7,16 @@ source:
   url: https://cpan.metacpan.org/authors/id/R/RJ/RJBS/Data-UUID-1.221.tar.gz
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
+    - gcc
     - perl-threaded
     - perl-app-cpanminus
     - perl-module-build
   run:
+    - libgcc
     - perl-threaded
 
 test:

--- a/recipes/perl-db-file/meta.yaml
+++ b/recipes/perl-db-file/meta.yaml
@@ -5,12 +5,14 @@ source:
   fn: DB_File-1.835.tar.gz
   url: https://cpan.metacpan.org/authors/id/P/PM/PMQS/DB_File-1.835.tar.gz
 build:
-  number: 4
+  number: 5
 requirements:
   build:
+    - gcc
     - perl-threaded
     - libdb
   run:
+    - libgcc
     - perl-threaded
     - libdb
 test:

--- a/recipes/perl-dbd-mysql/meta.yaml
+++ b/recipes/perl-dbd-mysql/meta.yaml
@@ -7,16 +7,18 @@ source:
   url: https://cpan.metacpan.org/authors/id/C/CA/CAPTTOFU/DBD-mysql-4.033.tar.gz
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
+    - gcc
     - perl-threaded
     - perl-app-cpanminus
     - perl-module-build
     - perl-dbi
     - mysqlclient
   run:
+    - libgcc
     - perl-threaded
     - perl-dbi
     - mysqlclient

--- a/recipes/perl-dbi/meta.yaml
+++ b/recipes/perl-dbi/meta.yaml
@@ -7,14 +7,16 @@ source:
   url: https://cpan.metacpan.org/authors/id/T/TI/TIMB/DBI-1.634.tar.gz
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
+    - gcc
     - perl-threaded
     - perl-app-cpanminus
     - perl-module-build
   run:
+    - libgcc
     - perl-threaded
 
 about:

--- a/recipes/perl-encode-locale/meta.yaml
+++ b/recipes/perl-encode-locale/meta.yaml
@@ -7,13 +7,15 @@ source:
   url: https://cpan.metacpan.org/authors/id/G/GA/GAAS/Encode-Locale-1.05.tar.gz
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
+    - gcc
     - perl-threaded
     - perl-app-cpanminus
   run:
+    - libgcc
     - perl-threaded
 
 about:

--- a/recipes/perl-file-fetch/meta.yaml
+++ b/recipes/perl-file-fetch/meta.yaml
@@ -7,14 +7,16 @@ source:
   url: https://cpan.metacpan.org/authors/id/B/BI/BINGOS/File-Fetch-0.48.tar.gz
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
+    - gcc
     - perl-threaded
     - perl-app-cpanminus
     - perl-module-build
   run:
+    - libgcc
     - perl-threaded
 
 test:

--- a/recipes/perl-file-sharedir-install/meta.yaml
+++ b/recipes/perl-file-sharedir-install/meta.yaml
@@ -7,14 +7,16 @@ source:
   url: https://cpan.metacpan.org/authors/id/G/GW/GWYN/File-ShareDir-Install-0.10.tar.gz
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
+    - gcc
     - perl-threaded
     - perl-app-cpanminus
     - perl-module-build
   run:
+    - libgcc
     - perl-threaded
 
 test:

--- a/recipes/perl-file-sharedir/meta.yaml
+++ b/recipes/perl-file-sharedir/meta.yaml
@@ -7,14 +7,16 @@ source:
   url: https://cpan.metacpan.org/authors/id/R/RE/REHSACK/File-ShareDir-1.102.tar.gz
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
+    - gcc
     - perl-threaded
     - perl-app-cpanminus
     - perl-module-build
   run:
+    - libgcc
     - perl-threaded
 
 test:

--- a/recipes/perl-gd/meta.yaml
+++ b/recipes/perl-gd/meta.yaml
@@ -6,13 +6,15 @@ source:
   url: https://cpan.metacpan.org/authors/id/L/LD/LDS/GD-2.56.tar.gz
   md5: c4b3afd98b2c4ce3c2e1027d101a8f1e
 build:
-  number: 1
+  number: 2
 requirements:
   build:
+    - gcc
     - perl-threaded >=5.22.0
     - libgd
     - perl-module-build
   run:
+    - libgcc
     - perl-threaded >=5.22.0
     - libgd
 test:

--- a/recipes/perl-gdgraph/meta.yaml
+++ b/recipes/perl-gdgraph/meta.yaml
@@ -11,15 +11,17 @@ source:
    # - fix.patch
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
+    - gcc
     - perl-threaded >=5.22.0
     - perl-gdtextutil
     - perl-gd
 
   run:
+    - libgcc
     - perl-threaded >=5.22.0
     - perl-gd
     - perl-gdtextutil

--- a/recipes/perl-gdtextutil/meta.yaml
+++ b/recipes/perl-gdtextutil/meta.yaml
@@ -11,14 +11,16 @@ source:
    # - fix.patch
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
+    - gcc
     - perl-threaded >=5.22.0
     - perl-gd
 
   run:
+    - libgcc
     - perl-threaded >=5.22.0
     - perl-gd
 

--- a/recipes/perl-ipc-system-simple/meta.yaml
+++ b/recipes/perl-ipc-system-simple/meta.yaml
@@ -7,14 +7,16 @@ source:
   url: https://cpan.metacpan.org/authors/id/P/PJ/PJF/IPC-System-Simple-1.25.tar.gz
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
+    - gcc
     - perl-threaded
     - perl-app-cpanminus
     - perl-module-build
   run:
+    - libgcc
     - perl-threaded
 
 test:

--- a/recipes/perl-lwp-protocol-https/meta.yaml
+++ b/recipes/perl-lwp-protocol-https/meta.yaml
@@ -7,16 +7,18 @@ source:
   url: https://cpan.metacpan.org/authors/id/M/MS/MSCHILLI/LWP-Protocol-https-6.06.tar.gz
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
+    - gcc
     - perl-threaded
     - openssl
     - perl-app-cpanminus
     - perl-lwp-simple
     - perl-module-build
   run:
+    - libgcc
     - perl-threaded
     - openssl
     - perl-lwp-simple

--- a/recipes/perl-lwp-simple/meta.yaml
+++ b/recipes/perl-lwp-simple/meta.yaml
@@ -7,15 +7,17 @@ source:
   url: https://cpan.metacpan.org/authors/id/E/ET/ETHER/libwww-perl-6.15.tar.gz
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
+    - gcc
     - perl-threaded
     - perl-app-cpanminus
     - perl-encode-locale
     - perl-module-build
   run:
+    - libgcc
     - perl-threaded
     - perl-encode-locale
 

--- a/recipes/perl-math-cdf/meta.yaml
+++ b/recipes/perl-math-cdf/meta.yaml
@@ -8,13 +8,15 @@ source:
   md5: 7866c7b6b9d27f0ce4b7637334478ab7
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
+    - gcc
     - perl-threaded
 
   run:
+    - libgcc
     - perl-threaded
 
 test:

--- a/recipes/perl-module-build/meta.yaml
+++ b/recipes/perl-module-build/meta.yaml
@@ -11,13 +11,15 @@ source:
    # - fix.patch
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
+    - gcc
     - perl-threaded >=5.22.0
 
   run:
+    - libgcc
     - perl-threaded >=5.22.0
 
 test:

--- a/recipes/perl-pcap/meta.yaml
+++ b/recipes/perl-pcap/meta.yaml
@@ -7,10 +7,11 @@ source:
   url: https://github.com/ICGC-TCGA-PanCancer/PCAP-core/archive/v1.11.1.tar.gz
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
+    - gcc
     - perl-threaded
     - perl-app-cpanminus
     - perl-file-sharedir-install
@@ -24,6 +25,7 @@ requirements:
     - perl-lwp-simple
     - perl-xml-parser
   run:
+    - libgcc
     - perl-threaded
     - perl-bio-db-sam
     - perl-bioperl

--- a/recipes/perl-pdf-api2/meta.yaml
+++ b/recipes/perl-pdf-api2/meta.yaml
@@ -7,14 +7,16 @@ source:
   url: https://cpan.metacpan.org/authors/id/S/SS/SSIMMS/PDF-API2-2.025.tar.gz
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
+    - gcc
     - perl-threaded
     - perl-app-cpanminus
     - perl-module-build
   run:
+    - libgcc
     - perl-threaded
 
 test:

--- a/recipes/perl-sanger-cgp-allelecount/meta.yaml
+++ b/recipes/perl-sanger-cgp-allelecount/meta.yaml
@@ -7,10 +7,11 @@ source:
   url: https://github.com/cancerit/alleleCount/archive/v2.1.2.tar.gz
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
+    - gcc
     - perl-threaded
     - perl-app-cpanminus
     - perl-module-build
@@ -18,6 +19,7 @@ requirements:
     - perl-bio-db-sam
     - perl-bioperl
   run:
+    - libgcc
     - perl-threaded
     - perl-sanger-cgp-vcf
     - perl-bio-db-sam

--- a/recipes/perl-sanger-cgp-battenberg/meta.yaml
+++ b/recipes/perl-sanger-cgp-battenberg/meta.yaml
@@ -7,10 +7,11 @@ source:
   url: https://github.com/cancerit/cgpBattenberg/archive/ef74823.tar.gz
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
+    - gcc
     - perl-threaded
     - perl-app-cpanminus
     - perl-module-build
@@ -20,6 +21,7 @@ requirements:
     - perl-sanger-cgp-allelecount
     - cancerit-allelecount
   run:
+    - libgcc
     - perl-threaded
     - perl-file-sharedir
     - perl-file-sharedir-install

--- a/recipes/perl-sanger-cgp-vcf/meta.yaml
+++ b/recipes/perl-sanger-cgp-vcf/meta.yaml
@@ -7,16 +7,18 @@ source:
   url: https://github.com/cancerit/cgpVcf/archive/v1.3.1.tar.gz
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
+    - gcc
     - perl-threaded
     - perl-app-cpanminus
     - perl-module-build
     - perl-data-uuid
     - perl-vcftools-vcf
   run:
+    - libgcc
     - perl-threaded
     - perl-data-uuid
     - perl-vcftools-vcf

--- a/recipes/perl-scalar-list-utils/meta.yaml
+++ b/recipes/perl-scalar-list-utils/meta.yaml
@@ -11,13 +11,15 @@ source:
    # - fix.patch
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
+    - gcc
     - perl-threaded
 
   run:
+    - libgcc
     - perl-threaded
 
 test:

--- a/recipes/perl-set-intervaltree/meta.yaml
+++ b/recipes/perl-set-intervaltree/meta.yaml
@@ -5,11 +5,13 @@ source:
   fn: Set-IntervalTree-0.10.tar.gz
   url: http://search.cpan.org/CPAN/authors/id/B/BE/BENBOOTH/Set-IntervalTree-0.10.tar.gz
 build:
-  number: 2
+  number: 3
 requirements:
   build:
+    - gcc
     - perl-threaded
   run:
+    - libgcc
     - perl-threaded
 test:
   imports:

--- a/recipes/perl-statistics-descriptive/meta.yaml
+++ b/recipes/perl-statistics-descriptive/meta.yaml
@@ -7,14 +7,16 @@ source:
   url: https://cpan.metacpan.org/authors/id/S/SH/SHLOMIF/Statistics-Descriptive-3.0609.tar.gz
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
+    - gcc
     - perl-threaded
     - perl-app-cpanminus
     - perl-module-build
   run:
+    - libgcc
     - perl-threaded
 
 about:

--- a/recipes/perl-sub-uplevel/meta.yaml
+++ b/recipes/perl-sub-uplevel/meta.yaml
@@ -8,13 +8,15 @@ source:
   md5: 5d0752dbfa94d0c91b25a264f47f5675
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
+    - gcc
     - perl-threaded
 
   run:
+    - libgcc
     - perl-threaded
 
 test:

--- a/recipes/perl-time-hires/meta.yaml
+++ b/recipes/perl-time-hires/meta.yaml
@@ -7,14 +7,16 @@ source:
   url: https://cpan.metacpan.org/authors/id/R/RJ/RJBS/Time-HiRes-1.9728.tar.gz
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
+    - gcc
     - perl-threaded
     - perl-app-cpanminus
     - perl-module-build
   run:
+    - libgcc
     - perl-threaded
 
 test:

--- a/recipes/perl-uri/meta.yaml
+++ b/recipes/perl-uri/meta.yaml
@@ -11,14 +11,16 @@ source:
    # - fix.patch
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
+    - gcc
     - perl-threaded
     - perl-scalar-list-utils
 
   run:
+    - libgcc
     - perl-threaded
     - perl-scalar-list-utils
 

--- a/recipes/perl-vcftools-vcf/meta.yaml
+++ b/recipes/perl-vcftools-vcf/meta.yaml
@@ -7,14 +7,16 @@ source:
   url: https://github.com/vcftools/vcftools/releases/download/v0.1.14/vcftools-0.1.14.tar.gz
 
 build:
-  number: 2
+  number: 3
 
 requirements:
   build:
+    - gcc
     - perl-threaded
     - perl-app-cpanminus
     - perl-module-build
   run:
+    - libgcc
     - perl-threaded
 
 test:

--- a/recipes/perl-xml-parser/meta.yaml
+++ b/recipes/perl-xml-parser/meta.yaml
@@ -7,15 +7,17 @@ source:
   url: https://cpan.metacpan.org/authors/id/T/TO/TODDR/XML-Parser-2.44.tar.gz
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
+    - gcc
     - perl-threaded
     - perl-app-cpanminus
     - perl-module-build
     - expat
   run:
+    - libgcc
     - perl-threaded
     - expat
 


### PR DESCRIPTION
Final PR in move to perl-threaded. Uses conda gcc for building
library packages so shared libraries are widely distributable.