### PR TITLE
New dependencies for cwltool and cwl-runner

### DIFF
--- a/osx-whitelist.txt
+++ b/osx-whitelist.txt
@@ -4,7 +4,6 @@ appdirs
 argh
 arrow
 art
-arvados-cli
 arvados-python-client
 avro
 awscli

--- a/osx-whitelist.txt
+++ b/osx-whitelist.txt
@@ -4,6 +4,9 @@ appdirs
 argh
 arrow
 art
+arvados-cli
+arvados-python-client
+avro
 awscli
 backports.csv
 bamtools
@@ -120,9 +123,11 @@ infinity
 inheritance
 intervals
 ipython-cluster-helper
+isodate
 java-jdk
 jmespath
 joblib
+keepalive
 last
 libgd
 libgtextutils
@@ -241,6 +246,7 @@ samtools
 scikit-bio
 seqcluster
 seqtk
+shellescape
 skewer
 simple_sv_annotation
 simplejson

--- a/recipes/avro/build.sh
+++ b/recipes/avro/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/recipes/avro/meta.yaml
+++ b/recipes/avro/meta.yaml
@@ -1,0 +1,28 @@
+package:
+  name: avro
+  version: "1.8.0"
+
+source:
+  fn: avro-1.8.0.tar.gz
+  url: https://pypi.python.org/packages/source/a/avro/avro-1.8.0.tar.gz
+  md5: ea3172f1fd77d4e9dc996a08ffbafb0a
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  imports:
+    - avro
+
+about:
+  home: http://avro.apache.org/
+  license: Apache License 2.0
+  summary: 'Avro is a serialization and RPC framework.'

--- a/recipes/isodate/build.sh
+++ b/recipes/isodate/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/recipes/isodate/meta.yaml
+++ b/recipes/isodate/meta.yaml
@@ -1,0 +1,62 @@
+package:
+  name: isodate
+  version: "0.5.4"
+
+source:
+  fn: isodate-0.5.4.tar.gz
+  url: https://pypi.python.org/packages/source/i/isodate/isodate-0.5.4.tar.gz
+  md5: 9da3ea2af54a6261d854e73d2266030e
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+# build:
+  # noarch_python: True
+  # preserve_egg_dir: True
+  # entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - isodate = isodate:main
+    #
+    # Would create an entry point called isodate that calls isodate.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  # Python imports
+  imports:
+    - isodate
+    - isodate.tests
+
+  # commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: http://cheeseshop.python.org/pypi/isodate
+  license: BSD License
+  summary: 'An ISO 8601 date/time/duration parser and formatter'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/recipes/keepalive/build.sh
+++ b/recipes/keepalive/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/recipes/keepalive/meta.yaml
+++ b/recipes/keepalive/meta.yaml
@@ -1,0 +1,61 @@
+package:
+  name: keepalive
+  version: "0.5"
+
+source:
+  fn: keepalive-0.5.tar.gz
+  url: https://pypi.python.org/packages/source/k/keepalive/keepalive-0.5.tar.gz
+  md5: 8cbc104142c094ee8052f4c560968e96
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+# build:
+  # noarch_python: True
+  # preserve_egg_dir: True
+  # entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - keepalive = keepalive:main
+    #
+    # Would create an entry point called keepalive that calls keepalive.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  # Python imports
+  imports:
+    - keepalive
+
+  # commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: https://github.com/wikier/keepalive
+  license: Apache Software License
+  summary: 'urllib keepalive support for python'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/recipes/shellescape/build.sh
+++ b/recipes/shellescape/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/recipes/shellescape/meta.yaml
+++ b/recipes/shellescape/meta.yaml
@@ -1,0 +1,27 @@
+package:
+  name: shellescape
+  version: "3.4.1"
+
+source:
+  fn: shellescape-3.4.1.tar.gz
+  url: https://pypi.python.org/packages/source/s/shellescape/shellescape-3.4.1.tar.gz
+  md5: 8dc7545a9a27d19dfcc4d7b33a72c296
+build:
+  number: 0
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  imports:
+    - shellescape
+
+about:
+  home: https://github.com/chrissimpkins/shellescape
+  license: MIT License
+  summary: 'Shell escape a string to safely use it as a token in a shell command (backport of Python shlex.quote for Python versions 2.x & < 3.3)'


### PR DESCRIPTION
Start of dependency tree: avro, isodate, keepalive, shellescape