### PR TITLE
formula cleanup: bowtie, libgtextutils, fastx_toolkit

### DIFF
--- a/recipes/bowtie/build.sh
+++ b/recipes/bowtie/build.sh
@@ -1,11 +1,3 @@
 #!/bin/bash
 
 make && make install prefix=$PREFIX
-
-PY3_BUILD="${PY_VER%.*}"
-
-PYTHON_FILES="bowtie bowtie-build bowtie-inspect"
-
-if [ $PY3_BUILD -eq 3 ]; then
-    for i in $PYTHON_FILES; do 2to3 --write $i; done
-fi

--- a/recipes/bowtie/meta.yaml
+++ b/recipes/bowtie/meta.yaml
@@ -8,7 +8,7 @@ package:
     version: 1.1.2
 
 build:
-  number: 1
+  number: 2
   skip: False
 
 requirements:
@@ -21,10 +21,11 @@ requirements:
         - libgcc [not osx]
         - python
 
-
 test:
     commands:
-        - (bowtie --version 2>&1) > /dev/null
+        - bowtie --version 2>&1 > /dev/null
+        - bowtie-build --version 2>&1 > /dev/null
+        - bowtie-inspect --version 2>&1 > /dev/null
 
 source:
   fn: bowtie-1.1.2.tar.gz

--- a/recipes/fastx_toolkit/build.sh
+++ b/recipes/fastx_toolkit/build.sh
@@ -3,11 +3,5 @@
 export GTEXTUTILS_CFLAGS="-I $PREFIX/include/gtextutils"
 export GTEXTUTILS_LIBS="$PREFIX/lib/libgtextutils.a"
 
-if [ "$(uname)" == "Darwin" ]; then
-    MACOSX_DEPLOYMENT_TARGET=10.7
-    CXXFLAGS="${CXXFLAGS} -std=c++11 -stdlib=libc++"
-fi
-
 ./configure --prefix=$PREFIX
-make
-make install
+make && make install

--- a/recipes/fastx_toolkit/meta.yaml
+++ b/recipes/fastx_toolkit/meta.yaml
@@ -8,29 +8,27 @@ source:
 
 build:
   preserve_egg_dir: True
-  number: 1
+  number: 2
   skip: False
 
 requirements:
   build:
-    - gcc [not osx]
-    - libgcc [not osx]
-    - llvm [osx]
+    - gcc
+    - libgcc
     - cython
     - nose
     - libgtextutils
 
   run:
-    - libgcc [not osx]
+    - libgcc
     - cython
     - nose
     - libgtextutils
     - gnuplot
-    #- pkg-config
 
 test:
     commands:
-      #- fastx_quality_stats -h  # This fails for some unknown reason, even though it prints the output successfully...
+#      - fastx_quality_stats -h  # help commands exit status != 0
 
 about:
   home: https://github.com/agordon/fastx_toolkit

--- a/recipes/libgtextutils/build.sh
+++ b/recipes/libgtextutils/build.sh
@@ -1,12 +1,4 @@
 #!/bin/bash
 
-if [ "$(uname)" == "Darwin" ]; then
-    # building the library requires an implementation of basic_stringbuf
-    # from the c++ standard library
-    # 10.9 seems to be the minimum possible deployment target
-    MACOSX_DEPLOYMENT_TARGET=10.9
-fi
-
 ./configure --prefix=$PREFIX
-make
-make install
+make && make install

--- a/recipes/libgtextutils/meta.yaml
+++ b/recipes/libgtextutils/meta.yaml
@@ -8,24 +8,20 @@ source:
 
 build:
   preserve_egg_dir: True
-  number: 1
+  number: 2
   skip: False
 
 requirements:
   build:
-    - gcc [not osx]
-    - libgcc [not osx]
-    - llvm [osx]
+    - gcc
+    - libgcc
     - cython
     - nose
-    #- pkg-config
 
   run:
-    - libgcc [not osx]
+    - libgcc
     - cython
     - nose
-    #- pkg-config
-
 
 about:
   home: https://github.com/agordon/libgtextutils


### PR DESCRIPTION
This removes noise introduced by my previous commits.

* The `2to3` conversion in bowtie happens after `make install` and thus has no effect. This works, because the scripts seem to be  python3 compatible in the first place.  Removing the 2to3 call to clean up the mess.

* the `MACOSX_DEPLOYMENT_TARGET` hacks are needed, because the scripts require a recent c++ stdlib that is not shipped with older OS X versions. Using the real gcc instead of apples clang should solve the problem without breaking compatibility.