### PR TITLE
add trinotate 3.0.1 ... the good version

### DIFF
--- a/recipes/trinotate/build.sh
+++ b/recipes/trinotate/build.sh
@@ -15,6 +15,6 @@ cd perl-build
 
 cp ${RECIPE_DIR}/Build.PL ./
 
-${PREFIX}/bin/perl ./Build.PL
-./Build manifest
-./Build install --installdirs site
+perl ./Build.PL
+perl ./Build manifest
+perl ./Build install --installdirs site

--- a/recipes/trinotate/meta.yaml
+++ b/recipes/trinotate/meta.yaml
@@ -10,7 +10,7 @@ build:
 
 package:
   name: trinotate
-  version: '3.2.2'
+  version: '3.0.1'
 
 requirements:
   build:


### PR DESCRIPTION
* [ ] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

The conda package version was not good. See: https://github.com/Trinotate/Trinotate/releases 
@bioconda/core can you remove the version 3.2.2