### PR TITLE
update chanjo to v3.3.0

### DIFF
--- a/recipes/chanjo/bld.bat
+++ b/recipes/chanjo/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/recipes/chanjo/meta.yaml
+++ b/recipes/chanjo/meta.yaml
@@ -1,15 +1,26 @@
 package:
   name: chanjo
-  version: "3.1.1"
+  version: "3.3.0"
 
 source:
-  fn: chanjo-3.1.1.tar.gz
-  url: https://pypi.python.org/packages/source/c/chanjo/chanjo-3.1.1.tar.gz
-  md5: 23a691d5e6f23e99901d77493e8597e6
+  fn: chanjo-3.3.0.tar.gz
+  url: https://pypi.python.org/packages/source/c/chanjo/chanjo-3.3.0.tar.gz
+  md5: 7b7d67863c1cb74a731b1ddb79d5595a
+#  patches:
+   # List any patch files here
+   # - fix.patch
 
 build:
+  # noarch_python: True
   preserve_egg_dir: True
   entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - chanjo = chanjo:main
+    #
+    # Would create an entry point called chanjo that calls chanjo.main()
+
     - chanjo = chanjo.__main__:root_command
 
   # If this is a new build for the same version, increment the build
@@ -19,6 +30,7 @@ build:
 requirements:
   build:
     - python
+    - setuptools
     - click
     - setuptools
     - toolz
@@ -28,6 +40,7 @@ requirements:
 
   run:
     - python
+    - setuptools
     - click
     - setuptools
     - toolz
@@ -67,8 +80,7 @@ test:
 
 about:
   home: http://www.chanjo.co/
-  license: MIT
-  license_file: LICENSE
+  license: MIT License
   summary: 'Coverage analysis tool for clinical sequencing'
 
 # See


### PR DESCRIPTION
Hi,

I hope this is the way you want to handle version upgrades

This is a minor release so the primary API doesn't change but the "load" command is now significantly faster and the bundled resources have been updated :smiley_cat: 