### PR TITLE
Updates: bcbio, CWL runners and VarDict

### DIFF
--- a/recipes/arvados-cwl-runner/build.sh
+++ b/recipes/arvados-cwl-runner/build.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+cd sdk/cwl
+sed -i.bak -e '/cmdclass=/s/^/#/' setup.py
+sed -i.bak "s/version='1.0'/version='$PKG_VERSION'/" setup.py
 $PYTHON setup.py install
 
 # Add more build steps here, if they are necessary.

--- a/recipes/arvados-cwl-runner/meta.yaml
+++ b/recipes/arvados-cwl-runner/meta.yaml
@@ -1,11 +1,13 @@
 package:
   name: arvados-cwl-runner
-  version: '1.0.20160318143738'
+  version: '1.0.20160323'
 
 source:
-  fn: arvados-cwl-runner-1.0.20160318143738.tar.gz
-  url: https://pypi.python.org/packages/source/a/arvados-cwl-runner/arvados-cwl-runner-1.0.20160318143738.tar.gz
-  md5: 72a30738253ccf4dbd69aedc5980bf61
+  fn: arvados-cwl-runner-1.0.20160323.tar.gz
+  url: https://github.com/curoverse/arvados/archive/c7539c2.tar.gz
+  #fn: arvados-cwl-runner-1.0.20160318143738.tar.gz
+  #url: https://pypi.python.org/packages/source/a/arvados-cwl-runner/arvados-cwl-runner-1.0.20160318143738.tar.gz
+  #md5: 72a30738253ccf4dbd69aedc5980bf61
 
 build:
   number: 0

--- a/recipes/bcbio-nextgen-vm/meta.yaml
+++ b/recipes/bcbio-nextgen-vm/meta.yaml
@@ -3,12 +3,12 @@ package:
   version: '0.1.0a'
 
 build:
-  number: 74
+  number: 75
   skip: True # [not py27]
 
 source:
-  fn: bcbio-nextgen-vm-a4f0e9d.tar.gz
-  url: https://github.com/chapmanb/bcbio-nextgen-vm/archive/a4f0e9d.tar.gz
+  fn: bcbio-nextgen-vm-2830cec.tar.gz
+  url: https://github.com/chapmanb/bcbio-nextgen-vm/archive/2830cec.tar.gz
 
 requirements:
   build:

--- a/recipes/bcbio-nextgen/meta.yaml
+++ b/recipes/bcbio-nextgen/meta.yaml
@@ -3,14 +3,14 @@ package:
   version: '0.9.7a'
 
 build:
-  number: 4
+  number: 5
   skip: True # [not py27]
 
 source:
   #fn: bcbio-nextgen-0.9.6.tar.gz
   #url: https://pypi.python.org/packages/source/b/bcbio-nextgen/bcbio-nextgen-0.9.6.tar.gz
-  fn: bcbio-nextgen-2378f1e.tar.gz
-  url: https://github.com/chapmanb/bcbio-nextgen/archive/2378f1e.tar.gz
+  fn: bcbio-nextgen-8f3ebbf.tar.gz
+  url: https://github.com/chapmanb/bcbio-nextgen/archive/8f3ebbf.tar.gz
 
 
 requirements:

--- a/recipes/cwltool/meta.yaml
+++ b/recipes/cwltool/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: cwltool
-  version: '1.0.20160318153100'
+  version: '1.0.20160323212343'
 
 source:
-  fn: cwltool-1.0.20160318153100.tar.gz
-  url: https://pypi.python.org/packages/source/c/cwltool/cwltool-1.0.20160316204054.tar.gz
-  md5: 6d88b09260dad924572db333169b857b
+  fn: cwltool-1.0.20160323212343.tar.gz
+  url: https://pypi.python.org/packages/source/c/cwltool/cwltool-1.0.20160323212343.tar.gz
+  md5: 3cb2629116dce1838e3946347a6f9c5c
 
 build:
   number: 0

--- a/recipes/vardict-java/meta.yaml
+++ b/recipes/vardict-java/meta.yaml
@@ -3,13 +3,11 @@ package:
   version: '1.4.5'
 
 source:
-  fn: VarDict-1.4.5.beta.zip
-  url: https://github.com/AstraZeneca-NGS/VarDictJava/files/147038/VarDict-1.4.5.beta.zip
-  #url: https://github.com/AstraZeneca-NGS/VarDictJava/releases/download/v1.4.3/VarDict-1.4.3.zip
+  fn: VarDict-1.4.5.zip
+  url: https://github.com/AstraZeneca-NGS/VarDictJava/files/175955/VarDict-1.4.5.zip
 
 build:
-  number: 0
-  skip: False
+  number: 1
 
 requirements:
   run:


### PR DESCRIPTION
- bcbio: enable CWL runs without variant_regions
- bcbio-vm: improve update procedure
- arvados-cwl-runner, vardict-java, cwltool: bump to latest releases