### PR TITLE
Change CNVkit license to Apache 2.0

### DIFF
--- a/recipes/cnvkit/meta.yaml
+++ b/recipes/cnvkit/meta.yaml
@@ -37,5 +37,5 @@ test:
 
 about:
   home: https://github.com/etal/cnvkit
-  license: MIT
+  license: Apache License 2.0
   summary: Copy number variant detection from targeted DNA sequencing


### PR DESCRIPTION
The upstream CNVkit license is Apache 2.0, see: https://github.com/etal/cnvkit/blob/master/LICENSE