### PR TITLE
hap.py: new recipe (0.2.9)

### DIFF
--- a/recipes/hap.py/build.sh
+++ b/recipes/hap.py/build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+sed -i.bak -e '/^configure_files.*libz/s/^/#/' CMakeLists.txt
+sed -i.bak -e '/^configure_files.*tabix/s/^/#/' CMakeLists.txt
+sed -i.bak -e '/^configure_files.*bgzip/s/^/#/' CMakeLists.txt
+sed -i.bak -e '/^configure_files.*bcftools/s/^/#/' CMakeLists.txt
+sed -i.bak -e '/^configure_files.*samtools/s/^/#/' CMakeLists.txt
+mkdir -p build
+cd build
+cmake ../ -DCMAKE_INSTALL_PREFIX=$PREFIX -DBOOST_INCLUDEDIR=$PREFIX/include/boost -DBOOST_LIBRARYDIR=$PREFIX/lib
+make
+rm -f lib/libhts*so
+make install

--- a/recipes/hap.py/meta.yaml
+++ b/recipes/hap.py/meta.yaml
@@ -1,0 +1,47 @@
+package:
+  name: hap.py
+  version: '0.2.9'
+
+source:
+  fn: hap.py-0.2.9.tar.gz
+  url: https://github.com/Illumina/hap.py/archive/v0.2.9.tar.gz
+
+build:
+  number: 0
+  skip: True # [not py27]
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - zlib
+    - cython
+    - numpy
+    - pandas
+    - pybedtools
+    - pysam
+    - nose
+    - bx-python
+    - cmake
+
+  run:
+    - python
+    - cython
+    - zlib
+    - numpy
+    - pandas
+    - pybedtools
+    - pysam
+    - nose
+    - bx-python
+    - samtools
+    - bcftools
+
+test:
+  commands:
+    - hap.py -h
+    - som.py -h
+
+about:
+  home: https://github.com/sequencing/hap.py
+  license: BSD

--- a/recipes/hap.py/meta.yaml
+++ b/recipes/hap.py/meta.yaml
@@ -8,7 +8,7 @@ source:
 
 build:
   number: 0
-  skip: True # [not py27]
+  skip: True # [not py27 or osx]
 
 requirements:
   build:


### PR DESCRIPTION
graph based VCF validation tool from the Illumina team, used in GA4GH
validation working group comparisons