### PR TITLE
Version bump MSGF+.

### DIFF
--- a/recipes/msgf_plus/meta.yaml
+++ b/recipes/msgf_plus/meta.yaml
@@ -8,7 +8,7 @@ package:
   version: 2016.10.26
 
 build:
-  number: 1
+  number: 0
   skip: False
 
 source:

--- a/recipes/msgf_plus/meta.yaml
+++ b/recipes/msgf_plus/meta.yaml
@@ -1,5 +1,5 @@
 about:
-  home: http://proteomics.ucsd.edu/Software/MSGFPlus/
+  home: https://omics.pnl.gov/software/ms-gf
   license_file: LICENSE.txt
   summary: MS-GF+ is a new MS/MS database search tool that is sensitive (it identifies more peptides than other database search tools and as many peptides as spectral library search tools) and universal (works well for diverse types of spectra, different configurations of MS instruments and different experimental protocols).
 
@@ -13,8 +13,8 @@ build:
 
 source:
   fn: MSGFPlus.zip
-  url: http://proteomics.ucsd.edu/Software/MSGFPlus/MSGFPlus.zip
-  md5: 938cca2139fdbb3e678f0c4e5971950d
+  url: http://proteomics.ucsd.edu/SoftwBBare/MSGFPlus/MSGFPlus.zi://omics.pnl.gov/sites/default/files/MSGFPlus.zip 
+  md5: 1d6f174f88cabea3224a0dbbcc26f20d
 
 requirements:
   run:

--- a/recipes/msgf_plus/meta.yaml
+++ b/recipes/msgf_plus/meta.yaml
@@ -5,15 +5,15 @@ about:
 
 package:
   name: msgf_plus
-  version: 1.0.0
+  version: 2016.10.26
 
 build:
-  number: 0
+  number: 1
   skip: False
 
 source:
   fn: MSGFPlus.zip
-  url: http://proteomics.ucsd.edu/SoftwBBare/MSGFPlus/MSGFPlus.zi://omics.pnl.gov/sites/default/files/MSGFPlus.zip 
+  url: https://depot.galaxyproject.org/software/MSGFPlus/MSGFPlus_2016.10.26_src_all.zip
   md5: 1d6f174f88cabea3224a0dbbcc26f20d
 
 requirements:


### PR DESCRIPTION
* [X] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

The version of MSGF+ in bioconda is pretty old. Can't blame anyone because it was pretty hard to find another version and they are spread all over the place. Problems with this PR:

 + Where do I write the version of MSGF+? The meta.yaml previously had 1.0.0 which cannot be the version for the application (which was v9979)
 + MSGF downloads are updated all the time but the URL is not. Do we have a place to host files?