### PR TITLE
openbabel: fixed tests

### DIFF
--- a/recipes/openbabel/2.3.2_7d621d9/build.sh
+++ b/recipes/openbabel/2.3.2_7d621d9/build.sh
@@ -24,3 +24,7 @@ make install
 
 cd scripts/python
 OPENBABEL_INCLUDE_DIRS=$(pwd)/..:$PREFIX/include/openbabel-2.0 python setup.py install
+
+$PYTHON $SRC_DIR/test/test_pybel.py
+$PYTHON $SRC_DIR/test/testbindings.py
+$PYTHON $SRC_DIR/test/testexample.py

--- a/recipes/openbabel/2.3.2_7d621d9/meta.yaml
+++ b/recipes/openbabel/2.3.2_7d621d9/meta.yaml
@@ -5,6 +5,7 @@ package:
 source:
   url: https://github.com/openbabel/openbabel/archive/7d621d9c9f2f07a1f105896a765bf2afa22e6028.zip
   fn: 7d621d9c9f2f07a1f105896a765bf2afa22e6028.zip
+  md5: 0bead4b3c1a26264bac3c98e752ba8a8
 
   patches:
     - include-dirs.patch
@@ -12,7 +13,7 @@ source:
     - fix_data_path.diff
 
 build:
-  number: 0
+  number: 1
   detect_binary_files_with_prefix: true
   skip:
     - [win]
@@ -39,10 +40,6 @@ test:
   imports:
     - openbabel
     - pybel
-  commands:
-    - cd $SRC_DIR/test ; python test_pybel.py
-    - cd $SRC_DIR/test ; python testbindings.py
-    - cd $SRC_DIR/test ; python testexample.py
 
 about:
     home: http://www.openbabel.org/


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Those tests should better go in `build.sh`. During bulk testing the `$SRC_DIR` is not present and thus the test suite fails.