### PR TITLE
Salmon: update to avoid NFS malloc bug

### DIFF
--- a/recipes/salmon/build.sh
+++ b/recipes/salmon/build.sh
@@ -1,8 +1,31 @@
 #!/bin/bash
 set -eu -o pipefail
 
-mkdir -p build
-sed -i 's/Boost_USE_STATIC_LIBS ON/Boost_USE_STATIC_LIBS OFF/' CMakeLists.txt
-cd build
-cmake -DCMAKE_INSTALL_PREFIX=${PREFIX} -DBOOST_ROOT=$PREFIX -DBoost_NO_SYSTEM_PATHS=ON -DBoost_DEBUG=ON ..
-make install
+# pre-built version
+if [ "$(uname)" == "Darwin" ]; then
+    outdir=$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM
+    mkdir -p $outdir
+    mkdir -p $PREFIX/bin
+    cp -r bin lib $outdir
+    ln -s $outdir/bin/salmon $PREFIX/bin
+elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+    # Custom built version running into problems with NFS segfaults
+    # https://github.com/COMBINE-lab/salmon/issues/34
+    # Download and use tcmalloc in our build to avoid
+    mkdir -p $SRC_DIR/external
+    wget -O $SRC_DIR/external/gperftools-2.5.tar.gz https://github.com/gperftools/gperftools/releases/download/gperftools-2.5/gperftools-2.5.tar.gz
+    cd $SRC_DIR/external
+    tar -xzvpf gperftools-2.5.tar.gz
+    cd gperftools-2.5
+    ./configure --prefix=$SRC_DIR/external/install
+    make install
+    # build Salmon
+    cd $SRC_DIR
+    mkdir -p build
+    # Use the tcmalloc installed above
+    sed -i 's#set (HAVE_FAST_MALLOC FALSE)#set (HAVE_FAST_MALLOC TRUE)\nset (FAST_MALLOC_LIB ${CMAKE_CURRENT_SOURCE_DIR}/external/install/lib/libtcmalloc.a)#' CMakeLists.txt
+    sed -i 's/Boost_USE_STATIC_LIBS ON/Boost_USE_STATIC_LIBS OFF/' CMakeLists.txt
+    cd build
+    cmake -DCMAKE_INSTALL_PREFIX=${PREFIX} -DBOOST_ROOT=$PREFIX -DBoost_NO_SYSTEM_PATHS=ON -DBoost_DEBUG=ON ..
+    make install
+fi

--- a/recipes/salmon/meta.yaml
+++ b/recipes/salmon/meta.yaml
@@ -1,6 +1,7 @@
 build:
   number: 2
-  skip: False
+  # XXX OSX currently failing due to problem with bundled shared libraries
+  skip: True # [osx]
   string: boost{{CONDA_BOOST}}_{{PKG_BUILDNUM}}
 
 about:

--- a/recipes/salmon/meta.yaml
+++ b/recipes/salmon/meta.yaml
@@ -1,6 +1,6 @@
 build:
-  number: 1
-  skip: True # [osx]
+  number: 2
+  skip: False
   string: boost{{CONDA_BOOST}}_{{PKG_BUILDNUM}}
 
 about:
@@ -11,8 +11,10 @@ package:
     name: salmon
     version: 0.6.0
 source:
-    fn: v0.6.0.tar.gz
-    url: https://github.com/COMBINE-lab/salmon/archive/v0.6.0.tar.gz
+  fn: SalmonBeta-0.6.0_OSX_10.11.tar.gz # [osx]
+  url: https://github.com/COMBINE-lab/salmon/releases/download/v0.6.0/SalmonBeta-0.6.0_OSX_10.11.tar.gz # [osx]
+  fn: salmon-v0.6.0.tar.gz # [linux]
+  url: https://github.com/COMBINE-lab/salmon/archive/v0.6.0.tar.gz # [linux]
 requirements:
   build:
     - boost {{CONDA_BOOST}}*


### PR DESCRIPTION
* [X] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

- Download and compile against tcmalloc to avoid segfault problems:
  Fixes chapmanb/bcbio-nextgen#1376
- Install pre-built OSX binary