### PR TITLE
Remove unnecessary run dependencies for estscan version 3.0 recipe

### DIFF
--- a/recipes/estscan/3.0/meta.yaml
+++ b/recipes/estscan/3.0/meta.yaml
@@ -8,7 +8,7 @@ source:
   md5: 1252c862b41b03b59687f5ba148b77cd
 
 build:
-  number: 0
+  number: 1
   skip: True #[osx]
 
 requirements:

--- a/recipes/estscan/3.0/meta.yaml
+++ b/recipes/estscan/3.0/meta.yaml
@@ -14,12 +14,6 @@ build:
 requirements:
   build:
     - gcc
-  run:
-    - blast-legacy
-    - gnuplot
-    - perl-estscan1
-    - perl-estscan2
-    - r
 
 test:
   commands:


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

The installation documentation here https://sourceforge.net/projects/estscan/files/documentation/Feb-2007/ is confusing in that it seems to state that these run-time dependencies are required just to execute this C version of estscan.  But these additional packages are only needed to use estscan features that this recipe does not cover (e.g. generating new scores matrices files).  In any case, neither of the perl-estscan components are needed here.