### PR TITLE
Add Python version to buildstring.

### DIFF
--- a/recipes/merfishtools/meta.yaml
+++ b/recipes/merfishtools/meta.yaml
@@ -5,9 +5,9 @@ package:
   version: {{version}}
 
 build:
-  number: 0
+  number: 1
   skip: True # [not py3k or osx]
-  string: "gsl{{CONDA_GSL}}_{{PKG_BUILDNUM}}"
+  string: "py{{CONDA_PY}}_gsl{{CONDA_GSL}}_{{PKG_BUILDNUM}}"
 
 source:
   fn: merfishtools-{{version}}.tar.gz

--- a/recipes/prosic/meta.yaml
+++ b/recipes/prosic/meta.yaml
@@ -3,8 +3,8 @@ package:
   version: "1.0"
 
 build:
-  number: 0
-  string: "gsl{{CONDA_GSL}}_gmp{{CONDA_GMP}}_{{PKG_BUILDNUM}}"
+  number: 1
+  string: "py{{CONDA_PY}}_gsl{{CONDA_GSL}}_gmp{{CONDA_GMP}}_{{PKG_BUILDNUM}}"
   skip: True # [not py3k]
 
 source:


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

This should fix merfishtools and prosic conflicts occuring in combination with Python 3.5 environments.