### PR TITLE
Bump hisat2 to 2.0.2.

### DIFF
--- a/recipes/hisat2/build.sh
+++ b/recipes/hisat2/build.sh
@@ -4,7 +4,7 @@ mkdir -p $PREFIX/bin
 
 if [ $PY3K -eq 1 ]
 then
-    2to3 --write extract_exons.py extract_snps.py extract_splice_sites.py hisat2-build hisat2-inspect simulate_reads.py 
+    2to3 --write hisat2_extract_exons.py hisat2_extract_HLA_vars.py hisat2_extract_snps_haplotypes_UCSC.py hisat2_extract_splice_sites.py hisat2-build hisat2-inspect hisat2_simulate_reads.py hisat2_extract_snps_haplotypes_VCF.py 
 fi
 
 for i in \
@@ -17,11 +17,13 @@ for i in \
     hisat2-inspect \
     hisat2-inspect-s \
     hisat2-inspect-l \
-    extract_splice_sites.py \
-    extract_snps.py \
-    extract_exons.py \
-    simulate_reads.py \
-;do
+    hisat2_extract_splice_sites.py \
+    hisat2_extract_exons.py \
+    hisat2_simulate_reads.py \
+    hisat2_extract_HLA_vars.py \
+    hisat2_extract_snps_haplotypes_UCSC.py \
+    hisat2_extract_snps_haplotypes_VCF.py;
+do
     echo $i
     cp $i $PREFIX/bin
     chmod +x $PREFIX/bin/$i

--- a/recipes/hisat2/meta.yaml
+++ b/recipes/hisat2/meta.yaml
@@ -4,7 +4,7 @@ about:
     summary: graph-based alignment of next generation sequencing reads to a population of genomes
 package:
     name: hisat2
-    version: 2.0.1beta
+    version: 2.0.2beta
 requirements:
     build:
         - python
@@ -15,10 +15,10 @@ test:
         - hisat2 --version
 
 source:
-  fn: hisat2-2.0.1-beta-Linux_x86_64.zip #[linux]
-  url: ftp://ftp.ccb.jhu.edu/pub/infphilo/hisat2/downloads/hisat2-2.0.1-beta-Linux_x86_64.zip #[linux]
-  md5: f2fa54657ccc52eb3a70938197cca607 #[linux]
+  fn: hisat2-2.0.2-beta-Linux_x86_64.zip #[linux]
+  url: ftp://ftp.ccb.jhu.edu/pub/infphilo/hisat2/downloads/hisat2-2.0.2-beta-Linux_x86_64.zip #[linux]
+  sha256: 1b38d53ddf1c437457d333d91e196a86d67080091e28cbaa28711f534d7cb389 #[linux]
 
-  fn: hisat2-2.0.1-beta-OSX_x86_64.zip #[osx]
-  url: ftp://ftp.ccb.jhu.edu/pub/infphilo/hisat2/downloads/hisat2-2.0.1-beta-OSX_x86_64.zip #[osx]
-  md5: 24a848f93b439b4466ba0fbe51956951 #[osx]
+  fn: hisat2-2.0.2-beta-OSX_x86_64.zip #[osx]
+  url: ftp://ftp.ccb.jhu.edu/pub/infphilo/hisat2/downloads/hisat2-2.0.2-beta-OSX_x86_64.zip #[osx]
+  sha256: 69e85d1f462dfd8b7ea2c45f78bf0fdba856ffa560dc63c54091e35a46734839 #[osx]


### PR DESCRIPTION
Does what it says on the box. A possible breaking change for downstream consumers, 2.0.2 changes the names of some of the python scripts, prefixing them with `hisat2_`