### PR TITLE
Add pipefail patch to lumpy distribution

### DIFF
--- a/recipes/lumpy-sv/142.diff
+++ b/recipes/lumpy-sv/142.diff
@@ -1,0 +1,20 @@
+diff --git a/scripts/lumpyexpress b/scripts/lumpyexpress
+index d486504..05e45d1 100755
+--- scripts/lumpyexpress
++++ scripts/lumpyexpress
+@@ -406,7 +406,6 @@ else
+ 	    # calculate read length if not provided
+ 	    set +o pipefail
+ 	    LIB_READ_LENGTH_LIST+=(`$SAMT view ${FULL_BAM_LIST[$i]} | head -n 10000 | gawk 'BEGIN { MAX_LEN=0 } { LEN=length($10); if (LEN>MAX_LEN) MAX_LEN=LEN } END { print MAX_LEN }'`)
+-	    set -o pipefail
+ 	    echo "Library read groups: ${LIB_RG_LIST[$j]}"
+ 	    echo "Library read length: ${LIB_READ_LENGTH_LIST[$j]}"
+ 	    $SAMT_STREAM ${FULL_BAM_LIST[$i]} \
+@@ -415,6 +414,7 @@ else
+ 		| tail -n 1000000 \
+ 		| $PYTHON $PAIREND_DISTRO -r ${LIB_READ_LENGTH_LIST[$j]} -X 4 -N 1000000 -o ${TEMP_DIR}/$OUTBASE.sample$(($i+1)).lib$(($j+1)).x4.histo \
+ 		> ${TEMP_DIR}/$OUTBASE.sample$(($i+1)).lib$(($j+1)).insert.stats
++	    set -o pipefail
+ 	done
+ 	echo "done"
+ 

--- a/recipes/lumpy-sv/meta.yaml
+++ b/recipes/lumpy-sv/meta.yaml
@@ -4,10 +4,13 @@ package:
 source:
   git_url: https://github.com/arq5x/lumpy-sv.git
   git_rev: 66c83c8
+  patches:
+    # Fix issues with pipefails
+    - 142.diff
   #fn: lumpy-sv-0.2.11.tar.gz
   #url: https://github.com/arq5x/lumpy-sv/releases/download/0.2.11/lumpy-sv-0.2.11.tar.gz
 build:
-  number: 2
+  number: 3
   skip: True # [not py27]
 requirements:
   build:


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Fixes problems with lumpyexpress when running head to check for insert
stats: chapmanb/bcbio-nextgen#1055