### PR TITLE
Fix for "no LP solvers" error in cobra

### DIFF
--- a/recipes/cobra/meta.yaml
+++ b/recipes/cobra/meta.yaml
@@ -1,16 +1,17 @@
 package:
   name: cobra
-  version: "0.4.0b6"
+  version: "0.4.0"
 
 source:
   git_url: https://github.com/opencobra/cobrapy.git
-  git_tag: 2348ef3df3fa924622d792193c1aeff1bbdd0170
+  git_tag: de484b5a044da58496b4733f9d7c0302a55f4285
 
 requirements:
   build:
     - python
     - setuptools
     - six
+    - cython
     - gcc
     - glpk
 
@@ -42,4 +43,4 @@ test:
 about:
   home: https://opencobra.github.io/cobrapy
   license: GNU Lesser General Public License v2 or later (LGPLv2+) or GNU General Public License v2 or later (GPLv2+)
-  summary: 'COBRApy is a package for constraints-based modeling of biological networks'
+  summary: 'COBRApy is a package for constraint-based modeling of biological networks'


### PR DESCRIPTION
The previous version did not compile the LP solver bindings due to cython being missing from the build requirements in the meta.yaml. This pull request adds cython and yields a working cobra build.

Additionally the recipe gets bumped to the latest version and I fixed a typo in the description.