### PR TITLE
Add ncbi-vdb recipe

### DIFF
--- a/osx-whitelist.txt
+++ b/osx-whitelist.txt
@@ -123,7 +123,9 @@ mummer
 muscle
 mvicuna
 mygene
+ncbi-vdb
 netifaces
+ngs-sdk
 novoalign
 oauth2client
 oncofuse

--- a/recipes/ncbi-vdb/build.sh
+++ b/recipes/ncbi-vdb/build.sh
@@ -1,0 +1,5 @@
+
+./configure --with-ngs-sdk-prefix="$PREFIX" --prefix="$PREFIX" --build-prefix="$PREFIX/share/ncbi"
+make
+make install
+

--- a/recipes/ncbi-vdb/meta.yaml
+++ b/recipes/ncbi-vdb/meta.yaml
@@ -1,0 +1,15 @@
+about:
+  home: https://github.com/ncbi/ncbi-vdb
+  license: Public Domain
+  summary: NGS SDK Language Bindings
+package:
+  name: ncbi-vdb
+  version: 2.5.8.1
+
+requirements:
+    build:
+        - ngs-sdk
+source:
+  fn: 2.5.8-1.tar.gz
+  url: https://github.com/ncbi/ncbi-vdb/archive/2.5.8-1.tar.gz
+  sha256: e171183a611101b3769a12fcd862664adbb47c343e0bcae411945c52fdea908e


### PR DESCRIPTION
This and `ngs-sdk` package  are requirements for NCBI's [sra-tools](https://github.com/ncbi/sra-tools). I am working on `sra-tools`'s recipe.