### PR TITLE
sambamba: add samtools and bcftools as runtime dependencies

### DIFF
--- a/recipes/sambamba/meta.yaml
+++ b/recipes/sambamba/meta.yaml
@@ -6,10 +6,12 @@ source:
   url: https://github.com/lomereiter/sambamba/releases/download/v0.5.9/sambamba_v0.5.9_linux.tar.bz2 # [linux]
   url: https://github.com/lomereiter/sambamba/releases/download/v0.5.9/sambamba_v0.5.9_osx.tar.bz2 # [osx]
 build:
-  number: 0
+  number: 1
 requirements:
   build:
   run:
+    - samtools # required for mpileup
+    - bcftools # required for mpileup
 test:
   commands:
     - sambamba view


### PR DESCRIPTION
sambamba mpileup “relies on external tools and acts as a multi-core
implementation of samtools and bcftools” This adds samtools and
bcftools as runtime dependencies of sambamba so multicore mpileup via
sambamba can be used