### PR TITLE
add biopython 1.68

### DIFF
--- a/recipes/biopython/build.sh
+++ b/recipes/biopython/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$PYTHON setup.py install 

--- a/recipes/biopython/meta.yaml
+++ b/recipes/biopython/meta.yaml
@@ -1,0 +1,107 @@
+package:
+  name: biopython
+  version: "1.68"
+
+about:
+  home: http://www.biopython.org/
+  license: MIT
+  summary: 'Freely available tools for computational molecular biology.'
+  license_family: MIT
+
+source:
+  fn: biopython-1.68.tar.gz
+  url: https://pypi.python.org/packages/72/6c/e1e13b9df73f9c2539b67d12bc22be6b19779230cadbed04c24f3f3e5ef4/biopython-1.68.tar.gz
+  md5: 078e915185485a5327937029b7577ddc
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - python
+    - numpy
+    - reportlab
+    - mmtf-python
+
+  run:
+    - python
+    - numpy
+    - reportlab
+    - mmtf-python
+
+test:
+  imports:
+    - Bio
+    - Bio.Align
+    - Bio.Align.Applications
+    - Bio.AlignIO
+    - Bio.Alphabet
+    - Bio.Application
+    - Bio.Blast
+    - Bio.CAPS
+    - Bio.Compass
+    - Bio.Crystal
+    - Bio.Data
+    - Bio.Emboss
+    - Bio.Entrez
+    - Bio.ExPASy
+    - Bio.FSSP
+    - Bio.GA
+    - Bio.GA.Crossover
+    - Bio.GA.Mutation
+    - Bio.GA.Repair
+    - Bio.GA.Selection
+    - Bio.GenBank
+    - Bio.Geo
+    - Bio.Graphics
+    - Bio.Graphics.GenomeDiagram
+    - Bio.HMM
+    - Bio.KEGG
+    - Bio.KEGG.Compound
+    - Bio.KEGG.Enzyme
+    - Bio.KEGG.KGML
+    - Bio.KEGG.Map
+    - Bio.Medline
+    - Bio.NMR
+    - Bio.NeuralNetwork
+    - Bio.NeuralNetwork.BackPropagation
+    - Bio.NeuralNetwork.Gene
+    - Bio.Nexus
+    - Bio.PDB
+    - Bio.PDB.QCPSuperimposer
+    - Bio.PDB.mmtf
+    - Bio.Pathway
+    - Bio.Pathway.Rep
+    - Bio.Phylo
+    - Bio.Phylo.Applications
+    - Bio.Phylo.PAML
+    - Bio.PopGen
+    - Bio.PopGen.Async
+    - Bio.PopGen.FDist
+    - Bio.PopGen.GenePop
+    - Bio.PopGen.SimCoal
+    - Bio.Restriction
+    - Bio.SCOP
+    - Bio.SVDSuperimposer
+    - Bio.SearchIO
+    - Bio.SearchIO.BlastIO
+    - Bio.SearchIO.ExonerateIO
+    - Bio.SearchIO.HmmerIO
+    - Bio.SearchIO._model
+    - Bio.SeqIO
+    - Bio.SeqUtils
+    - Bio.Sequencing
+    - Bio.Sequencing.Applications
+    - Bio.Statistics
+    - Bio.SubsMat
+    - Bio.SwissProt
+    - Bio.TogoWS
+    - Bio.UniGene
+    - Bio.UniProt
+    - Bio.Wise
+    - Bio._py3k
+    - Bio.codonalign
+    - Bio.motifs
+    - Bio.motifs.applications
+    - Bio.motifs.jaspar
+    - BioSQL

--- a/recipes/mmtf-python/build.sh
+++ b/recipes/mmtf-python/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$PYTHON setup.py install 

--- a/recipes/mmtf-python/meta.yaml
+++ b/recipes/mmtf-python/meta.yaml
@@ -1,0 +1,38 @@
+package:
+  name: mmtf-python
+  version: "1.0.2"
+
+about:
+  home: https://github.com/rcsb/mmtf-python.git
+  license: MIT License
+  summary: 'A decoding libary for the PDB mmtf format'
+  license_family: MIT
+
+source:
+  fn: mmtf-python-1.0.2.tar.gz
+  url: https://pypi.python.org/packages/c8/4b/619ceac90e14d80653a2c0f50840b388c9f6c632fff9d0bc6bb4e383cf4b/mmtf-python-1.0.2.tar.gz
+  md5: 317cfc5562c7783ca407161cadd4ac62
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - msgpack-python
+
+  run:
+    - python
+    - msgpack-python
+
+test:
+  imports:
+    - mmtf
+    - mmtf.api
+    - mmtf.codecs
+    - mmtf.codecs.decoders
+    - mmtf.codecs.encoders
+    - mmtf.converters
+    - mmtf.tests
+    - mmtf.utils


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [x] This PR adds a new recipe.
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

At the end of September the NCBI will be deprecating their HTTP Entrez API in favor of the HTTPS version. A newer version of biopython that uses the HTTPS version is available (v1.68; released August 25, 2016), but it is not yet in the default conda channel. Until it is, we should probably have a package available.