### PR TITLE
Added recipe for blast+-2.2.18 binaries

### DIFF
--- a/recipes/blast/2.2.18/build.sh
+++ b/recipes/blast/2.2.18/build.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e -x -o pipefail
+
+mkdir -p $PREFIX/bin
+
+if [ "$(uname)" == "Darwin" ]; then
+    echo "Platform: Mac"
+
+    # export CFLAGS='-O3'
+    # export CXXFLAGS='-O3'
+
+    cp $SRC_DIR/bin/* $PREFIX/bin
+
+elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+    echo "Platform: Linux"
+    
+    # Blast binaries require libpcre.so.0, but pcre packages comes with libpcre.so.1
+    LIBPCRE_TRUE_PATH="$(readlink --canonicalize ${PREFIX}/lib/libpcre.so.1)"
+    ln -s $LIBPCRE_TRUE_PATH ${PREFIX}/lib/libpcre.so.0
+    
+    cp $SRC_DIR/bin/* $PREFIX/bin/
+fi
+
+chmod +x $PREFIX/bin/*

--- a/recipes/blast/2.2.18/legacy_blast.pl.patch
+++ b/recipes/blast/2.2.18/legacy_blast.pl.patch
@@ -1,0 +1,8 @@
+--- bin/legacy_blast.pl
++++ bin/legacy_blast.pl
+@@ -1,4 +1,4 @@
+-#! /usr/bin/perl -w
++#!/usr/bin/env perl
+ # $Id: legacy_blast.pl 140187 2008-09-15 16:35:34Z camacho $
+ # ===========================================================================
+ #

--- a/recipes/blast/2.2.18/meta.yaml
+++ b/recipes/blast/2.2.18/meta.yaml
@@ -1,0 +1,50 @@
+package:
+    name: blast
+    version: 2.2.18
+
+source:
+    fn: ncbi-blast-2.2.18+-linux.tar.gz # [linux]
+    url: ftp://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/2.2.18/ncbi-blast-2.2.18+-x64-linux.tar.gz # [linux]
+    md5: 2c5f4ecbba46ceff0338c9deeadb7faa # [linux]
+    fn: ncbi-blast-2.2.18+-universal-macosx.tar.gz # [osx]
+    url: ftp://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/2.2.18/ncbi-blast-2.2.18+-universal-macosx.tar.gz # [osx]
+    md5: 71a3e6d7dfe84dd3ef0f8e4d30be1f8b # [osx]
+    patches:
+        - legacy_blast.pl.patch
+        - update_blastdb.pl.patch
+
+build:
+  number: 0
+
+requirements:
+    build:
+        - pcre # Need to link a dynamic library
+    run:
+        - perl
+        - pcre
+        - libgcc    # [not osx]
+
+test:
+    commands:
+        - blastdb_aliastool -version > /dev/null
+        - blastdbcmd -version > /dev/null
+        - blastn -version > /dev/null
+        - blastp -version > /dev/null
+        - blastx -version > /dev/null
+        - dustmasker -version > /dev/null
+        - legacy_blast.pl --version > /dev/null
+        - makeblastdb -version > /dev/null
+        - makembindex -version > /dev/null
+        - psiblast -version > /dev/null
+        - rpsblast -version > /dev/null
+        - rpstblastn -version > /dev/null
+        - segmasker -version > /dev/null
+        - tblastn -version > /dev/null
+        - tblastx -version > /dev/null
+        - windowmasker -version > /dev/null
+        #- update_blastdb.pl --version > /dev/null # --version does not exist yet
+
+about:
+    home: http://blast.ncbi.nlm.nih.gov/Blast.cgi?PAGE_TYPE=BlastDocs
+    license: Public Domain
+    summary: BLAST+ is a new suite of BLAST tools that utilizes the NCBI C++ Toolkit.

--- a/recipes/blast/2.2.18/update_blastdb.pl.patch
+++ b/recipes/blast/2.2.18/update_blastdb.pl.patch
@@ -1,0 +1,8 @@
+--- bin/update_blastdb.pl
++++ bin/update_blastdb.pl
+@@ -1,4 +1,4 @@
+-#! /usr/bin/perl -w
++#!/usr/bin/env perl
+ # $Id: update_blastdb.pl 143045 2008-10-14 19:56:23Z camacho $
+ # ===========================================================================
+ #


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [x] This PR adds a new recipe.
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

An issue with a lib: some of the binaries require `libcpre.so.0`. `pcre` versions in conda generate `libpcre.so.1`. Therefore I linked `libpcre.so.1` to `libpcre.so.0` in the `lib` folder to make it work.