### PR TITLE
Hardcode htslib and samtools versions in pysam

### DIFF
--- a/recipes/pysam/meta.yaml
+++ b/recipes/pysam/meta.yaml
@@ -8,24 +8,24 @@ source:
     md5: 66913000ff50817bdcf56dfd3a52396f
 
 build:
-    number: 1
+    number: 2
 
 requirements:
     build:
         - gcc  # [linux]
         - llvm # [osx]
-        - htslib
-        - samtools
-        - bcftools
+        - htslib ==1.3
+        - samtools ==1.3
+        - bcftools ==1.3
         - cython
         - python
         - setuptools
 
     run:
         - libgcc # [linux]
-        - htslib
-        - samtools
-        - bcftools
+        - htslib ==1.3
+        - samtools ==1.3
+        - bcftools ==1.3
         - python
 
 test:
@@ -37,4 +37,3 @@ about:
     home: https://github.com/pysam-developers/pysam
     license: MIT
     summary: "Pysam is a python module for reading and manipulating Samfiles. It is a lightweight wrapper of the samtools C-API. Pysam also includes an interface for tabix."
-


### PR DESCRIPTION
So pysam dynamically links to htslib and also calls samtools.  For these reasons, we should probably hard-pin the versions to ensure compatibility.  

@sebastian-luna-valero  what do you think?  I worry that people could get strange results if we don't force the recipe to use all the same versions.  