### PR TITLE
Fix htseq version

### DIFF
--- a/recipes/htseq/meta.yaml
+++ b/recipes/htseq/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: htseq
-  version: !!str 0.6.1p1
+  version: "0.6.1.post1"
 
 source:
   fn: HTSeq-0.6.1p1.tar.gz
@@ -9,7 +9,7 @@ source:
 
 build:
   preserve_egg_dir: True
-  number: 1
+  number: 0
   skip: True # [not py27]
 
 requirements:


### PR DESCRIPTION
* [ ] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

`0.6.1p1` is not a valid PEP-386 version, so conda doesn't see it as newer than `0.6.1`. As a result, `conda install htseq` installs `htseq ==0.6.1` which has an older numpy build pinned to `numpy ==1.7.1` which in turn causes libgfortran errors (see https://github.com/ContinuumIO/anaconda-issues/issues/686 for details on that).

This changes the version to `0.6.1.post1` to be seen as newer than `0.6.1` (e.g., see [here](https://www.python.org/dev/peps/pep-0386/#the-new-versioning-algorithm), and confirmed with `verlib`).