### PR TITLE
Generalize dependency pinning using an environment variable matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,17 +56,17 @@ Bioconductor packages will be built using:
 
 Then, you can test it in the docker container with:
 
-    docker run -v `pwd`:/bioconda-recipes bioconda/bioconda-builder --packages your_package
+    docker run -v `pwd`:/bioconda-recipes bioconda/bioconda-builder --packages your_package --env-matrix scripts/env_matrix.yml
 
 To optionally build for a specific Python version, provide the `CONDA_PY`
 environmental variable. For example, to build specifically for Python 3.4:
 
-    docker run -e CONDA_PY=34 -v `pwd`:/bioconda-recipes bioconda/bioconda-builder --packages your_package
+    docker run -e CONDA_PY=34 -v `pwd`:/bioconda-recipes bioconda/bioconda-builder --packages your_package --env-matrix scripts/env_matrix.yml
 
 To optionally build and test all packages (if they don't already exist), leave off the
 package name:
 
-    docker run -v `pwd`:/tmp/conda-recipes bioconda/bioconda-builder
+    docker run -v `pwd`:/tmp/conda-recipes bioconda/bioconda-builder --env-matrix scripts/env_matrix.yml
 
 If rebuilding a previously-built package and the version number hasn't changed,
 be sure to increment the build number in `meta.yaml` (the default build number

--- a/scripts/build-packages.py
+++ b/scripts/build-packages.py
@@ -6,7 +6,7 @@ import glob
 import subprocess as sp
 import argparse
 import sys
-from collections import defaultdict
+from collections import defaultdict, Iterable
 from itertools import product, chain
 
 import networkx as nx

--- a/scripts/env_matrix.yml
+++ b/scripts/env_matrix.yml
@@ -1,0 +1,6 @@
+CONDA_PY:
+  - "2.7"
+  - "3.5"
+CONDA_BOOST: "1.60"
+CONDA_PERL: "5.22.0"
+CONDA_NPY: "110"

--- a/scripts/travis-run.sh
+++ b/scripts/travis-run.sh
@@ -4,18 +4,18 @@ set -euo pipefail
 if [[ $TRAVIS_OS_NAME = "linux" ]]
 then
     # run CentOS5 based docker container
-    docker run -e SUBDAG -e SUBDAGS -e TRAVIS_BRANCH -e TRAVIS_PULL_REQUEST -e ANACONDA_TOKEN -v `pwd`:/bioconda-recipes bioconda/bioconda-builder
+    docker run -e SUBDAG -e SUBDAGS -e TRAVIS_BRANCH -e TRAVIS_PULL_REQUEST -e ANACONDA_TOKEN -v `pwd`:/bioconda-recipes bioconda/bioconda-builder --env-matrix scripts/env_matrix.yml
 
     if [[ $SUBDAG = 0 ]]
     then
       if [[ $TRAVIS_BRANCH = "master" && "$TRAVIS_PULL_REQUEST" = false ]]
       then
         # build package documentation
-        ./scripts/build-docs.sh
+        scripts/build-docs.sh
       fi
     fi
 else
     export PATH=/anaconda/bin:$PATH
     # build packages
-    scripts/build-packages.py --repository .
+    scripts/build-packages.py --repository . --env-matrix scripts/env_matrix.yml
 fi

--- a/scripts/travis-run.sh
+++ b/scripts/travis-run.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 if [[ $TRAVIS_OS_NAME = "linux" ]]
 then
     # run CentOS5 based docker container
-    docker run -e SUBDAG -e SUBDAGS -e TRAVIS_BRANCH -e TRAVIS_PULL_REQUEST -e ANACONDA_TOKEN -v `pwd`:/bioconda-recipes bioconda/bioconda-builder --env-matrix scripts/env_matrix.yml
+    docker run -e SUBDAG -e SUBDAGS -e TRAVIS_BRANCH -e TRAVIS_PULL_REQUEST -e ANACONDA_TOKEN -v `pwd`:/bioconda-recipes bioconda/bioconda-builder --env-matrix /bioconda-recipes/scripts/env_matrix.yml
 
     if [[ $SUBDAG = 0 ]]
     then


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

This PR generalizes the pinning mechanism. In the future, we can add new environment variables for pinning recipes using `scripts/env_matrix.yml`. Our build script will automatically build all combinations. It won't build a recipe twice if it is not affected by a particular combination. E.g., non-python recipes will be build only once, although we have two python versions in our matrix.

Still, I think we should keep the number of parallel versions minimal. I would suggest to let Python be the only case where we support more than one version.