### PR TITLE
adding hpc-runner-scheduler as a dep to hpc-runner-slurm

### DIFF
--- a/recipes/perl-biox-workflow-plugin-fileexists/bld.bat
+++ b/recipes/perl-biox-workflow-plugin-fileexists/bld.bat
@@ -1,0 +1,29 @@
+:: If it has Build.PL use that, otherwise use Makefile.PL
+IF exist Build.PL (
+    perl Build.PL
+    IF errorlevel 1 exit 1
+    Build
+    IF errorlevel 1 exit 1
+    Build test
+    :: Make sure this goes in site
+    Build install --installdirs site
+    IF errorlevel 1 exit 1
+) ELSE IF exist Makefile.PL (
+    :: Make sure this goes in site
+    perl Makefile.PL INSTALLDIRS=site
+    IF errorlevel 1 exit 1
+    make
+    IF errorlevel 1 exit 1
+    make test
+    IF errorlevel 1 exit 1
+    make install
+) ELSE (
+    ECHO 'Unable to find Build.PL or Makefile.PL. You need to modify bld.bat.'
+    exit 1
+)
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/recipes/perl-biox-workflow-plugin-fileexists/build.sh
+++ b/recipes/perl-biox-workflow-plugin-fileexists/build.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# If it has Build.PL use that, otherwise use Makefile.PL
+cpanm --installdeps .
+if [ -f Build.PL ]; then
+    perl Build.PL
+    ./Build
+    ./Build test
+    # Make sure this goes in site
+    ./Build install --installdirs site
+elif [ -f Makefile.PL ]; then
+    # Make sure this goes in site
+    perl Makefile.PL INSTALLDIRS=site
+    make
+    make test
+    make install
+else
+    echo 'Unable to find Build.PL or Makefile.PL. You need to modify build.sh.'
+    exit 1
+fi
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/recipes/perl-biox-workflow-plugin-fileexists/meta.yaml
+++ b/recipes/perl-biox-workflow-plugin-fileexists/meta.yaml
@@ -1,0 +1,50 @@
+package:
+  name: perl-biox-workflow-plugin-fileexists
+  version: "0.13"
+
+source:
+  fn: BioX-Workflow-Plugin-FileExists-0.13.tar.gz
+  url: https://cpan.metacpan.org/authors/id/J/JI/JILLROWE/BioX-Workflow-Plugin-FileExists-0.13.tar.gz
+  md5: 32d4be6dcf5a578e334c0c2d63d07359
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+build:
+  skip: True # [osx]
+  number: 1
+
+requirements:
+  build:
+    - perl-threaded
+    - perl-app-cpanminus
+    - perl-moose
+    - perl-module-build
+    - perl-biox-workflow
+    - perl-test-simple
+
+  run:
+    - perl-threaded
+    - perl-moose
+    - perl-biox-workflow
+
+test:
+  # Perl 'use' tests
+  imports:
+    - BioX::Workflow::Plugin::FileExists
+
+  # You can also put a file called run_test.pl (or run_test.py) in the recipe
+  # that will be run at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: https://github.com/jerowe/BioX-Workflow-Plugin-FileExists
+  license: perl_5
+  summary: 'a plugin to BioX::Workflow'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/recipes/perl-hpc-runner-slurm/2.58/meta.yaml
+++ b/recipes/perl-hpc-runner-slurm/2.58/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   skip: True # [osx]
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -35,6 +35,7 @@ requirements:
     - perl-capture-tiny
     - perl-termreadkey
     - perl-hpc-runner
+    - perl-hpc-runner-scheduler
     - perl-hpc-runner-mce
 
   run:


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [x] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Rebuilding perl-hpc-runner-slurm with perl-hpc-runner-scheduler as a dep.

Adding in perl-biox-workflow-plugin-fileexists
