### PR TITLE
Update: biobambam, samblaster with MC fixes

### DIFF
--- a/recipes/biobambam/meta.yaml
+++ b/recipes/biobambam/meta.yaml
@@ -1,9 +1,9 @@
 package:
   name: biobambam
-  version: '2.0.44'
+  version: '2.0.57'
 source:
-  fn: biobambam2-2.0.44.tar.gz
-  url: https://github.com/gt1/biobambam2/releases/download/2.0.44-release-20160517104101/biobambam2-2.0.44-release-20160517104101-x86_64-etch-linux-gnu.tar.gz
+  fn: biobambam2-2.0.57.tar.gz
+  url: https://github.com/gt1/biobambam2/releases/download/2.0.57-release-20160918185932/biobambam2-2.0.57-release-20160918185932-x86_64-etch-linux-gnu.tar.gz
 build:
   number: 0
   binary_relocation: false

--- a/recipes/samblaster/meta.yaml
+++ b/recipes/samblaster/meta.yaml
@@ -6,14 +6,16 @@ build:
 
 package:
   name: samblaster
-  version: '0.1.22'
+  version: '0.1.23'
 source:
-  fn: samblaster-v.0.1.22.tar.gz
-  url: https://github.com/GregoryFaust/samblaster/releases/download/v.0.1.22/samblaster-v.0.1.22.tar.gz
+  fn: samblaster-v.0.1.23.tar.gz
+  url: https://github.com/GregoryFaust/samblaster/releases/download/v.0.1.23/samblaster-v.0.1.23.tar.gz
 
 requirements:
   build:
+    - gcc
   run:
+    - libgcc
 
 test:
     commands:


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Both tools have recent releases which avoid empty mate cigar tags (MC)
which cause validation errors in Picard and htslib derived tools.