### PR TITLE
Two fixes for subdag parallelization.

### DIFF
--- a/scripts/build-packages.py
+++ b/scripts/build-packages.py
@@ -152,7 +152,12 @@ def test_recipes():
     subdags_n = int(os.environ.get("SUBDAGS", 1))
     subdag_i = int(os.environ.get("SUBDAG", 0))
     # Get connected subdags and sort by nodes
-    subdags = sorted(map(list, nx.connected_components(dag.to_undirected())))
+    if args.testonly:
+        # use each node as a subdag (they are grouped into equal sizes below)
+        subdags = sorted([[n] for n in nx.nodes(dag)])
+    else:
+        # take connected components as subdags
+        subdags = sorted(map(sorted, nx.connected_components(dag.to_undirected())))
     # chunk subdags such that we have at most args.subdags many
     if subdags_n < len(subdags):
         chunks = [[n for subdag in subdags[i::subdags_n] for n in subdag]


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

Sort each connected component lexicographically (this fixes a bug causing subdag order to differ between runs). Don't use connected components in testonly mode (resulting subdags can become too big).