### PR TITLE
perl Tie::File module

### DIFF
--- a/recipes/perl-tie-file/build.sh
+++ b/recipes/perl-tie-file/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+cpanm -i .

--- a/recipes/perl-tie-file/meta.yaml
+++ b/recipes/perl-tie-file/meta.yaml
@@ -1,0 +1,25 @@
+package:
+  name: perl-tie-file
+  version: '1.0'
+
+source:
+  fn: Tie-File-1.00.tar.gz
+  url: http://search.cpan.org/CPAN/authors/id/T/TO/TODDR/Tie-File-1.00.tar.gz
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - gcc
+    - perl-threaded
+    - perl-app-cpanminus
+    - perl-module-build
+  run:
+    - libgcc
+    - perl-threaded
+
+about:
+  home: http://search.cpan.org/~toddr/Tie-File-1.00/lib/Tie/File.pm
+  license: Perl
+  summary: Access the lines of a disk file via a Perl array


### PR DESCRIPTION
Doesn't need a test section because cpanm does the testing.