### PR TITLE
add script to copy novoalign license file to conda bin/

### DIFF
--- a/recipes/novoalign/build.sh
+++ b/recipes/novoalign/build.sh
@@ -4,3 +4,10 @@ set -eu
 mkdir -p $PREFIX/bin
 chmod a+x *novo*
 cp isnovoindex novo2paf novoalign novoalignCS novoalignCSMPI novoalignMPI novobarcode novoindex novomethyl novope2bed.pl novorun.pl novosort novoutil $PREFIX/bin
+
+SOURCE_FILE=$RECIPE_DIR/novoalign-license-register.sh
+DEST_FILE=$PACKAGE_HOME/novoalign-license-register
+
+cp "$SOURCE_FILE" "$DEST_FILE"
+
+chmod +x $DEST_FILE

--- a/recipes/novoalign/build.sh
+++ b/recipes/novoalign/build.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 set -eu
 
-mkdir -p $PREFIX/bin
+PACKAGE_HOME=$PREFIX/bin
+
+mkdir -p $PACKAGE_HOME
 chmod a+x *novo*
-cp isnovoindex novo2paf novoalign novoalignCS novoalignCSMPI novoalignMPI novobarcode novoindex novomethyl novope2bed.pl novorun.pl novosort novoutil $PREFIX/bin
+cp isnovoindex novo2paf novoalign novoalignCS novoalignCSMPI novoalignMPI novobarcode novoindex novomethyl novope2bed.pl novorun.pl novosort novoutil $PACKAGE_HOME
 
 SOURCE_FILE=$RECIPE_DIR/novoalign-license-register.sh
 DEST_FILE=$PACKAGE_HOME/novoalign-license-register

--- a/recipes/novoalign/meta.yaml
+++ b/recipes/novoalign/meta.yaml
@@ -9,7 +9,7 @@ source:
   md5: c878a3398f47055988514c2a37e8c85a # [osx]
 
 build:
-  number: 0
+  number: 1
   skip: False
 
 requirements:

--- a/recipes/novoalign/meta.yaml
+++ b/recipes/novoalign/meta.yaml
@@ -9,7 +9,7 @@ source:
   md5: c878a3398f47055988514c2a37e8c85a # [osx]
 
 build:
-  number: 1
+  number: 2
   skip: False
 
 requirements:

--- a/recipes/novoalign/novoalign-license-register.sh
+++ b/recipes/novoalign/novoalign-license-register.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Find original directory of bash script, resovling symlinks
+# http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in/246128#246128
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+    DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+    SOURCE="$(readlink "$SOURCE")"
+    [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+ENV_PREFIX="$(dirname $DIR)"
+
+LICENSE_DESTINATION="$ENV_PREFIX/bin/novoalign.lic"
+
+function print_usage(){
+    echo "This will copy a Novoalign license file (novoalign.lic) to the conda environment."
+    echo "  Usage: $(basename $0) /path/to/novoalign.lic"
+}
+
+if [[ "$#" -ne 1 ]]; then
+    if [[ ! -e "$LICENSE_DESTINATION" ]]; then
+        echo "  It looks like a Novoalign license has not yet been installed."
+        echo ""
+        print_usage
+        exit 1
+    else
+        echo "  It looks like a Novoalign license is already installed in your conda environment."
+        echo "  Run:"
+        echo "      novoalign"
+        exit 0
+    fi
+fi
+
+file_ext=$(echo $1 | sed -nE 's/.*.(lic)/\1/p')
+
+if [[ "$file_ext" != "lic" ]]; then
+    echo "Extension specifed is not expected: $(basename $1)"
+    print_usage
+    exit 1
+fi
+
+echo "Copying $(basename $1) to $ENV_PREFIX/bin"
+cp "$1" "$LICENSE_DESTINATION"
+echo "...done!"


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

Novoalign expects a license file, “novoalign.lic” to coexist in the same directory as the main novoalign binary (for multi-threaded operation. single-thread operation is allowed without a license file). This adds a script, `novoalign-register-license`, to copy in a license file to the conda `bin/` directory.