### PR TITLE
Bump clusterprofiler to 3.0.4. Enable OSX builds.

### DIFF
--- a/recipes/bioconductor-clusterprofiler/meta.yaml
+++ b/recipes/bioconductor-clusterprofiler/meta.yaml
@@ -1,13 +1,12 @@
 package:
   name: bioconductor-clusterprofiler
-  version: 2.4.3
+  version: 3.0.4
 source:
-  fn: clusterProfiler_2.4.3.tar.gz
-  url: http://bioconductor.org/packages/release/bioc/src/contrib/clusterProfiler_2.4.3.tar.gz
-  md5: 3db664f806e380de993bbb671fe6077a
+  fn: clusterProfiler_3.0.4.tar.gz
+  url: http://bioconductor.org/packages/release/bioc/src/contrib/clusterProfiler_3.0.4.tar.gz
+  md5: f4156869dfc5fe62279dc141ccf2466c
 build:
-  number: 0
-  skip: True # [osx]
+  number: 1
   rpaths:
     - lib/R/lib/
     - lib/
@@ -18,24 +17,28 @@ requirements:
     - bioconductor-go.db
     - bioconductor-gosemsim
     - bioconductor-keggrest
+    - bioconductor-gseabase
     - bioconductor-qvalue
     - bioconductor-topgo
     - 'r >=3.1.0'
     - r-ggplot2
     - r-magrittr
     - r-plyr
+    - r-tidyr
   run:
     - bioconductor-annotationdbi
     - bioconductor-dose
     - bioconductor-go.db
     - bioconductor-gosemsim
     - bioconductor-keggrest
+    - bioconductor-gseabase
     - bioconductor-qvalue
     - bioconductor-topgo
     - 'r >=3.1.0'
     - r-ggplot2
     - r-magrittr
     - r-plyr
+    - r-tidyr
 test:
   commands:
     - '$R -e "library(''clusterProfiler'')"'


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

This a) bumps clusterprofiler up to 3.0.4, fixing some missing dependencies and b) enables it to be installed on OSX.