### PR TITLE
Update gatk to 3.7 and fix python issue

### DIFF
--- a/recipes/gatk/gatk.py
+++ b/recipes/gatk/gatk.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/opt/anaconda1anaconda2anaconda3/bin/python
 #
 # Wrapper script for Java Conda packages that ensures that the java runtime
 # is invoked with the right options. Adapted from the bash script (http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in/246128#246128).

--- a/recipes/gatk/meta.yaml
+++ b/recipes/gatk/meta.yaml
@@ -5,10 +5,10 @@ about:
 
 package:
   name: gatk
-  version: '3.6'
+  version: '3.7'
 
 build:
-  number: 6
+  number: 0
   skip: False
 
 requirements:


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Fixes problem where gatk.py wrapper script refers to /usr/bin/env python
instead of the direct path to the installed anaconda python. This can
cause issues when the former picks up a different python version.
Fixes chapmanb/bcbio-nextgen#1689