### PR TITLE
Bump RapMap to 0.2.0.

### DIFF
--- a/recipes/rapmap/build.sh
+++ b/recipes/rapmap/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 mkdir build && cd build
-cmake ..
+cmake -DNO_NATIVE_ARCH=TRUE -DCMAKE_CXX_FLAGS=-mno-avx ..
 make
 make install
 mkdir -p $PREFIX/bin

--- a/recipes/rapmap/meta.yaml
+++ b/recipes/rapmap/meta.yaml
@@ -1,16 +1,16 @@
 package:
   name: rapmap
-  version: "v0.1.0pre"
+  version: "v0.2.0"
 source:
-  fn: v0.1.0-pre.tar.gz
-  url: https://github.com/COMBINE-lab/RapMap/archive/v0.1.0-pre.tar.gz
-  sha256: 3c4c16191c32804c4aa3a4ce633884c5eeb62e82065bcb57a05bebf5223c1900
+  fn: v0.2.0.tar.gz
+  url: https://github.com/COMBINE-lab/RapMap/archive/v0.2.0.tar.gz
+  sha256: e130a26dda7fbaba933bbddc31b00bafc68231012608b9b5054bc74bd9f81f60
 requirements:
   build:
     - cmake
   run:
 build:
-  number: 3
+  number: 1
 about:
   home: https://github.com/COMBINE-lab/RapMap
   license: GPL


### PR DESCRIPTION
Includes a fix to make the compiled binary more universal.