### PR TITLE
vphaser2 dylib isolation

### DIFF
--- a/recipes/vphaser2/build.sh
+++ b/recipes/vphaser2/build.sh
@@ -2,17 +2,28 @@
 
 set -e -x -o pipefail
 
-mkdir -p $PREFIX/bin/
+BINARY_HOME=$PREFIX/bin
+PACKAGE_HOME=$PREFIX/opt/$PKG_NAME-$PKG_VERSION
+
+mkdir -p $BINARY_HOME
+
+mkdir -p $PREFIX/bin
+mkdir -p $PACKAGE_HOME
 
 if [ "$(uname)" == "Darwin" ]; then
     echo "Copying in *.dylib for OSX"
     mkdir -p $PREFIX/lib/
-    cp $SRC_DIR/V-Phaser-2.0/MacOSX/*.dylib $PREFIX/lib
-    cp $SRC_DIR/V-Phaser-2.0/MacOSX/variant_caller $PREFIX/bin
+    # store the dylib with the binary so it does not
+    # collide with the dylibs provided by libgcc
+    cp $SRC_DIR/V-Phaser-2.0/MacOSX/*.dylib $PACKAGE_HOME
+    cp $SRC_DIR/V-Phaser-2.0/MacOSX/variant_caller $PACKAGE_HOME
 elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
     echo "Platform: Linux"
-
-    cp $SRC_DIR/V-Phaser-2.0/linux64/variant_caller $PREFIX/bin
+    cp $SRC_DIR/V-Phaser-2.0/linux64/variant_caller $PACKAGE_HOME
 fi
-chmod +x $PREFIX/bin/variant_caller
-ln -s $PREFIX/bin/variant_caller $PREFIX/bin/vphaser2
+
+cd $PACKAGE_HOME && chmod +x variant_caller
+
+# create links for either common name
+ln -s $PACKAGE_HOME/variant_caller $PREFIX/bin/variant_caller
+ln -s $PACKAGE_HOME/variant_caller $PREFIX/bin/vphaser2

--- a/recipes/vphaser2/build.sh
+++ b/recipes/vphaser2/build.sh
@@ -13,10 +13,12 @@ mkdir -p $PACKAGE_HOME
 if [ "$(uname)" == "Darwin" ]; then
     echo "Copying in *.dylib for OSX"
     mkdir -p $PREFIX/lib/
-    # store the dylib with the binary so it does not
+    # store the dylib with the binary (with custom name) so it does not
     # collide with the dylibs provided by libgcc
     cp $SRC_DIR/V-Phaser-2.0/MacOSX/*.dylib $PACKAGE_HOME
+    mv $PACKAGE_HOME/libgomp.1.dylib $PACKAGE_HOME/libgomp_custom.1.dylib
     cp $SRC_DIR/V-Phaser-2.0/MacOSX/variant_caller $PACKAGE_HOME
+    install_name_tool -change '@executable_path/libgomp.1.dylib' "@executable_path/libgomp_custom.1.dylib" $PACKAGE_HOME/variant_caller
 elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
     echo "Platform: Linux"
     cp $SRC_DIR/V-Phaser-2.0/linux64/variant_caller $PACKAGE_HOME

--- a/recipes/vphaser2/meta.yaml
+++ b/recipes/vphaser2/meta.yaml
@@ -8,7 +8,7 @@ package:
 source:
   git_url: https://github.com/broadinstitute/v-phaser2.git #[osx or linux64]
 build:
-  number: 2
+  number: 3
   rpaths:
     - "$PREFIX/opt/$PKG_NAME-$PKG_VERSION"
     - lib/

--- a/recipes/vphaser2/meta.yaml
+++ b/recipes/vphaser2/meta.yaml
@@ -8,8 +8,10 @@ package:
 source:
   git_url: https://github.com/broadinstitute/v-phaser2.git #[osx or linux64]
 build:
-  number: 1
-  skip: False
+  number: 2
+  rpaths:
+    - "$PREFIX/opt/$PKG_NAME-$PKG_VERSION"
+    - lib/
 requirements:
   build:
     - bamtools


### PR DESCRIPTION
previously, libgomp.1.dylib provided by vphaser2 was copied into the
conda env lib/, but it can conflict with the dylib provided by libgcc,
which supports different symbols