### PR TITLE
Add mysql-python/

### DIFF
--- a/recipes/mysql-python/build.sh
+++ b/recipes/mysql-python/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install 
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/recipes/mysql-python/meta.yaml
+++ b/recipes/mysql-python/meta.yaml
@@ -1,0 +1,35 @@
+package:
+  name: mysql-python
+  version: "1.2.5"
+
+source:
+  fn: MySQL-python-1.2.5.zip
+  url: https://pypi.python.org/packages/a5/e9/51b544da85a36a68debe7a7091f068d802fc515a3a202652828c73453cad/MySQL-python-1.2.5.zip
+  md5: 654f75b302db6ed8dc5a898c625e030c
+
+build:
+  skip: True # [not py27]
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - configparser
+    - mysql-connector-c
+
+  run:
+    - python
+    - configparser
+    - mysql-connector-c
+
+test:
+  # Python imports
+  imports:
+    - MySQLdb
+
+about:
+  home: https://github.com/farcepest/MySQLdb1
+  license: GNU General Public License (GPL)
+  summary: 'Python interface to MySQL'
+  license_family: LGPL


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [x] This PR adds a new recipe.
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

It exist a mysql-python recipe at anaconda but it is not built for osx. It seems that they are not planning to build it according this [open issue](https://github.com/ContinuumIO/anaconda-issues/issues/254).

It is needed to build ete2 and other dependencies for osx.  ping @bioconda/core 