### PR TITLE
Upgrade RSEM to 1.2.28

### DIFF
--- a/recipes/rsem/build.sh
+++ b/recipes/rsem/build.sh
@@ -2,27 +2,37 @@
 pushd $SRC_DIR
 
 binaries="\
-rsem-build-read-index \
-rsem-synthesis-reference-transcripts \
-rsem-tbam2gbam \
-rsem-parse-alignments \
-rsem-simulate-reads \
-rsem-calculate-credibility-intervals \
-rsem-scan-for-paired-end-reads \
-rsem-sam-validator \
-rsem-bam2wig \
-rsem-run-em \
-rsem-get-unique \
-rsem-extract-reference-transcripts \
-rsem-bam2readdepth \
-rsem-preref \
-rsem-run-gibbs \
-rsem_perl_utils.pm \
-EBSeq/rsem-for-ebseq-calculate-clustering-info \
 EBSeq/rsem-for-ebseq-find-DE \
 EBSeq/rsem-for-ebseq-generate-ngvector-from-clustering-info \
+convert-sam-for-rsem \
+rsem-bam2readdepth \
+rsem-bam2wig \
+rsem-build-read-index \
+rsem-calculate-credibility-intervals \
+rsem-calculate-expression \
+rsem-control-fdr \
+rsem-extract-reference-transcripts \
+rsem-gen-transcript-plots \
+rsem-generate-data-matrix \
+rsem-generate-ngvector \
+rsem-get-unique \
+rsem-gff3-to-gtf \
+rsem-parse-alignments \
+rsem-plot-model \
+rsem-plot-transcript-wiggles \
+rsem-prepare-reference \
+rsem-preref \
+rsem-refseq-extract-primary-assembly \
+rsem-run-ebseq \
+rsem-run-em \
+rsem-run-gibbs \
+rsem-sam-validator \
+rsem-scan-for-paired-end-reads \
+rsem-simulate-reads \
+rsem-synthesis-reference-transcripts \
+rsem-tbam2gbam \
+rsem_perl_utils.pm \
 "
-WHAT_IS_NEW="WHAT_IS_NEW"
 
 INSTALLDIR=$PREFIX/lib/rsem
 BINDIR=$PREFIX/bin
@@ -33,10 +43,9 @@ make
 make ebseq
 
 for i in $binaries; do cp $i $INSTALLDIR && chmod +x $INSTALLDIR/$(basename $i); done
-cp $WHAT_IS_NEW $INSTALLDIR;
 for i in $binaries; do
     echo "#! /bin/bash" > $BINDIR/$(basename $i);
     echo 'DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )' >>  $BINDIR/$(basename $i);
-    echo '$DIR/../lib/rsem/'$(basename $i) >> $BINDIR/$(basename $i);
+    echo '$DIR/../lib/rsem/'$(basename $i) '$@' >> $BINDIR/$(basename $i);
     chmod +x $BINDIR/$(basename $i);
 done

--- a/recipes/rsem/meta.yaml
+++ b/recipes/rsem/meta.yaml
@@ -4,11 +4,12 @@ about:
   summary: RSEM (RNA-Seq by Expectation-Maximization)
 package:
   name: rsem
-  version: 1.2.22
+  version: 1.2.28
 build:
   rpaths:
     - lib/R/lib/
     - lib/
+  number: 0
 requirements:
   build:
     - r >=3.1.0
@@ -16,9 +17,10 @@ requirements:
     - r >=3.1.0
 test:
   commands:
-    - rsem-prepare-reference 2>&1 | grep rsem-prepare-reference > /dev/null
+    - rsem-prepare-reference 2>&1 | grep reference_name > /dev/null
     - rsem-for-ebseq-find-DE 2>&1 | grep Usage > /dev/null
+    - rsem-bam2wig foo bar foobar 2>&1 | grep 'fail to open file' > /dev/null
 source:
-  fn: v1.2.22.tar.gz
-  url: https://github.com/deweylab/RSEM/archive/v1.2.22.tar.gz
-  md5: 7a8373711ca0da79d9e4c9b314955cb3
+  fn: v1.2.28.tar.gz
+  url: https://github.com/deweylab/RSEM/archive/v1.2.28.tar.gz
+  md5: a589c7b8f3fdb59ec4bb33aa27b44dd3


### PR DESCRIPTION
- update list of executables
- update test to include actual test of parameters
- pass missing parameters from wrappers to binaries