### PR TITLE
Add rust-bio-tools.

### DIFF
--- a/recipes/rust-bio-tools/build.sh
+++ b/recipes/rust-bio-tools/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -e
+
+# build statically linked binary with Rust
+LIBRARY_PATH=$PREFIX/lib cargo install --root $PREFIX

--- a/recipes/rust-bio-tools/build.sh
+++ b/recipes/rust-bio-tools/build.sh
@@ -1,4 +1,4 @@
 #!/bin/bash -e
 
 # build statically linked binary with Rust
-LIBRARY_PATH=$PREFIX/lib cargo install --root $PREFIX
+C_INCLUDE_PATH=$PREFIX/include LIBRARY_PATH=$PREFIX/lib cargo install --root $PREFIX

--- a/recipes/rust-bio-tools/meta.yaml
+++ b/recipes/rust-bio-tools/meta.yaml
@@ -17,6 +17,7 @@ requirements:
   build:
     - rust
     - gcc
+    - zlib
 
 test:
   commands:

--- a/recipes/rust-bio-tools/meta.yaml
+++ b/recipes/rust-bio-tools/meta.yaml
@@ -18,6 +18,9 @@ requirements:
     - rust
     - gcc
     - zlib
+  run:
+    - zlib
+    - libgcc
 
 test:
   commands:

--- a/recipes/rust-bio-tools/meta.yaml
+++ b/recipes/rust-bio-tools/meta.yaml
@@ -1,0 +1,30 @@
+{% set version = "0.1.1" %}
+
+package:
+  name: rust-bio-tools
+  version: {{version}}
+
+build:
+  number: 0
+  skip: True # [osx]
+
+source:
+  fn: merfishtools-{{version}}.tar.gz
+  url: https://github.com/rust-bio/rust-bio-tools/archive/v{{version}}.tar.gz
+  md5: 3e48658079abe85d5d03415de54da926
+
+requirements:
+  build:
+    - rust
+    - gcc
+
+test:
+  commands:
+    - rbt --help &> /dev/null
+
+about:
+  home: https://github.com/rust-bio/rust-bio-tools
+  license: MIT
+  summary: |
+    A growing collection of fast and secure command line utililities for dealing with NGS data
+    implemented on top of Rust-Bio.


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [x] This PR adds a new recipe.
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

@bioconda/core sorry for misusing this PR for ads ;-), but my feeling is that you guys might have a natural interest in this. I have started to build a set of somehow "missing" NGS related command line utilities (the rust-bio-tools) on top of my rust-bio library. The key idea is to leverage the powers of Rust to build ultra-fast and memory-safe tools for common tasks that are not easily (or quickly) solvable with what is out there right now. So, in case anybody is interested in joining or using that project, feel free to have a look. So far, I have:

* a linear time implementation for fuzzy matching of vcf/bcf files
* a linear time round-robin FASTQ splitter that splits a given FASTQ files into a given number of chunks
* a tool to extract depth information from BAMs at given loci, which is much faster than samtools for that case

If not, just ignore this message ;-).