### PR TITLE
Bump version and add runtime python dependencies

### DIFF
--- a/recipes/tepid/meta.yaml
+++ b/recipes/tepid/meta.yaml
@@ -9,7 +9,7 @@ build:
 
 package:
   name: tepid
-  version: '0.7'
+  version: '0.8'
 
 requirements:
   build:
@@ -27,6 +27,11 @@ requirements:
       - libgcc
       - zlib
       - python
+      - pybedtools
+      - numpy ==1.9.2
+      - pandas
+      - 'pysam <0.9,>0.8'
+      - nose
       - bowtie2
       - samtools ==1.2
       - samblaster
@@ -34,10 +39,12 @@ requirements:
       - yaha
 
 source:
-  fn: '0.7.tar.gz'
-  url: 'https://github.com/ListerLab/TEPID/archive/0.7.tar.gz'
-  sha256: 0ef9221f7602e75c5c4dc08947e345cbb1ffc3c94c80fa79932e46464e88d52f
+  fn: '0.8.tar.gz'
+  url: 'https://github.com/ListerLab/TEPID/archive/0.8.tar.gz'
+  sha256: 2f9ff777705f74abe54f916bd33783085696a4687c47efe61146dd9827c4e241
 
 test:
   commands:
     - tepid-map | grep data
+    - tepid-discover --version
+    - tepid-refine --version


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Both tepid-refine and tepid-discover need all of the python dependencies at runtime.