### PR TITLE
Update: varscan to 2.4.1

### DIFF
--- a/recipes/varscan/meta.yaml
+++ b/recipes/varscan/meta.yaml
@@ -4,17 +4,16 @@ about:
     summary: variant detection in massively parallel sequencing data
 package:
     name: varscan
-    version: 2.4.0
+    version: 2.4.1
 build:
-  number: 1
-  skip: False
+  number: 0
 source:
-    fn: VarScan-2.4.0.jar
-    url: https://github.com/dkoboldt/varscan/raw/master/VarScan.v2.4.0.jar
+    fn: VarScan-2.4.1.jar
+    url: https://github.com/dkoboldt/varscan/raw/master/VarScan.v2.4.1.jar
 requirements:
   build:
   run:
+    - java-jdk
 test:
     commands:
-      # skip test on build boxes since it requires java
-      #- varscan mpileup2cns --help
+      - varscan mpileup2cns --help


### PR DESCRIPTION
The 2.4.1 release provides a bug fix for 2.4.0 reducing the false
positive rate by ~10x.