### PR TITLE
Updates: ipython-cluster-helper, snpeff, bcbio

### DIFF
--- a/recipes/bcbio-nextgen/meta.yaml
+++ b/recipes/bcbio-nextgen/meta.yaml
@@ -3,15 +3,15 @@ package:
   version: '0.9.9a0'
 
 build:
-  number: 1
+  number: 2
   skip: True # [not py27]
 
 source:
   #fn: bcbio-nextgen-0.9.8.tar.gz
   #url: https://pypi.python.org/packages/2c/ff/da0d27f43a045fbef606b20c311dd6003fa17964964907b88e0cafb38cfd/bcbio-nextgen-0.9.8.tar.gz
   #md5: 9c7ed62caef5363a0ed95d6a9c390396
-  fn: bcbio-nextgen-24d46d1.tar.gz
-  url: https://github.com/chapmanb/bcbio-nextgen/archive/24d46d1.tar.gz
+  fn: bcbio-nextgen-d3d670a.tar.gz
+  url: https://github.com/chapmanb/bcbio-nextgen/archive/d3d670a.tar.gz
 
 requirements:
   build:

--- a/recipes/ipython-cluster-helper/meta.yaml
+++ b/recipes/ipython-cluster-helper/meta.yaml
@@ -1,12 +1,13 @@
 package:
   name: ipython-cluster-helper
-  version: 0.5.1
+  version: 0.5.2
 
 source:
-  fn: ipython-cluster-helper-0.5.1.tar.gz
-  url: https://pypi.python.org/packages/source/i/ipython-cluster-helper/ipython-cluster-helper-0.5.1.tar.gz
+  fn: ipython-cluster-helper-0.5.2.tar.gz
+  url: https://pypi.python.org/packages/97/df/8a9b0ef7657344bdad15ba9bc187c8d5182f27d5afda51c493a961d0f9a1/ipython-cluster-helper-0.5.2.tar.gz
 
 build:
+  number: 0
   skip: True # [not py27]
 
 requirements:
@@ -18,7 +19,7 @@ requirements:
   run:
     - python
     - setuptools
-    - ipyparallel
+    - ipyparallel >=4.0,<5.0
     - pyzmq
     - netifaces
 

--- a/recipes/snpeff/meta.yaml
+++ b/recipes/snpeff/meta.yaml
@@ -5,16 +5,15 @@ about:
 
 package:
   name: snpeff
-  version: '4.2'
+  version: '4.3'
 
 build:
   number: 0
   skip: False
 
 source:
-  fn: snpEff_v4_2_core.zip
-  md5: 25ae5b062d57072de6cfb8677ca3625a
-  url: http://downloads.sourceforge.net/project/snpeff/snpEff_v4_2_core.zip
+  fn: snpEff_v4_3_0.zip
+  url: http://downloads.sourceforge.net/project/snpeff/snpEff_development.zip
 
 requirements:
   run:


### PR DESCRIPTION
* [X] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

- ipython-cluster-helper fixes issue on SGE.
- snpeff update to development 4.3 version
- bcbio fixes issues for CWL generation and parallelization