### PR TITLE
hap.py: allow symlinks to runner scripts

### DIFF
--- a/recipes/hap.py/build.sh
+++ b/recipes/hap.py/build.sh
@@ -4,6 +4,9 @@ sed -i.bak -e '/^configure_files.*tabix/s/^/#/' CMakeLists.txt
 sed -i.bak -e '/^configure_files.*bgzip/s/^/#/' CMakeLists.txt
 sed -i.bak -e '/^configure_files.*bcftools/s/^/#/' CMakeLists.txt
 sed -i.bak -e '/^configure_files.*samtools/s/^/#/' CMakeLists.txt
+# Allow symlinks to the main run scripts
+sed -i.bak 's/__file__/os.path.realpath(__file__)/' src/python/hap.py
+sed -i.bak 's/__file__/os.path.realpath(__file__)/' src/python/som.py
 mkdir -p build
 cd build
 cmake ../ -DCMAKE_INSTALL_PREFIX=$PREFIX -DBOOST_INCLUDEDIR=$PREFIX/include/boost -DBOOST_LIBRARYDIR=$PREFIX/lib

--- a/recipes/hap.py/meta.yaml
+++ b/recipes/hap.py/meta.yaml
@@ -7,7 +7,7 @@ source:
   url: https://github.com/Illumina/hap.py/archive/v0.2.9.tar.gz
 
 build:
-  number: 0
+  number: 1
   skip: True # [not py27 or osx]
 
 requirements:


### PR DESCRIPTION
High level scripts re-locate themselves using __file__ to
enable import of Python libraries, and this allows them
to resolve symlinks.