### PR TITLE
Increase build number for perl-bioperl

### DIFF
--- a/recipes/perl-bioperl/meta.yaml
+++ b/recipes/perl-bioperl/meta.yaml
@@ -3,24 +3,18 @@ package:
   version: "1.6.924"
 
 build:
-  number: 6
+  number: 7
 
 requirements:
   build:
-    - perl-threaded
+    - perl
     - perl-bioperl-core ==1.6.924
     - perl-bioperl-run
-    - perl-bio-asn1-entrezgene
-    - perl-bio-featureio
-    - perl-bio-samtools
 
   run:
-    - perl-threaded
+    - perl
     - perl-bioperl-core ==1.6.924
     - perl-bioperl-run
-    - perl-bio-asn1-entrezgene
-    - perl-bio-featureio
-    - perl-bio-samtools
 
 about:
   home: http://metacpan.org/pod/BioPerl


### PR DESCRIPTION
This was missed in #2876.
Also:
- change `perl-threaded` requiments to `perl`.
- remove requirements provided by `perl-bioperl-core` >= 1.6.924-pl5.22.0_2

* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
