### PR TITLE
fix include.patch, xref #1606

### DIFF
--- a/scripts/ucsc/include.patch
+++ b/scripts/ucsc/include.patch
@@ -2,10 +2,10 @@
 +++ kent/src/inc/common.mk
 @@ -17,7 +17,7 @@
  endif
- 
+
  HG_DEFS=-D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_GNU_SOURCE -DMACHTYPE_${MACHTYPE}
 -HG_INC+=-I../inc -I../../inc -I../../../inc -I../../../../inc -I../../../../../inc
-+HG_INC+=-I../inc -I../../inc -I../../../inc -I../../../../inc -I../../../../../inc -I /anaconda/include
- 
++HG_INC+=-I../inc -I../../inc -I../../../inc -I../../../../inc -I../../../../../inc -I ${PREFIX}/include
+
  # to check for Mac OSX Darwin specifics:
  UNAME_S := $(shell uname -s)


### PR DESCRIPTION
* [ ] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

Fixes the include.patch generated by ucsc utils helper script, see #1606 
