### PR TITLE
Cutadapt: Require xopen >= 0.1.1

### DIFF
--- a/recipes/cutadapt/meta.yaml
+++ b/recipes/cutadapt/meta.yaml
@@ -13,16 +13,16 @@ source:
   md5: 27039acb5ae6259f82abfcff186bee7a
 
 build:
-  number: 0
+  number: 1
   script: $PYTHON setup.py install
 
 requirements:
   build:
     - python
-    - xopen
+    - xopen >=0.1.1
   run:
     - python
-    - xopen
+    - xopen >=0.1.1
 
 test:
   imports:


### PR DESCRIPTION
xopen 0.1.0 can hang on gzipped files. See https://github.com/chapmanb/bcbio-nextgen/issues/1700
and https://github.com/marcelm/cutadapt/commit/d096ff2bd49112e91313a6613bf5c5306b657727

* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
