### PR TITLE
F/networkxgmml

### DIFF
--- a/recipes/networkxgmml/bld.bat
+++ b/recipes/networkxgmml/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/recipes/networkxgmml/build.sh
+++ b/recipes/networkxgmml/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/recipes/networkxgmml/meta.yaml
+++ b/recipes/networkxgmml/meta.yaml
@@ -1,0 +1,63 @@
+package:
+  name: networkxgmml
+  version: "0.1.6"
+
+source:
+  fn: networkxgmml-0.1.6.tar.gz
+  url: https://pypi.python.org/packages/source/n/networkxgmml/networkxgmml-0.1.6.tar.gz
+  md5: 7a272461cf96cf6c2cebd06f2ab2ee4f
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+build:
+  # noarch_python: True
+  preserve_egg_dir: True
+  # entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - networkxgmml = networkxgmml:main
+    #
+    # Would create an entry point called networkxgmml that calls networkxgmml.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - networkx
+
+  run:
+    - python
+    - setuptools
+    - networkx
+
+# test:
+  # Python imports
+  # imports:
+
+  # commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: https://github.com/informationsea/networkxxgmml
+  license: UNKNOWN
+  summary: 'XGMML parser for networkx'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/recipes/networkxgmml/meta.yaml
+++ b/recipes/networkxgmml/meta.yaml
@@ -24,7 +24,8 @@ build:
 
   # If this is a new build for the same version, increment the build
   # number. If you do not include this key, it defaults to 0.
-  # number: 1
+  number: 1
+  skip: False
 
 requirements:
   build:


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [x] This PR adds a new recipe.
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

@bioconda/core 

NetworkX does not like the formats that cytoscape exports as.  Even when exported from cytoscape as graphml (a common format between them) networkx will not import correctly.  This library allows networkx to import graphs exported from cytoscape in the XGMML format.

This is a simple `conda skeleton pypi networkxgmml` followed by setting the meta.yaml tags: build.number / build.skip.

