### PR TITLE
Add perl dependencies to fastx_toolkit

### DIFF
--- a/recipes/fastx_toolkit/meta.yaml
+++ b/recipes/fastx_toolkit/meta.yaml
@@ -8,7 +8,7 @@ source:
 
 build:
   preserve_egg_dir: True
-  number: 2
+  number: 3
   skip: False
 
 requirements:
@@ -25,11 +25,17 @@ requirements:
     - nose
     - libgtextutils
     - gnuplot
+    - libgd >=2.1.1post 1
+    - perl-threaded
+    - perl-perlio-gzip
+    - perl-gd >=2.5.6 2
+    - perl-gdgraph-histogram
     #- pkg-config
 
 test:
     commands:
-      #- fastx_quality_stats -h  # This fails for some unknown reason, even though it prints the output successfully...
+      - SCRIPT=$(which fasta_clipping_histogram.pl) && perl5.22.0 "$SCRIPT"
+      - 'fastx_trimmer -h | grep "Part of FASTX Toolkit 0.0.14 by A. Gordon (assafgordon@gmail.com)"'
 
 about:
   home: https://github.com/agordon/fastx_toolkit


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

runtime dependencies. This is required for fasta_clipping_histogram.pl.
Also fixes tests (all fastx_* -h commands exit with exit-code 1) by
grepping for `Part of FASTX Toolkit 0.0.14 by A. Gordon
(assafgordon@gmail.com)`.

@bgruening, can you have a look at this? In particular, I don't understand why simply saying `fasta_clipping_histogram.pl` will use the system's perl (hence this awkward hack to retrieve the path to `fasta_clipping_histogram.pl`). I would have assumed for perl to be on PATH, but that perl won't have GD.pm in @INC.