### PR TITLE
add (installer for) gatk-protected (full, license-restricted GATK)

### DIFF
--- a/recipes/gatk/build.sh
+++ b/recipes/gatk/build.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+BINARY_HOME=$PREFIX/bin
+PACKAGE_HOME=$PREFIX/opt/$PKG_NAME-$PKG_VERSION
+
+mkdir -p $PREFIX/bin
+mkdir -p $PACKAGE_HOME
+
+cp $RECIPE_DIR/gatk.sh $PACKAGE_HOME/gatk.sh
+
+SOURCE_FILE=$RECIPE_DIR/gatk-register.sh
+DEST_FILE=$PACKAGE_HOME/gatk-register.sh
+
+
+echo "#!/bin/bash" > $DEST_FILE
+echo "PKG_NAME=$PKG_NAME" >> $DEST_FILE
+echo "PKG_VERSION=$PKG_VERSION" >> $DEST_FILE
+
+cat $SOURCE_FILE >> $DEST_FILE
+
+chmod +x $PACKAGE_HOME/*.sh
+
+ln -s $PACKAGE_HOME/gatk.sh $PREFIX/bin/gatk
+ln -s $PACKAGE_HOME/gatk.sh $PREFIX/bin/GenomeAnalysisTK
+ln -s $PACKAGE_HOME/gatk-register.sh $PREFIX/bin/gatk-register

--- a/recipes/gatk/gatk-register.sh
+++ b/recipes/gatk/gatk-register.sh
@@ -1,0 +1,91 @@
+
+# Note: $PKG_* variables are inserted above this line by the build script.
+
+
+# Find original directory of bash script, resovling symlinks
+# http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in/246128#246128
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+    DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+    SOURCE="$(readlink "$SOURCE")"
+    [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+ENV_PREFIX="$(dirname $(dirname $DIR))"
+
+
+function print_license_notice(){
+    echo ""
+    echo "  Due to license restrictions, this recipe cannot distribute "
+    echo "  and install GATK directly. To fully install GATK, you must "
+    echo "  download a licensed copy of GATK from the Broad Institute: "
+    echo "    https://www.broadinstitute.org/gatk/download/ "
+    echo "  and run (after installing this package):"
+    echo "    gatk-register /path/to/GenomeAnalysisTK[-$PKG_VERSION.tar.bz2|.jar], "
+    echo "   This will copy GATK into your conda environment."
+}
+
+function print_usage(){
+    echo "  Usage: $(basename $0) /path/to/GenomeAnalysisTK[-$PKG_VERSION.tar.bz2|.jar]"
+}
+
+function check_version(){
+    # exits if version does not match version defined in conda package
+    jar_version=$(java -jar $1 --version | grep -oEi '[0-9]\.[0-9]')
+    if [[ "$jar_version" != "$PKG_VERSION" ]]; then
+        echo "The version of the jar specified, $jar_version, does not match the version expected by conda: $PKG_VERSION"
+        exit 1
+    else
+        echo "jar file specified matches expected version"
+    fi    
+}
+
+if [[ "$#" -ne 1 ]]; then
+    if ! $(java -jar $ENV_PREFIX/opt/$PKG_NAME-$PKG_VERSION/GenomeAnalysisTK.jar --version &> /dev/null); then
+        echo "  It looks like GATK has not yet been installed."
+        echo ""
+        print_usage
+        print_license_notice
+        exit 1
+    else
+        echo "  It looks like GATK is already installed in your conda environment."
+        echo "  Run:"
+        echo "      gatk"
+        echo "    (or)"
+        echo "      GenomeAnalysisTK"
+        exit 0
+    fi
+fi
+
+echo "ENV_PREFIX $ENV_PREFIX"
+
+file_ext=$(echo $1 | sed -nE 's/.*.(tar.bz2|jar)/\1/p')
+archive_base=$(echo "$(basename $1)" | cut -d'.' -f-1)
+
+if [[ "$file_ext" != "jar" && "$file_ext" != "tar.bz2" ]];then
+    echo "Extension specifed is not expected: $(basename $1)"
+    print_usage
+    exit 1
+fi
+
+echo "Processing $(basename $1) as *.$file_ext"
+
+mkdir -p $ENV_PREFIX/opt/$PKG_NAME-$PKG_VERSION/
+
+if [[ "$file_ext" == "jar" ]]; then
+    # copy in to conda env opt/
+    check_version $1
+    echo "Copying $(basename $1) to $ENV_PREFIX/opt/$PKG_NAME-$PKG_VERSION"
+    cp $1 $ENV_PREFIX/opt/$PKG_NAME-$PKG_VERSION
+elif [[ "$file_ext" == "tar.bz2" ]]; then
+    # extract archive and copy in
+    echo "Extracting $(basename $1)"
+
+    mkdir /tmp/gatk
+    cd /tmp/gatk
+    tar -vxjf $1
+    
+    check_version ./GenomeAnalysisTK.jar
+    echo "Moving $(basename $1) to $ENV_PREFIX/opt/$PKG_NAME-$PKG_VERSION"
+    mv ./GenomeAnalysisTK.jar $ENV_PREFIX/opt/$PKG_NAME-$PKG_VERSION/
+fi

--- a/recipes/gatk/gatk.sh
+++ b/recipes/gatk/gatk.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# GATK (protected) executable shell script
+set -eu -o pipefail
+
+set -o pipefail
+export LC_ALL=en_US.UTF-8
+
+# Find original directory of bash script, resovling symlinks
+# http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in/246128#246128
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+    DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+    SOURCE="$(readlink "$SOURCE")"
+    [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+
+JAR_DIR=$DIR
+
+java=java
+
+# if JAVA_HOME is set (non-empty), use it. Otherwise keep "java"
+if [ ! -z "${JAVA_HOME:=}" ]; then
+  if [ -e "$JAVA_HOME/bin/java" ]; then
+      java="$JAVA_HOME/bin/java"
+  fi
+fi
+
+# extract memory and system property Java arguments from the list of provided arguments
+# http://java.dzone.com/articles/better-java-shell-script
+default_jvm_mem_opts="-Xms512m -Xmx1g"
+jvm_mem_opts=""
+jvm_prop_opts=""
+pass_args=""
+for arg in "$@"; do
+    case $arg in
+        '-D'*)
+            jvm_prop_opts="$jvm_prop_opts $arg"
+            ;;
+        '-XX'*)
+            jvm_prop_opts="$jvm_prop_opts $arg"
+            ;;
+         '-Xm'*)
+            jvm_mem_opts="$jvm_mem_opts $arg"
+            ;;
+         *)
+            pass_args="$pass_args $arg"
+            ;;
+    esac
+done
+
+if [ "$jvm_mem_opts" == "" ]; then
+    jvm_mem_opts="$default_jvm_mem_opts"
+fi
+
+if [[ ! -f "$JAR_DIR/GenomeAnalysisTK.jar" ]]; then
+  echo "GATK jar file not found. Have you run \"gatk-register\"?"
+  exit 1
+fi
+
+pass_arr=($pass_args)
+if [[ ${pass_arr[0]:=} == org* ]]
+then
+    eval "$java" $jvm_mem_opts $jvm_prop_opts -cp "$JAR_DIR/GenomeAnalysisTK.jar" $pass_args
+else
+    eval "$java" $jvm_mem_opts $jvm_prop_opts -jar "$JAR_DIR/GenomeAnalysisTK.jar" $pass_args
+fi
+exit

--- a/recipes/gatk/meta.yaml
+++ b/recipes/gatk/meta.yaml
@@ -1,6 +1,6 @@
 about:
-  home: https://github.com/chapmanb/gatk
-  license: MIT
+  home: https://www.broadinstitute.org/gatk/
+  license: https://www.broadinstitute.org/gatk/about/#licensing
   summary: The full Genome Analysis Toolkit (GATK) framework, license restricted.
 
 package:

--- a/recipes/gatk/meta.yaml
+++ b/recipes/gatk/meta.yaml
@@ -1,0 +1,20 @@
+about:
+  home: https://github.com/chapmanb/gatk
+  license: MIT
+  summary: The full Genome Analysis Toolkit (GATK) framework, license restricted.
+
+package:
+  name: gatk
+  version: '3.6'
+
+build:
+  number: 1
+  skip: False
+
+requirements:
+  run:
+    - java-jdk >=7,<8
+    - bzip2 # needed by gatk-register to extract GATK archive
+
+extra:
+  notes: Due to license restrictions, this recipe cannot distribute and install GATK directly. To fully install GATK, you must download a licensed copy of GATK from the Broad Institute (https://www.broadinstitute.org/gatk/download/), install this package, and call "gatk-register /path/to/GenomeAnalysisTK[-$PKG_VERSION.tar.bz2|.jar]", which will copy GATK into your conda environment.

--- a/recipes/gatk/meta.yaml
+++ b/recipes/gatk/meta.yaml
@@ -13,7 +13,7 @@ build:
 
 requirements:
   run:
-    - java-jdk >=7,<8
+    - java-jdk >=7
     - bzip2 # needed by gatk-register to extract GATK archive
 
 extra:


### PR DESCRIPTION
The license for the full version of GATK prevents it from being redistributed. This adds a recipe for a GATK package that provides the commands “gatk” and “gatk-register”. The former is a thin wrapper around the gatk.jar file, and the latter is an installer that copies a user-supplied GenomeAnalysisTK.jar file (or unpacked tar.bz2 file) to the conda environment. It includes helpful messages that instruct the user on what to do.