### PR TITLE
Update: bcbio-vm, java for libnet

### DIFF
--- a/recipes/bcbio-nextgen-vm/meta.yaml
+++ b/recipes/bcbio-nextgen-vm/meta.yaml
@@ -3,12 +3,12 @@ package:
   version: '0.1.0a'
 
 build:
-  number: 83
+  number: 84
   skip: True # [not py27]
 
 source:
-  fn: bcbio-nextgen-vm-5815ebd.tar.gz
-  url: https://github.com/chapmanb/bcbio-nextgen-vm/archive/5815ebd.tar.gz
+  fn: bcbio-nextgen-vm-c61d5f7.tar.gz
+  url: https://github.com/chapmanb/bcbio-nextgen-vm/archive/c61d5f7.tar.gz
 
 requirements:
   build:

--- a/recipes/java-jdk/build.sh
+++ b/recipes/java-jdk/build.sh
@@ -29,6 +29,8 @@ then
     mv lib/amd64/jli/*.so lib
     mv lib/amd64/*.so lib
     rm -r lib/amd64
+    # libnio.so does not find this within jre/lib/amd64 subdirectory
+    cp jre/lib/amd64/libnet.so lib
 
     # fonts
     mkdir -p jre/lib/fonts

--- a/recipes/java-jdk/meta.yaml
+++ b/recipes/java-jdk/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: 8.0.92
 
 build:
-  number: 0
+  number: 1
   skip: False
 
 test:


### PR DESCRIPTION
* [X] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

- java-jdk: move libnet.so to `lib` to avoid problems with libio finding
  it.
- bcbio-nextgen-vm: include support for bundling new GATK in docker with
  bioconda gatk-register approach