### PR TITLE
easydev: put the no_arch to False

### DIFF
--- a/recipes/easydev/meta.yaml
+++ b/recipes/easydev/meta.yaml
@@ -11,7 +11,7 @@ source:
    # - fix.patch
 
 build:
-  noarch_python: True
+  # noarch_python: True
   # preserve_egg_dir: True
   entry_points:
     - easydev_buildPackage=easydev.package:buildPackage


### PR DESCRIPTION
no_arch causes trouble building bioservices