### PR TITLE
Recipe for mgs-canopy

### DIFF
--- a/recipes/mgs-canopy/build.sh
+++ b/recipes/mgs-canopy/build.sh
@@ -11,3 +11,4 @@ echo "> Building target: cc.bin"
 g++ -o cc.bin -fopenmp -I${PREFIX}/include -L${PREFIX}/lib -lboost_program_options $(find . -name "*.o")
 
 cp cc.bin $PREFIX/bin
+ln -s $PREFIX/bin/cc.bin $PREFIX/bin/canopy

--- a/recipes/mgs-canopy/build.sh
+++ b/recipes/mgs-canopy/build.sh
@@ -1,0 +1,14 @@
+export LD_LIBRARY_PATH=$PREFIX
+cd src/
+
+echo "> Compiling sources"
+for F in $(find . -name "*.cpp") ; do
+	echo "  - $F"
+	FF=${F%.*}
+	g++ -o $FF.o -fopenmp -c -Wall -Wextra -O3 -march=native -I./ -I${PREFIX}/include -L${PREFIX}/lib $FF.cpp
+done;
+
+echo "> Building target: cc.bin"
+g++ -o cc.bin -fopenmp -I${PREFIX}/include -L${PREFIX}/lib -lboost_program_options $(find . -name "*.o")
+
+cp cc.bin $PREFIX/bin

--- a/recipes/mgs-canopy/build.sh
+++ b/recipes/mgs-canopy/build.sh
@@ -3,7 +3,6 @@ cd src/
 
 echo "> Compiling sources"
 for F in $(find . -name "*.cpp") ; do
-	echo "  - $F"
 	FF=${F%.*}
 	g++ -o $FF.o -fopenmp -c -Wall -Wextra -O3 -march=native -I./ -I${PREFIX}/include -L${PREFIX}/lib $FF.cpp
 done;

--- a/recipes/mgs-canopy/meta.yaml
+++ b/recipes/mgs-canopy/meta.yaml
@@ -11,6 +11,7 @@ source:
 
 build:
   number: 0
+  skip: True  # [osx]
 
 requirements:
   build:

--- a/recipes/mgs-canopy/meta.yaml
+++ b/recipes/mgs-canopy/meta.yaml
@@ -1,13 +1,16 @@
 {% set name = "mgs-canopy" %}
 {% set version = "1.0" %}
+{% set sha256 = "9f227c6554c65054f552ad274e48102084dfc126cec9f28f8a3caf5afe922489" %}
+{% set md5 = "027627c3090a7adc8ad7238d4900636a" %}
 
 package:
   name: {{ name }}
   version: {{ version }}
 
 source:
-  git_rev: 00a60e0
-  git_url: https://github.com/fplaza/mgs-canopy-algorithm.git
+  url: https://github.com/fplaza/mgs-canopy-algorithm/archive/00a60e0.tar.gz
+  sha256: {{ sha256 }}
+  md5: {{ md5 }}
 
 build:
   number: 0
@@ -15,12 +18,12 @@ build:
 
 requirements:
   build:
-    - boost
+    - boost {{ CONDA_BOOST }}*
     - gcc   # [not osx]
     - llvm  # [osx]
 
   run:
-    - boost
+    - boost {{ CONDA_BOOST }}*
     - libgcc    # [not osx]
 
 test:

--- a/recipes/mgs-canopy/meta.yaml
+++ b/recipes/mgs-canopy/meta.yaml
@@ -26,6 +26,7 @@ requirements:
 test:
   commands:
     - command -v cc.bin
+    - command -v canopy
 
 about:
   home: "https://github.com/fplaza/mgs-canopy-algorithm"

--- a/recipes/mgs-canopy/meta.yaml
+++ b/recipes/mgs-canopy/meta.yaml
@@ -1,0 +1,37 @@
+{% set name = "mgs-canopy" %}
+{% set version = "1.0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  git_rev: 00a60e0
+  git_url: https://github.com/fplaza/mgs-canopy-algorithm.git
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - boost
+    - gcc   # [not osx]
+    - llvm  # [osx]
+
+  run:
+    - boost
+    - libgcc    # [not osx]
+
+test:
+  commands:
+    - command -v cc.bin
+
+about:
+  home: "https://github.com/fplaza/mgs-canopy-algorithm"
+  license: "GPL3"
+  summary: "Canopy clustering algorithm"
+
+extra:
+  maintainers:
+    - keuv-grvl
+  doi: 10.1038/nbt.2939


### PR DESCRIPTION
- [x] I have read the guidelines above.
- [x] This PR adds a new recipe.
- [ ] This PR updates an existing recipe.
- [ ] This PR does something else (explain below).

The [mgs-canopy-algorithm](https://github.com/fplaza/mgs-canopy-algorithm) repo have a pretty well written Makefile for system-wide install, but it does not work within Conda. This is due to `boost` location, even by setting `BOOST_INCDIR` and others. So I compile "manually" the sources.
