### PR TITLE
Add Python as runtime requirement of quast and cgat-report.

### DIFF
--- a/recipes/cgat-report/meta.yaml
+++ b/recipes/cgat-report/meta.yaml
@@ -28,6 +28,7 @@ requirements:
     - pillow
 
   run:
+    - python
     - matplotlib-venn
     - seaborn
     - ggplot

--- a/recipes/matplotlib-venn/meta.yaml
+++ b/recipes/matplotlib-venn/meta.yaml
@@ -1,6 +1,5 @@
 build:
   number: 0
-  skip: True # [osx]
 
 package:
   name: matplotlib-venn

--- a/recipes/quast/meta.yaml
+++ b/recipes/quast/meta.yaml
@@ -16,6 +16,7 @@ requirements:
   - gcc
 
   run:
+  - python
   - libgcc
   - matplotlib
 

--- a/recipes/sphinxcontrib-programoutput/meta.yaml
+++ b/recipes/sphinxcontrib-programoutput/meta.yaml
@@ -1,6 +1,5 @@
 build:
   number: 0
-  skip: True # [osx]
 
 package:
   name: sphinxcontrib-programoutput


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Omitting this causes wrong build strings.