### PR TITLE
Add bwa and pandoc to runtime requirements

### DIFF
--- a/recipes/abyss/1.9.0/meta.yaml
+++ b/recipes/abyss/1.9.0/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: "1.9.0"
 
 build:
-  number: 1
+  number: 2
   string: boost{{CONDA_BOOST}}_{{PKG_BUILDNUM}}
 
 source:
@@ -20,6 +20,7 @@ requirements:
   - sqlite
 
   run:
+  - bwa
   - libgcc # [not osx]
   - sqlite
 

--- a/recipes/abyss/meta.yaml
+++ b/recipes/abyss/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 build:
   skip: True # [osx]
-  number: 0
+  number: 1
   string: boost{{CONDA_BOOST}}_{{PKG_BUILDNUM}}
 
 source:
@@ -24,7 +24,9 @@ requirements:
   - sqlite
 
   run:
+  - bwa
   - libgcc # [not osx]
+  - pandoc
   - sqlite
 
 test:


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

bwa is needed for scaffolding with long sequences.
pandoc is needed to produce '-stats.html' files from Markdown.

Ping @druvus.