### PR TITLE
Fix hard-coded shebangs in autoconf

### DIFF
--- a/recipes/autoconf/build.sh
+++ b/recipes/autoconf/build.sh
@@ -2,4 +2,12 @@
 
 ./configure --prefix=$PREFIX
 make
+
+sed -i.bak 's|/usr/bin/perl|/usr/bin/env perl|' bin/autom4te
+sed -i.bak 's|/usr/bin/perl|/usr/bin/env perl|' bin/autoheader 
+sed -i.bak 's|/usr/bin/perl|/usr/bin/env perl|' bin/autoreconf 
+sed -i.bak 's|/usr/bin/perl|/usr/bin/env perl|' bin/ifnames 
+sed -i.bak 's|/usr/bin/perl|/usr/bin/env perl|' bin/autoscan 
+sed -i.bak 's|/usr/bin/perl|/usr/bin/env perl|' bin/autoupdate
+
 make install

--- a/recipes/autoconf/meta.yaml
+++ b/recipes/autoconf/meta.yaml
@@ -1,6 +1,5 @@
 build:
-  number: 0
-  skip: True # [osx]
+  number: 1
 
 package:
   name: autoconf
@@ -19,9 +18,10 @@ requirements:
 
 test:
   commands:
-    - autoconf --help
-
+    - autoconf -V
+    - autoreconf -V
 about:
   home: http://www.gnu.org/software/autoconf/
+  summary: 'Autoconf is an extensible package of M4 macros that produce shell scripts to automatically configure software source code packages.'
   license: GPL 3
 


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

This will fix the hard coded path in shebangs. Added an extra test to verify that the path is set correctly. The problem with the previous test was that the main autoconf script used as a test is a bash script while the most others are perl scripts. 