### PR TITLE
Trinotate add perl-dbd-sqlite

### DIFF
--- a/recipes/trinotate/meta.yaml
+++ b/recipes/trinotate/meta.yaml
@@ -6,7 +6,7 @@ about:
     transcriptomes, from model or non-model organisms'
 
 build:
-  number: 0
+  number: 1
 
 package:
   name: trinotate
@@ -18,6 +18,7 @@ requirements:
       - perl-threaded
       - perl-module-build
       - perl-dbi
+      - perl-dbd-sqlite
       - perl-file-find-rule
   run:
       - sqlite
@@ -25,6 +26,7 @@ requirements:
       - perl-threaded
       - perl-module-build
       - perl-dbi
+      - perl-dbd-sqlite
       - blast
       - hmmer
       - perl-file-find-rule


### PR DESCRIPTION
* [ ] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).


```
|  CMD: TrinotateSeqLoader.pl --sqlite Trinotate.sqlite --gene_trans_map /tmp/tmpn9SjWG/files/000/dataset_12.dat --transcript_fasta /tmp/tmpn9SjWG/files/000/dataset_10.dat --transdecoder_pep /tmp/tmpn9SjWG/files/000/dataset_11.dat --bulk_load
|  install_driver(SQLite) failed: Can't locate DBD/SQLite.pm in @INC (you may need to install the DBD::SQLite module) (@INC contains: /usr/local/genome2/psort/lib64/perl5/site_perl/5.8.8/x86_64-linux-thread-multi /usr/local/genome2/trans-ABySS/wrappers /usr/local/genome2/lib/perl5/ /tmp/tmpn9SjWG/job_working_directory/000/16/conda-env/lib/perl5/site_perl/5.22.0/x86_64-linux-thread-multi /tmp/tmpn9SjWG/job_working_directory/000/16/conda-env/lib/perl5/site_perl/5.22.0 /tmp/tmpn9SjWG/job_working_directory/000/16/conda-env/lib/perl5/5.22.0/x86_64-linux-thread-multi /tmp/tmpn9SjWG/job_working_directory/000/16/conda-env/lib/perl5/5.22.0 .) at (eval 5) line 3.
|  Perhaps the DBD::SQLite perl module hasn't been fully installed,
|  or perhaps the capitalisation of 'SQLite' isn't right.
|  Available drivers: DBM, ExampleP, File, Gofer, Proxy, Sponge.
|  at /tmp/tmpn9SjWG/job_working_directory/000/16/conda-env/bin/TrinotateSeqLoader.pl line 78.
```