### PR TITLE
samtools 0.1.19 requires ncurses

### DIFF
--- a/recipes/samtools/0.1.19/meta.yaml
+++ b/recipes/samtools/0.1.19/meta.yaml
@@ -9,7 +9,8 @@ package:
   version: 0.1.19
 requirements:
   build: []
-  run: []
+  run:
+    - ncurses
 source:
   fn: samtools-0.1.19.tar.bz2
   sha256: d080c9d356e5f0ad334007e4461cbcee3c4ca97b8a7a5a48c44883cf9dee63d4

--- a/recipes/samtools/0.1.19/meta.yaml
+++ b/recipes/samtools/0.1.19/meta.yaml
@@ -8,9 +8,12 @@ package:
   name: samtools
   version: 0.1.19
 requirements:
-  build: []
+  build:
+  - ncurses
+  - zlib
   run:
-    - ncurses
+  - ncurses
+  - zlib
 source:
   fn: samtools-0.1.19.tar.bz2
   sha256: d080c9d356e5f0ad334007e4461cbcee3c4ca97b8a7a5a48c44883cf9dee63d4


### PR DESCRIPTION
This was on Arch Linux
```
samtools: error while loading shared libraries: libncurses.so.5: cannot open shared object file: No such file or directory
```

Manually installing ncurses fixed the issue