### PR TITLE
omit krona from viral-ngs recipe for now

### DIFF
--- a/recipes/viral-ngs/meta.yaml
+++ b/recipes/viral-ngs/meta.yaml
@@ -33,7 +33,7 @@ requirements:
     - bmtagger ==3.101
     - last ==719
     - gatk
-    - krona ==2.6.1
+    #- krona ==2.6.1
     - kraken-all # [linux]
     - mafft ==7.221
     - mummer ==3.23
@@ -66,7 +66,7 @@ requirements:
     - bmtagger ==3.101
     - last ==719
     - gatk
-    - krona ==2.6.1
+    #- krona ==2.6.1
     - kraken-all # [linux]
     - mafft ==7.221
     - mummer ==3.23


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

omit krona from viral-ngs recipe until upstream tags a new release, since viral-ngs applies custom patches to updateTaxonomy.sh