### PR TITLE
Remove GCC and zlib from the container

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -2,22 +2,30 @@ FROM centos:centos5
 
 # add tools useful for compilation
 RUN rpm -Uvh http://dl.fedoraproject.org/pub/epel/5/x86_64/epel-release-5-4.noarch.rpm
-RUN yum install -y \
-    wget bzip2 bzip2-devel git gcc gcc-c++ patch zlib-devel make gcc44 \
-    gcc44-c++ cmake ncurses-devel unzip byacc && \
-    yum clean all
+
+# Install wget first so we can download devtools-2 and autotools repos
+RUN yum install -y wget
 RUN wget http://people.centos.org/tru/devtools-2/devtools-2.repo -O /etc/yum.repos.d/devtools-2.repo && \
     wget --no-check-certificate https://copr.fedoraproject.org/coprs/praiskup/autotools/repo/epel-5/praiskup-autotools-epel-5.repo -O /etc/yum.repos.d/autotools.repo
+
 RUN yum install -y \
-    devtoolset-2-gcc devtoolset-2-binutils devtoolset-2-gcc-c++ \
-    devtoolset-2-gcc-gfortran autotools-latest pkgconfig which file gpg \
-    # Needed for perl-db-file
-    db4-devel \
-    # install X11 dependencies and openGL/mesa
-    xorg-x11-apps mesa-libGLU-devel \
+    autotools-latest \
+    byacc \
+    bzip2 \
+    bzip2-devel \
+    cmake \
+    devtoolset-2-binutils \
+    file \
+    git \
+    gpg \
+    make \
+    mesa-libGLU-devel \
+    patch \
+    pkgconfig \
+    unzip \
+    which \
+    xorg-x11-apps \
     && yum clean all
-
-
 
 # install conda
 RUN mkdir -p /tmp/conda-build && wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh && bash Miniconda3-latest-Linux-x86_64.sh -b -p /anaconda
@@ -28,12 +36,16 @@ RUN mkdir -p /anaconda/conda-bld/linux-64 /anaconda/conda-bld/osx-64 # workaroun
 
 # setup conda
 ADD requirements.txt requirements.txt
+RUN conda update conda
 RUN conda install -y --file requirements.txt
+RUN conda update conda-build
 RUN conda index /anaconda/conda-bld/linux-64 /anaconda/conda-bld/osx-64
 RUN conda config --add channels bioconda
 RUN conda config --add channels r
 RUN conda config --add channels file://anaconda/conda-bld
 RUN conda install -y toposort
+
+RUN mv /usr/bin/gcc /opt/gcc
 
 # setup entrypoint (assuming that repo is mounted under /bioconda-recipes)
 ENTRYPOINT ["/bioconda-recipes/scripts/build-packages.py"]


### PR DESCRIPTION
This one will remove a lot of dependencies, gcc, g++, zlib. This is to force new recipes to use stricter build- and run-time dependencies.

This PR is mainly to start a discussion. I once tried to remove zlib and fix all old recipes and failed because it can be really hard for some recipes or the URL from these old packages were not available.