### PR TITLE
Pandaseq fix

### DIFF
--- a/recipes/pandaseq/meta.yaml
+++ b/recipes/pandaseq/meta.yaml
@@ -12,6 +12,7 @@ source:
 
 requirements:
   build:
+  - perl-threaded
   - gcc [linux]
   - llvm [osx]
   - autoconf
@@ -24,7 +25,7 @@ requirements:
 
 test:
   commands:
-    - pandaseq -h  2>&1 | grep Usage > /dev/null
+    - pandaseq -h 2>&1 | grep 'Usage' > /dev/null
 
 about:
   home: https://github.com/neufeld/pandaseq


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

The pandaseq recipe was passing the tests but failed to generate bioconda package. It seems it was /usr/bin/perl so I am trying to add perl-threaded as a build dep.
