### PR TITLE
pipmir/meta.yaml: use viennarna 1.8.5

### DIFF
--- a/recipes/pipmir/meta.yaml
+++ b/recipes/pipmir/meta.yaml
@@ -9,17 +9,17 @@ source:
 
 build:
   skip: True  # [not linux]
-  number: 0
+  number: 1
 
 requirements:
   build:
     - java-jdk
     - samtools
-    - viennarna
+    - viennarna 1.8.5
   run:
     - java-jdk
     - samtools
-    - viennarna
+    - viennarna 1.8.5
 
 test:
   commands:


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

pipmir does not work with the latest RNAfold version, 2.3.0.