### PR TITLE
Upgrade schema-salad to 1.18.20160907135919.

### DIFF
--- a/recipes/schema-salad/meta.yaml
+++ b/recipes/schema-salad/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: schema-salad
-  version: "1.14.20160708181155"
+  version: '1.18.20160907135919'
 
 source:
-  fn: schema-salad-1.14.20160708181155.tar.gz
-  url: https://pypi.python.org/packages/57/01/14d5e22dbc71da0b7efd80f115e14e4a2d59710b85b4164719af6faf3da7/schema-salad-1.14.20160708181155.tar.gz
-  md5: a8a320bd213164db31377957d6404b19
+  fn: schema-salad-1.18.20160907135919.tar.gz
+  url: https://pypi.python.org/packages/22/5b/798667bcf7728612cb0cf9d0d3f71c4f8509efef60e61434b93cbefd6696/schema-salad-1.18.20160907135919.tar.gz
+  sha256: 67550518a6919404383e9bf6c7d449804442d36b38d7d0c7955fdfb06b809ed1
 
 build:
   entry_points:
@@ -23,6 +23,8 @@ requirements:
     - mistune
     - typing
     - ruamel.yaml
+    - cachecontrol
+    - lockfile
     - avro # [py27]
     - avro-python3 # [not py27]
 
@@ -34,6 +36,8 @@ requirements:
     - mistune
     - typing
     - ruamel.yaml
+    - cachecontrol
+    - lockfile
     - avro # [py27]
     - avro-python3 # [not py27]
 


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Hey ya'll, in addition to moving to a new version, this adds the cachecontrol and lockfile depdendencies, and switches md5sum to sha256sum. This upgrade is necessary to get the newest version of cwltool to build.