### PR TITLE
arvados-python-client: ensure proper pycurl version

### DIFF
--- a/recipes/arvados-python-client/meta.yaml
+++ b/recipes/arvados-python-client/meta.yaml
@@ -8,7 +8,7 @@ source:
   md5: bfbd2c16dbfacd2af9b64d5534abdb70
 
 build:
-  number: 0
+  number: 1
   skip: True # [not py27]
 
 requirements:
@@ -18,7 +18,7 @@ requirements:
     - ciso8601
     - google-api-python-client
     - httplib2
-    - pycurl
+    - pycurl <7.21.5,>=7.19.5.1
     - python-gflags
     - requests
     - rsa
@@ -31,7 +31,7 @@ requirements:
     - ciso8601
     - google-api-python-client
     - httplib2
-    - pycurl
+    - pycurl <7.21.5,>=7.19.5.1
     - python-gflags
     - requests
     - rsa


### PR DESCRIPTION
* [X] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

arvados-python-client requires a specific version of pycurl and default
install pulls in more recent version. Thanks to @lijiayong