### PR TITLE
Bump DOSE version to 2.10.6.

### DIFF
--- a/recipes/bioconductor-dose/meta.yaml
+++ b/recipes/bioconductor-dose/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: bioconductor-dose
-  version: 2.8.3
+  version: 2.10.6
 source:
-  fn: DOSE_2.8.3.tar.gz
-  url: http://bioconductor.org/packages/release/bioc/src/contrib/DOSE_2.8.3.tar.gz
-  md5: 9bd036a04898f4a2beb786acb207eea8
+  fn: DOSE_2.10.6.tar.gz
+  url: http://bioconductor.org/packages/release/bioc/src/contrib/DOSE_2.10.6.tar.gz
+  md5: ea27afcd886bd08fabbe67107bd4277f
 build:
   number: 0
   rpaths:


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

This bumps DOSE to 2.10.6 to prepare to bump clusterProfileR up to a more recent version.