### PR TITLE
use gnu ftpmirror url

### DIFF
--- a/recipes/autoconf/meta.yaml
+++ b/recipes/autoconf/meta.yaml
@@ -8,7 +8,7 @@ package:
 
 source:
   fn: autoconf-2.69.tar.gz
-  url: http://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz
+  url: http://ftpmirror.gnu.org/autoconf/autoconf-2.69.tar.gz
   md5: 82d05e03b93e45f5a39b828dc9c6c29b
 
 requirements:

--- a/recipes/datamash/1.0.6/meta.yaml
+++ b/recipes/datamash/1.0.6/meta.yaml
@@ -16,7 +16,7 @@ requirements:
 source:
   fn: datamash-1.0.6.tar.gz
   sha256: 0154c25c45b5506b6d618ca8e18d0ef093dac47946ac0df464fb21e77b504118
-  url: http://ftp.gnu.org/gnu/datamash/datamash-1.0.6.tar.gz
+  url: http://ftpmirror.gnu.org/datamash/datamash-1.0.6.tar.gz
 test:
   commands:
     - datamash --help &> /dev/null

--- a/recipes/datamash/1.1.0/meta.yaml
+++ b/recipes/datamash/1.1.0/meta.yaml
@@ -16,7 +16,7 @@ requirements:
 source:
   fn: datamash-1.1.0.tar.gz
   sha256: a9e5acc86af4dd64c7ac7f6554718b40271aa67f7ff6e9819bdd919a25904bb0
-  url: http://ftp.gnu.org/gnu/datamash/datamash-1.1.0.tar.gz
+  url: http://ftpmirror.gnu.org/datamash/datamash-1.1.0.tar.gz
 test:
   commands:
     - datamash --help &> /dev/null

--- a/recipes/gawk/meta.yaml
+++ b/recipes/gawk/meta.yaml
@@ -6,7 +6,7 @@ build:
   skip: False
 source:
   fn: gawk-4.1.3.tar.xz
-  url: http://ftp.gnu.org/gnu/gawk/gawk-4.1.3.tar.xz
+  url: http://ftpmirror.gnu.org/gawk/gawk-4.1.3.tar.xz
 requirements:
   build:
   run:

--- a/recipes/gettext/meta.yaml
+++ b/recipes/gettext/meta.yaml
@@ -11,7 +11,7 @@ package:
 source:
   fn: gettext-0.18.3.tar.gz # [osx]
   md5: 3fa4236c41b7e837355de144210207ec # [osx]
-  url: http://ftp.gnu.org/gnu/gettext/gettext-0.18.3.tar.gz # [osx]
+  url: http://ftpmirror.gnu.org/gettext/gettext-0.18.3.tar.gz # [osx]
 requirements:
   build:
     - gcc # [osx]

--- a/recipes/glpk/meta.yaml
+++ b/recipes/glpk/meta.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   fn: glpk-4.57.tar.gz
-  url: http://ftp.gnu.org/gnu/glpk/glpk-4.57.tar.gz
+  url: http://ftpmirror.gnu.org/glpk/glpk-4.57.tar.gz
   md5: 237531a54f73155842f8defe51aedb0f
 
 build:

--- a/recipes/m4/meta.yaml
+++ b/recipes/m4/meta.yaml
@@ -8,7 +8,7 @@ package:
 
 source:
   fn: m4-1.4.17.tar.gz
-  url: http://ftp.gnu.org/gnu/m4/m4-1.4.17.tar.gz
+  url: http://ftpmirror.gnu.org/m4/m4-1.4.17.tar.gz
   md5: a5e9954b1dae036762f7b13673a2cf76
 
 test:

--- a/recipes/ocrad/0.21/meta.yaml
+++ b/recipes/ocrad/0.21/meta.yaml
@@ -6,7 +6,7 @@ build:
   #skip: True # [osx]
 source:
   fn: ocrad-0.21.tar.gz
-  url: http://mirror.checkdomain.de/gnu/ocrad/ocrad-0.21.tar.gz
+  url: http://ftpmirror.gnu.org/ocrad/ocrad-0.21.tar.gz
 requirements:
   build:
     - gcc   [linux]

--- a/recipes/parallel/meta.yaml
+++ b/recipes/parallel/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: 20150922
 
 source:
-  url: http://gnu.mirror.iweb.com/parallel/parallel-20150922.tar.bz2
+  url: http://ftpmirror.gnu.org/parallel/parallel-20150922.tar.bz2
   fn: parallel-20150922.tar.bz2
 
 build:


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

to download gnu software we should use the ftpmirror.gnu.org url because it will automatically
pick the closest mirror on-the-fly.

I don't think I need to bump the build number in this case, @bioconda/core comments ?