### PR TITLE
Sync Bowtie2 2.2.5 recipe with 2.2.8 one

### DIFF
--- a/recipes/bowtie2/2.2.5/build.sh
+++ b/recipes/bowtie2/2.2.5/build.sh
@@ -1,4 +1,30 @@
-#!/bin/sh
-make
-mv ./* $PREFIX
-chmod +x $PREFIX/*
+#!/bin/bash
+set -eu -o pipefail
+
+if [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+    make
+fi
+
+binaries="\
+bowtie2 \
+bowtie2-align-l \
+bowtie2-align-s \
+bowtie2-build \
+bowtie2-build-l \
+bowtie2-build-s \
+bowtie2-inspect \
+bowtie2-inspect-l \
+bowtie2-inspect-s \
+"
+directories="scripts"
+pythonfiles="bowtie2-build bowtie2-inspect"
+
+PY3_BUILD="${PY_VER%.*}"
+
+if [ $PY3_BUILD -eq 3 ]
+then
+    for i in $pythonfiles; do 2to3 --write $i; done
+fi
+
+for i in $binaries; do cp $i $PREFIX/bin && chmod +x $PREFIX/bin/$i; done
+for d in $directories; do cp -r $d $PREFIX/bin; done

--- a/recipes/bowtie2/2.2.5/meta.yaml
+++ b/recipes/bowtie2/2.2.5/meta.yaml
@@ -9,26 +9,33 @@ about:
     footprint is typically around 3.2 GB. Bowtie 2 supports gapped, local, and paired-end
     alignment modes.   http://bowtie-bio.sourceforge.net/bowtie2/index.shtml '
 
-build:
-  number: 1
-  skip: True # [osx]
-
 package:
   name: bowtie2
   version: 2.2.5
 
-requirements:
-    build:
-        - python
-    run:
-        - python
-        - perl-threaded
-
 source:
-  fn: bowtie2-2.2.5-source.zip
-  sha256: e22766dd9421c10e82a3e207ee1f0eb924c025b909ad5fffa36633cd7978d3b0
-  url: http://downloads.sourceforge.net/project/bowtie-bio/bowtie2/2.2.5/bowtie2-2.2.5-source.zip
+  fn: bowtie2-2.2.5-source.zip # [linux]
+  url: http://downloads.sourceforge.net/project/bowtie-bio/bowtie2/2.2.5/bowtie2-2.2.5-source.zip # [linux]
+  sha256: e22766dd9421c10e82a3e207ee1f0eb924c025b909ad5fffa36633cd7978d3b0 # [linux]
+  fn: bowtie2-2.2.5-macos-x86_64.zip # [osx]
+  url: http://downloads.sourceforge.net/project/bowtie-bio/bowtie2/2.2.5/bowtie2-2.2.5-macos-x86_64.zip # [osx]
+  sha256: 0f142477738accc73276f3e47877d54a64b6f7ac7911d0609b662adcd15374a0 # [osx]
+
+build:
+  number: 2
+
+requirements:
+  build:
+    - gcc   # [linux]
+    - python
+  run:
+    - python
+    - perl-threaded
+    - libgcc    # [linux]
 
 test:
   commands:
-    - (bowtie2 --version 2>&1) > /dev/null
+    - bowtie2 --version
+    - bowtie2-build --help
+    - bowtie2-inspect-l --help
+    - bowtie2-align-s --help

--- a/recipes/bowtie2/meta.yaml
+++ b/recipes/bowtie2/meta.yaml
@@ -1,14 +1,11 @@
 about:
-    home: 'http://bowtie-bio.sourceforge.net/bowtie2/index.shtml'
-    license: GPLv3
-    summary: Fast and sensitive read alignment
+  home: 'http://bowtie-bio.sourceforge.net/bowtie2/index.shtml'
+  license: GPLv3
+  summary: Fast and sensitive read alignment
 
 package:
-    name: bowtie2
-    version: 2.2.8
-
-build:
-  number: 2
+  name: bowtie2
+  version: 2.2.8
 
 source:
   fn: bowtie2-2.2.8-source.zip # [linux]
@@ -16,19 +13,23 @@ source:
   md5: c3d5dd807f053b9fd7cc786312e6e3fb # [linux]
   fn: bowtie2-2.2.8-macos-x86_64.zip # [osx]
   url: http://downloads.sourceforge.net/project/bowtie-bio/bowtie2/2.2.8/bowtie2-2.2.8-macos-x86_64.zip # [osx]
+  sha256: f1ed9079d5699eb123e74a749df447820422b7c8216d69f2ffb3f3487844a1b7 # [osx]
+
+build:
+  number: 2
 
 requirements:
-    build:
-        - gcc   # [linux]
-        - llvm  # [osx]
-        - python
-    run:
-        - python
-        - perl-threaded
-        - libgcc    # [linux]
+  build:
+    - gcc   # [linux]
+    - python
+  run:
+    - python
+    - perl-threaded
+    - libgcc    # [linux]
+
 test:
-    commands:
-        - bowtie2 --version
-        - bowtie2-build --help
-        - bowtie2-inspect-l --help
-        - bowtie2-align-s --help
+  commands:
+    - bowtie2 --version
+    - bowtie2-build --help
+    - bowtie2-inspect-l --help
+    - bowtie2-align-s --help


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

bowtie2 binaries were not found because they were not moved to `bin/` subdirectory.
Remove llvm requirement since OSX zip file contains already compiled binaries.