### PR TITLE
CrossMap: added samtools dependency

### DIFF
--- a/recipes/crossmap/meta.yaml
+++ b/recipes/crossmap/meta.yaml
@@ -27,6 +27,7 @@ requirements:
     - cython
     - numpy
     - setuptools
+    - samtools ==0.1.19
     - nose
     - pysam ==0.6
     - bx-python

--- a/recipes/crossmap/meta.yaml
+++ b/recipes/crossmap/meta.yaml
@@ -8,7 +8,7 @@ source:
     - setup_remove_deps.diff
 
 build:
-    number: 2
+    number: 3
 
     # CrossMap is very particular about Python version.
     skip: True # [not py27 or osx]


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

This is an update for CrossMap which uses samtools  under the hood. Samtools has changed certain arguments in 1.0.0 and are incompatible with CrossMap, which is the reason I fixed the version.