### PR TITLE
STAR-Fusion: added utilities + dependencies (STAR, gmap_build, bowtie-build)

### DIFF
--- a/recipes/star-fusion/build.sh
+++ b/recipes/star-fusion/build.sh
@@ -8,3 +8,11 @@ cp -r * $PREFIX/lib/STAR-Fusion
 echo "#!/bin/bash" > $PREFIX/bin/STAR-Fusion
 echo "$PREFIX/lib/STAR-Fusion/STAR-Fusion \$@" >> $PREFIX/bin/STAR-Fusion
 chmod +x $PREFIX/bin/STAR-Fusion
+
+echo "#!/bin/bash" > $PREFIX/bin/blast_and_promiscuity_filter.pl
+echo "$PREFIX/lib/STAR-Fusion/FusionFilter/blast_and_promiscuity_filter.pl \$@" >> $PREFIX/bin/blast_and_promiscuity_filter.pl
+chmod +x $PREFIX/bin/blast_and_promiscuity_filter.pl
+
+echo "#!/bin/bash" > $PREFIX/bin/prep_genome_lib.pl
+echo "$PREFIX/lib/STAR-Fusion/FusionFilter/prep_genome_lib.pl \$@" >> $PREFIX/bin/prep_genome_lib.pl
+chmod +x $PREFIX/bin/prep_genome_lib.pl

--- a/recipes/star-fusion/meta.yaml
+++ b/recipes/star-fusion/meta.yaml
@@ -6,7 +6,7 @@ source:
   fn: STAR-Fusion_v0.5.4.FULL.tar.gz
   url: https://github.com/STAR-Fusion/STAR-Fusion/releases/download/v0.5.4/STAR-Fusion_v0.5.4.FULL.tar.gz
 build:
-  number: 1
+  number: 2
   skip: True # [osx]
 
 requirements:
@@ -16,10 +16,15 @@ requirements:
       - perl-set-intervaltree
       - perl-db-file
       - perl-uri
+      - star
+      - blast
+      - gmap
 
 test:
   commands:
       - STAR-Fusion --help 2>&1 | grep Optional > /dev/null
+      - prep_genome_lib.pl -h 2>&1 | grep "STAR-Fusion" > /dev/null
+      - blast_and_promiscuity_filter.pl -h 2>&1 | grep Optional > /dev/null
 
 about:
   home: https://github.com/STAR-Fusion/STAR-Fusion

--- a/recipes/star-fusion/meta.yaml
+++ b/recipes/star-fusion/meta.yaml
@@ -17,8 +17,8 @@ requirements:
       - perl-db-file
       - perl-uri
       - star
-      - blast
       - gmap
+      - bowtie
 
 test:
   commands:


### PR DESCRIPTION
This PR updates STAR-Fusion and solves https://github.com/bioconda/bioconda-recipes/issues/1005. In order to solve that issue, the corresponding utilities need to depend on `STAR` itself, `bowtie-build` and `gmap_build` as can be seen here:

https://github.com/FusionFilter/FusionFilter/blob/14f87fbe2d93cf5aa7b4bbfe6bf1df203c92b03d/prep_genome_lib.pl#L123