### PR TITLE
Recommend against redirecting test output to /dev/null

### DIFF
--- a/GUIDELINES.md
+++ b/GUIDELINES.md
@@ -164,8 +164,8 @@ An example of this is [fastq-screen](recipes/fastq-screen).
 
 For command-line tools, running the program with no arguments, checking the
 programs version (e.g. with `-v`) or checking the command-line help is
-sufficient if doing so returns an exit code 0.  Often the output is piped to
-`/dev/null` to avoid output during recipe builds.
+sufficient if doing so returns an exit code 0.  We recommend to not redirect
+output to `/dev/null` because it may hide helpful debugging information.
 
 Examples:
 


### PR DESCRIPTION
* [ ] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

Hiding test output is not that useful: The output may be less cluttered, but when the recipe builds, then no one looks at the Travis log anyway. If it does not build, on the other hand, then crucial error messages may get hidden, as in PR #3020.