### PR TITLE
Configure user.email for gh-pages.

### DIFF
--- a/scripts/build-docs.sh
+++ b/scripts/build-docs.sh
@@ -28,6 +28,7 @@ git add .nojekyll
 echo '.*' >> .gitignore
 git add .
 git config user.name "Travis CI"
+git config user.email "bioconda@users.noreply.github.com"
 git commit --all -m "Updated docs to commit ${TRAVIS_COMMIT}."
 git push -f -q "https://${GITHUB_TOKEN}@github.com/${GITHUB_USERNAME}/bioconda.github.io.git" master &> /dev/null
 


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

With seemingly an updated git on Travis, our homepage deployment fails because the git email address was not set. This PR adds a generic github email address for bioconda to solve the issue.