### PR TITLE
Update: CWL support, bcbio and bcbio-prioritize

### DIFF
--- a/recipes/arvados-cwl-runner/meta.yaml
+++ b/recipes/arvados-cwl-runner/meta.yaml
@@ -1,15 +1,15 @@
 package:
   name: arvados-cwl-runner
-  version: '1.0.20160314171956'
+  version: '1.0.20160318143738'
 
 source:
-  fn: arvados-cwl-runner-1.0.20160314171956.tar.gz
-  url: https://pypi.python.org/packages/source/a/arvados-cwl-runner/arvados-cwl-runner-1.0.20160314171956.tar.gz
-  md5: bb75849b70c53e130b3ff7d4768760e2
+  fn: arvados-cwl-runner-1.0.20160318143738.tar.gz
+  url: https://pypi.python.org/packages/source/a/arvados-cwl-runner/arvados-cwl-runner-1.0.20160318143738.tar.gz
+  md5: 72a30738253ccf4dbd69aedc5980bf61
 
 build:
   number: 0
-  skip: True # [not py27 or osx]
+  skip: True # [not py27]
 
 requirements:
   build:

--- a/recipes/arvados-python-client/meta.yaml
+++ b/recipes/arvados-python-client/meta.yaml
@@ -1,15 +1,15 @@
 package:
   name: arvados-python-client
-  version: '0.1.20160301181511'
+  version: '0.1.20160318153100'
 
 source:
-  fn: arvados-python-client-0.1.20160301181511.tar.gz
-  url: https://pypi.python.org/packages/source/a/arvados-python-client/arvados-python-client-0.1.20160301181511.tar.gz
-  md5: 3b0833193809fae982071841722c5156
+  fn: arvados-python-client-0.1.20160318153100.tar.gz
+  url: https://pypi.python.org/packages/source/a/arvados-python-client/arvados-python-client-0.1.20160318153100.tar.gz
+  md5: 52da9504e4242204a342ceb10fa94557
 
 build:
   number: 0
-  skip: True # [not py27 or osx]
+  skip: True # [not py27]
 
 requirements:
   build:

--- a/recipes/bcbio-nextgen-vm/meta.yaml
+++ b/recipes/bcbio-nextgen-vm/meta.yaml
@@ -3,12 +3,12 @@ package:
   version: '0.1.0a'
 
 build:
-  number: 73
-  skip: True # [not py27 or osx]
+  number: 74
+  skip: True # [not py27]
 
 source:
-  fn: bcbio-nextgen-vm-e6a1e5e.tar.gz
-  url: https://github.com/chapmanb/bcbio-nextgen-vm/archive/e6a1e5e.tar.gz
+  fn: bcbio-nextgen-vm-2378f1e.tar.gz
+  url: https://github.com/chapmanb/bcbio-nextgen-vm/archive/2378f1e.tar.gz
 
 requirements:
   build:

--- a/recipes/bcbio-nextgen-vm/meta.yaml
+++ b/recipes/bcbio-nextgen-vm/meta.yaml
@@ -7,8 +7,8 @@ build:
   skip: True # [not py27]
 
 source:
-  fn: bcbio-nextgen-vm-2378f1e.tar.gz
-  url: https://github.com/chapmanb/bcbio-nextgen-vm/archive/2378f1e.tar.gz
+  fn: bcbio-nextgen-vm-a4f0e9d.tar.gz
+  url: https://github.com/chapmanb/bcbio-nextgen-vm/archive/a4f0e9d.tar.gz
 
 requirements:
   build:

--- a/recipes/bcbio-nextgen/meta.yaml
+++ b/recipes/bcbio-nextgen/meta.yaml
@@ -3,14 +3,14 @@ package:
   version: '0.9.7a'
 
 build:
-  number: 3
-  skip: True # [not py27 or osx]
+  number: 4
+  skip: True # [not py27]
 
 source:
   #fn: bcbio-nextgen-0.9.6.tar.gz
   #url: https://pypi.python.org/packages/source/b/bcbio-nextgen/bcbio-nextgen-0.9.6.tar.gz
-  fn: bcbio-nextgen-2dac347.tar.gz
-  url: https://github.com/chapmanb/bcbio-nextgen/archive/2dac347.tar.gz
+  fn: bcbio-nextgen-2378f1e.tar.gz
+  url: https://github.com/chapmanb/bcbio-nextgen/archive/2378f1e.tar.gz
 
 
 requirements:

--- a/recipes/bcbio-prioritize/meta.yaml
+++ b/recipes/bcbio-prioritize/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: bcbio-prioritize
-  version: 0.0.5
+  version: 0.0.6
 
 source:
   fn: bcbio-prioritize
-  url: https://github.com/chapmanb/bcbio.prioritize/releases/download/v0.0.5/bcbio-prioritize
+  url: https://github.com/chapmanb/bcbio.prioritize/releases/download/v0.0.6/bcbio-prioritize
 
 build:
   number: 1

--- a/recipes/cwltool/meta.yaml
+++ b/recipes/cwltool/meta.yaml
@@ -1,14 +1,15 @@
 package:
   name: cwltool
-  version: '1.0.20160311201238'
+  version: '1.0.20160318153100'
 
 source:
-  fn: cwltool-1.0.20160311201238.tar.gz
-  url: https://pypi.python.org/packages/source/c/cwltool/cwltool-1.0.20160311201238.tar.gz
+  fn: cwltool-1.0.20160318153100.tar.gz
+  url: https://pypi.python.org/packages/source/c/cwltool/cwltool-1.0.20160316204054.tar.gz
+  md5: 6d88b09260dad924572db333169b857b
 
 build:
   number: 0
-  skip: True # [not py27 or osx]
+  skip: True # [not py27]
 
 requirements:
   build:

--- a/recipes/schema-salad/meta.yaml
+++ b/recipes/schema-salad/meta.yaml
@@ -1,17 +1,16 @@
 package:
   name: schema-salad
-  version: "1.7"
+  version: "1.7.20160316203940"
 
 source:
-  fn: schema-salad-1.7.tar.gz
-  url: https://pypi.python.org/packages/source/s/schema-salad/schema-salad-1.7.tar.gz
-  md5: 19883cdfa53705d5f3a2afa8c3ee864d
+  fn: schema-salad-1.7.20160316203940.tar.gz
+  url: https://pypi.python.org/packages/source/s/schema-salad/schema-salad-1.7.20160316203940.tar.gz
+  md5: 4b50e8201b3dc6ae9b80501ef570292b
 
 build:
   entry_points:
     - schema-salad-tool=schema_salad.main:main
   number: 0
-  skip: True # [osx]
 
 requirements:
   build:


### PR DESCRIPTION
- Updates requirements for running bcbio CWL locally and on Arvados
  to avoid issues with large javascript parsing.
- Updates bcbio-prioritize to fix problems with large VCF inputs.