### PR TITLE
Gmap 2016.09.23 added, old 2015.09.10 kept as old version

### DIFF
--- a/recipes/gmap/2015.09.10/build.sh
+++ b/recipes/gmap/2015.09.10/build.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+env MAX_READLENGTH=500 ./configure --prefix=$PREFIX
+make
+make install prefix=$PREFIX

--- a/recipes/gmap/2015.09.10/meta.yaml
+++ b/recipes/gmap/2015.09.10/meta.yaml
@@ -32,3 +32,7 @@ build:
     - bin/gmap_uncompress
     - bin/gtf_introns
     - bin/gtf_splicesites
+test:
+  commands: 
+    - gmap --version
+    - gsnap --version

--- a/recipes/gmap/2015.09.10/meta.yaml
+++ b/recipes/gmap/2015.09.10/meta.yaml
@@ -1,0 +1,34 @@
+package:
+  name: gmap
+  version: "2015.09.10"
+source:
+  fn: gmap-gsnap-2015-09-10.tar.gz
+  url: http://research-pub.gene.com/gmap/src/gmap-gsnap-2015-09-10.tar.gz
+  sha1: c175c0d45ee7d79036fc08e357a66ab327dcb14f
+requirements:
+  build:
+  run:
+about:
+  home: http://research-pub.gene.com/gmap/
+  license: Non-commercial
+  summary: Genomic mapping and alignment program for mRNA and EST sequences
+build:
+  skip: True # [osx]
+  binary_has_prefix_files:
+    - bin/atoiindex
+    - bin/cmetindex
+    - bin/gmap
+    - bin/gmapl
+    - bin/gsnap
+    - bin/gsnapl
+    - bin/mpi_gsnap
+    - bin/snpindex
+    - bin/uniqscan
+    - bin/uniqscanl
+  has_prefix_files:
+    - bin/gff3_introns
+    - bin/gff3_splicesites
+    - bin/gmap_build
+    - bin/gmap_uncompress
+    - bin/gtf_introns
+    - bin/gtf_splicesites

--- a/recipes/gmap/build.sh
+++ b/recipes/gmap/build.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
-env MAX_READLENGTH=500 ./configure --prefix=$PREFIX
+./configure MAX_READLENGTH=500 --prefix=$PREFIX
 make
 make install prefix=$PREFIX

--- a/recipes/gmap/build.sh
+++ b/recipes/gmap/build.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
-./configure MAX_READLENGTH=500 --prefix=$PREFIX
+env MAX_READLENGTH=500 ./configure --prefix=$PREFIX
 make
 make install prefix=$PREFIX

--- a/recipes/gmap/meta.yaml
+++ b/recipes/gmap/meta.yaml
@@ -13,7 +13,7 @@ about:
   license: Non-commercial
   summary: Genomic mapping and alignment program for mRNA and EST sequences
 build:
-  skip: True # [osx]
+  skip: False # [osx]
   binary_has_prefix_files:
     - bin/atoiindex
     - bin/cmetindex
@@ -27,3 +27,7 @@ build:
     - bin/gmap_uncompress
     - bin/gtf_introns
     - bin/gtf_splicesites
+test:
+  commands: 
+    - gmap --version
+    - gsnap --version

--- a/recipes/gmap/meta.yaml
+++ b/recipes/gmap/meta.yaml
@@ -17,11 +17,6 @@ build:
   binary_has_prefix_files:
     - bin/atoiindex
     - bin/cmetindex
-    - bin/gmap
-    - bin/gmapl
-    - bin/gsnap
-    - bin/gsnapl
-    - bin/mpi_gsnap
     - bin/snpindex
     - bin/uniqscan
     - bin/uniqscanl

--- a/recipes/gmap/meta.yaml
+++ b/recipes/gmap/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: gmap
-  version: "2015.09.10"
+  version: "2016.09.23"
 source:
-  fn: gmap-gsnap-2015-09-10.tar.gz
-  url: http://research-pub.gene.com/gmap/src/gmap-gsnap-2015-09-10.tar.gz
-  sha1: c175c0d45ee7d79036fc08e357a66ab327dcb14f
+  fn: gmap-gsnap-2016-09-23.tar.gz
+  url: http://research-pub.gene.com/gmap/src/gmap-gsnap-2016-09-23.tar.gz
+  sha1: 9d56ebcf47da5b4c1326bbeed37e37971657bbf7
 requirements:
   build:
   run:


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [X] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

This PR adds new version of gmap recipe (version [2016.09.23](http://research-pub.gene.com/gmap/)) and keeps old version as optional (dir "2015.09.10" under gmap)