### PR TITLE
Alignlib lite

### DIFF
--- a/recipes/alignlib-lite/meta.yaml
+++ b/recipes/alignlib-lite/meta.yaml
@@ -20,17 +20,11 @@ requirements:
     - cython
 
   run:
-    - gcc  # [linux]
-    - llvm # [osx]
+    - libcc # [linux]
     - python
 
 
 test:
-  requires:
-    - gcc  # [linux]
-    - llvm # [osx]
-    - python
-
   imports:
     - alignlib_lite
 

--- a/recipes/alignlib-lite/meta.yaml
+++ b/recipes/alignlib-lite/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - cython
 
   run:
-    - libcc # [linux]
+    - libgcc # [linux]
     - python
 
 

--- a/recipes/alignlib-lite/meta.yaml
+++ b/recipes/alignlib-lite/meta.yaml
@@ -8,7 +8,7 @@ source:
   md5: d9088eff6542ca417718874605b0d062
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:


### PR DESCRIPTION

libgcc as runtime dep instead of gcc
