### PR TITLE
Parafly. Skipping binary relocation to prevent build error.

### DIFF
--- a/recipes/parafly/meta.yaml
+++ b/recipes/parafly/meta.yaml
@@ -8,7 +8,7 @@ source:
   sha256: 64cf7ac2d4af0801b78d58f4057a1489d76b2b8ae59c78997f434d1239fa4abe
 
 build:
-  number: 0
+  number: 1
   binary_relocation: False
 
 requirements:

--- a/recipes/parafly/meta.yaml
+++ b/recipes/parafly/meta.yaml
@@ -9,6 +9,7 @@ source:
 
 build:
   number: 0
+  binary_relocation: False
 
 requirements:
   build:


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Add `binary_relocation: False` like in #2686