### PR TITLE
temporarily disable idr; see #1491

### DIFF
--- a/recipes/idr/meta.yaml
+++ b/recipes/idr/meta.yaml
@@ -9,7 +9,8 @@ source:
 
 build:
   number: 1
-  skip: True # [py2k or osx]
+  #skip: True # [py2k or osx]
+  skip: True  # temporarily disable until md5 issue resolved, see #1491
 
 requirements:
   build:


### PR DESCRIPTION
* [ ] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Disabling idr (mismatching md5) in order to continue debugging build issues (xref #1491)