### PR TITLE
bump samtools build after switch to conda-forge

### DIFF
--- a/recipes/htslib/meta.yaml
+++ b/recipes/htslib/meta.yaml
@@ -2,7 +2,7 @@ package:
   name: htslib
   version: "1.3.1"
 build:
-  number: 0
+  number: 1
   skip: False
 source:
   fn: htslib-1.3.1.tar.bz2

--- a/recipes/pysam/meta.yaml
+++ b/recipes/pysam/meta.yaml
@@ -8,7 +8,7 @@ source:
     md5: d87765ad1e0afe534255c20cce5478e4
 
 build:
-    number: 0
+    number: 1
     skip: False
 
 requirements:

--- a/recipes/samtools/meta.yaml
+++ b/recipes/samtools/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 3
+  number: 4
   skip: False
 
 source:


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

I seem to be having trouble with the OSX build of samtools (`dyld: Symbol not found: _stdscr`) after depending on conda-forge. Triggering Travis to rebuild to see if it is just me...