### PR TITLE
Bump version of Canu

### DIFF
--- a/recipes/canu/meta.yaml
+++ b/recipes/canu/meta.yaml
@@ -5,7 +5,7 @@ package:
 source:
   # Canu currently needs to come from git to get its version string right
   git_url: https://github.com/marbl/canu.git
-  git_rev: v1.3
+  git_rev: v1.4
 
 build:
     detect_binary_files_with_prefix: True

--- a/recipes/canu/meta.yaml
+++ b/recipes/canu/meta.yaml
@@ -13,10 +13,11 @@ build:
 
 requirements:
     build:
-        - gcc
+        - gcc  # [not osx]
+        - llvm  # [osx]
         - perl-threaded
     run:
-        - libgcc
+        - libgcc # [not osx]
         - perl-threaded
         - perl-filesys-df
         - java-jdk

--- a/recipes/canu/meta.yaml
+++ b/recipes/canu/meta.yaml
@@ -1,11 +1,12 @@
 package:
   name: canu
-  version: 1.3
+  version: 1.4
 
 source:
   # Canu currently needs to come from git to get its version string right
-  git_url: https://github.com/marbl/canu.git
-  git_rev: v1.4
+  url: https://github.com/marbl/canu/archive/v1.4.tar.gz
+  fn: v1.4.tar.gz
+  md5: f0115f042c79cb5c1a247743236cd83b
 
 build:
     detect_binary_files_with_prefix: True


### PR DESCRIPTION
A new version of Canu has been released.

https://github.com/marbl/canu/releases


- [x] I have read the guidelines above.
- [ ] This PR adds a new recipe.
- [x] This PR updates an existing recipe.
- [ ] This PR does something else (explain below).


