### PR TITLE
Update: Toil and cwltool to support CWL v1.0

### DIFF
--- a/recipes/bd2k-python-lib/meta.yaml
+++ b/recipes/bd2k-python-lib/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: bd2k-python-lib
-  version: "1.14a1.dev28"
+  version: "1.14a1.dev29"
 
 source:
-  fn: bd2k-python-lib-1.14a1.dev28.tar.gz
-  url: https://pypi.python.org/packages/f6/0f/c7155779534def4fe7a33c2ee1b5951c12993b26b5a7e6c4097ce9f0cfe5/bd2k-python-lib-1.14a1.dev28.tar.gz
-  md5: 6a4c41c2b5f4f58854e5238b9a135408
+  fn: bd2k-python-lib-1.14a1.dev29.tar.gz
+  url: https://pypi.python.org/packages/cc/3c/95e9da6a948f2c61f41c12ca68c6294a95971fb5315600a6d1d5b8f98330/bd2k-python-lib-1.14a1.dev29.tar.gz
+  md5: fbb36b80943e7cc1104c5779410dbcd7
 
 build:
   number: 0

--- a/recipes/cwltool/meta.yaml
+++ b/recipes/cwltool/meta.yaml
@@ -1,14 +1,14 @@
 package:
   name: cwltool
-  version: '1.0.20160427142240'
+  version: '1.0.20160714182449'
 
 source:
-  fn: cwltool-1.0.20160427142240.tar.gz
-  url: https://pypi.python.org/packages/b6/4e/5d015bbc4eef04dcd5411e19e4a2788c6a38ae260fd8fe14b34672464932/cwltool-1.0.20160427142240.tar.gz
-  md5: 4f5ac0d494ddd559c7267374ecb971eb
+  fn: cwltool-1.0.20160714182449.tar.gz
+  url: https://pypi.python.org/packages/ca/e9/925d71a466a9eed4c6b23911c7e07b309481fc705380d560316df8a3a949/cwltool-1.0.20160714182449.tar.gz
+  md5: e3c4c0e2de8b664215e70a639096a93f
 
 build:
-  number: 1
+  number: 0
   skip: True # [not py27]
 
 requirements:
@@ -16,21 +16,23 @@ requirements:
     - python
     - setuptools
     - requests
-    - pyyaml
+    - ruamel.yaml
     - rdflib
     - rdflib-jsonld
     - shellescape
-    - schema-salad
+    - schema-salad ==1.14.20160708181155 
+    - typing
 
   run:
     - python
     - setuptools
     - requests
-    - pyyaml
+    - ruamel.yaml
     - rdflib
     - rdflib-jsonld
     - shellescape
-    - schema-salad
+    - schema-salad ==1.14.20160708181155 
+    - typing
 
 test:
   imports:

--- a/recipes/ruamel.yaml/meta.yaml
+++ b/recipes/ruamel.yaml/meta.yaml
@@ -1,0 +1,41 @@
+# From conda-forge: https://github.com/conda-forge/ruamel.yaml-feedstock
+
+{% set version = "0.11.11" %}
+
+package:
+    name: ruamel.yaml
+    version: {{ version }}
+
+source:
+    fn: ruamel.yaml.{{ version }}.tar.gz
+    url: https://bitbucket.org/ruamel/yaml/get/{{ version }}.tar.bz2
+    md5: 88e58c8f50c3f471dc3a73e4d603e327
+
+build:
+    number: 1
+    script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+    build:
+        - python
+        - setuptools
+        - ruamel.ordereddict   # [py26 or py27]
+    run:
+        - python
+        - setuptools
+        - ruamel.ordereddict   # [py26 or py27]
+
+test:
+    imports:
+        - ruamel.yaml
+
+about:
+    home: https://bitbucket.org/ruamel/yaml
+    license: MIT
+    summary: "A YAML package for Python. It is a derivative of Kirill Simonov's PyYAML 3.11 which supports YAML1.1"
+
+extra:
+    recipe-maintainers:
+         - jakirkham
+         - pelson
+         - mwcraig

--- a/recipes/schema-salad/build.sh
+++ b/recipes/schema-salad/build.sh
@@ -1,9 +1,3 @@
 #!/bin/bash
 
-$PYTHON setup.py install
-
-# Add more build steps here, if they are necessary.
-
-# See
-# http://docs.continuum.io/conda/build.html
-# for a list of environment variables that are set during the build process.
+$PYTHON setup.py install --single-version-externally-managed --record=record.txt

--- a/recipes/schema-salad/meta.yaml
+++ b/recipes/schema-salad/meta.yaml
@@ -1,39 +1,39 @@
 package:
   name: schema-salad
-  version: "1.7.20160316203940"
+  version: "1.14.20160708181155"
 
 source:
-  fn: schema-salad-1.7.20160316203940.tar.gz
-  url: https://pypi.python.org/packages/source/s/schema-salad/schema-salad-1.7.20160316203940.tar.gz
-  md5: 4b50e8201b3dc6ae9b80501ef570292b
+  fn: schema-salad-1.14.20160708181155.tar.gz
+  url: https://pypi.python.org/packages/57/01/14d5e22dbc71da0b7efd80f115e14e4a2d59710b85b4164719af6faf3da7/schema-salad-1.14.20160708181155.tar.gz
+  md5: a8a320bd213164db31377957d6404b19
 
 build:
   entry_points:
     - schema-salad-tool=schema_salad.main:main
   number: 0
-  skip: False
+  skip: True # [not py27]
 
 requirements:
   build:
     - python
     - setuptools
     - requests
-    - pyyaml
     - rdflib >=4.2.0
     - rdflib-jsonld >=0.3.0
     - mistune
     - typing
+    - ruamel.yaml
     - avro # [py27]
     - avro-python3 # [not py27]
 
   run:
     - python
     - requests
-    - pyyaml
     - rdflib >=4.2.0
     - rdflib-jsonld >=0.3.0
     - mistune
     - typing
+    - ruamel.yaml
     - avro # [py27]
     - avro-python3 # [not py27]
 

--- a/recipes/toil/1048.diff
+++ b/recipes/toil/1048.diff
@@ -1,0 +1,47 @@
+diff --git a/src/toil/batchSystems/singleMachine.py b/src/toil/batchSystems/singleMachine.py
+index 86b2ad6..b975ffc 100644
+--- src/toil/batchSystems/singleMachine.py
++++ src/toil/batchSystems/singleMachine.py
+@@ -120,6 +120,33 @@ def __init__(self, config, maxCores, maxMemory, maxDisk):
+             self.workerThreads.append(worker)
+             worker.start()
+ 
++    def _getDebugCmd(self, jobCommand):
++        """Calculate useful debugging command line, handling CWL runs.
++
++        Tries to print out underlying CWL base command being run if possible,
++        otherwise defaulting to the toil jobCommand.
++        """
++        debug_cmd = jobCommand
++        cmd_args = jobCommand.split()
++        if len(cmd_args) == 3 and cmd_args[0] == "_toil_worker":
++            _, job_store_locator, job_store_id = cmd_args
++            if job_store_locator.startswith("file:") or os.path.exists(job_store_locator):
++                import cPickle
++                import marshal as pickler
++                job_store_locator = job_store_locator.replace("file:", "")
++                job_cmd_file = os.path.join(job_store_locator, "tmp", job_store_id, "job")
++                with open(job_cmd_file) as in_handle:
++                    job = pickler.load(in_handle)
++                if job.get("command"):
++                    command_parts = job["command"].split()
++                    input_pickle_file = os.path.join(job_store_locator, "tmp", command_parts[1])
++                    with open(input_pickle_file) as in_handle:
++                        input = cPickle.load(in_handle)
++                    if (hasattr(input, "cwltool") and hasattr(input.cwltool, "tool")
++                            and "baseCommand" in input.cwltool.tool):
++                        debug_cmd = " ".join(input.cwltool.tool["baseCommand"])
++        return debug_cmd
++
+     # Note: The input queue is passed as an argument because the corresponding attribute is reset
+     # to None in shutdown()
+ 
+@@ -141,7 +168,7 @@ def worker(self, inputQueue):
+                                   jobCores)
+                         with self.coreFractions.acquisitionOf(coreFractions):
+                             with self.disk.acquisitionOf(jobDisk):
+-                                log.info("Executing command: '%s'.", jobCommand)
++                                log.info("Executing command: '%s'.", self._getDebugCmd(jobCommand))
+                                 startTime = time.time() #Time job is started
+                                 with self.popenLock:
+                                     popen = subprocess.Popen(jobCommand,

--- a/recipes/toil/meta.yaml
+++ b/recipes/toil/meta.yaml
@@ -1,10 +1,12 @@
 package:
   name: toil
-  version: '3.3.0a1'
+  version: '3.4.0a1'
 
 source:
-  fn: toil-0a613b7.tar.gz
-  url: https://github.com/BD2KGenomics/toil/archive/0a613b7.tar.gz
+  fn: toil-5a5e4b8.tar.gz
+  url: https://github.com/BD2KGenomics/toil/archive/5a5e4b8.tar.gz
+  patches:
+    - 1048.diff
 
 build:
   number: 0
@@ -14,26 +16,26 @@ requirements:
   build:
     - python
     - setuptools
-    - bd2k-python-lib
+    - bd2k-python-lib ==1.14a1.dev29
     - dill
     - psutil
     - cgcloud-lib
     - boto
     - azure
-    - cwltool
+    - cwltool ==1.0.20160714182449
     # Packages to add -- Google and encryption support
     #- gcs-oauth2-boto-plugin
     #- pynacl
 
   run:
     - python
-    - bd2k-python-lib
+    - bd2k-python-lib ==1.14a1.dev29
     - dill
     - psutil
     - cgcloud-lib
     - boto
     - azure
-    - cwltool
+    - cwltool ==1.0.20160714182449
     # Packages to add -- Google and encryption support
     #- gcs-oauth2-boto-plugin
     #- pynacl


### PR DESCRIPTION
* [X] I have read the guidelines above.
* [X] This PR adds a new recipe.
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

- Add ruamel.yaml and ruamel.ordereddict dependencies, migrated
  from conda-forge
- Update schema-salad and cwltool reference implementation to latest
  version supporting 1.0
- Update Toil to latest development with support for CWL 1.0