### PR TITLE
Add OSX support for pear.

### DIFF
--- a/recipes/pear/meta.yaml
+++ b/recipes/pear/meta.yaml
@@ -11,7 +11,6 @@ source:
   url: http://sco.h-its.org/exelixis/web/software/pear/files/pear-0.9.6-src.tar.gz
 build:
   number: 1
-  skip: True # [osx]
 requirements:
   build:
     - pkgconfig


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Removes skip in meta.yaml to add support for pear under Mac OS X. Not clear for me why the skip was added, as building under OSX works fine here.