### PR TITLE
try a package with fortran error

### DIFF
--- a/recipes/r-multitaper/meta.yaml
+++ b/recipes/r-multitaper/meta.yaml
@@ -16,11 +16,10 @@ build:
 requirements:
   build:
     - r
-    - gcc #[linux]
-    - llvm #[osx]
+    - gcc
   run:
     - r
-    - libgcc  # [linux]
+    - libgcc
 
 test:
   commands:

--- a/sorted-r-blacklist
+++ b/sorted-r-blacklist
@@ -5,7 +5,7 @@ recipes/cap-mirseq
 
 
 # TODO: r-multitaper has an unresolved libgfortran issue
-recipes/r-multitaper
+# recipes/r-multitaper
 
 
 # recipes/r-readbrukerflexdata


### PR DESCRIPTION
* [ ] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).


@bgruening gfortran is in gcc, but we specify llvm for osx. LLVM doesn't have gfortran, so we get errors like this:

https://travis-ci.org/bioconda/bioconda-recipes/jobs/171435317#L277

I don't know enough about gcc/llvm to know what kinds of issues having both would have. Any ideas for handling this?

xref #2475 