### PR TITLE
add older Trinity back again

### DIFF
--- a/recipes/trinity/date.2011_11_26/README.md
+++ b/recipes/trinity/date.2011_11_26/README.md
@@ -1,0 +1,1 @@
+Maintainers: There are algorithmic changes in Trinity v2 and later, and the recipe for this dated version should be preserved to serve users who prefer the older algorithm.

--- a/recipes/trinity/date.2011_11_26/RunButterfly.cc.patch
+++ b/recipes/trinity/date.2011_11_26/RunButterfly.cc.patch
@@ -1,0 +1,7 @@
+--- Chrysalis/analysis/RunButterfly.cc	2011-11-28 09:14:40.000000000 -0500
++++ Chrysalis/analysis/RunButterfly.cc	2015-12-15 16:54:00.000000000 -0500
+@@ -1,3 +1,4 @@
++#include <unistd.h>
+ #include <string>
+ #include "base/CommandLineParser.h"
+ #include "base/FileParser.h"

--- a/recipes/trinity/date.2011_11_26/Trinity.pl.patch
+++ b/recipes/trinity/date.2011_11_26/Trinity.pl.patch
@@ -1,0 +1,12 @@
+--- Trinity.pl	2011-11-28 09:14:58.000000000 -0500
++++ Trinity.pl	2015-12-15 16:54:00.000000000 -0500
+@@ -208,7 +208,8 @@
+ 
+ ## Check Java version:
+ my $java_version = `java -version 2>&1 `;
+-unless ($java_version =~ /java version \"1\.6\./) {
++$java_version =~ /^(?:openjdk|java) version "1\.(\d+)\./;
++unless ($1 >= 6) {
+     die "Error, Trinity requires access to Java version 1.6.  Currently installed version is: $java_version";
+ }
+ 

--- a/recipes/trinity/date.2011_11_26/build.sh
+++ b/recipes/trinity/date.2011_11_26/build.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+BINARY=Trinity
+BINARY_HOME=$PREFIX/bin
+TRINITY_HOME=$PREFIX/opt/trinity-$PKG_VERSION
+
+cd $SRC_DIR
+
+export CPATH=${PREFIX}/include
+
+make
+
+# remove the sample data
+rm -rf $SRC_DIR/sample_data
+
+# copy source to bin
+mkdir -p $PREFIX/bin
+mkdir -p $TRINITY_HOME
+cp -R $SRC_DIR/* $TRINITY_HOME/
+cd $TRINITY_HOME && chmod +x Trinity.pl
+
+echo $'#!/bin/sh' > $TRINITY_HOME/Trinity-runner.sh
+echo $'cd $(dirname $0)/$(dirname $(readlink $0) )' >> $TRINITY_HOME/Trinity-runner.sh
+echo $'./Trinity.pl $@' >> $TRINITY_HOME/Trinity-runner.sh
+
+echo $'#!/bin/sh' > $TRINITY_HOME/Trinity-test.sh
+echo $'cd $(dirname $0)/$(dirname $(readlink $0) )' >> $TRINITY_HOME/Trinity-test.sh
+echo $'perl -c ./Trinity.pl &> /dev/null' >> $TRINITY_HOME/Trinity-test.sh
+
+chmod +x $TRINITY_HOME/Trinity-*.sh
+
+cd $BINARY_HOME
+ln -s $TRINITY_HOME/Trinity-runner.sh $BINARY
+ln -s $TRINITY_HOME/Trinity-test.sh "$BINARY-test"

--- a/recipes/trinity/date.2011_11_26/meta.yaml
+++ b/recipes/trinity/date.2011_11_26/meta.yaml
@@ -1,0 +1,40 @@
+about:
+    home: 'https://github.com/trinityrnaseq/trinityrnaseq'
+    license: "https://raw.githubusercontent.com/trinityrnaseq/trinityrnaseq/master/LICENSE.txt"
+    summary: "Trinity assembles transcript sequences from Illumina RNA-Seq data"
+build:
+  number: 5
+  string: ncurses{{CONDA_NCURSES}}_{{PKG_BUILDNUM}}
+package:
+  name: trinity
+  version: 'date.2011_11_26'
+source:
+  fn: trinityrnaseq_r2011-11-26.tgz
+  md5: 3a4c4691908d37042ca63ca469c75fd3
+  url: http://sourceforge.net/projects/trinityrnaseq/files/trinityrnaseq_r2011-11-26.tgz
+  patches:
+    - RunButterfly.cc.patch # this file is missing a header include
+    - Trinity.pl.patch # Trinity requires exactly Java 1.6, but works fine >1.6, so adjust to be more permissive
+    - samtools_makefile.patch # patch samtools Makefile due to missing curses.h
+requirements:
+  build:
+    - perl-threaded
+    - gcc
+    - java-jdk >=6
+    - bzip2
+    - zlib
+    - ncurses {{CONDA_NCURSES}}*
+  run:
+    - perl-threaded
+    - libgcc
+    - java-jdk >=6
+    - bzip2
+    - zlib
+    - ncurses {{CONDA_NCURSES}}*
+extra:
+  notes: "Trinity version date.2011_11_26 relies on a custom wrapper script, symlinked to bin/: Trinity-runner.sh. This script changes the current working directory to that of the Trinity.pl perl script before calling Trinity, so relative paths work as expected (particularly for Trinity plugins). All arguments are passed to Trinity.pl (via $@)"
+test:
+    commands:
+        # This version of Trinity does not have a quick function to exit 0
+        # So at least check that we can compile the file
+        - "$PREFIX/bin/Trinity-test &> /dev/null"

--- a/recipes/trinity/date.2011_11_26/samtools_makefile.patch
+++ b/recipes/trinity/date.2011_11_26/samtools_makefile.patch
@@ -1,0 +1,19 @@
+--- trinity-plugins/RSEM-mod/sam/Makefile	2016-06-27 15:59:27.000000000 -0400
++++ trinity-plugins/RSEM-mod/sam/Makefile	2016-06-27 16:00:05.000000000 -0400
+@@ -1,6 +1,6 @@
+ CC=			gcc
+-CFLAGS=		-g -Wall -O2 #-m64 #-arch ppc
+-DFLAGS=		-D_FILE_OFFSET_BITS=64 -D_USE_KNETFILE -D_CURSES_LIB=1
++CFLAGS=		-Wall
++DFLAGS=		-D_FILE_OFFSET_BITS=64 -D_USE_KNETFILE -D_CURSES_LIB=0
+ KNETFILE_O=	knetfile.o
+ LOBJS=		bgzf.o kstring.o bam_aux.o bam.o bam_import.o sam.o bam_index.o	\
+ 			bam_pileup.o bam_lpileup.o bam_md.o glf.o razf.o faidx.o \
+@@ -12,7 +12,6 @@
+ INCLUDES=	-I.
+ SUBDIRS=	. bcftools misc
+ LIBPATH=
+-LIBCURSES=	-lcurses # -lXCurses
+ 
+ .SUFFIXES:.c .o
+ 


### PR DESCRIPTION
There are algorithmic changes in Trinity v2 and later, and the recipe for this dated version should be preserved to serve users who prefer the older algorithm.