### PR TITLE
ViennaRNA: activate python2 interface (for linux)

### DIFF
--- a/recipes/viennarna/0001-patch-also-look-for-tool-as-python-config.patch
+++ b/recipes/viennarna/0001-patch-also-look-for-tool-as-python-config.patch
@@ -1,0 +1,25 @@
+From f1b0343eb837f920e1f6bdbbd49361fda937d610 Mon Sep 17 00:00:00 2001
+From: Daniel Maticzka <maticzkd@informatik.uni-freiburg.de>
+Date: Sun, 20 Nov 2016 11:45:23 +0100
+Subject: [PATCH] patch: also look for tool as python-config
+
+---
+ configure | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure b/configure
+index eb9fcb8..e122c7d 100755
+--- a/configure
++++ b/configure
+@@ -22561,7 +22561,7 @@ test -n "$PYTHON2" || PYTHON2="no"
+ 
+ 
+     if test "${PYTHON2}" != "no" ; then
+-      for ac_prog in python2-config python2.7-config python2.6-config
++      for ac_prog in python-config python2-config python2.7-config python2.6-config
+ do
+   # Extract the first word of "$ac_prog", so it can be a program name with args.
+ set dummy $ac_prog; ac_word=$2
+-- 
+2.7.4
+

--- a/recipes/viennarna/build.sh
+++ b/recipes/viennarna/build.sh
@@ -10,7 +10,7 @@ if [ `uname` == Darwin ] ; then
                           --without-python3
                           LDFLAGS=-Wl,-headerpad_max_install_names"
 else ## linux
-    if [ $PY3K == 1 ] ; then
+    if [ $PY3K -eq 1 ] ; then
         extra_config_options="--with-python3 --without-python"
     fi
 fi

--- a/recipes/viennarna/build.sh
+++ b/recipes/viennarna/build.sh
@@ -12,6 +12,8 @@ if [ `uname` == Darwin ] ; then
 else ## linux
     if [ $PY3K -eq 1 ] ; then
         extra_config_options="--with-python3 --without-python"
+    else
+        extra_config_options="--with-python --without-python3"
     fi
 fi
 

--- a/recipes/viennarna/build.sh
+++ b/recipes/viennarna/build.sh
@@ -10,7 +10,9 @@ if [ `uname` == Darwin ] ; then
                           --without-python3
                           LDFLAGS=-Wl,-headerpad_max_install_names"
 else ## linux
-    extra_config_options="--with-python3"
+    if [ $PY3K == 1 ] ; then
+        extra_config_options="--with-python3"
+    else
 fi
 
 ./configure --prefix=$PREFIX \

--- a/recipes/viennarna/build.sh
+++ b/recipes/viennarna/build.sh
@@ -12,7 +12,7 @@ if [ `uname` == Darwin ] ; then
 else ## linux
     if [ $PY3K == 1 ] ; then
         extra_config_options="--with-python3"
-    else
+    fi
 fi
 
 ./configure --prefix=$PREFIX \

--- a/recipes/viennarna/build.sh
+++ b/recipes/viennarna/build.sh
@@ -8,6 +8,7 @@ if [ `uname` == Darwin ] ; then
     extra_config_options="--disable-openmp 
                           --enable-universal-binary
                           --without-python3
+                          --without-python
                           LDFLAGS=-Wl,-headerpad_max_install_names"
 else ## linux
     if [ $PY3K -eq 1 ] ; then

--- a/recipes/viennarna/build.sh
+++ b/recipes/viennarna/build.sh
@@ -11,7 +11,7 @@ if [ `uname` == Darwin ] ; then
                           LDFLAGS=-Wl,-headerpad_max_install_names"
 else ## linux
     if [ $PY3K == 1 ] ; then
-        extra_config_options="--with-python3"
+        extra_config_options="--with-python3 --without-python"
     fi
 fi
 

--- a/recipes/viennarna/build.sh
+++ b/recipes/viennarna/build.sh
@@ -10,7 +10,7 @@ if [ `uname` == Darwin ] ; then
                           --without-python3
                           LDFLAGS=-Wl,-headerpad_max_install_names"
 else ## linux
-    extra_config_options=""
+    extra_config_options="--with-python3"
 fi
 
 ./configure --prefix=$PREFIX \

--- a/recipes/viennarna/build.sh
+++ b/recipes/viennarna/build.sh
@@ -10,11 +10,11 @@ if [ `uname` == Darwin ] ; then
                           --without-python3
                           LDFLAGS=-Wl,-headerpad_max_install_names"
 else ## linux
-    extra_config_options="--with-python3"
+    extra_config_options=""
 fi
 
 ./configure --prefix=$PREFIX \
-            --without-perl --without-python \
+            --without-perl \
             --with-kinwalker \
             --disable-lto \
             --without-doc \

--- a/recipes/viennarna/meta.yaml
+++ b/recipes/viennarna/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - python # [linux]
   run:
     - libgcc # [linux]
+    - python # [linux]
 
 test:
   requires:

--- a/recipes/viennarna/meta.yaml
+++ b/recipes/viennarna/meta.yaml
@@ -18,6 +18,7 @@ requirements:
     - python
   run:
     - libgcc # [linux]
+    - python
 
 test:
   requires:

--- a/recipes/viennarna/meta.yaml
+++ b/recipes/viennarna/meta.yaml
@@ -17,15 +17,15 @@ requirements:
     - gcc   # [linux]
     - llvm  # [osx]
     - perl-threaded
-    - python
+    - python # [linux]
   run:
     - libgcc # [linux]
 
 test:
   requires:
-   - python
+   - python # [linux]
   imports:
-   - RNA
+   - RNA    # [linux]
   commands:
    - RNAalifold --version
    - RNAeval    --version

--- a/recipes/viennarna/meta.yaml
+++ b/recipes/viennarna/meta.yaml
@@ -20,7 +20,6 @@ requirements:
     - python
   run:
     - libgcc # [linux]
-    - python
 
 test:
   requires:

--- a/recipes/viennarna/meta.yaml
+++ b/recipes/viennarna/meta.yaml
@@ -9,6 +9,8 @@ source:
   fn: ViennaRNA-2.3.0.tar.gz
   url: http://www.tbi.univie.ac.at/RNA/packages/source/ViennaRNA-2.3.0.tar.gz
   sha256: dd5b8c9c42dabc2521be11de99f1f102e912cf921b3789345e90e51a64be33ff
+  patches:
+    - 0001-patch-also-look-for-tool-as-python-config.patch
   
 requirements:
   build:

--- a/recipes/viennarna/meta.yaml
+++ b/recipes/viennarna/meta.yaml
@@ -15,10 +15,14 @@ requirements:
     - gcc   # [linux]
     - llvm  # [osx]
     - perl-threaded
+    - python
   run:
     - libgcc # [linux]
+    - python
 
 test:
+  imports:
+   - RNA
   commands:
    - RNAalifold --version
    - RNAeval    --version

--- a/recipes/viennarna/meta.yaml
+++ b/recipes/viennarna/meta.yaml
@@ -23,10 +23,6 @@ requirements:
     - python # [linux]
 
 test:
-  requires:
-   - python # [linux]
-  imports:
-   - RNA    # [linux]
   commands:
    - RNAalifold --version
    - RNAeval    --version

--- a/recipes/viennarna/meta.yaml
+++ b/recipes/viennarna/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: 2.3.0
 
 build:
-  number: 1
+  number: 2
 
 source:
   fn: ViennaRNA-2.3.0.tar.gz
@@ -18,9 +18,10 @@ requirements:
     - python
   run:
     - libgcc # [linux]
-    - python
 
 test:
+  requires:
+    - python
   imports:
    - RNA
   commands:

--- a/recipes/viennarna/meta.yaml
+++ b/recipes/viennarna/meta.yaml
@@ -21,7 +21,7 @@ requirements:
 
 test:
   requires:
-    - python
+   - python
   imports:
    - RNA
   commands:


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

This adds the python2 interface. This is enabled by the patch for the autotools configure that now also searches for "python-config" in addition to "python2-config.

I added the python runtime dependency to enable builds for python 2 and 3. Can we have this behaviour without the actual dependency? It's not required at runtime.

The python2 interface does not work with osx, same as for python3...

@s-will @bgruening What'ya'think? This would introduce different versions of ViennaRNA depending on the python lib to be used. This seems a bit awkward to me, but we can't compile both interfaces at the same time. (I think).
