### PR TITLE
Update: GATK for 3.6 and bcbio-prioritize

### DIFF
--- a/recipes/bcbio-prioritize/meta.yaml
+++ b/recipes/bcbio-prioritize/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: bcbio-prioritize
-  version: 0.0.7
+  version: 0.0.8
 
 source:
   fn: bcbio-prioritize
-  url: https://github.com/chapmanb/bcbio.prioritize/releases/download/v0.0.7/bcbio-prioritize
+  url: https://github.com/chapmanb/bcbio.prioritize/releases/download/v0.0.8/bcbio-prioritize
 
 build:
   number: 0

--- a/recipes/gatk-framework/gatk-framework
+++ b/recipes/gatk-framework/gatk-framework
@@ -6,7 +6,17 @@
 set -o pipefail
 export LC_ALL=en_US.UTF-8
 
-JAR_DIR="$(cd "$(dirname "$0")" && pwd -P)"
+# Find original directory of bash script, resovling symlinks
+# http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in/246128#246128
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+    DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+    SOURCE="$(readlink "$SOURCE")"
+    [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+
+JAR_DIR=$DIR
 
 java=java
 if [ -e "$JAVA_HOME/bin/java" ]
@@ -40,9 +50,6 @@ done
 if [ "$jvm_mem_opts" == "" ]; then
     jvm_mem_opts="$default_jvm_mem_opts"
 fi
-
-echo "GATK is free for academic and non commercial use."
-echo "For more information please see https://www.broadinstitute.org/gatk/about/#licensing"
 
 pass_arr=($pass_args)
 if [[ ${pass_arr[0]} == org* ]]

--- a/recipes/gatk-framework/meta.yaml
+++ b/recipes/gatk-framework/meta.yaml
@@ -5,19 +5,19 @@ about:
 
 package:
   name: gatk-framework
-  version: '3.5.21'
+  version: '3.6.24'
 
 build:
   number: 0
   skip: False
 
 source:
-  fn: gatk-framework-3.5-21.tar.gz
-  url: https://github.com/chapmanb/gatk/releases/download/v3.5-21-framework/gatk-framework-3.5-21.tar.gz
+  fn: gatk-framework-3.6-24.tar.gz
+  url: https://github.com/chapmanb/gatk/releases/download/v3.6-24-framework/gatk-framework-3.6-24.tar.gz
 
 requirements:
   run:
-    - java-jdk >=7,<8
+    - java-jdk >=8,<9
 
 test:
     commands:

--- a/recipes/gatk/meta.yaml
+++ b/recipes/gatk/meta.yaml
@@ -13,7 +13,7 @@ build:
 
 requirements:
   run:
-    - java-jdk >=7
+    - java-jdk >=8,<9
     - bzip2 # needed by gatk-register to extract GATK archive
 
 extra:


### PR DESCRIPTION
* [X] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

- Updates gatk-framework and gatk for 3.6 release, which requires Java 8
  (chapmanb/bcbio-nextgen#1420)
- Update bcbio-prioritize with fixes for VCF and BED annotations.