### PR TITLE
abyss: Remove google-sparsehash from run

### DIFF
--- a/recipes/abyss/meta.yaml
+++ b/recipes/abyss/meta.yaml
@@ -20,7 +20,6 @@ requirements:
 
   run:
   - libgcc
-  - google-sparsehash
   - sqlite
 
 test:


### PR DESCRIPTION
google-sparsehash is a build dependency only.