### PR TITLE
Aria2 1.23.0

### DIFF
--- a/recipes/aria2/build.sh
+++ b/recipes/aria2/build.sh
@@ -2,6 +2,15 @@
 
 export PKG_CONFIG_PATH=${PREFIX}/lib/pkgconfig
 
-./configure --prefix=${PREFIX} --with-libz --with-libxml2 --with-libssh2 --with-libcares --with-sqlite3
+if [ `uname` == Darwin ]; then
+    # Needed for C++11 support.
+    export MACOSX_DEPLOYMENT_TARGET=10.7
+    # Needed to avoid the linker seeing the system-installed libxml2
+    export LD_LIBRARY_PATH=${PREFIX}/lib
+    ./configure --prefix=${PREFIX} --with-appletls --with-libz --with-libxml2 --with-libssh2 --with-libcares --with-sqlite3
+else
+    ./configure --prefix=${PREFIX} --with-openssl --with-libz --with-libxml2 --with-libssh2 --with-libcares --with-sqlite3
+fi
+
 make -j 2
 make install

--- a/recipes/aria2/build.sh
+++ b/recipes/aria2/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+export PKG_CONFIG_PATH=${PREFIX}/lib/pkgconfig
+
+./configure --prefix=${PREFIX} --with-libz --with-libxml2 --with-libssh2 --with-libcares --with-sqlite3
+make -j 2
+make install

--- a/recipes/aria2/meta.yaml
+++ b/recipes/aria2/meta.yaml
@@ -1,0 +1,40 @@
+package:
+  name: aria2
+  version: "1.23.0"
+
+source:
+  fn: aria2-1.23.0.tar.gz
+  url: https://github.com/aria2/aria2/releases/download/release-1.23.0/aria2-1.23.0.tar.gz
+  md5: 0a28844c8db660d6a20d8a34ae4b0f37
+
+build:
+  number: 0
+  skip: True # [osx]
+
+requirements:
+    build:
+      - gcc
+      - zlib
+      - openssl
+      - sqlite
+      - libssh2
+      - c-ares
+      - libxml2
+        
+    run:
+      - libgcc
+      - zlib
+      - openssl
+      - sqlite
+      - libssh2
+      - c-ares
+      - libxml2
+ 
+test:
+  commands:
+    - aria2c -v > /dev/null
+
+about:
+  home: https://aria2.github.io/
+  summary: aria2 is a lightweight multi-protocol & multi-source, cross platform download utility operated in command-line. It supports HTTP/HTTPS, FTP, SFTP, BitTorrent and Metalink.
+  license: GPLv2

--- a/recipes/aria2/meta.yaml
+++ b/recipes/aria2/meta.yaml
@@ -9,27 +9,29 @@ source:
 
 build:
   number: 0
-  skip: True # [osx]
 
 requirements:
     build:
-      - gcc
+      - gcc # [linux]
+      - llvm # [osx]
+      - pkg-config # [osx]
       - zlib
-      - openssl
+      - openssl # [linux]
       - sqlite
       - libssh2
       - c-ares
       - libxml2
         
     run:
-      - libgcc
+      - libgcc # [linux]
       - zlib
-      - openssl
+      - openssl # [linux]
       - sqlite
       - libssh2
       - c-ares
       - libxml2
  
+
 test:
   commands:
     - aria2c -v > /dev/null

--- a/recipes/c-ares/build.sh
+++ b/recipes/c-ares/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+./configure --prefix=${PREFIX}
+make
+make install

--- a/recipes/c-ares/meta.yaml
+++ b/recipes/c-ares/meta.yaml
@@ -22,7 +22,7 @@ test:
   commands:
     - test -f ${PREFIX}/lib/libcares.a
     - test -f ${PREFIX}/lib/libcares.so.2.1.0 # [linux]
-    - test -f ${PREFIX}/lib/libcares.2.dynlib # [osx]
+    - test -f ${PREFIX}/lib/libcares.2.dylib # [osx]
     - test -f ${PREFIX}/include/ares.h
 
 about:

--- a/recipes/c-ares/meta.yaml
+++ b/recipes/c-ares/meta.yaml
@@ -1,0 +1,31 @@
+package:
+  name: c-ares
+  version: "1.11.0"
+
+source:
+  fn: c-ares-1.11.0.tar.gz
+  url: http://c-ares.haxx.se/download/c-ares-1.11.0.tar.gz
+  md5: d5c6d522cfc54bb6f215a0b7912d46be
+
+build:
+  number: 0
+
+requirements:
+    build:
+      - gcc # [linux]
+      - llvm # [osx]
+        
+    run:
+      - libgcc # [linux]
+ 
+test:
+  commands:
+    - test -f ${PREFIX}/lib/libcares.a
+    - test -f ${PREFIX}/lib/libcares.so.2.1.0 # [linux]
+    - test -f ${PREFIX}/lib/libcares.2.dynlib # [osx]
+    - test -f ${PREFIX}/include/ares.h
+
+about:
+  home: http://c-ares.haxx.se/
+  summary:  c-ares is a C library for asynchronous DNS requests (including name resolves)
+  license: MIT

--- a/recipes/libssh2/build.sh
+++ b/recipes/libssh2/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+export C_INCLUDE_PATH="$PREFIX/include"
+export LIBRARY_PATH="$PREFIX/lib"
+
+./configure --prefix=${PREFIX} --with-openssl --with-libz --with-libssl-prefix=${PRERIX} --with-libz-prefix=${PREFIX}
+make
+make install

--- a/recipes/libssh2/meta.yaml
+++ b/recipes/libssh2/meta.yaml
@@ -1,0 +1,36 @@
+package:
+  name: libssh2
+  version: "1.7.0"
+
+source:
+  fn: libssh2-1.7.0.tar.gz
+  url: https://www.libssh2.org/download/libssh2-1.7.0.tar.gz
+  md5: b01662a210e94cccf2f76094db7dac5c
+
+build:
+  number: 0
+
+requirements:
+    build:
+      - gcc # [linux]
+      - llvm # [osx]
+      - zlib
+      - openssl
+        
+    run:
+      - libgcc # [linux]
+      - zlib
+      - openssl 
+
+test:
+  commands:
+    - test -f ${PREFIX}/lib/libssh2.a
+    - test -f ${PREFIX}/lib/libssh2.so.1.0.1 # [linux]
+    - test -f ${PREFIX}/lib/libssh2.1.dylib # [osx]
+    - test -f ${PREFIX}/include/libssh2.h
+
+about:
+  home: https://www.libssh2.org/
+  summary: libssh2 is a client-side C library implementing the SSH2 protocol
+  license: Custom OSS
+  license_file: COPYING


### PR DESCRIPTION
* [X] I have read the guidelines above.
* [X] This PR adds a new recipe.
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

This adds the `aria2` package, and needed dependencies `libssh2` and `c-ares`.  

Question for @bioconda/core - is there a recommended way to do testing for library only packages?  The `libssh2` and `c-ares` packages are both library-only.  What I've done previously is just test to see if the main libs and header files exist, so I did that here as well.  Just wondering if there's an alternate way that's preferred?