### PR TITLE
Bump links to 1.8.4

### DIFF
--- a/recipes/links/build.sh
+++ b/recipes/links/build.sh
@@ -1,8 +1,11 @@
 mkdir -p $PREFIX/bin
 
+#Copying perl script to bin folder
 cp  LINKS $PREFIX/bin
 chmod +x $PREFIX/bin/LINKS
 
+
+#Recompiling C code
 cd lib/bloomfilter/swig/
 
 PERL5DIR=`(perl -e 'use Config; print $Config{archlibexp}, "\n";') 2>/dev/null`
@@ -10,7 +13,7 @@ swig -Wall -c++ -perl5 BloomFilter.i
 g++ -c BloomFilter_wrap.cxx -I$PERL5DIR/CORE -fPIC -Dbool=char -O3
 g++ -Wall -shared BloomFilter_wrap.o -o BloomFilter.so -O3
 
-
+#Installing included perl module 
 h2xs -n BloomFilter -O  -F -'I ../../../'
 cd BloomFilter
 perl Makefile.PL

--- a/recipes/links/build.sh
+++ b/recipes/links/build.sh
@@ -2,3 +2,17 @@ mkdir -p $PREFIX/bin
 
 cp  LINKS $PREFIX/bin
 chmod +x $PREFIX/bin/LINKS
+
+cd lib/bloomfilter/swig/
+
+PERL5DIR=`(perl -e 'use Config; print $Config{archlibexp}, "\n";') 2>/dev/null`
+swig -Wall -c++ -perl5 BloomFilter.i
+g++ -c BloomFilter_wrap.cxx -I$PERL5DIR/CORE -fPIC -Dbool=char -O3
+g++ -Wall -shared BloomFilter_wrap.o -o BloomFilter.so -O3
+
+
+h2xs -n BloomFilter -O  -F -'I ../../../'
+cd BloomFilter
+perl Makefile.PL
+make
+make install

--- a/recipes/links/links.patch
+++ b/recipes/links/links.patch
@@ -1,18 +1,18 @@
-
---- LINKS.old   2016-02-16 22:12:55.467119807 +0100
-+++ LINKS       2016-02-16 22:13:35.715954268 +0100
+--- LINKS.bak   2016-09-15 14:42:25.137348211 +0200
++++ LINKS       2016-09-15 14:22:04.514717448 +0200
 @@ -1,4 +1,4 @@
 -#!/usr/bin/perl
 +#!/usr/bin/env perl
- ##!/gsc/software/linux-x86_64-centos5/perl-5.16.3/bin/perl
 
  #AUTHOR
-@@ -77,7 +77,7 @@
-    #perl 5.8.8
-    ##use lib "$FindBin::Bin/./lib/Bloom-Faster-1.6/bloom/lib64/perl5/site_perl/5.8.8/x86_64-linux-thread-multi";
-    ##perl 5.16.3
--   use lib "$FindBin::Bin/./lib/Bloom-Faster-1.7/bloom5-16-3/lib/site_perl/5.16.3/x86_64-linux";###rebuild against PERL version or replace by pre-built
-+   ##use lib "$FindBin::Bin/./lib/Bloom-Faster-1.7/bloom5-16-3/lib/site_perl/5.16.3/x86_64-linux";###rebuild against PERL version or replace by pre-built
-    use Bloom::Faster;
- }
+ #   Rene Warren
+@@ -24,7 +24,7 @@
+ use strict;
+ use POSIX;
+ use FindBin;
+-use lib "$FindBin::Bin/./lib/bloomfilter/swig";
++#use lib "$FindBin::Bin/./lib/bloomfilter/swig";
+ use BloomFilter;
+ use Time::HiRes;
+ use Getopt::Std;
 

--- a/recipes/links/meta.yaml
+++ b/recipes/links/meta.yaml
@@ -14,7 +14,7 @@ source:
 
 build:
   number: 0
-  skip: False
+  skip: True # [osx]
 
 requirements:
   build:

--- a/recipes/links/meta.yaml
+++ b/recipes/links/meta.yaml
@@ -1,11 +1,13 @@
+{% set version = "1.8.4" %}
+
 package:
   name: links
-  version: "1.5.2"
+  version: {{ version }}
 
 source:
-  fn: links_v1-5-2.tar.gz
-  url: http://www.bcgsc.ca/platform/bioinfo/software/links/releases/1.5.2/links_v1-5-2.tar.gz
-  md5: 8ba3933b9e37c7d3712b2c690056545f
+  fn: links_{{ version }}.tar.gz
+  url: http://www.bcgsc.ca/platform/bioinfo/software/links/releases/1.8.4/links_v1-8-4.tar.gz
+  md5: 2777029b27c7b9359a7ecef936adcab8
 
   patches:
     - links.patch
@@ -17,12 +19,12 @@ build:
 requirements:
   build:
     - perl-threaded
-    - perl-bloom-faster
-
+    - swig
+    - gcc  # [not osx]
+    - llvm  # [osx]
   run:
     - perl-threaded
-    - perl-bloom-faster
-
+    - libgcc # [not osx]
 test:
   commands:
     - LINKS  | grep 'Usage' > /dev/null
@@ -30,5 +32,5 @@ test:
 about:
   summary: Long Interval Nucleotide K-mer Scaffolder
   home: http://www.bcgsc.ca/platform/bioinfo/software/links
-  license: GPL
+  license: GPLv3
   license_file: LINKS-readme.txt


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

This PR bumps links to current version. The difference from previous version is that links now depends on another perl module that is not in cpan. Briefly, the recipe is recompiling the C code and installing the included perl module and copying the links runner script. Unfortunately, I can't get it to compile on osx. 

This recipe needs a review by @bioconda/core as it is offers a custom solution. 

