### PR TITLE
fix error code in travis-run.sh; blacklist failing package

### DIFF
--- a/build-fail-blacklist
+++ b/build-fail-blacklist
@@ -1,0 +1,2 @@
+recipes/autoconf
+recipes/gvcftools

--- a/config.yml
+++ b/config.yml
@@ -1,6 +1,7 @@
 env_matrix: "scripts/env_matrix.yml"
 blacklists:
     - "sorted-r-blacklist"
+    - "build-fail-blacklist"
 
 docker_image: "continuumio/conda_builder_linux:5.11-5.2-0-1"
 channels:

--- a/scripts/travis-run.sh
+++ b/scripts/travis-run.sh
@@ -5,7 +5,7 @@ if [[ $TRAVIS_OS_NAME = "linux" ]]
 then
     docker run -e SUBDAG -e SUBDAGS -e TRAVIS_BRANCH -e TRAVIS_PULL_REQUEST -e ANACONDA_TOKEN -e BIOCONDA_UTILS_ARGS \
                -v `pwd`:/bioconda-recipes condaforge/linux-anvil /bin/bash -c \
-               "cd /bioconda-recipes; conda install --file scripts/requirements.txt; pip install git+https://github.com/bioconda/bioconda-utils.git@$BIOCONDA_UTILS_TAG; pip install git+https://github.com/bioconda/conda-build.git@fix-build-skip-existing; set -x; bioconda-utils build recipes config.yml $BIOCONDA_UTILS_ARGS; set +x"
+               "set -euo pipefail; cd /bioconda-recipes; conda install --file scripts/requirements.txt; pip install git+https://github.com/bioconda/bioconda-utils.git@$BIOCONDA_UTILS_TAG; pip install git+https://github.com/bioconda/conda-build.git@fix-build-skip-existing; set -x; bioconda-utils build recipes config.yml $BIOCONDA_UTILS_ARGS; set +x"
 
     if [[ $SUBDAG = 0 ]]
     then

--- a/sorted-r-blacklist
+++ b/sorted-r-blacklist
@@ -482,3 +482,6 @@ recipes/poretools/0.5.1
 recipes/mgkit
 recipes/r-mixomics
 recipes/bioconductor-minfi
+
+
+recipes/gvcftools


### PR DESCRIPTION
* [ ] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

@bioconda/all if you have submitted a PR since Oct 11, you may have to re-submit. The build system has been giving false positives. Builds would fail, but at the end the exit code would be 0 so travis-ci would incorrectly report the build as passing.

The problem was [this change](https://github.com/bioconda/bioconda-recipes/commit/6411abd8bb8c1cac1a32b4e9e5a30f816fcb4f63#diff-a666270151818014dbda5ced5b3bc54eR8). While `set -euo pipefail` is set at the script level, it is not set in the call to the docker container. This means that the final reported exit code from docker was from the `set +x` call, which was always zero even if the build failed.

This PR adds `set -euo pipefail` to the docker command to fix the issue.

I'm sorry to say this was my change that caused the error, so I'll be going through all the commits since then to make sure they build correctly now. It may take some time, so if you want to make sure your package is available in the bioconda channel then you may want to re-submit.

Sorry for the inconvenience, and please watch this PR for updates.

