### PR TITLE
Add PyPI intervaltree package

### DIFF
--- a/recipes/intervaltree/bld.bat
+++ b/recipes/intervaltree/bld.bat
@@ -1,0 +1,2 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1

--- a/recipes/intervaltree/build.sh
+++ b/recipes/intervaltree/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$PYTHON setup.py install

--- a/recipes/intervaltree/meta.yaml
+++ b/recipes/intervaltree/meta.yaml
@@ -1,0 +1,30 @@
+package:
+  name: intervaltree
+  version: "2.1.0"
+
+source:
+  fn: intervaltree-2.1.0.tar.gz
+  url: https://files.pythonhosted.org/packages/ca/c1/450d109b70fa58ca9d77972b02f69222412f9175ccf99fdeaf167be9583c/intervaltree-2.1.0.tar.gz
+  md5: 33bef3448aaf30b78aa093dc7c315c2c
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - sortedcontainers
+
+  run:
+    - python
+    - sortedcontainers
+
+test:
+  imports:
+    - intervaltree
+
+  requires:
+    - pytest
+
+about:
+  home: https://github.com/chaimleib/intervaltree
+  license: Apache Software License
+  summary: 'Editable interval tree data structure for Python 2 and 3'

--- a/recipes/sortedcontainers/bld.bat
+++ b/recipes/sortedcontainers/bld.bat
@@ -1,0 +1,2 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1

--- a/recipes/sortedcontainers/build.sh
+++ b/recipes/sortedcontainers/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$PYTHON setup.py install

--- a/recipes/sortedcontainers/meta.yaml
+++ b/recipes/sortedcontainers/meta.yaml
@@ -1,0 +1,25 @@
+package:
+  name: sortedcontainers
+  version: "1.5.3"
+
+source:
+  fn: sortedcontainers-1.5.3.tar.gz
+  url: https://files.pythonhosted.org/packages/88/9e/949ef5f596f8b1e5776d148c1a4f16129b671ed377f6fa38e7e3f170cb84/sortedcontainers-1.5.3.tar.gz
+  md5: 9536cd5a99ab8e65b47059420e29f6ff
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  imports:
+    - sortedcontainers
+
+about:
+  home: http://www.grantjenks.com/docs/sortedcontainers/
+  license: Apache Software License
+  summary: 'Python Sorted Container Types: SortedList, SortedDict, and SortedSet'


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [x] This PR adds a new recipe.
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Adds the intervaltree package from PyPI, together with its sortedcontainers dependency. I think this is a useful package for bioconda, as intervaltrees are frequently used for fast querying of (genomic) positions.