### PR TITLE
Update: samtools against new r ncurses subversion

### DIFF
--- a/recipes/samtools/meta.yaml
+++ b/recipes/samtools/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 1
+  number: 2
   skip: False
 
 source:


### PR DESCRIPTION
* [X] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [ ] This PR updates an existing recipe.
* [X] This PR does something else (explain below).

The r-channel updated their sub-version of ncurses from 5.9-1 to 5.9-8
recently:

https://anaconda.org/r/ncurses/files

5.9-1 had symlinks to libncurses.so.5, which previous samtools compiled
against, but the new r version has libncursesw.so.5 so is not
compatible. This bump re-compiles against the new version and
fixes #1644