### PR TITLE
Kobas fix

### DIFF
--- a/recipes/kobas/meta.yaml
+++ b/recipes/kobas/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: "2.1.1"
 
 build:
-  number: 0
+  number: 1
   skip: True # [py3k]
 
 source:
@@ -35,7 +35,6 @@ test:
   commands:
     - kobas-annotate -h
     - kobas-identify -h
-    - kobas-run -h
 
 about:
   home: http://http://kobas.cbi.pku.edu.cn/index.php

--- a/recipes/kobas/package.patch
+++ b/recipes/kobas/package.patch
@@ -1,12 +1,11 @@
-From 6eed68bad779b7b168302c62714595bb7c1f3864 Mon Sep 17 00:00:00 2001
 From: blankclemens <blankclemens@gmail.com>
 Date: Wed, 5 Oct 2016 13:52:39 +0200
 Subject: [PATCH] Add setup.py and run.py for packaging.
 
 ---
- src/kobas/scripts/run.py | 10 ++++++++++
- src/setup.py             | 19 +++++++++++++++++++
- 2 files changed, 29 insertions(+)
+ src/kobas/scripts/run.py | 7 ++++++++++
+ src/setup.py             | 20 +++++++++++++++++++
+ 2 files changed, 27 insertions(+)
  create mode 100755 src/kobas/scripts/run.py
  create mode 100644 src/setup.py
 
@@ -15,11 +14,8 @@ new file mode 100755
 index 0000000..99ea45a
 --- /dev/null
 +++ src/kobas/scripts/run.py
-@@ -0,0 +1,10 @@
+@@ -0,0 +1,7 @@
 +#!/usr/bin/env python
-+
-+def run_kobas():
-+    from kobas.scripts import run_kobas
 +
 +def identify():
 +    from kobas.scripts import identify

--- a/recipes/planemo/meta.yaml
+++ b/recipes/planemo/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: planemo
-  version: "0.33.2"
+  version: "0.34.1"
 
 source:
-  fn: planemo-0.33.2.tar.gz
-  url: https://pypi.python.org/packages/d9/56/074bc99330b3f3903125d183d5382abe27552a113f1a0f8fa53dce416a3d/planemo-0.33.2.tar.gz
-  md5: 311fce18254a91196f71dfec9fb517c2
+  fn: planemo-0.34.1.tar.gz
+  url: https://pypi.python.org/packages/99/3c/6f1004343bad1e79106eb47030a055b02655e08137f55036ca13f71f55cc/planemo-0.34.1.tar.gz
+  md5: cdb907816e915acaa873f61522166739
 
 build:
   preserve_egg_dir: True


### PR DESCRIPTION
Fixed the `kobas-run` command by removing it. Kobas consist of two consecutive tools, annotate and identify, which are both executed by the `run_kobas.py` script. However, running this script in a wrapper `run.py` didn't work since there is some kind of a problem with routing the command line arguments.

Since that's just a wrapper I decided to remove it.

* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).