### PR TITLE
fixed bcftools plugin search path

### DIFF
--- a/recipes/bcftools/1.3.1/build.sh
+++ b/recipes/bcftools/1.3.1/build.sh
@@ -2,5 +2,4 @@
 
 export CPPFLAGS="-I$PREFIX/include"
 export LDFLAGS="-L$PREFIX/lib"
-make plugins
-make prefix=$PREFIX CPPFLAGS=$CPPFLAGS LDFLAGS=$LDFLAGS install
+make prefix=$PREFIX CPPFLAGS=$CPPFLAGS LDFLAGS=$LDFLAGS plugins install

--- a/recipes/bcftools/1.3.1/meta.yaml
+++ b/recipes/bcftools/1.3.1/meta.yaml
@@ -8,7 +8,7 @@ about:
     streaming from a pipe. Indexed VCF and BCF will work in all situations. Un-indexed
     VCF and BCF and streams will work in most, but not all situations.
 build:
-  number: 0
+  number: 1
 package:
   name: bcftools
   version: '1.3.1'
@@ -25,3 +25,4 @@ test:
   commands:
     - "bcftools -h > /dev/null"
     - bcftools --version
+    - bcftools plugin -lv


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

  added detect_binary_files_with_prefix build option
  to make conda automatically fix the path

bcftools plugin command has a default search path to look for plugins, and it was poiting to ``/anaconda/envs/_build/libexec/bcftools`` , this commit sets the ``detect_binary_files_with_prefix`` conda option to have conda automatically look for these paths on the binaries and update them at install time, this fixes the problem.
