### PR TITLE
Update vcfanno to 0.1.0.

### DIFF
--- a/recipes/vcfanno/build.sh
+++ b/recipes/vcfanno/build.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 chmod a+x vcfanno
 mkdir -p $PREFIX/bin
 cp vcfanno $PREFIX/bin/vcfanno

--- a/recipes/vcfanno/meta.yaml
+++ b/recipes/vcfanno/meta.yaml
@@ -1,12 +1,14 @@
 package:
   name: vcfanno
-  version: '0.0.11'
+  version: '0.1.0'
 
 source:
-  fn: vcfanno_0.0.11-beta_darwin_amd64.zip # [osx]
-  url: https://github.com/brentp/vcfanno/releases/download/v0.0.11-beta/vcfanno_0.0.11-beta_darwin_amd64.zip # [osx]
-  fn: vcfanno_0.0.11-beta_linux_amd64.tar.gz # [linux64]
-  url: https://github.com/brentp/vcfanno/releases/download/v0.0.11-beta/vcfanno_0.0.11-beta_linux_amd64.tar.gz # [linux64]
+  fn: vcfanno_0.1.0_darwin_amd64.zip # [osx]
+  url: https://github.com/brentp/vcfanno/releases/download/v0.1.0/vcfanno_0.1.0_darwin_amd64.zip # [osx]
+  sha256: 34a2d1ab40d9bf9220d7590dccc9b7b2395513db7c61a16b7237869d5abb7b97 # [osx]
+  fn: vcfanno_0.1.0_linux_amd64.tar.gz # [linux]
+  url: https://github.com/brentp/vcfanno/releases/download/v0.1.0/vcfanno_0.1.0_linux_amd64.tar.gz # [linux]
+  sha256: 43e4fe5bc9b46af756326ad26650688190591dadca4c1cac53a33a4813e21fe8 # [linux]
 
 build:
   number: 0


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

Adds sha256 sums as well. This recipe is broken, and I could use a hand figuring out why. patchelf produces a binary that core dumps:

```
/home/vagrant/local/share/bcbio/anaconda/conda-bld/vcfanno_1474044392940/test_tmp/run_test.sh: line 3:  5683 Segmentation fault      (core dumped) vcfanno
```

I put a link to the original binary that doesn't core dump on linux64 and the patched one that does:

https://dl.dropboxusercontent.com/u/2822886/vcfanno-binaries.tar

If I don't update the recipe and try to rebuild the original files they also core dump. Any ideas?