### PR TITLE
Add perl-proc-fork Proc::Fork version 0.804

### DIFF
--- a/recipes/perl-exporter-tidy/bld.bat
+++ b/recipes/perl-exporter-tidy/bld.bat
@@ -1,0 +1,29 @@
+:: If it has Build.PL use that, otherwise use Makefile.PL
+IF exist Build.PL (
+    perl Build.PL
+    IF errorlevel 1 exit 1
+    Build
+    IF errorlevel 1 exit 1
+    Build test
+    :: Make sure this goes in site
+    Build install --installdirs site
+    IF errorlevel 1 exit 1
+) ELSE IF exist Makefile.PL (
+    :: Make sure this goes in site
+    perl Makefile.PL INSTALLDIRS=site
+    IF errorlevel 1 exit 1
+    make
+    IF errorlevel 1 exit 1
+    make test
+    IF errorlevel 1 exit 1
+    make install
+) ELSE (
+    ECHO 'Unable to find Build.PL or Makefile.PL. You need to modify bld.bat.'
+    exit 1
+)
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/recipes/perl-exporter-tidy/build.sh
+++ b/recipes/perl-exporter-tidy/build.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# If it has Build.PL use that, otherwise use Makefile.PL
+if [ -f Build.PL ]; then
+    perl Build.PL
+    ./Build
+    ./Build test
+    # Make sure this goes in site
+    ./Build install --installdirs site
+elif [ -f Makefile.PL ]; then
+    # Make sure this goes in site
+    perl Makefile.PL INSTALLDIRS=site
+    make
+    make test
+    make install
+else
+    echo 'Unable to find Build.PL or Makefile.PL. You need to modify build.sh.'
+    exit 1
+fi
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/recipes/perl-exporter-tidy/meta.yaml
+++ b/recipes/perl-exporter-tidy/meta.yaml
@@ -1,0 +1,45 @@
+package:
+  name: perl-exporter-tidy
+  version: "0.08"
+
+source:
+  fn: Exporter-Tidy-0.08.tar.gz
+  url: https://cpan.metacpan.org/authors/id/J/JU/JUERD/Exporter-Tidy-0.08.tar.gz
+  md5: 025866016bd6ca361052acb30bcf07f4
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+# build:
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+  # skip: False
+
+requirements:
+  build:
+    - perl-threaded >=5.22.0
+
+  run:
+    - perl-threaded >=5.22.0
+
+test:
+  # Perl 'use' tests
+  imports:
+    - Exporter::Tidy
+
+  # You can also put a file called run_test.pl (or run_test.py) in the recipe
+  # that will be run at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: http://metacpan.org/pod/Exporter-Tidy
+  license: unknown
+  summary: 'Another way of exporting symbols'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/recipes/perl-proc-fork/bld.bat
+++ b/recipes/perl-proc-fork/bld.bat
@@ -1,0 +1,29 @@
+:: If it has Build.PL use that, otherwise use Makefile.PL
+IF exist Build.PL (
+    perl Build.PL
+    IF errorlevel 1 exit 1
+    Build
+    IF errorlevel 1 exit 1
+    Build test
+    :: Make sure this goes in site
+    Build install --installdirs site
+    IF errorlevel 1 exit 1
+) ELSE IF exist Makefile.PL (
+    :: Make sure this goes in site
+    perl Makefile.PL INSTALLDIRS=site
+    IF errorlevel 1 exit 1
+    make
+    IF errorlevel 1 exit 1
+    make test
+    IF errorlevel 1 exit 1
+    make install
+) ELSE (
+    ECHO 'Unable to find Build.PL or Makefile.PL. You need to modify bld.bat.'
+    exit 1
+)
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/recipes/perl-proc-fork/build.sh
+++ b/recipes/perl-proc-fork/build.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# If it has Build.PL use that, otherwise use Makefile.PL
+if [ -f Build.PL ]; then
+    perl Build.PL
+    ./Build
+    ./Build test
+    # Make sure this goes in site
+    ./Build install --installdirs site
+elif [ -f Makefile.PL ]; then
+    # Make sure this goes in site
+    perl Makefile.PL INSTALLDIRS=site
+    make
+    make test
+    make install
+else
+    echo 'Unable to find Build.PL or Makefile.PL. You need to modify build.sh.'
+    exit 1
+fi
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/recipes/perl-proc-fork/meta.yaml
+++ b/recipes/perl-proc-fork/meta.yaml
@@ -1,0 +1,46 @@
+package:
+  name: perl-proc-fork
+  version: "0.804"
+
+source:
+  fn: Proc-Fork-0.804.tar.gz
+  url: https://cpan.metacpan.org/authors/id/A/AR/ARISTOTLE/Proc-Fork-0.804.tar.gz
+  md5: 0fd512eb21f365a11d9ff7de3b77a624
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+# build:
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - perl-threaded >=5.22.0
+    - perl-exporter-tidy
+
+  run:
+    - perl-threaded >=5.22.0
+    - perl-exporter-tidy
+
+test:
+  # Perl 'use' tests
+  imports:
+    - Proc::Fork
+
+  # You can also put a file called run_test.pl (or run_test.py) in the recipe
+  # that will be run at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: http://github.com/ap/Proc-Fork
+  license: perl_5
+  summary: 'simple, intuitive interface to the fork() system call'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [x] This PR adds a new recipe.
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

I'm working on adding the dependencies for iDES (https://cappseq.stanford.edu/). See also: https://github.com/bioconda/bioconda-recipes/pull/1540. If preferred I can make a single PR with all the dependencies.

- Make a recipe for `Proc::Fork` version 0.804
- Make a recipe for the dependency of `Proc::Fork`, `Exporter::Tidy` version 0.08

Suggested reviewers: @bioconda/core 