### PR TITLE
samtools: Fix curl linking for s3 support

### DIFF
--- a/recipes/samtools/build.sh
+++ b/recipes/samtools/build.sh
@@ -9,6 +9,11 @@ sed -i.bak 's/^LDFLAGS  =$//g' htslib-$PKG_VERSION/Makefile
 # varfilter.py in install fails because we don't install Python
 sed -i.bak 's#misc/varfilter.py##g' Makefile
 
+# Remove rdynamic which can cause build issues on OSX
+# https://sourceforge.net/p/samtools/mailman/message/34699333/
+sed -i.bak 's/ -rdynamic//g' Makefile
+sed -i.bak 's/ -rdynamic//g' htslib-1.3.1/configure
+
 export CPPFLAGS="-I$PREFIX/include"
 export LDFLAGS="-L$PREFIX/lib"
 
@@ -16,5 +21,7 @@ cd htslib*
 ./configure --prefix=$PREFIX --enable-libcurl CFLAGS="-I$PREFIX/include" LDFLAGS="-L$PREFIX/lib"
 make
 cd ..
-./configure --prefix=$PREFIX
-make install prefix=$PREFIX LIBS+=-lcurl LIBS+=-lcrypto
+# Problem with ncurses from default channel we now get in bioconda so skip tview
+# https://github.com/samtools/samtools/issues/577
+./configure --prefix=$PREFIX --enable-libcurl --without-curses
+make install prefix=$PREFIX LIBS+=-lcrypto LIBS+=-lcurl

--- a/recipes/samtools/meta.yaml
+++ b/recipes/samtools/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 4
+  number: 5
   skip: False
 
 source:
@@ -15,11 +15,15 @@ source:
 
 requirements:
   build:
-  - ncurses {{CONDA_NCURSES}}*
+  - gcc  # [not osx]
+  - llvm # [osx]
+    #- ncurses {{CONDA_NCURSES}}*
   - zlib
   - curl
   run:
-  - ncurses {{CONDA_NCURSES}}*
+  - libgcc # [not osx]
+    # curses from default channel fails, see note in build.sh
+    #- ncurses {{CONDA_NCURSES}}*
   - zlib
   - curl
 


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Ensures correct curl flags passed to internal htslib. Also updates to
use bioconda gcc and tinfo. Fixes #3042