### PR TITLE
Fix build string of mapsplice.

### DIFF
--- a/recipes/mapsplice/meta.yaml
+++ b/recipes/mapsplice/meta.yaml
@@ -14,7 +14,7 @@ source:
 build:
   number: 1
   skip: True # [osx]
-  string: "ncurses{{CONDA_NCURSES}}_{{PKG_BUILDNUM}}"
+  string: "py{{CONDA_PY}}_ncurses{{CONDA_NCURSES}}_{{PKG_BUILDNUM}}"
 
 requirements:
   build:


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

If a package depends on Python and has a custom build string, it has to be ensured that `py{{CONDA_PY}}` is contained in the build string. Otherwise, this can result in a dependency conflict because Python is automatically pinned to the minor version.