### PR TITLE
bowtie2: bump to 2.2.8; fix build issues; add OSX

### DIFF
--- a/recipes/bowtie2/build.sh
+++ b/recipes/bowtie2/build.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
+set -eu -o pipefail
 
-make
+if [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+    make
+fi
 
 binaries="\
 bowtie2 \
@@ -23,7 +26,5 @@ then
     for i in $pythonfiles; do 2to3 --write $i; done
 fi
 
-for d in $directories; do cp -r $d $PREFIX; done
-
-cp -r ./* $PREFIX
-chmod +x $PREFIX/*
+for i in $binaries; do cp $i $PREFIX/bin && chmod +x $PREFIX/bin/$i; done
+for d in $directories; do cp -r $d $PREFIX/bin; done

--- a/recipes/bowtie2/meta.yaml
+++ b/recipes/bowtie2/meta.yaml
@@ -3,13 +3,19 @@ about:
     license: GPLv3
     summary: Fast and sensitive read alignment
 
-build:
-  number: 1
-  skip: True # [osx]
-
 package:
     name: bowtie2
-    version: 2.2.7
+    version: 2.2.8
+
+build:
+  number: 0
+
+source:
+  fn: bowtie2-2.2.8-source.zip # [linux]
+  url: http://downloads.sourceforge.net/project/bowtie-bio/bowtie2/2.2.8/bowtie2-2.2.8-source.zip # [linux]
+  md5: c3d5dd807f053b9fd7cc786312e6e3fb # [linux]
+  fn: bowtie2-2.2.8-macos-x86_64.zip # [osx]
+  url: http://downloads.sourceforge.net/project/bowtie-bio/bowtie2/2.2.8/bowtie2-2.2.8-macos-x86_64.zip # [osx]
 
 requirements:
     build:
@@ -18,11 +24,7 @@ requirements:
         - python
 test:
     commands:
-        - (bowtie2 --version 2>&1) > /dev/null
+        - bowtie2 --version
         - bowtie2-build --help
         - bowtie2-inspect-l --help
         - bowtie2-align-s --help
-source:
-  fn: bowtie2-2.2.7-source.zip
-  url: http://downloads.sourceforge.net/project/bowtie-bio/bowtie2/2.2.7/bowtie2-2.2.7-source.zip
-  md5: 1e36afb656c765d9a16489a42a795983


### PR DESCRIPTION
- Fix build problem: bowtie2 not installed on previous version.
- Updates bowtie2 to the latest release 2.2.8
- Adds OSX target using pre-compiled binaries
- Fixes build issues where bowtie2 was not installed with switch to
  compilation on Linux. @bgruening, I'm not sure why the build file
  changed in your update but I put it back to the previous approach
  which works with the manual build.