### PR TITLE
disable docs building on bioconda-recipes

### DIFF
--- a/scripts/travis-run.sh
+++ b/scripts/travis-run.sh
@@ -18,17 +18,20 @@ fi
 
 set -x; bioconda-utils build recipes config.yml $USE_DOCKER $BIOCONDA_UTILS_ARGS; set +x;
 
+
+# Documentation is now built on bioconda-utils
+#
 # build package documentation
-if [[ $TRAVIS_OS_NAME = "linux" ]]
-then
-    if [[ $TRAVIS_BRANCH = "master" && "$TRAVIS_PULL_REQUEST" = false ]]
-    then
-        echo "Push containers to quay.io"
-        cat $CONTAINER_PUSH_COMMANDS_PATH
-        bash $CONTAINER_PUSH_COMMANDS_PATH
-        if [[ $SUBDAG = 0 ]]
-        then
-            scripts/build-docs.sh
-        fi
-    fi
-fi
+# if [[ $TRAVIS_OS_NAME = "linux" ]]
+# then
+#     if [[ $TRAVIS_BRANCH = "master" && "$TRAVIS_PULL_REQUEST" = false ]]
+#     then
+#         echo "Push containers to quay.io"
+#         cat $CONTAINER_PUSH_COMMANDS_PATH
+#         bash $CONTAINER_PUSH_COMMANDS_PATH
+#         if [[ $SUBDAG = 0 ]]
+#         then
+#             scripts/build-docs.sh
+#         fi
+#     fi
+# fi


### PR DESCRIPTION
* [ ] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

docs are now built in the bioconda-utils repo, so disabling building here