### PR TITLE
Compile FastTree with double precision

### DIFF
--- a/recipes/fasttree/build.sh
+++ b/recipes/fasttree/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-gcc -O3 -finline-functions -funroll-loops -Wall -o FastTree FastTree.c -lm
+gcc -O3 -DUSE_DOUBLE -finline-functions -funroll-loops -Wall -o FastTree FastTree.c -lm
 
 mkdir -p $PREFIX/bin
 cp FastTree $PREFIX/bin

--- a/recipes/fasttree/meta.yaml
+++ b/recipes/fasttree/meta.yaml
@@ -4,7 +4,7 @@ package:
 
 source:
   fn: FastTree.c
-  url: "http://www.microbesonline.org/fasttree/FastTree.c"
+  url: "http://meta.microbesonline.org/fasttree/FastTree-2.1.8.c"
   md5: "c7e85689a26cabba241378d4f633c2fa"
 
 build:

--- a/recipes/fasttree/meta.yaml
+++ b/recipes/fasttree/meta.yaml
@@ -8,7 +8,7 @@ source:
   md5: "c7e85689a26cabba241378d4f633c2fa"
 
 build:
-  number: 1
+  number: 2
   skip: True # [osx]
 
 test:


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Use double precision with FastTree. It defaults to single precision which can result in numerical stability issues. See concerns [here](http://darlinglab.org/blog/2015/03/23/not-so-fast-fasttree.html)