### PR TITLE
Add recipe for VelvetOptimiser 2.2.5

### DIFF
--- a/recipes/perl-velvetoptimiser/MANIFEST
+++ b/recipes/perl-velvetoptimiser/MANIFEST
@@ -1,0 +1,9 @@
+Changes
+Makefile.PL
+MANIFEST
+README
+t/VelvetOpt.t
+lib/VelvetOpt/Assembly.pm
+lib/VelvetOpt/gwrap.pm
+lib/VelvetOpt/hwrap.pm
+lib/VelvetOpt/Utils.pm

--- a/recipes/perl-velvetoptimiser/Makefile.PL
+++ b/recipes/perl-velvetoptimiser/Makefile.PL
@@ -1,0 +1,14 @@
+use 5.022000;
+use ExtUtils::MakeMaker;
+# See lib/ExtUtils/MakeMaker.pm for details of how to influence
+# the contents of the Makefile that is written.
+WriteMakefile(
+    NAME              => 'VelvetOpt',
+    VERSION           => '2.2.5', # finds $VERSION, requires EU::MM from perl >= 5.5
+    PREREQ_PM         => {}, # e.g., Module::Name => 1.1
+    ABSTRACT          => 'The VelvetOptimiser is designed to run as a wrapper script for the Velvet assembler (Daniel Zerbino, EBI UK) and to assist with optimising the assembly.', # retrieve abstract from module
+    AUTHOR            => 'Simon Gladman & Torsten Seemann',
+    LICENSE           => 'gpl',
+    #Value must be from legacy list of licenses here
+    #http://search.cpan.org/perldoc?Module%3A%3ABuild%3A%3AAPI
+);

--- a/recipes/perl-velvetoptimiser/build.sh
+++ b/recipes/perl-velvetoptimiser/build.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 
-TMP_DIR=`mktemp -d`
+if [ "$(uname)" == "Darwin" ]; then
+    TMP_DIR=`mktemp -d -t 'tmpdir'`
+else
+    TMP_DIR=`mktemp -d`
+fi
+
 BUILD_DIR=${TMP_DIR}/VelvetOpt
 mkdir -p ${PREFIX}/bin
 cp VelvetOptimiser.pl ${PREFIX}/bin

--- a/recipes/perl-velvetoptimiser/build.sh
+++ b/recipes/perl-velvetoptimiser/build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+TMP_DIR=`mktemp -d`
+BUILD_DIR=${TMP_DIR}/VelvetOpt
+mkdir -p ${PREFIX}/bin
+cp VelvetOptimiser.pl ${PREFIX}/bin
+cd ${TMP_DIR}
+h2xs -AX -n VelvetOpt
+rm ${BUILD_DIR}/lib/VelvetOpt.pm
+cp -R ${SRC_DIR}/VelvetOpt ${BUILD_DIR}/lib
+cp ${RECIPE_DIR}/{MANIFEST,Makefile.PL} ${BUILD_DIR}
+cd ${BUILD_DIR}
+perl Makefile.PL INSTALLDIRS=site
+make
+make install

--- a/recipes/perl-velvetoptimiser/meta.yaml
+++ b/recipes/perl-velvetoptimiser/meta.yaml
@@ -1,0 +1,31 @@
+package:
+  name: perl-velvetoptimiser
+  version: "2.2.5"
+
+source:
+  fn: 2.2.5.tar.gz
+  url: https://github.com/tseemann/VelvetOptimiser/archive/2.2.5.tar.gz
+  md5: 66966ce03f61321a2f81a5cfb45a3be9
+  patches:
+    - perl_path.patch
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - perl-threaded
+
+  run:
+    - perl-threaded
+    - perl-bioperl >=1.4
+    - velvet >=0.7.51
+
+test:
+    commands:
+      - VelvetOptimiser.pl --version > /dev/null 2>&1
+
+about:
+  home: https://github.com/tseemann/VelvetOptimiser
+  license: GPLv2
+  summary: Automatically optimise three of Velvet's assembly parameters.

--- a/recipes/perl-velvetoptimiser/perl_path.patch
+++ b/recipes/perl-velvetoptimiser/perl_path.patch
@@ -1,0 +1,8 @@
+--- VelvetOptimiser.pl	2012-10-05 01:06:28.000000000 +0000
++++ VelvetOptimiser.pl.new	2016-05-03 20:13:32.676376334 +0000
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ #
+ #       VelvetOptimiser.pl
+ #


### PR DESCRIPTION
* [X] I have read the guidelines above.
* [X] This PR adds a new recipe.
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

This package isn't on CPAN, nor does the source repo include the needed distribution files.  In order for the install to be done in the standard way, the build recipe first creates a barebones distribution via `h2xs`.  Then the usual method can be used for the final build and install.