### PR TITLE
Use one subdag by default and remove it entirely later on

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,12 @@ sudo: required
 services:
 - docker
 install: scripts/travis-setup.sh
-script: travis_wait 75 scripts/travis-run.sh
+script: travis_wait 120 scripts/travis-run.sh
 env:
   global:
   - secure: WS9nwlZfrSgdU5bUw9ZXh5xD067PyUVq+UZnPazORgh5kgkTTX4EsNnXPtmUiQ9DOwVvBiCZzn6c7N+YPuUdEROOR/pBjtFA+w/APFk4ug1tcIzRH7z2we+fZaAnKK3SRqOhHkUYa8tjZFGr53RsaKaxKEc0SIqsHGbDupdBz9KC4raXyUQobcLxWbE6BQq2jhyJGqWxOrhTTrd3WCRKVTgjUlQmwimk6s9txfnEbEguE7UlRhlO0CSqgBj2oUvwtJQSkZWAFminUi2Jcmnduebu42iYX6IF3bYNLVxy8d56v2APGv6reipsD9m3l6URRtpgGygMF4EI9X6dlCjT2qMrwwuWQcZJncFkR584dL+MiPfA2RXamGQybX8HSlnrn60ZKzr5gmw4hetffUGwmOA2VlEW1Wcxcwcef+/8osWwnfLT4I3i736P71LARcBWjBaXKKCXCkCLegv0WB0V/JXyo6IfdLToB0ElAwNfoSlhK1ZtTejngMQewzh6HFcyJwbyPog8/WCL+/j+OohdLZYgiXuldeoLoTwM8YmrSV7twUg3rl2Uc9AWd6iKXC2n8t+2XXdSTwcyrLAEp5J2gZA+HPE/4R6/K1YLbILfMp+u2k8TpazSVX7oRwIcp5UJK6NGx9KDLnT5nJXFW2J5SuBdvQjOXGNSVxyAhBg2AAM=
-  - SUBDAGS=2
+  - SUBDAGS=1
   - BIOCONDA_UTILS_TAG=master
   - BIOCONDA_UTILS_ARGS="--loglevel=info --mulled-test"
   matrix:
   - SUBDAG=0
-  - SUBDAG=1


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

@bioconda/core I was in contact with Travis the last weeks and could get an extended build-time of 2h. Thanks to Travis!

I think we can just use one subdag, aka only one DAG from now on. My hope is that this will increase our turnaround as we use less concurrent builds for one PR. Most of our PRs only have a few packages included and for large restructurings like R rebuilds I hope 2h is enough.

