### PR TITLE
bzip2 - added recipe for bzip2 and libbzip2

### DIFF
--- a/recipes/bzip2/build.sh
+++ b/recipes/bzip2/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -euf -o pipefail
+
+make
+make PREFIX=$PREFIX install
+

--- a/recipes/bzip2/meta.yaml
+++ b/recipes/bzip2/meta.yaml
@@ -1,0 +1,22 @@
+build:
+  number: 0
+
+package:
+  name: bzip2
+  version: "1.0.6"
+source:
+  fn: bzip2-1.0.6.tar.gz
+  url: http://www.bzip.org/1.0.6/bzip2-1.0.6.tar.gz
+  md5: 00b516f4704d4a7cb50a1d97e6e8e15b
+requirements:
+  build:
+    - gcc
+  run:
+    - libgcc
+test:
+  commands:
+    - bzip2 --help 2>&1 | grep "bzip2, a block-sorting file compressor.  Version 1.0.6, 6-Sept-2010" > /dev/null
+about:
+  home: http://www.bzip.org/
+  license: BSD-style
+  summary: bzip2 is a freely available, patent free (see below), high-quality data compressor.


### PR DESCRIPTION
* [X ] I have read the guidelines above.
* [X] This PR adds a new recipe.
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Adding this to enable compiling the kmc k-mer counter from source, but of course many other things also have libbzip2 as a dependency.

@bioconda/core 

