### PR TITLE
Check that conda-bld is not empty in simulate_travis

### DIFF
--- a/recipes/_dummy/meta.yaml
+++ b/recipes/_dummy/meta.yaml
@@ -1,0 +1,2 @@
+package:
+  name: _dummy


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

Make sure that conda-bld directory is a valid conda channel
(i.e. it contains a package index) when running `simulate_travis.py`. 
This is done by adding the directory as a channel, updating the index, and installing a dummy package
if the update failed.