### PR TITLE
update htseq build

### DIFF
--- a/recipes/htseq/meta.yaml
+++ b/recipes/htseq/meta.yaml
@@ -9,7 +9,7 @@ source:
 
 build:
   preserve_egg_dir: True
-  number: 0
+  number: 1
   skip: True # [not py27]
 
 requirements:


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

importing current HTSeq was giving libfortran issues; htseq recipe was originally created using old bioconda-build. Hopefully rebuilding the same version on the recent builder will fix this...?

The problem is that

```bash
conda create -n htseq-test -c bioconda htseq
source activate htseq-test
python -c 'import HTSeq'
```
gives

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/anaconda2/envs/htseq_test/lib/python2.7/site-packages/HTSeq/__init__.py", line 9, in <module>
    from _HTSeq import *
  File "numpy.pxd", line 155, in init HTSeq._HTSeq (src/_HTSeq.c:34392)
  File "/anaconda2/envs/htseq_test/lib/python2.7/site-packages/numpy/__init__.py", line 137, in <module>
    import add_newdocs
  File "/anaconda2/envs/htseq_test/lib/python2.7/site-packages/numpy/add_newdocs.py", line 9, in <module>
    from numpy.lib import add_newdoc
  File "/anaconda2/envs/htseq_test/lib/python2.7/site-packages/numpy/lib/__init__.py", line 13, in <module>
    from polynomial import *
  File "/anaconda2/envs/htseq_test/lib/python2.7/site-packages/numpy/lib/polynomial.py", line 17, in <module>
    from numpy.linalg import eigvals, lstsq, inv
  File "/anaconda2/envs/htseq_test/lib/python2.7/site-packages/numpy/linalg/__init__.py", line 48, in <module>
    from linalg import *
  File "/anaconda2/envs/htseq_test/lib/python2.7/site-packages/numpy/linalg/linalg.py", line 23, in <module>
    from numpy.linalg import lapack_lite
ImportError: libgfortran.so.1: cannot open shared object file: No such file or directory
```


