### PR TITLE
corrected badge generator instruction

### DIFF
--- a/docs/_static/badge-generator/index.html
+++ b/docs/_static/badge-generator/index.html
@@ -42,7 +42,7 @@
 <div class="container">
   <h1>Bioconda Poster Badge Generator</h1>
   <p class="lead">You can use this page to generate badges for your favorite Bioconda packages, suitable for screen and poster presentations.</p>
-  <p>Update the values below to change the badges. When you're happy, just click on a badge to open it in a new tab. From there you can Save As.</p>
+  <p>Update the values below to change the badges. When you're happy, just click one of the buttons below a badge to download it in <code>.svg</code> or <code>.png</code> format.</p>
   <form class="form-horizontal" method="get" action="">
     <div class="form-group">
       <label for="n" class="col-sm-2 control-label">Package Name</label>


### PR DESCRIPTION
changed the way the page worked, but forgot to update the instructions.
Whoops! This fixes it.