### PR TITLE
trinity: 2011 patch version check for openjdk

### DIFF
--- a/recipes/trinity/date.2011_11_26/Trinity.pl.patch
+++ b/recipes/trinity/date.2011_11_26/Trinity.pl.patch
@@ -1,12 +1,11 @@
 --- Trinity.pl	2011-11-28 09:14:58.000000000 -0500
 +++ Trinity.pl	2015-12-15 16:54:00.000000000 -0500
 @@ -208,7 +208,8 @@
- 
+
  ## Check Java version:
  my $java_version = `java -version 2>&1 `;
 -unless ($java_version =~ /java version \"1\.6\./) {
-+$java_version =~ /java version "1\.(\d+)\./;
++$java_version =~ /version "1\.(\d+)\./;
 +unless ($1 >= 6) {
      die "Error, Trinity requires access to Java version 1.6.  Currently installed version is: $java_version";
  }
- 


### PR DESCRIPTION
* [ ] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

The version output of `java-jdk` package is:
```
$ java -version
openjdk version "1.6.0-77"
OpenJDK Runtime Environment (Zulu 6.11.0.2-linux64) (build 1.6.0-77-b77)
OpenJDK 64-Bit Server VM (Zulu 6.11.0.2-linux64) (build 23.77-b01, mixed mode)
```

For broadinstitute/viral-ngs#267