### PR TITLE
PeptideShaker copy the jar file, lib, and resources to cwd

### DIFF
--- a/recipes/peptide-shaker/1.11.0/meta.yaml
+++ b/recipes/peptide-shaker/1.11.0/meta.yaml
@@ -16,7 +16,7 @@ package:
     version: {{ version }}
 
 build:
-  number: 0
+  number: 1
 
 source:
     fn: {{ name }}-{{ version }}.zip

--- a/recipes/peptide-shaker/1.11.0/peptide-shaker.py
+++ b/recipes/peptide-shaker/1.11.0/peptide-shaker.py
@@ -84,7 +84,7 @@ def main():
     we copy the jar file, lib, and resources to the exec_dir directory.
     """
     (mem_opts, prop_opts, pass_args, exec_dir) = jvm_opts(sys.argv[1:])
-    jar_dir = real_dirname(exec_dir if exec_dir else sys.argv[0])
+    jar_dir = exec_dir if exec_dir else real_dirname(sys.argv[0])
 
     if pass_args != [] and pass_args[0].startswith('eu'):
         jar_arg = '-cp'

--- a/recipes/peptide-shaker/1.11.0/peptide-shaker.py
+++ b/recipes/peptide-shaker/1.11.0/peptide-shaker.py
@@ -9,6 +9,7 @@
 import os
 import subprocess
 import sys
+import shutil
 from os import access
 from os import getenv
 from os import X_OK
@@ -70,7 +71,14 @@ def jvm_opts(argv):
 
 def main():
     java = java_executable()
-    jar_dir = real_dirname(sys.argv[0])
+    """
+    PeptideShaker updates files relative to the path of the jar file.
+    Thus we need to copy the jar file, lib, and resources to the working directory
+    when this script is first invoked in a job.
+    """
+    jar_dir = os.path.join(os.getcwd(),'bin')
+    if not os.path.exists(jar_dir):
+        shutil.copytree(real_dirname(sys.argv[0]), jar_dir, symlinks=False, ignore=None)
     (mem_opts, prop_opts, pass_args) = jvm_opts(sys.argv[1:])
 
     if pass_args != [] and pass_args[0].startswith('eu'):

--- a/recipes/peptide-shaker/1.11.0/peptide-shaker.py
+++ b/recipes/peptide-shaker/1.11.0/peptide-shaker.py
@@ -46,6 +46,7 @@ def jvm_opts(argv):
     mem_opts = []
     prop_opts = []
     pass_args = []
+    exec_dir = None
 
     for arg in argv:
         if arg.startswith('-D'):
@@ -54,6 +55,10 @@ def jvm_opts(argv):
             prop_opts.append(arg)
         elif arg.startswith('-Xm'):
             mem_opts.append(arg)
+        elif arg.startswith('--exec_dir='):
+            exec_dir = arg.split('=')[1].strip('"').strip("'")
+            if not os.path.exists(exec_dir):
+                shutil.copytree(real_dirname(sys.argv[0]), exec_dir, symlinks=False, ignore=None)
         else:
             pass_args.append(arg)
 
@@ -66,20 +71,20 @@ def jvm_opts(argv):
     if mem_opts == [] and getenv('_JAVA_OPTIONS') is None:
         mem_opts = default_jvm_mem_opts
 
-    return (mem_opts, prop_opts, pass_args)
+    return (mem_opts, prop_opts, pass_args, exec_dir)
 
 
 def main():
     java = java_executable()
     """
     PeptideShaker updates files relative to the path of the jar file.
-    Thus we need to copy the jar file, lib, and resources to the working directory
-    when this script is first invoked in a job.
+    In a multiuser setting, the option --exec_dir="exec_dir"
+    can be used as the location for the peptide-shaker distribution.
+    If the exec_dir dies not exist,
+    we copy the jar file, lib, and resources to the exec_dir directory.
     """
-    jar_dir = os.path.join(os.getcwd(),'bin')
-    if not os.path.exists(jar_dir):
-        shutil.copytree(real_dirname(sys.argv[0]), jar_dir, symlinks=False, ignore=None)
-    (mem_opts, prop_opts, pass_args) = jvm_opts(sys.argv[1:])
+    (mem_opts, prop_opts, pass_args, exec_dir) = jvm_opts(sys.argv[1:])
+    jar_dir = real_dirname(exec_dir if exec_dir else sys.argv[0])
 
     if pass_args != [] and pass_args[0].startswith('eu'):
         jar_arg = '-cp'

--- a/recipes/peptide-shaker/1.13.3/meta.yaml
+++ b/recipes/peptide-shaker/1.13.3/meta.yaml
@@ -16,7 +16,7 @@ package:
     version: {{ version }}
 
 build:
-  number: 0
+  number: 1
 
 source:
     fn: {{ name }}-{{ version }}.zip

--- a/recipes/peptide-shaker/1.13.3/peptide-shaker.py
+++ b/recipes/peptide-shaker/1.13.3/peptide-shaker.py
@@ -84,7 +84,7 @@ def main():
     we copy the jar file, lib, and resources to the exec_dir directory.
     """
     (mem_opts, prop_opts, pass_args, exec_dir) = jvm_opts(sys.argv[1:])
-    jar_dir = real_dirname(exec_dir if exec_dir else sys.argv[0])
+    jar_dir = exec_dir if exec_dir else real_dirname(sys.argv[0])
 
     if pass_args != [] and pass_args[0].startswith('eu'):
         jar_arg = '-cp'

--- a/recipes/peptide-shaker/1.13.3/peptide-shaker.py
+++ b/recipes/peptide-shaker/1.13.3/peptide-shaker.py
@@ -9,6 +9,7 @@
 import os
 import subprocess
 import sys
+import shutil
 from os import access
 from os import getenv
 from os import X_OK
@@ -70,7 +71,14 @@ def jvm_opts(argv):
 
 def main():
     java = java_executable()
-    jar_dir = real_dirname(sys.argv[0])
+    """
+    PeptideShaker updates files relative to the path of the jar file.
+    Thus we need to copy the jar file, lib, and resources to the working directory
+    when this script is first invoked in a job.
+    """
+    jar_dir = os.path.join(os.getcwd(),'bin')
+    if not os.path.exists(jar_dir):
+        shutil.copytree(real_dirname(sys.argv[0]), jar_dir, symlinks=False, ignore=None)
     (mem_opts, prop_opts, pass_args) = jvm_opts(sys.argv[1:])
 
     if pass_args != [] and pass_args[0].startswith('eu'):

--- a/recipes/peptide-shaker/1.13.3/peptide-shaker.py
+++ b/recipes/peptide-shaker/1.13.3/peptide-shaker.py
@@ -46,6 +46,7 @@ def jvm_opts(argv):
     mem_opts = []
     prop_opts = []
     pass_args = []
+    exec_dir = None
 
     for arg in argv:
         if arg.startswith('-D'):
@@ -54,6 +55,10 @@ def jvm_opts(argv):
             prop_opts.append(arg)
         elif arg.startswith('-Xm'):
             mem_opts.append(arg)
+        elif arg.startswith('--exec_dir='):
+            exec_dir = arg.split('=')[1].strip('"').strip("'")
+            if not os.path.exists(exec_dir):
+                shutil.copytree(real_dirname(sys.argv[0]), exec_dir, symlinks=False, ignore=None)
         else:
             pass_args.append(arg)
 
@@ -66,20 +71,20 @@ def jvm_opts(argv):
     if mem_opts == [] and getenv('_JAVA_OPTIONS') is None:
         mem_opts = default_jvm_mem_opts
 
-    return (mem_opts, prop_opts, pass_args)
+    return (mem_opts, prop_opts, pass_args, exec_dir)
 
 
 def main():
     java = java_executable()
     """
     PeptideShaker updates files relative to the path of the jar file.
-    Thus we need to copy the jar file, lib, and resources to the working directory
-    when this script is first invoked in a job.
+    In a multiuser setting, the option --exec_dir="exec_dir"
+    can be used as the location for the peptide-shaker distribution.
+    If the exec_dir dies not exist,
+    we copy the jar file, lib, and resources to the exec_dir directory.
     """
-    jar_dir = os.path.join(os.getcwd(),'bin')
-    if not os.path.exists(jar_dir):
-        shutil.copytree(real_dirname(sys.argv[0]), jar_dir, symlinks=False, ignore=None)
-    (mem_opts, prop_opts, pass_args) = jvm_opts(sys.argv[1:])
+    (mem_opts, prop_opts, pass_args, exec_dir) = jvm_opts(sys.argv[1:])
+    jar_dir = real_dirname(exec_dir if exec_dir else sys.argv[0])
 
     if pass_args != [] and pass_args[0].startswith('eu'):
         jar_arg = '-cp'

--- a/recipes/peptide-shaker/1.13.6/meta.yaml
+++ b/recipes/peptide-shaker/1.13.6/meta.yaml
@@ -16,7 +16,7 @@ package:
     version: {{ version }}
 
 build:
-  number: 0
+  number: 1
 
 source:
     fn: {{ name }}-{{ version }}.zip

--- a/recipes/peptide-shaker/1.13.6/peptide-shaker.py
+++ b/recipes/peptide-shaker/1.13.6/peptide-shaker.py
@@ -84,7 +84,7 @@ def main():
     we copy the jar file, lib, and resources to the exec_dir directory.
     """
     (mem_opts, prop_opts, pass_args, exec_dir) = jvm_opts(sys.argv[1:])
-    jar_dir = real_dirname(exec_dir if exec_dir else sys.argv[0])
+    jar_dir = exec_dir if exec_dir else real_dirname(sys.argv[0])
 
     if pass_args != [] and pass_args[0].startswith('eu'):
         jar_arg = '-cp'

--- a/recipes/peptide-shaker/1.13.6/peptide-shaker.py
+++ b/recipes/peptide-shaker/1.13.6/peptide-shaker.py
@@ -9,6 +9,7 @@
 import os
 import subprocess
 import sys
+import shutil
 from os import access
 from os import getenv
 from os import X_OK
@@ -70,7 +71,14 @@ def jvm_opts(argv):
 
 def main():
     java = java_executable()
-    jar_dir = real_dirname(sys.argv[0])
+    """
+    PeptideShaker updates files relative to the path of the jar file.
+    Thus we need to copy the jar file, lib, and resources to the working directory
+    when this script is first invoked in a job.
+    """
+    jar_dir = os.path.join(os.getcwd(),'bin')
+    if not os.path.exists(jar_dir):
+        shutil.copytree(real_dirname(sys.argv[0]), jar_dir, symlinks=False, ignore=None)
     (mem_opts, prop_opts, pass_args) = jvm_opts(sys.argv[1:])
 
     if pass_args != [] and pass_args[0].startswith('eu'):

--- a/recipes/peptide-shaker/1.13.6/peptide-shaker.py
+++ b/recipes/peptide-shaker/1.13.6/peptide-shaker.py
@@ -46,6 +46,7 @@ def jvm_opts(argv):
     mem_opts = []
     prop_opts = []
     pass_args = []
+    exec_dir = None
 
     for arg in argv:
         if arg.startswith('-D'):
@@ -54,6 +55,10 @@ def jvm_opts(argv):
             prop_opts.append(arg)
         elif arg.startswith('-Xm'):
             mem_opts.append(arg)
+        elif arg.startswith('--exec_dir='):
+            exec_dir = arg.split('=')[1].strip('"').strip("'")
+            if not os.path.exists(exec_dir):
+                shutil.copytree(real_dirname(sys.argv[0]), exec_dir, symlinks=False, ignore=None)
         else:
             pass_args.append(arg)
 
@@ -66,20 +71,20 @@ def jvm_opts(argv):
     if mem_opts == [] and getenv('_JAVA_OPTIONS') is None:
         mem_opts = default_jvm_mem_opts
 
-    return (mem_opts, prop_opts, pass_args)
+    return (mem_opts, prop_opts, pass_args, exec_dir)
 
 
 def main():
     java = java_executable()
     """
     PeptideShaker updates files relative to the path of the jar file.
-    Thus we need to copy the jar file, lib, and resources to the working directory
-    when this script is first invoked in a job.
+    In a multiuser setting, the option --exec_dir="exec_dir"
+    can be used as the location for the peptide-shaker distribution.
+    If the exec_dir dies not exist,
+    we copy the jar file, lib, and resources to the exec_dir directory.
     """
-    jar_dir = os.path.join(os.getcwd(),'bin')
-    if not os.path.exists(jar_dir):
-        shutil.copytree(real_dirname(sys.argv[0]), jar_dir, symlinks=False, ignore=None)
-    (mem_opts, prop_opts, pass_args) = jvm_opts(sys.argv[1:])
+    (mem_opts, prop_opts, pass_args, exec_dir) = jvm_opts(sys.argv[1:])
+    jar_dir = real_dirname(exec_dir if exec_dir else sys.argv[0])
 
     if pass_args != [] and pass_args[0].startswith('eu'):
         jar_arg = '-cp'

--- a/recipes/peptide-shaker/meta.yaml
+++ b/recipes/peptide-shaker/meta.yaml
@@ -16,7 +16,7 @@ package:
     version: {{ version }}
 
 build:
-  number: 0
+  number: 1
 
 source:
     fn: {{ name }}-{{ version }}.zip

--- a/recipes/peptide-shaker/peptide-shaker.py
+++ b/recipes/peptide-shaker/peptide-shaker.py
@@ -84,7 +84,7 @@ def main():
     we copy the jar file, lib, and resources to the exec_dir directory.
     """
     (mem_opts, prop_opts, pass_args, exec_dir) = jvm_opts(sys.argv[1:])
-    jar_dir = real_dirname(exec_dir if exec_dir else sys.argv[0])
+    jar_dir = exec_dir if exec_dir else real_dirname(sys.argv[0])
 
     if pass_args != [] and pass_args[0].startswith('eu'):
         jar_arg = '-cp'

--- a/recipes/peptide-shaker/peptide-shaker.py
+++ b/recipes/peptide-shaker/peptide-shaker.py
@@ -9,6 +9,7 @@
 import os
 import subprocess
 import sys
+import shutil
 from os import access
 from os import getenv
 from os import X_OK
@@ -70,7 +71,14 @@ def jvm_opts(argv):
 
 def main():
     java = java_executable()
-    jar_dir = real_dirname(sys.argv[0])
+    """
+    PeptideShaker updates files relative to the path of the jar file.
+    Thus we need to copy the jar file, lib, and resources to the working directory
+    when this script is first invoked in a job.
+    """
+    jar_dir = os.path.join(os.getcwd(),'bin')
+    if not os.path.exists(jar_dir):
+        shutil.copytree(real_dirname(sys.argv[0]), jar_dir, symlinks=False, ignore=None)
     (mem_opts, prop_opts, pass_args) = jvm_opts(sys.argv[1:])
 
     if pass_args != [] and pass_args[0].startswith('eu'):

--- a/recipes/peptide-shaker/peptide-shaker.py
+++ b/recipes/peptide-shaker/peptide-shaker.py
@@ -46,6 +46,7 @@ def jvm_opts(argv):
     mem_opts = []
     prop_opts = []
     pass_args = []
+    exec_dir = None
 
     for arg in argv:
         if arg.startswith('-D'):
@@ -54,6 +55,10 @@ def jvm_opts(argv):
             prop_opts.append(arg)
         elif arg.startswith('-Xm'):
             mem_opts.append(arg)
+        elif arg.startswith('--exec_dir='):
+            exec_dir = arg.split('=')[1].strip('"').strip("'")
+            if not os.path.exists(exec_dir):
+                shutil.copytree(real_dirname(sys.argv[0]), exec_dir, symlinks=False, ignore=None)
         else:
             pass_args.append(arg)
 
@@ -66,20 +71,20 @@ def jvm_opts(argv):
     if mem_opts == [] and getenv('_JAVA_OPTIONS') is None:
         mem_opts = default_jvm_mem_opts
 
-    return (mem_opts, prop_opts, pass_args)
+    return (mem_opts, prop_opts, pass_args, exec_dir)
 
 
 def main():
     java = java_executable()
     """
     PeptideShaker updates files relative to the path of the jar file.
-    Thus we need to copy the jar file, lib, and resources to the working directory
-    when this script is first invoked in a job.
+    In a multiuser setting, the option --exec_dir="exec_dir"
+    can be used as the location for the peptide-shaker distribution.
+    If the exec_dir dies not exist,
+    we copy the jar file, lib, and resources to the exec_dir directory.
     """
-    jar_dir = os.path.join(os.getcwd(),'bin')
-    if not os.path.exists(jar_dir):
-        shutil.copytree(real_dirname(sys.argv[0]), jar_dir, symlinks=False, ignore=None)
-    (mem_opts, prop_opts, pass_args) = jvm_opts(sys.argv[1:])
+    (mem_opts, prop_opts, pass_args, exec_dir) = jvm_opts(sys.argv[1:])
+    jar_dir = real_dirname(exec_dir if exec_dir else sys.argv[0])
 
     if pass_args != [] and pass_args[0].startswith('eu'):
         jar_arg = '-cp'


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

PeptideShaker updates files relative to the path of the jar file.  Thus
we need to copy the jar file, lib, and resources to the working
directory when this script is first invoked in a job.