### PR TITLE
Fix for installing perl-estscan2 version 2.1

### DIFF
--- a/recipes/perl-estscan2/2.1/build.sh
+++ b/recipes/perl-estscan2/2.1/build.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Make sure deprecated Perl code is compatible with new Perl.
+sed -i -e 's/defined @/@/' ESTScan
+
 # If it has Build.PL use that, otherwise use Makefile.PL
 if [ -f Build.PL ]; then
     perl Build.PL


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

This resolves Perl 5 incompatibilities by eliminating very old, deprecated Perl code in the ESTScan Perl module.