### PR TITLE
Enable OSX installation for DEGreport.

### DIFF
--- a/recipes/bioconductor-degreport/build.sh
+++ b/recipes/bioconductor-degreport/build.sh
@@ -4,7 +4,9 @@
 # R refuses to build packages that mark themselves as
 # "Priority: Recommended"
 mv DESCRIPTION DESCRIPTION.old
-grep -v '^Priority: ' DESCRIPTION.old > DESCRIPTION
+grep -v '^Priority: ' DESCRIPTION.old | grep -v logging > DESCRIPTION
+mv NAMESPACE NAMESPACE.old
+grep -v 'import(logging)' NAMESPACE.old > NAMESPACE
 #
 $R CMD INSTALL --build .
 #

--- a/recipes/bioconductor-degreport/meta.yaml
+++ b/recipes/bioconductor-degreport/meta.yaml
@@ -4,8 +4,7 @@ package:
 source:
   git_url: https://github.com/Bioconductor-mirror/DEGreport
 build:
-  number: 1
-  skip: True # [osx]
+  number: 2
   rpaths:
     - lib/R/lib/
     - lib/
@@ -18,6 +17,14 @@ requirements:
     - r-nozzle.r1
     - r-plyr
     - bioconductor-edger
+    - r-quantreg
+    - r-dplyr
+    - r-tidyr
+    - r-pheatmap
+    - r-gridextra
+    - r-coda
+    - r-reshape
+    - r-knitr
   run:
     - bioconductor-biobase
     - 'bioconductor-biocgenerics >=0.7.5'
@@ -26,6 +33,14 @@ requirements:
     - r-nozzle.r1
     - r-plyr
     - bioconductor-edger
+    - r-quantreg
+    - r-dplyr
+    - r-tidyr
+    - r-pheatmap
+    - r-gridextra
+    - r-coda
+    - r-reshape
+    - r-knitr
 test:
   commands:
     - '$R -e "library(''DEGreport'')"'


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Enable OSX installation for DEGreport. Remove unused logging dependency as well.