### PR TITLE
Fix channel priorities for building and in the docs.

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -5,7 +5,7 @@ blacklists:
 docker_image: "continuumio/conda_builder_linux:5.11-5.2-0-1"
 channels:
     - anaconda
-    - conda-forge
     - r
+    - conda-forge
     - bioconda
 docker_client_version: '1.20'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -51,8 +51,8 @@ Step 2: Setup Bioconda
 
 After installing Miniconda, you can use the ``conda`` command to setup bioconda with::
 
-   conda config --add channels conda-forge
    conda config --add channels r
+   conda config --add channels conda-forge
    conda config --add channels bioconda
 
 The ``r`` channel is added to satisfy the `R language <https://www.r-project.org/>`_

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -51,9 +51,9 @@ Step 2: Setup Bioconda
 
 After installing Miniconda, you can use the ``conda`` command to setup bioconda with::
 
+   conda config --add channels conda-forge
    conda config --add channels r
    conda config --add channels bioconda
-   conda config --add channels conda-forge
 
 The ``r`` channel is added to satisfy the `R language <https://www.r-project.org/>`_
 dependencies of some packages as well as some non-R dependencies.
@@ -61,7 +61,9 @@ Even if you don't plan on installing R packages, the `r` channel is required
 for some Bioconda packages. Similarly, the ``conda-forge`` channel contains
 many dependencies that are not strictly for bioinformatics but that are
 required for Bioconda packages to work (see more at
-`https://conda-forge.github.io/_`)
+`https://conda-forge.github.io`_).
+Be sure to add the channels in the given order, because it defines how conda handles ambiguity between channels.
+See `http://conda.pydata.org/docs/channels.html`_ for more information.
 
 Step 3: Install packages or create environments
 -----------------------------------------------


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

@bioconda/core: as you know, we depend on 3 channels since some time:

| channel | dependency |
| ---------- | --------------- |
| anaconda | - |
| r | anaconda |
| conda-forge | anaconda |

Unfortunately, those channels are not disjoint. Some packages are available in at least two of them. From time to time, it can happen that those packages are binary incompatible, and hence not interchangeable when pulling dependencies (e.g. PR #2569). Currently, conda does not have a good mechanism to solve such problems.
The best we can do at the moment is to enforce an order (i.e. prioritization) of channels, that causes the least problems. My feeling is that this is the order `anaconda > r > conda-forge`. Why? Because the R channel builds on several packages that are also in conda-forge, while this is quite unlikely vice versa. We need to ensure that an r-channel dependency does not pull a binary incompatible package from conda-forge. My hope is that this ordering will help here.

This is only a temporal workaround. A real solution would be one of the following:

* ensure binary compatibility between channels, 
* support pinning of dependencies beyond the plain version
* to support channel dependencies in the conda dependency solver

This is a quite pressing issue, and I would really appreciate your help on this. In order to not fragment the discussion, only post about the workaround here.
For the general problem, please join the discussion with people from the other channels here: #2569.