### PR TITLE
Update: GATK and gvcf_regions

### DIFF
--- a/recipes/gatk/gatk-register.sh
+++ b/recipes/gatk/gatk-register.sh
@@ -42,7 +42,7 @@ function check_version(){
     fi    
 }
 
-if [[ "$#" -ne 1 ]]; then
+if [[ "$#" -lt 1 ]]; then
     if ! $(${JAVA} -jar $ENV_PREFIX/opt/$PKG_NAME-$PKG_VERSION/GenomeAnalysisTK.jar --version &> /dev/null); then
         echo "  It looks like GATK has not yet been installed."
         echo ""
@@ -76,18 +76,23 @@ mkdir -p $ENV_PREFIX/opt/$PKG_NAME-$PKG_VERSION/
 
 if [[ "$file_ext" == "jar" ]]; then
     # copy in to conda env opt/
-    check_version $1
+    if [[ "$2" != "--noversioncheck" ]]; then
+      check_version $1
+    fi
     echo "Copying $(basename $1) to $ENV_PREFIX/opt/$PKG_NAME-$PKG_VERSION"
     cp $1 $ENV_PREFIX/opt/$PKG_NAME-$PKG_VERSION
 elif [[ "$file_ext" == "tar.bz2" ]]; then
     # extract archive and copy in
-    echo "Extracting $(basename $1)"
+    abspath_tarball="$(cd "$(dirname "$1")"; pwd)/$(basename "$1")"
+    echo "Extracting $(basename $abspath_tarball)"
 
     mkdir /tmp/gatk
     cd /tmp/gatk
-    tar -vxjf $1
+    tar -vxjf $abspath_tarball
     
-    check_version ./GenomeAnalysisTK.jar
-    echo "Moving $(basename $1) to $ENV_PREFIX/opt/$PKG_NAME-$PKG_VERSION"
+    if [[ "$2" != "--noversioncheck" ]]; then
+      check_version ./GenomeAnalysisTK.jar
+    fi
+    echo "Moving $(basename $abspath_tarball) to $ENV_PREFIX/opt/$PKG_NAME-$PKG_VERSION"
     mv ./GenomeAnalysisTK.jar $ENV_PREFIX/opt/$PKG_NAME-$PKG_VERSION/
 fi

--- a/recipes/gatk/gatk.sh
+++ b/recipes/gatk/gatk.sh
@@ -16,8 +16,9 @@ done
 DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
 JAR_DIR=$DIR
-
-java=java
+ENV_PREFIX="$(dirname $(dirname $DIR))"
+# Use Java installed with Anaconda to ensure correct version
+java="$ENV_PREFIX/bin/java"
 
 # if JAVA_HOME is set (non-empty), use it. Otherwise keep "java"
 if [ ! -z "${JAVA_HOME:=}" ]; then

--- a/recipes/gatk/meta.yaml
+++ b/recipes/gatk/meta.yaml
@@ -8,7 +8,7 @@ package:
   version: '3.6'
 
 build:
-  number: 4
+  number: 5
   skip: False
 
 requirements:

--- a/recipes/gvcf-regions/meta.yaml
+++ b/recipes/gvcf-regions/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: gvcf-regions
-  version: '2016.05.24'
+  version: '2016.06.21'
 
 source:
-  fn: gvcf_regions-d87d108.tar.gz
-  url: https://github.com/lijiayong/gvcf_regions/archive/d87d108.tar.gz
+  fn: gvcf_regions-f6d2dba.tar.gz
+  url: https://github.com/lijiayong/gvcf_regions/archive/f6d2dba.tar.gz
 
 build:
   number: 0


### PR DESCRIPTION
* [X] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

- gatk: Fixes for gatk-register -- ensure we have full path to tar.bz2
  input and allow use of non-versioned tarballs like nightlies with
  --noversioncheck parameter. Fixes for gatk -- use the anaconda
  installed java by default.
- gvcf_regions: Fix bug with 0 based elements in Platypus gVCF output