### PR TITLE
diamond: Remove -march=native optimization

### DIFF
--- a/recipes/diamond/build.sh
+++ b/recipes/diamond/build.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
+sed -i.bak 's/-march=native/-march=x86-64/' CMakeLists.txt
+
 mkdir build
 cd build
+
 
 cmake .. \
       -DCMAKE_INSTALL_PREFIX=$PREFIX \

--- a/recipes/diamond/meta.yaml
+++ b/recipes/diamond/meta.yaml
@@ -1,6 +1,5 @@
 build:
-  number: 1
-  string: boost{{CONDA_BOOST}}_{{PKG_BUILDNUM}}
+  number: 2
 
 package:
   name: diamond
@@ -13,12 +12,10 @@ source:
 # We pin on gcc version to avoid gcc-5 dual ABI issues depending on boost.
 requirements:
   build:
-    - gcc >=4.8.5,<5 # [unix]
-    - boost >=1.53.0,{{CONDA_BOOST}}*
+    - gcc # [unix]
     - cmake
   run:
-    - libgcc >=4.8.5,<5 # [unix]
-    - boost {{CONDA_BOOST}}*
+    - libgcc # [unix]
 
 test:
   commands:


### PR DESCRIPTION
- Diamond no longer depends on boost.
- Diamond now builds with an `-march=native` optimization that is being replaced to build for generic x86.
