### PR TITLE
Bump bowtie2 version

### DIFF
--- a/recipes/bowtie2/meta.yaml
+++ b/recipes/bowtie2/meta.yaml
@@ -4,7 +4,7 @@ about:
     summary: Fast and sensitive read alignment
 package:
     name: bowtie2
-    version: 2.2.6
+    version: 2.2.7
 requirements:
     build:
         - python
@@ -15,6 +15,6 @@ test:
         - (bowtie2 --version 2>&1) > /dev/null
 
 source:
-  fn: bowtie2-2.2.6-linux-x86_64.zip
-  url: http://sourceforge.net/projects/bowtie-bio/files/bowtie2/2.2.6/bowtie2-2.2.6-linux-x86_64.zip
-  md5: 074884c2989437491685cfdec649d424
+  fn: bowtie2-2.2.7-linux-x86_64.zip
+  url: http://sourceforge.net/projects/bowtie-bio/files/bowtie2/2.2.7/bowtie2-2.2.7-linux-x86_64.zip
+  md5: bf348768459f116c4a529efa6b3a2e77


### PR DESCRIPTION
Bumping the bowtie2 version. 

Current recipe only contains linux binaries so it should be swapped to source code in the future. 