### PR TITLE
New: typing, avro-python3; updated: bcbio

### DIFF
--- a/osx-whitelist.txt
+++ b/osx-whitelist.txt
@@ -7,6 +7,7 @@ arrow
 art
 arvados-python-client
 avro
+avro-python3
 awscli
 backports.csv
 bamtools
@@ -273,6 +274,7 @@ toposort
 trackhub
 trimmomatic
 trinity
+typing
 ucsc-axttomaf
 ucsc-axttopsl
 ucsc-bedclip

--- a/recipes/avro-python3/bld.bat
+++ b/recipes/avro-python3/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/recipes/avro-python3/build.sh
+++ b/recipes/avro-python3/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/recipes/avro-python3/meta.yaml
+++ b/recipes/avro-python3/meta.yaml
@@ -1,0 +1,29 @@
+package:
+  name: avro-python3
+  version: "1.8.0"
+
+source:
+  fn: avro-python3-1.8.0.tar.gz
+  url: https://pypi.python.org/packages/source/a/avro-python3/avro-python3-1.8.0.tar.gz
+  md5: d137b3a0d625816354abdbe92c825b7f
+
+build:
+  number: 0
+  skip: True # [py27]
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  imports:
+    - avro
+
+about:
+  home: http://avro.apache.org/
+  license: Apache License 2.0
+  summary: 'Avro is a serialization and RPC framework.'

--- a/recipes/bcbio-nextgen/meta.yaml
+++ b/recipes/bcbio-nextgen/meta.yaml
@@ -3,14 +3,15 @@ package:
   version: '0.9.7a'
 
 build:
-  number: 0
+  number: 1
   skip: True # [not py27]
 
 source:
   #fn: bcbio-nextgen-0.9.6.tar.gz
   #url: https://pypi.python.org/packages/source/b/bcbio-nextgen/bcbio-nextgen-0.9.6.tar.gz
-  fn: bcbio-nextgen-85dbbbc.tar.gz
-  url: https://github.com/chapmanb/bcbio-nextgen/archive/85dbbbc.tar.gz
+  fn: bcbio-nextgen-ee18f80.tar.gz
+  url: https://github.com/chapmanb/bcbio-nextgen/archive/ee18f80.tar.gz
+
 
 requirements:
   build:

--- a/recipes/typing/bld.bat
+++ b/recipes/typing/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/recipes/typing/build.sh
+++ b/recipes/typing/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/recipes/typing/meta.yaml
+++ b/recipes/typing/meta.yaml
@@ -1,0 +1,27 @@
+package:
+  name: typing
+  version: "3.5.0.1"
+
+source:
+  fn: typing-3.5.0.1.tar.gz
+  url: https://pypi.python.org/packages/source/t/typing/typing-3.5.0.1.tar.gz
+  md5: dae3d560f98c8b236a64ef1c0f55273a
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - python
+
+  run:
+    - python
+
+test:
+  imports:
+    - typing
+
+about:
+  home: https://docs.python.org/3.5/library/typing.html
+  license: Python Software Foundation License
+  summary: 'Type Hints for Python'


### PR DESCRIPTION
typing and avro-python3 are new dependencies for the latest
schema-salad release for python 3 support.