### PR TITLE
remove skip:True [osx] for recipe flash

### DIFF
--- a/recipes/flash/meta.yaml
+++ b/recipes/flash/meta.yaml
@@ -1,7 +1,5 @@
 build:
   number: 0
-  skip: False
-
 package:
   name: flash
   version: '1.2.11'

--- a/recipes/flash/meta.yaml
+++ b/recipes/flash/meta.yaml
@@ -1,6 +1,6 @@
 build:
   number: 0
-  skip: True # [osx]
+  skip: False
 
 package:
   name: flash


### PR DESCRIPTION
* [X] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

I've confirmed that this recipe [flash] builds fine on osx64.  Per issue #1012, can we remove the skip: True for [osx]?