### PR TITLE
Fix version info and update from 1.1.8 to 1.1.9 for CIRCexplorer

### DIFF
--- a/recipes/circexplorer/meta.yaml
+++ b/recipes/circexplorer/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: "1.1.9"
 
 build:
-  number: 1
+  number: 0
 
 source:
   fn: CIRCexplorer-1.1.9.tar.gz

--- a/recipes/circexplorer/meta.yaml
+++ b/recipes/circexplorer/meta.yaml
@@ -8,7 +8,7 @@ build:
 source:
   fn: CIRCexplorer-1.1.9.tar.gz
   url: https://github.com/YangLab/CIRCexplorer/archive/1.1.9.tar.gz
-  md5: 5e1001a0bdba98b535dcfda57e374388
+  md5: 0e97caf8359683534aa4b22a5fda10c1
 
 requirements:
   build:

--- a/recipes/circexplorer/meta.yaml
+++ b/recipes/circexplorer/meta.yaml
@@ -1,14 +1,14 @@
 package:
   name: circexplorer
-  version: "0.1"
+  version: "1.1.9"
 
 build:
   number: 1
 
 source:
-  fn: CIRCexplorer-1.1.8.tar.gz
-  url: https://github.com/YangLab/CIRCexplorer/archive/1.1.8.tar.gz
-  md5: 432816f7a67c9cb2eea35298d8366cba
+  fn: CIRCexplorer-1.1.9.tar.gz
+  url: https://github.com/YangLab/CIRCexplorer/archive/1.1.9.tar.gz
+  md5: 5e1001a0bdba98b535dcfda57e374388
 
 requirements:
   build:


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

* Fix version info using real version of CIRCexplorer
* Upgrade from CIRCexplorer 1.1.8 to 1.1.9