### PR TITLE
updateTaxonomy.sh improvements

### DIFF
--- a/recipes/krona/2.5/build.sh
+++ b/recipes/krona/2.5/build.sh
@@ -3,3 +3,5 @@ mkdir -p $PREFIX/opt/krona
 mv ./* $PREFIX/opt/krona
 cd $PREFIX/opt/krona
 ./install.pl --prefix=$PREFIX
+ln -s $PREFIX/opt/krona/updateTaxonomy.sh $PREFIX/bin/ktUpdateTaxonomy.sh
+echo 1 > $PREFIX/opt/krona/taxonomy/placeholder

--- a/recipes/krona/2.5/meta.yaml
+++ b/recipes/krona/2.5/meta.yaml
@@ -4,7 +4,7 @@ about:
   summary: 'Krona Tools is a set of scripts to create Krona charts from several Bioinformatics
             tools as well as from text and XML files.'
 build:
-  number: 3
+  number: 4
 package:
   name: krona
   version: 2.5

--- a/recipes/krona/2.5/post-link.sh
+++ b/recipes/krona/2.5/post-link.sh
@@ -1,0 +1,14 @@
+echo "
+Krona installed.  You still need to manually update the taxonomy
+databases before Krona can generate taxonomic reports.  The update
+script is ktUpdateTaxonomy.sh.  The default location for storing
+taxonomic databases is $PREFIX/opt/krona/taxonomy
+
+If you would like the taxonomic data stored elsewhere, simply replace
+this directory with a symlink.  For example:
+
+rm -rf $PREFIX/opt/krona/taxonomy
+mkdir /path/on/big/disk/taxonomy
+ln -s /path/on/big/disk/taxonomy $PREFIX/opt/krona/taxonomy
+ktUpdateTaxonomy.sh
+" > $PREFIX/.messages.txt

--- a/recipes/krona/2.6/build.sh
+++ b/recipes/krona/2.6/build.sh
@@ -3,3 +3,18 @@ mkdir -p $PREFIX/opt/krona
 mv ./* $PREFIX/opt/krona
 cd $PREFIX/opt/krona
 ./install.pl --prefix=$PREFIX
+ln -s $PREFIX/opt/krona/updateTaxonomy.sh $PREFIX/bin/
+echo 1 > $PREFIX/opt/krona/taxonomy/placeholder
+
+echo "Krona installed.  You still need to manually call
+updateTaxonomy.sh before Krona can generate taxonomic reports.  The
+default location for storing taxonomic databases is
+$PREFIX/opt/krona/taxonomy. If you would like the taxonomic data
+stored elsewhere, simply replace this directory with a symlink to
+another directory.  For example:
+
+rm -rf $PREFIX/opt/krona/taxonomy
+mkdir /path/to/big/drive/taxonomy
+ln -s /path/to/big/drive/taxonomy $PREFIX/opt/krona/taxonomy
+updateTaxonomy.sh
+"

--- a/recipes/krona/2.6/build.sh
+++ b/recipes/krona/2.6/build.sh
@@ -3,18 +3,5 @@ mkdir -p $PREFIX/opt/krona
 mv ./* $PREFIX/opt/krona
 cd $PREFIX/opt/krona
 ./install.pl --prefix=$PREFIX
-ln -s $PREFIX/opt/krona/updateTaxonomy.sh $PREFIX/bin/
+ln -s $PREFIX/opt/krona/updateTaxonomy.sh $PREFIX/bin/ktUpdateTaxonomy.sh
 echo 1 > $PREFIX/opt/krona/taxonomy/placeholder
-
-echo "Krona installed.  You still need to manually call
-updateTaxonomy.sh before Krona can generate taxonomic reports.  The
-default location for storing taxonomic databases is
-$PREFIX/opt/krona/taxonomy. If you would like the taxonomic data
-stored elsewhere, simply replace this directory with a symlink to
-another directory.  For example:
-
-rm -rf $PREFIX/opt/krona/taxonomy
-mkdir /path/to/big/drive/taxonomy
-ln -s /path/to/big/drive/taxonomy $PREFIX/opt/krona/taxonomy
-updateTaxonomy.sh
-"

--- a/recipes/krona/2.6/meta.yaml
+++ b/recipes/krona/2.6/meta.yaml
@@ -4,7 +4,7 @@ about:
   summary: 'Krona Tools is a set of scripts to create Krona charts from several Bioinformatics
             tools as well as from text and XML files.'
 build:
-  number: 3
+  number: 4
 package:
   name: krona
   version: 2.6

--- a/recipes/krona/2.6/post-link.sh
+++ b/recipes/krona/2.6/post-link.sh
@@ -1,0 +1,14 @@
+echo "
+Krona installed.  You still need to manually update the taxonomy
+databases before Krona can generate taxonomic reports.  The update
+script is ktUpdateTaxonomy.sh.  The default location for storing
+taxonomic databases is $PREFIX/opt/krona/taxonomy
+
+If you would like the taxonomic data stored elsewhere, simply replace
+this directory with a symlink.  For example:
+
+rm -rf $PREFIX/opt/krona/taxonomy
+mkdir /path/on/big/disk/taxonomy
+ln -s /path/on/big/disk/taxonomy $PREFIX/opt/krona/taxonomy
+ktUpdateTaxonomy.sh
+" > $PREFIX/.messages.txt


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Added symlink so that updateTaxonomy.sh is accessible to user in PATH. 

Also, the default taxonomy directory is being left out during packaging, presumably b/c it is empty.  The placeholder file makes sure it is present for user after install.

I think it would be helpful if a message is emitted to user upon installation of this package.  I guess the user won't see the echo message from the build.sh script.  What is the better way to do this?  Does the meta.yaml support some kind of  "message" tag for this purpose?