### PR TITLE
pysam: avoid pinning to specific htslib versions

### DIFF
--- a/recipes/pysam/meta.yaml
+++ b/recipes/pysam/meta.yaml
@@ -8,16 +8,16 @@ source:
     md5: a7e0e9cbc972618cde7aea54894067d6
 
 build:
-    number: 0
+    number: 1
     skip: False
 
 requirements:
     build:
         - gcc  # [linux]
         - llvm # [osx]
-        - htslib ==1.3.1
-        - samtools ==1.3.1
-        - bcftools ==1.3.1
+        - htslib >=1.3
+        - samtools >=1.3
+        - bcftools >=1.3
         - cython
         - python
         - setuptools
@@ -26,9 +26,9 @@ requirements:
 
     run:
         - libgcc # [linux]
-        - htslib ==1.3.1
-        - samtools ==1.3.1
-        - bcftools ==1.3.1
+        - htslib >=1.3
+        - samtools >=1.3
+        - bcftools >=1.3
         - python
         - zlib
         - curl


### PR DESCRIPTION
The specific pins for htslib (and samtools, bcftools) cause resolution
errors now that there is a newer htslib (1.3.2, instead of 1.3.1). When
you install:

conda install htslib cnvkit

where the latest cnvkit relies on recent pysam (0.9.1.4) you'll get
htslib 1.3.2 and an old version of pysam and cnvkit prior to the version
pins. We relax these to these avoid confusing resolution issues and enable
both recent htslib and pysam.

* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
