### PR TITLE
gatk post-link script for user alert

### DIFF
--- a/recipes/gatk/meta.yaml
+++ b/recipes/gatk/meta.yaml
@@ -8,7 +8,7 @@ package:
   version: '3.6'
 
 build:
-  number: 2
+  number: 3
   skip: False
 
 requirements:

--- a/recipes/gatk/post-link.sh
+++ b/recipes/gatk/post-link.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# call gatk-register which will print its usage statement
+$PREFIX/gatk-register

--- a/recipes/gatk/post-link.sh
+++ b/recipes/gatk/post-link.sh
@@ -2,3 +2,6 @@
 
 # call gatk-register which will print its usage statement
 $PREFIX/gatk-register
+
+# exit 0 so the install is a success
+exit 0 


### PR DESCRIPTION
add post-link script to gatk package to call gatk-register and alert the user after install that additional manual actions are required before gatk is fully installed (the user must download a licensed copy of gatk and pass its path to gatk-register)