### PR TITLE
gatk: Use anaconda java for gatk-register

### DIFF
--- a/recipes/gatk/gatk-register.sh
+++ b/recipes/gatk/gatk-register.sh
@@ -12,6 +12,8 @@ while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symli
 done
 DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 ENV_PREFIX="$(dirname $(dirname $DIR))"
+# Use Java installed with Anaconda to ensure correct version
+JAVA="$ENV_PREFIX/bin/java"
 
 
 function print_license_notice(){
@@ -31,7 +33,7 @@ function print_usage(){
 
 function check_version(){
     # exits if version does not match version defined in conda package
-    jar_version=$(java -jar $1 --version | grep -oEi '[0-9]\.[0-9]')
+    jar_version=$(${JAVA} -jar $1 --version | grep -oEi '[0-9]\.[0-9]')
     if [[ "$jar_version" != "$PKG_VERSION" ]]; then
         echo "The version of the jar specified, $jar_version, does not match the version expected by conda: $PKG_VERSION"
         exit 1
@@ -41,7 +43,7 @@ function check_version(){
 }
 
 if [[ "$#" -ne 1 ]]; then
-    if ! $(java -jar $ENV_PREFIX/opt/$PKG_NAME-$PKG_VERSION/GenomeAnalysisTK.jar --version &> /dev/null); then
+    if ! $(${JAVA} -jar $ENV_PREFIX/opt/$PKG_NAME-$PKG_VERSION/GenomeAnalysisTK.jar --version &> /dev/null); then
         echo "  It looks like GATK has not yet been installed."
         echo ""
         print_usage

--- a/recipes/gatk/meta.yaml
+++ b/recipes/gatk/meta.yaml
@@ -8,7 +8,7 @@ package:
   version: '3.6'
 
 build:
-  number: 1
+  number: 2
   skip: False
 
 requirements:


### PR DESCRIPTION
* [X] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Ensures gatk-register uses the anaconda install java so it gets the
correct version, otherwise can fail with Java errors if 1.7 in
PATH before anaconda. (cc @tomkinsc)