### PR TITLE
New recipes supporting Google Cloud GCE

### DIFF
--- a/recipes/gcs_oauth2_boto_plugin/build.sh
+++ b/recipes/gcs_oauth2_boto_plugin/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/recipes/gcs_oauth2_boto_plugin/meta.yaml
+++ b/recipes/gcs_oauth2_boto_plugin/meta.yaml
@@ -1,0 +1,44 @@
+# Migrated from https://anaconda.org/quanyuan/gcs-oauth2-boto-plugin
+
+package:
+  name: gcs-oauth2-boto-plugin
+  version: "1.9"
+
+source:
+  fn: gcs-oauth2-boto-plugin-1.9.tar.gz
+  url: https://pypi.python.org/packages/source/g/gcs-oauth2-boto-plugin/gcs-oauth2-boto-plugin-1.9.tar.gz
+  md5: 30ce54681c83a23c93f1692c618f3b55
+
+build:
+  number: 0
+  skip: True # [not py27]
+
+requirements:
+  build:
+    - cryptography
+    - python
+    - setuptools
+    - boto >=2.29.1
+    - httplib2 >=0.8
+    - google-api-python-client >=1.1
+    - pyopenssl >=0.13
+    - socksipy-branch ==1.01
+    - retry_decorator >=1.0.0
+
+  run:
+    - python
+    - boto >=2.29.1
+    - httplib2 >=0.8
+    - google-api-python-client >=1.1
+    - pyopenssl >=0.13
+    - socksipy-branch ==1.01
+    - retry_decorator >=1.0.0
+
+test:
+  imports:
+    - gcs_oauth2_boto_plugin
+
+about:
+  home: https://developers.google.com/storage/docs/gspythonlibrary
+  license: Apache 2.0
+  summary: 'Auth plugin allowing use the use of OAuth 2.0 credentials for Google Cloud Storage in the Boto library.'

--- a/recipes/google-cloud-sdk/build.sh
+++ b/recipes/google-cloud-sdk/build.sh
@@ -7,6 +7,6 @@ mkdir -p $PREFIX/bin
 cp -r * $outdir
 for FNAME in gcloud gsutil bq
 do
-    sed -i.bak 's$#!/bin/sh$#!/bin/sh\nexport CLOUDSDK_PYTHON=/opt/anaconda1anaconda2anaconda3/bin/python$' $outdir/bin/$FNAME
+    sed -i.bak 's$# <cloud-sdk-sh-preamble>$export CLOUDSDK_PYTHON=/opt/anaconda1anaconda2anaconda3/bin/python$' $outdir/bin/$FNAME
     ln -s $outdir/bin/$FNAME $PREFIX/bin
 done

--- a/recipes/google-cloud-sdk/build.sh
+++ b/recipes/google-cloud-sdk/build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+outdir=$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM
+mkdir -p $outdir
+mkdir -p $PREFIX/bin
+
+cp -r * $outdir
+for FNAME in gcloud gsutil bq
+do
+    sed -i.bak 's$#!/bin/sh$#!/bin/sh\nexport CLOUDSDK_PYTHON=/opt/anaconda1anaconda2anaconda3/bin/python$' $outdir/bin/$FNAME
+    ln -s $outdir/bin/$FNAME $PREFIX/bin
+done

--- a/recipes/google-cloud-sdk/meta.yaml
+++ b/recipes/google-cloud-sdk/meta.yaml
@@ -1,0 +1,32 @@
+{% set version = "120.0.0" %}
+
+package:
+  name: google-cloud-sdk
+  version: {{ version }}
+
+source:
+  fn: google-cloud-sdk-{{ version }}-linux-x86_64.tar.gz # [linux]
+  url: https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-{{ version }}-linux-x86_64.tar.gz # [linux]
+  sha1: 5c70c10230670ac79af5629b38410eb0eeaf30eb # [linux]
+  fn: google-cloud-sdk-{{ version }}-darwin-x86_64.tar.gz # [osx]
+  url: https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-{{ version }}-darwin-x86_64.tar.gz # [osx]
+  sha1: 257ce86746ef4273e5e0bebfeacdf4035fe4a16a # [osx]
+
+build:
+  number: 0
+  skip: True # [not py27]
+
+requirements:
+  build:
+  run:
+    - python
+
+test:
+  commands:
+    - gcloud version
+    - gsutil help
+
+about:
+  home: https://cloud.google.com/sdk/
+  license: Apache v2.0
+  summary: Command-line interface for Google Cloud Platform products and services

--- a/recipes/retry_decorator/build.sh
+++ b/recipes/retry_decorator/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/recipes/retry_decorator/meta.yaml
+++ b/recipes/retry_decorator/meta.yaml
@@ -1,0 +1,28 @@
+package:
+  name: retry_decorator
+  version: "1.1.0"
+
+source:
+  fn: retry_decorator-1.1.0.tar.gz
+  url: https://pypi.python.org/packages/95/7a/807ac21749ecd26ae3337c3069ed6ac8658b9fbc85f109e419a812b18ab7/retry_decorator-1.1.0.tar.gz
+  md5: ee933c38020839e30699519a7611b3f2
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  imports:
+    - retry_decorator
+
+about:
+  home: https://github.com/pnpnpn/retry-decorator
+  license: MIT
+  summary: 'Retry Decorator'

--- a/recipes/socksipy-branch/build.sh
+++ b/recipes/socksipy-branch/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/recipes/socksipy-branch/meta.yaml
+++ b/recipes/socksipy-branch/meta.yaml
@@ -1,0 +1,23 @@
+package:
+  name: socksipy-branch
+  version: "1.01"
+
+source:
+  fn: SocksiPy-branch-1.01.tar.gz
+  url: https://pypi.python.org/packages/69/ed/3659a7e2cff38c3156cf919f8f6ee63360147ba97460c0a8c130f8b781e0/SocksiPy-branch-1.01.tar.gz
+  md5: a59e29647320211202ce79b0cf873106
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - python
+
+  run:
+    - python
+
+about:
+  home: http://socksipy.sourceforge.net/
+  license: BSD
+  summary: 'A Python SOCKS module'


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [x] This PR adds a new recipe.
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

- google-cloud-sdk provides easy command line interface
  to Google Compute services
- retry_decorator, socksipy-branch are dependencies for
  gcs-oauth2-boto-plugin
- gcs-oauth2-boto-plugin required for Toil GCE support