### PR TITLE
Updates: bcbio and CWL

### DIFF
--- a/recipes/arvados-cwl-runner/meta.yaml
+++ b/recipes/arvados-cwl-runner/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: arvados-cwl-runner
-  version: '1.0.20160406195023'
+  version: '1.0.20160411202258'
 
 source:
-  fn: arvados-cwl-runner-1.0.20160406195023.tar.gz
-  url: https://pypi.python.org/packages/source/a/arvados-cwl-runner/arvados-cwl-runner-1.0.20160406195023.tar.gz
-  md5: 5298b30d5e46d00f0207dae5b0c973ca
+  fn: arvados-cwl-runner-1.0.20160411202258.tar.gz
+  url: https://pypi.python.org/packages/source/a/arvados-cwl-runner/arvados-cwl-runner-1.0.20160411202258.tar.gz
+  md5: 250d609dbeefe2653f293b17f106c7ee
 
 build:
   number: 0

--- a/recipes/arvados-python-client/meta.yaml
+++ b/recipes/arvados-python-client/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: arvados-python-client
-  version: '0.1.20160331153549'
+  version: '0.1.20160412193510'
 
 source:
-  fn: arvados-python-client-0.1.20160331153549.tar.gz
-  url: https://pypi.python.org/packages/source/a/arvados-python-client/arvados-python-client-0.1.20160331153549.tar.gz
-  md5: 703974e87c8f14abc21f3b1f4bc6baaf
+  fn: arvados-python-client-0.1.20160412193510.tar.gz
+  url: https://pypi.python.org/packages/source/a/arvados-python-client/arvados-python-client-0.1.20160412193510.tar.gz
+  md5: ee0b9a0db0dc5ba9a48d11568efb943f
 
 build:
   number: 0

--- a/recipes/bcbio-nextgen-vm/meta.yaml
+++ b/recipes/bcbio-nextgen-vm/meta.yaml
@@ -3,12 +3,12 @@ package:
   version: '0.1.0a'
 
 build:
-  number: 78
+  number: 79
   skip: True # [not py27]
 
 source:
-  fn: bcbio-nextgen-vm-abe7195.tar.gz
-  url: https://github.com/chapmanb/bcbio-nextgen-vm/archive/abe7195.tar.gz
+  fn: bcbio-nextgen-vm-354e51f.tar.gz
+  url: https://github.com/chapmanb/bcbio-nextgen-vm/archive/354e51f.tar.gz
 
 requirements:
   build:

--- a/recipes/bcbio-nextgen/meta.yaml
+++ b/recipes/bcbio-nextgen/meta.yaml
@@ -3,14 +3,14 @@ package:
   version: '0.9.8a0'
 
 build:
-  number: 2
+  number: 3
   skip: True # [not py27]
 
 source:
   #fn: bcbio-nextgen-0.9.7.tar.gz
   #url: https://pypi.python.org/packages/source/b/bcbio-nextgen/bcbio-nextgen-0.9.7.tar.gz
-  fn: bcbio-nextgen-6b56434.tar.gz
-  url: https://github.com/chapmanb/bcbio-nextgen/archive/6b56434.tar.gz
+  fn: bcbio-nextgen-1e23d67.tar.gz
+  url: https://github.com/chapmanb/bcbio-nextgen/archive/1e23d67.tar.gz
 
 requirements:
   build:
@@ -57,7 +57,6 @@ requirements:
     - pyzmq
     - reportlab
     - requests
-    - scikit-learn
     - scipy
     - seaborn
     - seqcluster

--- a/recipes/bcbio-variation-recall/meta.yaml
+++ b/recipes/bcbio-variation-recall/meta.yaml
@@ -1,14 +1,14 @@
 package:
   name: bcbio-variation-recall
-  version: 0.1.4
+  version: 0.1.5
 
 source:
   fn: bcbio-variation-recall
-  url: https://github.com/chapmanb/bcbio.variation.recall/releases/download/v0.1.4/bcbio-variation-recall
-  md5: 18c238c26ca06bfe8ee9b85fe921efe7
+  url: https://github.com/chapmanb/bcbio.variation.recall/releases/download/v0.1.5/bcbio-variation-recall
+  md5: 1b18c7968339395cf33ea61463ce479c
 
 build:
-  number: 2
+  number: 0
   skip: False
 
 requirements:

--- a/recipes/cwltool/meta.yaml
+++ b/recipes/cwltool/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: cwltool
-  version: '1.0.20160408133555'
+  version: '1.0.20160413143011'
 
 source:
-  fn: cwltool-1.0.20160408133555.tar.gz
-  url: https://pypi.python.org/packages/source/c/cwltool/cwltool-1.0.20160408133555.tar.gz
-  md5: 2a48f0431e6c97aecfea0dbe15cb1250
+  fn: cwltool-1.0.20160413143011.tar.gz
+  url: https://pypi.python.org/packages/source/c/cwltool/cwltool-1.0.20160413143011.tar.gz
+  md5: 132c1cb03900cc6ca3c860555c5ab709
 
 build:
   number: 0


### PR DESCRIPTION
- bcbio-variation-recall: Support genotype qualities for FreeBayes
  recalls
- bcbio-nextgen: Remove requirement on scikit learn (fixes
  chapmanb/bcbio-nextgen#1337)
- bcbio-vm: Fix update to include arvados dependencies
- New versions for arvados-cwl and cwltool