### PR TITLE
Recipe for plink2.

### DIFF
--- a/recipes/plink2/build.sh
+++ b/recipes/plink2/build.sh
@@ -1,0 +1,17 @@
+# Portable sha1 sums across linux and os x
+sed -i.bak -e "s/shasum/openssl sha1 -r/g" plink_first_compile
+# Remove "make plink" so we can call it with overrides
+sed -i.bak -e "s/make plink//g" plink_first_compile
+# This downloads and builds a local zlib-1.2.8
+./plink_first_compile
+
+# Build using Makefile.std as recommended in the README
+if [[ -z "$OSX_ARCH" ]]; then
+    make CFLAGS="-Wall -O2 -I$PREFIX/include" BLASFLAGS="-L$PREFIX/lib -lopenblas" -f Makefile.std plink
+else
+    make -f Makefile.std plink
+fi
+
+# Install as plink2       
+mkdir -p $PREFIX/bin     
+cp plink $PREFIX/bin/plink2

--- a/recipes/plink2/meta.yaml
+++ b/recipes/plink2/meta.yaml
@@ -1,0 +1,23 @@
+package:
+  name: plink2
+  version: "1.90b3.35"
+
+source:
+  fn: 8990fc72295b299c1ace05266861884d319cf082.tar.gz
+  url: https://github.com/chrchang/plink-ng/archive/8990fc72295b299c1ace05266861884d319cf082.tar.gz
+
+requirements:
+  build:
+    - openblas # [not osx]
+  run:
+    - openblas # [not osx]
+
+test:
+  commands:
+    - plink2 --help | grep "PLINK v1.90p 64-bit (25 Mar 2016)"
+
+about:
+  home: https://www.cog-genomics.org/plink2
+  license: GPL
+  license_file: LICENSE
+  summary: Whole genome association analysis toolset, designed to perform a range of basic, large-scale analyses in a computationally efficient manner.


### PR DESCRIPTION
Plink2 has odd versioning. The betas are called plink 1.9, presumably 
the final version will be plink 2. The sub-version comes from the 
homepage, the builds from this changeset are called beta 3.35.