### PR TITLE
[MRG] gnuplot: do not link against x11 libraries

### DIFF
--- a/recipes/gnuplot/build.sh
+++ b/recipes/gnuplot/build.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
 
-./configure --prefix=$PREFIX
+./configure \
+    --prefix=$PREFIX \
+    --without-x \
+    --without-fontconfig
+
 make && make install

--- a/recipes/gnuplot/meta.yaml
+++ b/recipes/gnuplot/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: 5.0.3
 
 build:
-  number: 1
+  number: 2
 
 source:
   url: https://sourceforge.net/projects/gnuplot/files/gnuplot/5.0.3/gnuplot-5.0.3.tar.gz
@@ -17,9 +17,11 @@ requirements:
     - llvm [osx]
     - pkg-config [osx]
     - libgd *.bioconda
+    - ncurses
   run:
     - libgcc [not osx]
     - libgd *.bioconda
+    - ncurses
 
 about:
   home: https://github.com/gnuplot/gnuplot

--- a/recipes/libgd/build.sh
+++ b/recipes/libgd/build.sh
@@ -7,7 +7,9 @@
             --with-freetype \
             --with-zlib \
             --without-vpx \
-            --without-xpm
+            --without-xpm \
+            --without-x \
+            --without-fontconfig
 
 make
 make install

--- a/recipes/libgd/meta.yaml
+++ b/recipes/libgd/meta.yaml
@@ -2,6 +2,9 @@ package:
   name: libgd
   version: 2.1.1.bioconda
 
+build:
+  number: 1
+
 requirements:
   build:
     - gcc [not osx]


### PR DESCRIPTION
Sorry for keeping you busy here. I just realized that the X11 headers / libs are optional on OS X. Therefore we have to explicitly forbid linking against them or we risk library lookup failures for some users.