### PR TITLE
Convert freebayes python scripts for Python 3 using 2to3.

### DIFF
--- a/recipes/freebayes/build.sh
+++ b/recipes/freebayes/build.sh
@@ -19,6 +19,15 @@ make autoversion
 make CPPFLAGS="-I$PREFIX/include" LDFLAGS="-L$PREFIX/lib"
 cd ..
 
+pythonfiles="scripts/fasta_generate_regions.py scripts/coverage_to_regions.py"
+
+PY3_BUILD="${PY_VER%.*}"
+
+if [ $PY3_BUILD -eq 3 ]
+then
+    for i in $pythonfiles; do 2to3 --write $i; done
+fi
+
 mkdir -p $PREFIX/bin
 cp bin/freebayes $PREFIX/bin
 cp scripts/freebayes-parallel $PREFIX/bin

--- a/recipes/freebayes/meta.yaml
+++ b/recipes/freebayes/meta.yaml
@@ -7,7 +7,7 @@ source:
   git_rev: 41c1313
 
 build:
-  number: 0
+  number: 1
   skip: False
 
 requirements:


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

This PR modifies the freebayes build script to convert its two python scripts for Python 3 using 2to3. This allows freebayes-parallel to be used under Python 3.