### PR TITLE
Update: ipython-cluster-helper; Perl libs

### DIFF
--- a/recipes/ipython-cluster-helper/meta.yaml
+++ b/recipes/ipython-cluster-helper/meta.yaml
@@ -1,14 +1,17 @@
 package:
   name: ipython-cluster-helper
-  version: 0.5.2
+  version: 0.5.3
 
 source:
-  fn: ipython-cluster-helper-0.5.2.tar.gz
-  url: https://pypi.python.org/packages/97/df/8a9b0ef7657344bdad15ba9bc187c8d5182f27d5afda51c493a961d0f9a1/ipython-cluster-helper-0.5.2.tar.gz
+  fn: ipython-cluster-helper-0.5.3.tar.gz
+  url: https://pypi.python.org/packages/7a/eb/a931cb7b8784e350abc6ced71ec9c54eecee0ff6d07e36190f6a9bddaf1f/ipython-cluster-helper-0.5.3.tar.gz
+  md5: 0c48f79223d561fe6021121c7526604e
 
 build:
   number: 0
-  skip: True # [not py27]
+  # Failing on OSX builds with
+  # ImportError: dlopen(/anaconda/envs/_test/lib/python2.7/site-packages/zmq/backend/cython/constants.so, 2): Library not loaded: @rpath/./libzmq.4.dylib
+  skip: True # [not py27 or osx]
 
 requirements:
   build:

--- a/recipes/perl-number-format/meta.yaml
+++ b/recipes/perl-number-format/meta.yaml
@@ -7,19 +7,19 @@ source:
   url: https://cpan.metacpan.org/authors/id/W/WR/WRW/Number-Format-1.75.tar.gz
   md5: 2285c537dcf89a5bf556effaf706fd5f
 
-# build:
-  # If this is a new build for the same version, increment the build
-  # number. If you do not include this key, it defaults to 0.
-  # number: 1
+build:
+  number: 1
+  # Failing on OSX Travis builds with KeyError: 'perl'
+  skip: True # [osx]
 
 requirements:
   build:
-    - perl
+    - perl-threaded
     - perl-extutils-makemaker
     #- perl-test-simple
 
   run:
-    - perl
+    - perl-threaded
 
 test:
   # Perl 'use' tests

--- a/recipes/perl-statistics-basic/meta.yaml
+++ b/recipes/perl-statistics-basic/meta.yaml
@@ -7,10 +7,10 @@ source:
   url: https://cpan.metacpan.org/authors/id/J/JE/JETTERO/Statistics-Basic-1.6611.tar.gz
   md5: 1ee961c3a4b9c0a594dc3cfccbcd1ed1
 
-# build:
-  # If this is a new build for the same version, increment the build
-  # number. If you do not include this key, it defaults to 0.
-  # number: 1
+build:
+  number: 1
+  # Failing on OSX during builds due to KeyError: 'perl'
+  skip: true # [osx]
 
 requirements:
   build:


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

- v0.5.3 of ipython-cluster-helper
- Avoid pulling in perl and perl-threaded with perl-statistics-basic