### PR TITLE
Skip build graphmap 3.0 until fixed

### DIFF
--- a/recipes/graphmap/meta.yaml
+++ b/recipes/graphmap/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 build:
   number: 0
-  skip: True # [osx]
+  skip: True 
 
 source:
   fn: {{ name|lower }}_{{ version }}.tar.gz


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

Skip building graphmap (version 3.0) until I got time to figure out why the error. 