### PR TITLE
Restore the build.skip = False node in fastqc 0.11.5 meta.yaml

### DIFF
--- a/recipes/fastqc/meta.yaml
+++ b/recipes/fastqc/meta.yaml
@@ -7,6 +7,7 @@ about:
 build:
   detect_binary_files_with_prefix: true
   number: 1
+  skip: False
 
 requirements:
   run:


### PR DESCRIPTION
Somehow I lost this option in the meta.yaml file before I merged.  Fixing that.