### PR TITLE
add a new recipe for geven

### DIFF
--- a/recipes/gevent/bld.bat
+++ b/recipes/gevent/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/recipes/gevent/build.sh
+++ b/recipes/gevent/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/recipes/gevent/meta.yaml
+++ b/recipes/gevent/meta.yaml
@@ -1,0 +1,77 @@
+package:
+  name: gevent
+  version: "1.1rc4" # [py3k]
+  version: "1.0.2" # [py2k]
+
+
+# gevent support for Python 3.x is recent and introduced a python3 syntax that
+# leads to a syntax error in Python 2.x (gevent/_socket3.py ). Although the
+# syntax error is handled by pip, it is not within a docker of conda build. The
+# author do not plan to change this behavious for now since pip handles the
+# error (https://github.com/gevent/gevent/issues/478  and
+# https://github.com/gevent/gevent/pull/740 for information)
+#
+# So, we use two packages for python2 and python3
+source:
+  fn: gevent-1.1rc4.tar.gz # [py3k]
+  fn: gevent-1.0.2.tar.gz # [py2k]
+  url: https://pypi.python.org/packages/source/g/gevent/gevent-1.1rc4.tar.gz # [py3k]
+  url: https://pypi.python.org/packages/source/g/gevent/gevent-1.0.2.tar.gz # [py2k]
+  md5: 4abe8a99979dd095b145bb2e083dc4ff # [py3k]
+  md5: 117f135d57ca7416203fba3720bf71c1 # [py2k]
+
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+# build:
+  # noarch_python: True
+  # preserve_egg_dir: True
+  # entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - gevent = gevent:main
+    #
+    # Would create an entry point called gevent that calls gevent.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - greenlet >=0.4.9
+
+  run:
+    - python
+    - greenlet >=0.4.9
+
+test:
+  # Python imports
+  imports:
+    - gevent
+
+  # commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: http://www.gevent.org/
+  license: MIT License
+  summary: 'Coroutine-based network library'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml


### PR DESCRIPTION
This recipe is required as a dependencies for other biologically-oriented packages to be added (e.g. bioservices). conda provides gevent version 1.0.2, which is python2-compatible only. Here, we provide a recipe for py2k and py3k. One issue with the gevent recipe is that the newly py3k  version of gevent introduces a syntax that is not py2k compatible. although this is not an issue for pip installation where the syntax error is ignored, this causes trouble for bioconda build process. Consequently, the recipe provided uses one package for python 2 and another package for python 3. The version of the python 2 package is gevent 1.0.2 ( as in the official conda package) whereas the python3 version is the latest version (1.1.4).