### PR TITLE
Added vcflib scripts to freebayes recipe.

### DIFF
--- a/recipes/freebayes/build.sh
+++ b/recipes/freebayes/build.sh
@@ -59,6 +59,3 @@ cp scripts/generate_freebayes_region_scripts.sh $PREFIX/bin
 cp vcflib/bin/vcfstreamsort $PREFIX/bin
 cp vcflib/bin/vcfuniq $PREFIX/bin
 cp vcflib/scripts/vcffirstheader $PREFIX/bin
-
-# Copy library for vcflib.
-cp vcflib/tabixpp/htslib/libhts.so* $PREFIX/lib

--- a/recipes/freebayes/build.sh
+++ b/recipes/freebayes/build.sh
@@ -5,7 +5,7 @@ if [ "$(uname)" == "Darwin" ]; then
    sed -i.bak 's/LDFLAGS=-Wl,-s/LDFLAGS=/' vcflib/smithwaterman/Makefile
 fi
 
-# bamtools/cmake for zlib
+# Bamtools/cmake for zlib.
 export CPLUS_INCLUDE_PATH=${PREFIX}/include
 export LIBRARY_PATH=${PREFIX}/lib
 
@@ -19,7 +19,22 @@ make autoversion
 make CPPFLAGS="-I$PREFIX/include" LDFLAGS="-L$PREFIX/lib"
 cd ..
 
-pythonfiles="scripts/fasta_generate_regions.py scripts/coverage_to_regions.py"
+# Build vcflib (needed for freebayes-parallel).
+export C_INCLUDE_PATH=$PREFIX/include
+
+cd vcflib
+
+# Tabix missing library https://github.com/ekg/tabixpp/issues/5
+# Uses newline trick for OSX from: http://stackoverflow.com/a/24299845/252589
+sed -i.bak 's/SUBDIRS=./SUBDIRS=.\'$'\n''LOBJS=tabix.o/' tabixpp/Makefile
+sed -i.bak 's/-ltabix//' Makefile
+
+make
+
+cd ..
+
+# Translate for Python 3 if needed.
+pythonfiles="scripts/fasta_generate_regions.py scripts/coverage_to_regions.py vcflib/scripts/vcffirstheader"
 
 PY3_BUILD="${PY_VER%.*}"
 
@@ -28,10 +43,22 @@ then
     for i in $pythonfiles; do 2to3 --write $i; done
 fi
 
+# Copy executables.
 mkdir -p $PREFIX/bin
 cp -r bin/* $PREFIX/bin
+
+sed -i.bak 's/..\/vcflib\/scripts\///g; s/..\/vcflib\/bin\///g' scripts/freebayes-parallel
 cp scripts/freebayes-parallel $PREFIX/bin
+
 sed -i.bak 's@#!/usr/bin/python@#!/usr/bin/env python@g' scripts/fasta_generate_regions.py
 cp scripts/fasta_generate_regions.py $PREFIX/bin
+
 cp scripts/coverage_to_regions.py $PREFIX/bin
 cp scripts/generate_freebayes_region_scripts.sh $PREFIX/bin
+
+cp vcflib/bin/vcfstreamsort $PREFIX/bin
+cp vcflib/bin/vcfuniq $PREFIX/bin
+cp vcflib/scripts/vcffirstheader $PREFIX/bin
+
+# Copy library for vcflib.
+cp vcflib/tabixpp/htslib/libhts.so* $PREFIX/lib

--- a/recipes/freebayes/meta.yaml
+++ b/recipes/freebayes/meta.yaml
@@ -21,6 +21,7 @@ requirements:
     - zlib
     - python
     - libgcc  # [linux]
+    - htslib
 
 test:
   commands:

--- a/recipes/freebayes/meta.yaml
+++ b/recipes/freebayes/meta.yaml
@@ -7,21 +7,25 @@ source:
   git_rev: 41c1313
 
 build:
-  number: 2
-  skip: False
+  number: 3
+  skip: True  # [osx]
 
 requirements:
   build:
+    - gcc   # [linux]
+    - llvm  # [osx]
     - cmake
     - zlib
     - python
   run:
     - zlib
     - python
+    - libgcc  # [linux]
 
 test:
   commands:
     - freebayes --version
+    - vcfstreamsort -h
 
 about:
   home: https://github.com/ekg/freebayes


### PR DESCRIPTION
- [x] I have read the guidelines above.
- [ ] This PR adds a new recipe.
- [x] This PR updates an existing recipe.
- [ ] This PR does something else (explain below).

This pull request is a first stab at fixing the issues mentioned in #2148. Essentially, the modified recipe now also builds the vcflib submodule and copies the required scripts + library from the vcflib directory for freebayes-parallel.

The new recipe works fine on linux (tested in a docker container), but I have been unable to get it working on my Mac. The main issue lies in failing to build vcflib, which I think requires the C++11 stdlib for clang. The error I am currently getting on OSX is as follows:

``` bash
ar: creating archive libvcflib.a
cp libvcflib.a lib
cd intervaltree && /Applications/Xcode.app/Contents/Developer/usr/bin/make && cp *.h* /Users/Julian/Anaconda/conda-bld/freebayes_1476131480742/work/vcflib/include/
g++ -Wall interval_tree_test.cpp -o interval_tree_test -std=c++0x
clang: warning: libstdc++ is deprecated; move to libc++ with a minimum deployment target of OS X 10.9
interval_tree_test.cpp:2:10: fatal error: 'thread' file not found
#include <thread>
         ^
1 error generated.
make[1]: *** [interval_tree_test] Error 1
make: *** [intervaltree] Error 2
```

Any tips are welcome, as I would like the package to keep support for OSX! (An alternative would be to make a separate freebayes-parallel package that drops OSX support, if need be.)
