### PR TITLE
gnuplot: removed libgd version hack

### DIFF
--- a/recipes/gnuplot/meta.yaml
+++ b/recipes/gnuplot/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: 5.0.3
 
 build:
-  number: 3
+  number: 4
   skip: False
 
 source:
@@ -17,11 +17,11 @@ requirements:
     - libgcc [not osx]
     - llvm [osx]
     - pkg-config [osx]
-    - libgd *.bioconda
+    - libgd
     - ncurses
   run:
     - libgcc [not osx]
-    - libgd *.bioconda
+    - libgd
     - ncurses
 
 about:

--- a/recipes/libgd/meta.yaml
+++ b/recipes/libgd/meta.yaml
@@ -1,9 +1,9 @@
 package:
   name: libgd
-  version: 2.1.1.bioconda
+  version: 2.1.1post
 
 build:
-  number: 1
+  number: 0
   skip: False
 
 requirements:


### PR DESCRIPTION
Unfortunately, the cool hack using the `.bioconda` postfix in the dependency string does not work since >=conda-4.0.4. And the developers do not intend to bring back the old functionality. Therefore a different strategy is necessary now.

In order to shadow the broken libgd version in continuumio's default channel, the `post` postfix is the only solution I can think of at the moment.

The solution is not as nice as the previous one, but I don't see any dramatic downsides. After all the recipe offered by continuumio is broken anyway.

See https://github.com/conda/conda/issues/2297 for a reference to the discussion.