### PR TITLE
add spectacle

### DIFF
--- a/recipes/spectacle/Spectacle.sh
+++ b/recipes/spectacle/Spectacle.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# Wraps Spectacle.jar
+#
+# This is copied from https://github.com/chapmanb/gatk
+#
+set -o pipefail
+
+# Find original directory of bash script, resovling symlinks
+# http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in/246128#246128
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+    DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+    SOURCE="$(readlink "$SOURCE")"
+    [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+
+JAR_DIR=$DIR
+java=java
+if [ -e "$JAVA_HOME/bin/java" ]
+then
+java="$JAVA_HOME/bin/java"
+fi
+
+# extract memory and system property Java arguments from the list of provided arguments
+# http://java.dzone.com/articles/better-java-shell-script
+default_jvm_mem_opts="-Xms512m -Xmx1g"
+jvm_mem_opts=""
+jvm_prop_opts=""
+pass_args=""
+for arg in "$@"; do
+    case $arg in
+        '-D'*)
+            jvm_prop_opts="$jvm_prop_opts $arg"
+            ;;
+        '-XX'*)
+            jvm_prop_opts="$jvm_prop_opts $arg"
+            ;;
+         '-Xm'*)
+            jvm_mem_opts="$jvm_mem_opts $arg"
+            ;;
+         *)
+            pass_args="$pass_args $arg"
+            ;;
+    esac
+done
+
+if [ "$jvm_mem_opts" == "" ]; then
+    jvm_mem_opts="$default_jvm_mem_opts"
+fi
+
+pass_arr=($pass_args)
+if [[ ${pass_arr[0]} == org* ]]
+then
+    eval "$java" $jvm_mem_opts $jvm_prop_opts -cp "$JAR_DIR/Spectacle.jar" $pass_args
+else
+    eval "$java" $jvm_mem_opts $jvm_prop_opts -jar "$JAR_DIR/Spectacle.jar" $pass_args
+fi
+exit

--- a/recipes/spectacle/build.sh
+++ b/recipes/spectacle/build.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# tag v1.4 on github has everything as a single zip file, which also includes
+# example data.
+#
+
+# Unzip and clean up
+unzip Spectacle.zip
+rm Spectacle.zip
+mv Spectacle/* .
+rm -r Spectacle
+
+# Add #!/usr/bin/evn python to the wrapper script
+patch -p0 -i $RECIPE_DIR/shebang.patch
+
+# fix python wrapper to be py3 compatible
+2to3 -w Spectacle_python.py
+
+outdir=$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM
+mkdir -p $outdir
+mkdir -p $PREFIX/bin
+
+# We need the jarfile, python wrapper, and extra wrapper and downloading
+# script. The first two come from the repo; the second two are specific to this
+# recipe.
+cp Spectacle.jar $outdir/
+cp Spectacle_python.py $outdir/
+cp $RECIPE_DIR/Spectacle.sh $outdir/
+cp $RECIPE_DIR/download_spectacle_data.sh $outdir/
+
+chmod +x $outdir/Spectacle.sh
+chmod +x $outdir/Spectacle_python.py
+chmod +x $outdir/download_spectacle_data.sh
+
+ln -s $outdir/Spectacle.sh $PREFIX/bin
+ln -s $outdir/Spectacle_python.py $PREFIX/bin
+ln -s $outdir/download_spectacle_data.sh $PREFIX/bin
+
+# clean up data files
+rm -r ANCHORFILES CHROMSIZES COORDS SAMPLEDATA_HG19 SAMPLEDATA_HG18 OUTPUTSAMPLE_HG19
+rm hg19_inputfilelist.txt
+rm hg19_inputfilelist1.txt
+rm hg19_cellmarkfiletable.txt

--- a/recipes/spectacle/download_spectacle_data.sh
+++ b/recipes/spectacle/download_spectacle_data.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+set -o pipefail
+set -x
+
+if [[ -z "$1" ]]; then
+    echo
+    echo "Downloads Spectacle example data to <outdir>"
+    echo "Usage: $0 <outdir>"
+    echo
+    exit 1
+fi
+
+OUTDIR=$(readlink -f $1)
+mkdir -p $OUTDIR
+TMP=$(mktemp -d)
+cd $TMP
+curl -O -L https://github.com/jiminsong/Spectacle/archive/v1.4.tar.gz > v1.4.tar.gz
+tar -xf v1.4.tar.gz
+cd Spectacle-1.4
+unzip Spectacle.zip
+mv $TMP/Spectacle-1.4/Spectacle/ANCHORFILES $OUTDIR
+mv $TMP/Spectacle-1.4/Spectacle/CHROMSIZES $OUTDIR
+mv $TMP/Spectacle-1.4/Spectacle/COORDS $OUTDIR
+mv $TMP/Spectacle-1.4/Spectacle/SAMPLEDATA_HG19 $OUTDIR
+mv $TMP/Spectacle-1.4/Spectacle/SAMPLEDATA_HG18 $OUTDIR

--- a/recipes/spectacle/meta.yaml
+++ b/recipes/spectacle/meta.yaml
@@ -1,0 +1,27 @@
+package:
+  name: spectacle
+  version: 1.4
+
+source:
+  git_url: https://github.com/jiminsong/Spectacle.git
+  git_rev: v1.4
+# patches:
+#    - shebang.patch
+
+build:
+  detect_binary_files_with_prefix: True
+  number: 0
+
+requirements:
+  run:
+    - java-jdk
+    - scipy
+    - numpy
+
+about:
+  home: https://github.com/jiminsong/Spectacle
+  license: GPLv3
+  summary: 'This software implements a spectral learning algorithm for hidden Markov models for epigenomic data. Please see our paper for further details: Song, J and Chen, K. C. Spectacle: fast chromatin state annotation using spectral learning. Genome Biology, 16:33, 2015. http://genomebiology.com/2015/16/1/33'
+
+extra:
+  notes: 'The Spectacle github repo weighs in at around 500MB, a large portion of which is data files. These have been removed from the conda recipe, but a script (download_spectacle_data.sh) has been included here which will download those files from github.  In addition, a wrapper script `Spectacle.sh` has been included in this recipe and should be used when calling the program.'

--- a/recipes/spectacle/run_test.sh
+++ b/recipes/spectacle/run_test.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Basic tests for conda-specific wrapper and for the Spectacle-included python
+# wrapper.
+#
+# Note that the ChromHMM recipe tests BinarizeBam, but that version of ChromHMM
+# is not in Spectacle, so we test BinarizeBed instead.
+Spectacle.sh -Xmx512M BinarizeBed | grep -q 'usage BinarizeBed'
+Spectacle_python.py | grep -q 'file_directory fileID num_states'
+
+# Tests the extra data download script
+TMP=$(mktemp -d)
+download_spectacle_data.sh $TMP
+
+# Check a handful of files across the directories that should have been created
+for tst in \
+    COORDS/mm10/RefSeqExon.mm10.bed \
+    ANCHORFILES/hg19/RefSeqTSS.hg19.txt \
+    CHROMSIZES/danRer7.txt \
+    SAMPLEDATA_HG18/K562_chr11_binary.txt \
+    SAMPLEDATA_HG19/GM12878_chr10_binary.txt \
+; do
+    fn=$TMP/$tst
+    if [[ ! -e $fn ]]; then
+        echo $fn does not exist
+        exit 1
+    fi
+done

--- a/recipes/spectacle/shebang.patch
+++ b/recipes/spectacle/shebang.patch
@@ -1,0 +1,12 @@
+diff --git Spectacle_python.py Spectacle_python.py
+index 32e042f..82b395b 100644
+--- Spectacle_python.py
++++ Spectacle_python.py
+@@ -1,3 +1,4 @@
++#!/usr/bin/env python
+ """
+ Spectacle_python : An implementation of a spectral algorithm for Hidden Markov Models. The input file consists of sample (cross) moments computed from chromatin mark datasets (e.g. from ENCODE). The output file consists of Hidden Markov Model parameters (initial state distribution, emission matrix and transition matrix). This is a module inside the main Spectacle program which is written in Java and based on the ChromHMM software. Command line instructions:
+ 
+-- 
+1.9.1
+


### PR DESCRIPTION
Add [Spectacle](https://github.com/jiminsong/Spectacle) [(paper)](http://genomebiology.com/2015/16/1/33)

- Example data are stripped from the recipe, and a `download_spectacle_data.sh` script is included as noted in the `extra -> notes` field of `meta.yaml`
-  `run_test.sh` tests the shell wrapper (similar to the one used by ChromHMM), the Python wrapper that ships with Spectacle, and the download script
- The Python wrapper is converted with `2to3` for py3 compatibility.