### PR TITLE
trinity: 2011 version requires java 1.6.

### DIFF
--- a/recipes/trinity/date.2011_11_26/meta.yaml
+++ b/recipes/trinity/date.2011_11_26/meta.yaml
@@ -3,8 +3,8 @@ about:
     license: "https://raw.githubusercontent.com/trinityrnaseq/trinityrnaseq/master/LICENSE.txt"
     summary: "Trinity assembles transcript sequences from Illumina RNA-Seq data"
 build:
-  number: 1
-package: 
+  number: 2
+package:
   name: trinity
   version: 'date.2011_11_26'
 source:
@@ -18,11 +18,11 @@ requirements:
   build:
     - perl-threaded
     - gcc
-    - java-jdk # [not osx]
+    - java-jdk <7 # [not osx]
   run:
     - perl-threaded
     - libgcc
-    - java-jdk # [not osx]
+    - java-jdk <7 # [not osx]
 extra:
   notes: "Trinity version date.2011_11_26 relies on a custom wrapper script, symlinked to bin/: Trinity-runner.sh. This script changes the current working directory to that of the Trinity.pl perl script before calling Trinity, so relative paths work as expected (particularly for Trinity plugins). All arguments are passed to Trinity.pl (via $@)"
 test:


### PR DESCRIPTION
Fixing some more of trinity a la #1312