### PR TITLE
fix logic in selecting java version

### DIFF
--- a/recipes/picard/picard.sh
+++ b/recipes/picard/picard.sh
@@ -19,7 +19,8 @@ JAR_DIR=$DIR
 
 java=java
 
-if [ -z "${JAVA_HOME:=}" ]; then
+# if JAVA_HOME is set (non-empty), use it. Otherwise keep "java"
+if [ ! -z "${JAVA_HOME:=}" ]; then
   if [ -e "$JAVA_HOME/bin/java" ]; then
       java="$JAVA_HOME/bin/java"
   fi


### PR DESCRIPTION
* [X] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Previously java would be set if JAVA_HOME was UNset, which I assume was not the intended behaviour. This would cause picard to fail if the system installation was not the correct version to use. 

For me, picard 2.3.0 used `/bin/java` which was version 1.7.x instead of the version installed by conda.