### PR TITLE
Update: FreeBayes, snpEff, simple_sv_annotation

### DIFF
--- a/recipes/freebayes/build.sh
+++ b/recipes/freebayes/build.sh
@@ -5,6 +5,10 @@ if [ "$(uname)" == "Darwin" ]; then
    sed -i.bak 's/LDFLAGS=-Wl,-s/LDFLAGS=/' vcflib/smithwaterman/Makefile
 fi
 
+# bamtools/cmake for zlib
+export CPLUS_INCLUDE_PATH=${PREFIX}/include
+export LIBRARY_PATH=${PREFIX}/lib
+
 mkdir -p bamtools/build
 cd bamtools/build
 cmake ..
@@ -12,7 +16,7 @@ cd ../..
 
 cd src
 make autoversion
-make
+make CPPFLAGS="-I$PREFIX/include" LDFLAGS="-L$PREFIX/lib"
 cd ..
 
 mkdir -p $PREFIX/bin

--- a/recipes/freebayes/meta.yaml
+++ b/recipes/freebayes/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: freebayes
-  version: '1.0.2'
+  version: '1.0.2.29'
 
 source:
   git_url: https://github.com/ekg/freebayes.git
-  git_rev: 0cb2697
+  git_rev: 41c1313
 
 build:
   number: 0
@@ -13,7 +13,11 @@ build:
 requirements:
   build:
     - cmake
+    - zlib
+    - python
   run:
+    - zlib
+    - python
 
 test:
   commands:

--- a/recipes/simple_sv_annotation/meta.yaml
+++ b/recipes/simple_sv_annotation/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: simple_sv_annotation
-  version: 2015.11.24
+  version: 2016.06.15
 
 source:
 
-  fn: simple_sv_annotation-dd376c8.tar.gz
+  fn: simple_sv_annotation-ea46c8c.tar.gz
   url: https://github.com/AstraZeneca-NGS/simple_sv_annotation/archive/dd376c8.tar.gz
 
 build:

--- a/recipes/snpeff/meta.yaml
+++ b/recipes/snpeff/meta.yaml
@@ -8,12 +8,12 @@ package:
   version: '4.3'
 
 build:
-  number: 0
+  number: 1
   skip: False
 
 source:
-  fn: snpEff_v4_3_0.zip
-  url: http://downloads.sourceforge.net/project/snpeff/snpEff_development.zip
+  fn: snpEff_v4_3_1.zip
+  url: http://downloads.sourceforge.net/project/snpeff/snpEff_v4_3_core.zip
 
 requirements:
   run:


### PR DESCRIPTION
* [X] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

- FreeBayes update to latest development with fixes for gVCF output
  (correct reference bases) and VCF-specification ready GQ values
  (integers)
- snpEff update to latest 4.3 development version with SV fusion
  support.
- simple_sv_annotation handles problematic exon annotations