### PR TITLE
[MRG] gnuplot: relaunch build after fixing the conda-build-1.19.1 problems

### DIFF
--- a/recipes/gnuplot/build.sh
+++ b/recipes/gnuplot/build.sh
@@ -3,6 +3,6 @@
 ./configure \
     --prefix=$PREFIX \
     --without-x \
-    --without-fontconfig
+    --without-lua
 
 make && make install

--- a/recipes/gnuplot/meta.yaml
+++ b/recipes/gnuplot/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: 5.0.3
 
 build:
-  number: 2
+  number: 3
 
 source:
   url: https://sourceforge.net/projects/gnuplot/files/gnuplot/5.0.3/gnuplot-5.0.3.tar.gz


### PR DESCRIPTION
Upon merge travis complained about not being able to resolve the symbol ` ___stack_chk_guard`. This is surprising - as far as I understood it should not be required anyway.

```
+gnuplot -e 'set terminal dumb; set style histogram; p '\''test-data.txt'\'''
dyld: Symbol not found: ___stack_chk_guard
  Referenced from: /anaconda/envs/_test/bin/gnuplot
  Expected in: /anaconda/envs/_test/bin/../lib//libtiff.5.dylib
 in /anaconda/envs/_test/bin/gnuplot
/anaconda/conda-bld/test-tmp_dir/run_test.sh: line 3: 14162 Trace/BPT trap: 5       gnuplot -e "set terminal dumb; set style histogram; p 'test-data.txt'"
Using Anaconda Cloud api site https://api.anaconda.org
```

Here I am explicitly disabling the stack protector and see if this resolves the issue.