### PR TITLE
[Proof of Principle] bowtie gcc build

### DIFF
--- a/osx-whitelist.txt
+++ b/osx-whitelist.txt
@@ -59,6 +59,7 @@ bmtagger
 bmtool
 botocore
 bottle
+bowtie
 bwa
 bx-python
 chanjo

--- a/recipes/bowtie/build.sh
+++ b/recipes/bowtie/build.sh
@@ -1,25 +1,16 @@
 #!/bin/bash
 
-mkdir -p $PREFIX/bin
+if [ $(uname) == "Darwin" ]; then
+    CXXFLAGS="$CXXFLAGS -I$(xcrun --show-sdk-path)/usr/include"
+    LDFLAGS="$LDFLAGS -L$(xcrun --show-sdk-path)/usr/lib"
+fi
 
-binaries="\
-bowtie \
-bowtie-align-l \
-bowtie-align-s \
-bowtie-build \
-bowtie-build-l \
-bowtie-build-s \
-bowtie-inspect \
-bowtie-inspect-l \
-bowtie-inspect-s \
-"
-pythonfiles="bowtie-build bowtie-inspect"
+make && make install prefix=$PREFIX
 
 PY3_BUILD="${PY_VER%.*}"
 
-if [ $PY3_BUILD -eq 3 ]
-then
-    for i in $pythonfiles; do 2to3 --write $i; done
-fi
+PYTHON_FILES="bowtie bowtie-build bowtie-inspect"
 
-for i in $binaries; do cp $i $PREFIX/bin && chmod +x $PREFIX/bin/$i; done
+if [ $PY3_BUILD -eq 3 ]; then
+    for i in $PYTHON_FILES; do 2to3 --write $i; done
+fi

--- a/recipes/bowtie/meta.yaml
+++ b/recipes/bowtie/meta.yaml
@@ -1,20 +1,28 @@
 about:
-    home: 'http://bowtie-bio.sourceforge.net/index.shtml'
-    license: GPLv3
+    home: 'https://github.com/BenLangmead/bowtie'
+    license: Artistic
     summary: An ultrafast memory-efficient short read aligner
+
 package:
     name: bowtie
     version: 1.1.2
+
+build:
+    number: 1
 requirements:
     build:
         - python
+        - gcc
+        - libgcc
     run:
+        - libgcc
         - python
+
 test:
     commands:
         - (bowtie --version 2>&1) > /dev/null
 
 source:
-  fn: bowtie-1.1.2-linux-x86_64.zip
-  url: http://sourceforge.net/projects/bowtie-bio/files/bowtie/1.1.2/bowtie-1.1.2-linux-x86_64.zip
-  md5: c61f748e45bccae69f6e1de25eec9aae
+  fn: bowtie-1.1.2.tar.gz
+  url: https://github.com/BenLangmead/bowtie/archive/v1.1.2.tar.gz
+  sha256: 717145f12d599e9b3672981f5444fbbdb8e02bfde2a80eba577e28baa4125ba7


### PR DESCRIPTION
This should work as an alternative to https://github.com/bioconda/bioconda-recipes/pull/923. It makes system header files of OS X visible to conda's gcc compiler and thus allows building with gcc on both linux as OS X. Not intended for merging.