### PR TITLE
Update: bcbio and CWL runner dependencies

### DIFF
--- a/recipes/arvados-cwl-runner/build.sh
+++ b/recipes/arvados-cwl-runner/build.sh
@@ -4,4 +4,5 @@
 sed -i.bak -e '/cmdclass=/s/^/#/' setup.py
 sed -i.bak -e '/long_description=/s/^/#/' setup.py
 sed -i.bak "s/version='1.0'/version='$PKG_VERSION'/" setup.py
+sed -i.bak 's/cwltool==/cwltool>=/' setup.py
 $PYTHON setup.py install

--- a/recipes/arvados-cwl-runner/meta.yaml
+++ b/recipes/arvados-cwl-runner/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: arvados-cwl-runner
-  version: '1.0.20160411202258'
+  version: '1.0.20160421150319'
 
 source:
-  fn: arvados-cwl-runner-1.0.20160411202258.tar.gz
-  url: https://pypi.python.org/packages/source/a/arvados-cwl-runner/arvados-cwl-runner-1.0.20160411202258.tar.gz
-  md5: 250d609dbeefe2653f293b17f106c7ee
+  fn: arvados-cwl-runner-1.0.20160421150319.tar.gz
+  url: https://pypi.python.org/packages/de/3c/c6c162f446a2b24d2bb02aa123d8275eae3738cfda81a88cfc53a76181ae/arvados-cwl-runner-1.0.20160421150319.tar.gz
+  md5: d4b3dab22c1ba3c9a834bbcefc6fbf91
 
 build:
   number: 0

--- a/recipes/bcbio-nextgen/meta.yaml
+++ b/recipes/bcbio-nextgen/meta.yaml
@@ -3,14 +3,14 @@ package:
   version: '0.9.8a0'
 
 build:
-  number: 3
+  number: 4
   skip: True # [not py27]
 
 source:
   #fn: bcbio-nextgen-0.9.7.tar.gz
   #url: https://pypi.python.org/packages/source/b/bcbio-nextgen/bcbio-nextgen-0.9.7.tar.gz
-  fn: bcbio-nextgen-1e23d67.tar.gz
-  url: https://github.com/chapmanb/bcbio-nextgen/archive/1e23d67.tar.gz
+  fn: bcbio-nextgen-42cde9c.tar.gz
+  url: https://github.com/chapmanb/bcbio-nextgen/archive/42cde9c.tar.gz
 
 requirements:
   build:

--- a/recipes/cwltool/meta.yaml
+++ b/recipes/cwltool/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: cwltool
-  version: '1.0.20160413143011'
+  version: '1.0.20160422204730'
 
 source:
-  fn: cwltool-1.0.20160413143011.tar.gz
-  url: https://pypi.python.org/packages/source/c/cwltool/cwltool-1.0.20160413143011.tar.gz
-  md5: 132c1cb03900cc6ca3c860555c5ab709
+  fn: cwltool-1.0.20160422204730.tar.gz
+  url: https://pypi.python.org/packages/0d/50/4b92010907d8aa13edb2cd1ee53db46bc21e3fd10c48347db12d6392b8aa/cwltool-1.0.20160422204730.tar.gz
+  md5: c4a1278568c7e94502b7b6d2d9eaea3a
 
 build:
   number: 0


### PR DESCRIPTION
* [x] This PR updates an existing recipe.

Enables CWL runs using bcbio_vm without needing full bcbio install