### PR TITLE
Update CNVkit to 0.8.2

### DIFF
--- a/recipes/cnvkit/meta.yaml
+++ b/recipes/cnvkit/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: cnvkit
-  version: '0.8.1'
+  version: '0.8.2'
 
 source:
-  fn: v0.8.1.tar.gz
-  url: https://github.com/etal/cnvkit/archive/v0.8.1.tar.gz
+  fn: v0.8.2.tar.gz
+  url: https://github.com/etal/cnvkit/archive/v0.8.2.tar.gz
 
 build:
   number: 0
@@ -24,8 +24,7 @@ requirements:
     - matplotlib >=1.1
     - biopython >=1.62
     - reportlab >=3.0
-    - pysam >=0.8
-    - pyvcf >=0.5
+    - pysam >=0.9.1.4
     - r-pscbs
     - r-cghflasso
     - pyfaidx >=0.4.7


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

The PyVCF dependency is dropped in favor of a newer pysam.