### PR TITLE
Update Kaiju to 1.4.4, add OSX build.

### DIFF
--- a/recipes/kaiju/1.0/build.sh
+++ b/recipes/kaiju/1.0/build.sh
@@ -19,3 +19,4 @@ cp makeDB.sh $PREFIX/bin
 cp mergeOutputs $PREFIX/bin
 cp mkbwt $PREFIX/bin
 cp mkfmi $PREFIX/bin
+

--- a/recipes/kaiju/1.0/meta.yaml
+++ b/recipes/kaiju/1.0/meta.yaml
@@ -1,0 +1,27 @@
+package:
+  name: kaiju
+  version: "1.0"
+
+source:
+  git_url: https://github.com/bioinformatics-centre/kaiju.git
+
+build:
+  number: 0
+  skip: True # [osx] 
+  
+requirements:
+  build:
+    - gcc
+  run:
+    - libgcc 
+
+test:
+  commands:    
+    - kaiju 2>&1 | head -n 1 | grep -q '^Error:'; echo $?
+    
+#Tool always outputs error code one so created a workaround
+    
+about:
+  home: http://kaiju.binf.ku.dk/
+  license: GNU GPL v3
+  summary: 'Fast and sensitive taxonomic classification for metagenomics'

--- a/recipes/kaiju/meta.yaml
+++ b/recipes/kaiju/meta.yaml
@@ -1,27 +1,30 @@
 package:
   name: kaiju
-  version: "1.0"
+  version: "1.4.4"
 
 source:
-  git_url: https://github.com/bioinformatics-centre/kaiju.git
+  fn: v1.4.4.tar.gz
+  url: https://github.com/bioinformatics-centre/kaiju/archive/v1.4.4.tar.gz
+  md5: dfead4e9e0477fb619f9174e74c384ad
 
 build:
   number: 0
-  skip: True # [osx] 
-  
+
 requirements:
   build:
     - gcc
   run:
-    - libgcc 
+    - libgcc
+    - perl-threaded
 
 test:
-  commands:    
+  commands:
     - kaiju 2>&1 | head -n 1 | grep -q '^Error:'; echo $?
-    
+
 #Tool always outputs error code one so created a workaround
-    
+
 about:
   home: http://kaiju.binf.ku.dk/
   license: GNU GPL v3
   summary: 'Fast and sensitive taxonomic classification for metagenomics'
+  license_file: LICENSE


### PR DESCRIPTION
* [X] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

ping @bioconda/core since this is a non-standard OS X build.

Building this with `clang` requires a minimum `MACOSX_DEPLOYMENT_TARGET` of 10.9, which I believe we don't want to do for compatibility reasons.  Building with GCC on OS X works fine, but I wanted to confirm that's ok to do.