### PR TITLE
Ensure that help message is tested only.

### DIFF
--- a/recipes/prodigal/meta.yaml
+++ b/recipes/prodigal/meta.yaml
@@ -13,7 +13,7 @@ requirements:
   run:
 test:
   commands:
-    - prodigal
+    - prodigal -h
 about:
   home: http://prodigal.ornl.gov/
   license: GPL v3

--- a/recipes/prodigal/meta.yaml
+++ b/recipes/prodigal/meta.yaml
@@ -6,7 +6,7 @@ source:
   url: https://github.com/hyattpd/Prodigal/archive/v2.6.2.zip
   sha256: 8fb270872a144bbf60dbf4035339183c0771379ecc8749f494993ce9c7235306
 build:
-    number: 2
+    number: 3
     skip: False
 requirements:
   build:


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Try to fix failing weekly test of prodigal (see #1744). In the weekly test, prodigal thinks that STDIN is provided, and tries to read data from that instead of just printing the help message as it was intended in the test case.