### PR TITLE
Update: manta, umis, vardict-java, bcbio-vm, pytest-cov

### DIFF
--- a/recipes/bcbio-nextgen-vm/meta.yaml
+++ b/recipes/bcbio-nextgen-vm/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: '0.1.0a'
 
 build:
-  number: 87
+  number: 88
   skip: True # [not py27]
 
 source:
@@ -19,6 +19,7 @@ requirements:
     - python
     - setuptools
     - bcbio-nextgen >=1.0.1a0
+    - ipyparallel >=4.0,<5.0
     - arvados-cwl-runner
     - toil
     - nodejs

--- a/recipes/manta/meta.yaml
+++ b/recipes/manta/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.0.0" %}
+{% set version = "1.0.3" %}
 
 package:
   name: manta
@@ -6,6 +6,7 @@ package:
 source:
   fn: manta-{{ version }}.tar.bz2
   url: https://github.com/Illumina/manta/releases/download/v{{ version }}/manta-{{ version }}.centos5_x86_64.tar.bz2
+  md5: ebef4d9a6bba05c3d391cbaf91977eb8
 build:
   number: 0
   skip: True # [not py27 or osx]

--- a/recipes/pytest-cov/build.sh
+++ b/recipes/pytest-cov/build.sh
@@ -1,9 +1,2 @@
 #!/bin/bash
-
 $PYTHON setup.py install
-
-# Add more build steps here, if they are necessary.
-
-# See
-# http://docs.continuum.io/conda/build.html
-# for a list of environment variables that are set during the build process.

--- a/recipes/pytest-cov/meta.yaml
+++ b/recipes/pytest-cov/meta.yaml
@@ -1,31 +1,16 @@
 package:
   name: pytest-cov
-  version: "2.2.0"
+  version: "2.4.0"
 
 source:
-  fn: pytest-cov-2.2.0.tar.gz
-  url: https://pypi.python.org/packages/source/p/pytest-cov/pytest-cov-2.2.0.tar.gz
-  md5: 65a5238cdcfaa8618e6607c94faecbd6
-#  patches:
-   # List any patch files here
-   # - fix.patch
+  fn: pytest-cov-2.4.0.tar.gz
+  url: https://pypi.python.org/packages/00/c0/2bfd1fcdb9d407b8ac8185b1cb5ff458105c6b207a9a7f0e13032de9828f/pytest-cov-2.4.0.tar.gz
+  md5: 2fda09677d232acc99ec1b3c5831e33f
 
 build:
   skip: True # [osx]
-  # noarch_python: True
   preserve_egg_dir: True
-  # entry_points:
-    # Put any entry points (scripts to be generated automatically) here. The
-    # syntax is module:function.  For example
-    #
-    # - pytest-cov = pytest-cov:main
-    #
-    # Would create an entry point called pytest-cov that calls pytest-cov.main()
-
-
-  # If this is a new build for the same version, increment the build
-  # number. If you do not include this key, it defaults to 0.
-  # number: 1
+  number: 0
 
 requirements:
   build:
@@ -41,27 +26,10 @@ requirements:
     - coverage >=3.7.1
 
 test:
-  # Python imports
   imports:
     - pytest_cov
-
-  # commands:
-    # You can put test commands to be run here.  Use this to test that the
-    # entry points work.
-
-
-  # You can also put a file called run_test.py in the recipe that will be run
-  # at test time.
-
-  # requires:
-    # Put any additional test requirements here.  For example
-    # - nose
 
 about:
   home: https://github.com/pytest-dev/pytest-cov
   license: BSD License
   summary: 'Pytest plugin for measuring coverage.'
-
-# See
-# http://docs.continuum.io/conda/build.html for
-# more information about meta.yaml

--- a/recipes/umis/meta.yaml
+++ b/recipes/umis/meta.yaml
@@ -3,12 +3,12 @@ package:
   version: '0.3.1a0'
 
 build:
-  number: 1
+  number: 2
   skip: true # [not py27]
 
 source:
-  fn: umis-f0f3faba.tar.gz
-  url: https://github.com/chapmanb/umis/archive/f0f3faba.tar.gz
+  fn: umis-deca458.tar.gz
+  url: https://github.com/chapmanb/umis/archive/deca458.tar.gz
 
 requirements:
   build:

--- a/recipes/vardict-java/meta.yaml
+++ b/recipes/vardict-java/meta.yaml
@@ -1,10 +1,11 @@
 package:
   name: vardict-java
-  version: '1.4.6'
+  version: '1.4.7'
 
 source:
-  fn: VarDict-1.4.6.zip
-  url: https://github.com/AstraZeneca-NGS/VarDictJava/releases/download/v1.4.6/VarDict-1.4.6.zip
+  fn: VarDict-1.4.7.zip
+  url: https://github.com/AstraZeneca-NGS/VarDictJava/releases/download/v1.4.7/VarDict-1.4.7.zip
+  md5: f8546f67ae56a38619e27a34a8b68aaa
 
 build:
   number: 0


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

- Manta: update to latest point release 1.0.3
- VarDictJava: update to latest release 1.4.7
- umis: include fixes for tagging UMIs in fastq names
- pytest-cov: update to latest version to remove warning messages
- bcbio-vm: Force ipyparallel version to ensure latest version of
  bcbio-nextgen installed