### PR TITLE
Update: bcbio, bcbio-vm for Arvados/WDL

### DIFF
--- a/recipes/bcbio-nextgen-vm/meta.yaml
+++ b/recipes/bcbio-nextgen-vm/meta.yaml
@@ -3,12 +3,12 @@ package:
   version: '0.1.0a'
 
 build:
-  number: 85
+  number: 86
   skip: True # [not py27]
 
 source:
-  fn: bcbio-nextgen-vm-92ab799.tar.gz
-  url: https://github.com/chapmanb/bcbio-nextgen-vm/archive/92ab799.tar.gz
+  fn: bcbio-nextgen-vm-5769bcd.tar.gz
+  url: https://github.com/chapmanb/bcbio-nextgen-vm/archive/5769bcd.tar.gz
 
 requirements:
   build:

--- a/recipes/bcbio-nextgen/meta.yaml
+++ b/recipes/bcbio-nextgen/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: '1.0.0a0'
 
 build:
-  number: 7
+  number: 8
   skip: True # [not py27]
 
 source:
@@ -11,8 +11,8 @@ source:
   #fn: bcbio-nextgen-0.9.9.tar.gz
   #url: https://pypi.python.org/packages/4f/90/36f1908ef62b954102604cdfe9d4d7d490131050ae0cd294e27bac5989cc/bcbio-nextgen-0.9.9.tar.gz
   #md5: b7ff9a89c247016282762f2f1ae9a036
-  fn: bcbio-nextgen-e1baf12.tar.gz
-  url: https://github.com/chapmanb/bcbio-nextgen/archive/e1baf12.tar.gz
+  fn: bcbio-nextgen-d4031da.tar.gz
+  url: https://github.com/chapmanb/bcbio-nextgen/archive/d4031da.tar.gz
 
 requirements:
   build:


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Bumps bcbio and bcbio-vm to latest development versions to support
variable naming compatible with WDL and retrieval of genome_context
from Arvados Keep storage.