### PR TITLE
[MRG] gnuplot: fix png support

### DIFF
--- a/recipes/gnuplot/meta.yaml
+++ b/recipes/gnuplot/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: 5.0.3
 
 build:
-  number: 0
+  number: 1
 
 source:
   url: https://sourceforge.net/projects/gnuplot/files/gnuplot/5.0.3/gnuplot-5.0.3.tar.gz
@@ -16,10 +16,10 @@ requirements:
     - libgcc [not osx]
     - llvm [osx]
     - pkg-config [osx]
-    - libgd
+    - libgd *.bioconda
   run:
     - libgcc [not osx]
-    - libgd
+    - libgd *.bioconda
 
 about:
   home: https://github.com/gnuplot/gnuplot
@@ -31,3 +31,4 @@ test:
     - test-data.txt
   commands:
     - gnuplot -e "set terminal dumb; set style histogram; p 'test-data.txt'"
+    - gnuplot -e "set terminal png"

--- a/recipes/libgd/meta.yaml
+++ b/recipes/libgd/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: libgd
-  version: 2.1.1
+  version: 2.1.1.bioconda
 
 requirements:
   build:
@@ -19,7 +19,6 @@ requirements:
     - jpeg
     - libpng
     - libtiff
-
 
 source:
   fn: libgd-2.1.1.tar.gz


### PR DESCRIPTION
* Use a higher version number to favor bioconda's libgd version over the one in conda's default channels
* Verify that gnuplot actually supports png terminals