### PR TITLE
Set trinity java version

### DIFF
--- a/recipes/trinity/date.2011_11_26/Trinity.pl.patch
+++ b/recipes/trinity/date.2011_11_26/Trinity.pl.patch
@@ -5,7 +5,7 @@
  ## Check Java version:
  my $java_version = `java -version 2>&1 `;
 -unless ($java_version =~ /java version \"1\.6\./) {
-+$java_version =~ /java version "1\.(\d+)\./;
++$java_version =~ /^(?:openjdk|java) version "1\.(\d+)\./;
 +unless ($1 >= 6) {
      die "Error, Trinity requires access to Java version 1.6.  Currently installed version is: $java_version";
  }

--- a/recipes/trinity/date.2011_11_26/meta.yaml
+++ b/recipes/trinity/date.2011_11_26/meta.yaml
@@ -3,7 +3,7 @@ about:
     license: "https://raw.githubusercontent.com/trinityrnaseq/trinityrnaseq/master/LICENSE.txt"
     summary: "Trinity assembles transcript sequences from Illumina RNA-Seq data"
 build:
-  number: 2
+  number: 3
 package:
   name: trinity
   version: 'date.2011_11_26'

--- a/recipes/trinity/date.2011_11_26/meta.yaml
+++ b/recipes/trinity/date.2011_11_26/meta.yaml
@@ -18,11 +18,11 @@ requirements:
   build:
     - perl-threaded
     - gcc
-    - java-jdk >=6 # [not osx]
+    - java-jdk >=6,<=8 # [not osx]
   run:
     - perl-threaded
     - libgcc
-    - java-jdk >=6 # [not osx]
+    - java-jdk >=6,<=8 # [not osx]
 extra:
   notes: "Trinity version date.2011_11_26 relies on a custom wrapper script, symlinked to bin/: Trinity-runner.sh. This script changes the current working directory to that of the Trinity.pl perl script before calling Trinity, so relative paths work as expected (particularly for Trinity plugins). All arguments are passed to Trinity.pl (via $@)"
 test:

--- a/recipes/trinity/date.2011_11_26/meta.yaml
+++ b/recipes/trinity/date.2011_11_26/meta.yaml
@@ -18,11 +18,11 @@ requirements:
   build:
     - perl-threaded
     - gcc
-    - java-jdk >=7 # [not osx]
+    - java-jdk >=6 # [not osx]
   run:
     - perl-threaded
     - libgcc
-    - java-jdk >=7 # [not osx]
+    - java-jdk >=6 # [not osx]
 extra:
   notes: "Trinity version date.2011_11_26 relies on a custom wrapper script, symlinked to bin/: Trinity-runner.sh. This script changes the current working directory to that of the Trinity.pl perl script before calling Trinity, so relative paths work as expected (particularly for Trinity plugins). All arguments are passed to Trinity.pl (via $@)"
 test:

--- a/recipes/trinity/date.2011_11_26/meta.yaml
+++ b/recipes/trinity/date.2011_11_26/meta.yaml
@@ -18,11 +18,11 @@ requirements:
   build:
     - perl-threaded
     - gcc
-    - java-jdk <7 # [not osx]
+    - java-jdk >=7 # [not osx]
   run:
     - perl-threaded
     - libgcc
-    - java-jdk <7 # [not osx]
+    - java-jdk >=7 # [not osx]
 extra:
   notes: "Trinity version date.2011_11_26 relies on a custom wrapper script, symlinked to bin/: Trinity-runner.sh. This script changes the current working directory to that of the Trinity.pl perl script before calling Trinity, so relative paths work as expected (particularly for Trinity plugins). All arguments are passed to Trinity.pl (via $@)"
 test:


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

java version specified as minimum version, and trinity patched to allow java or openjdk