### PR TITLE
Add pbcore recipe

### DIFF
--- a/recipes/pbcore/build.sh
+++ b/recipes/pbcore/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$PYTHON setup.py install

--- a/recipes/pbcore/meta.yaml
+++ b/recipes/pbcore/meta.yaml
@@ -1,0 +1,42 @@
+{% set name = "pbcore" %}
+{% set version = "1.2.10" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name|lower }}_{{ version }}.tar.gz
+  url: https://github.com/PacificBiosciences/pbcore/archive/1.2.10.tar.gz
+  md5: a11d5bbb1ee7f0361cb53f949d3aadb4
+
+build:
+  skip: True # [not py27]
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - gcc # [not osx]
+    - llvm # [osx]
+    - cython
+    - numpy >=1.7.1
+    - h5py >=2.0.1
+    - pysam >=0.9.0
+
+  run:
+    - python
+    - libgcc  # [not osx]
+    - cython
+    - numpy >=1.7.1
+    - h5py >=2.0.1
+    - pysam >=0.9.0
+
+test:
+  imports:
+    - pbcore
+
+about:
+  home: https://github.com/PacificBiosciences/pbcore
+  license: BSD-3-Clause
+  summary: 'A Python library for reading and writing PacBio data files'

--- a/recipes/python-pbcore/build.sh
+++ b/recipes/python-pbcore/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$PYTHON setup.py install

--- a/recipes/python-pbcore/meta.yaml
+++ b/recipes/python-pbcore/meta.yaml
@@ -1,0 +1,42 @@
+{% set name = "python-pbcore" %}
+{% set version = "1.2.10" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name|lower }}_{{ version }}.tar.gz
+  url: https://github.com/PacificBiosciences/pbcore/archive/1.2.10.tar.gz
+  md5: a11d5bbb1ee7f0361cb53f949d3aadb4
+
+build:
+  skip: True # [not py27]
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - gcc # [not osx]
+    - llvm # [osx]
+    - cython
+    - numpy >=1.7.1
+    - h5py >=2.0.1
+    - pysam >=0.9.0
+
+  run:
+    - python
+    - libgcc  # [not osx]
+    - cython
+    - numpy >=1.7.1
+    - h5py >=2.0.1
+    - pysam >=0.9.0
+
+test:
+  imports:
+    - pbcore
+
+about:
+  home: https://github.com/PacificBiosciences/pbcore
+  license: BSD-3-Clause
+  summary: 'A Python library for reading and writing PacBio data files'


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [x] This PR adds a new recipe.
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Adding recipe for pbcore. I named it python-pbcore to follow the naming of the other pb recipe. 

Should it be called python-pbcore or only pbcore? Any opinions? @bioconda/core  