### PR TITLE
Update: CNVkit and goleft

### DIFF
--- a/recipes/cnvkit/meta.yaml
+++ b/recipes/cnvkit/meta.yaml
@@ -1,10 +1,11 @@
 package:
   name: cnvkit
-  version: '0.8.2'
+  version: '0.8.3a0'
 
 source:
-  fn: v0.8.2.tar.gz
-  url: https://github.com/etal/cnvkit/archive/v0.8.2.tar.gz
+  fn: v0.8.3a0.tar.gz
+  #url: https://github.com/etal/cnvkit/archive/v0.8.2.tar.gz
+  url: https://github.com/etal/cnvkit/archive/60794c84.tar.gz
 
 build:
   number: 0

--- a/recipes/goleft/meta.yaml
+++ b/recipes/goleft/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.1.6" %}
+{% set version = "0.1.8" %}
 
 package:
   name: goleft
@@ -7,8 +7,10 @@ package:
 source:
   fn: goleft-v{{ version }}-linux # [linux]
   url: https://github.com/brentp/goleft/releases/download/v{{ version }}/goleft_linux64 # [linux]
+  md5: 824aa277344b94637b480f0d9c9fd7dd # [linux]
   fn: goleft-v{{ version }}-osx # [osx]
   url: https://github.com/brentp/goleft/releases/download/v{{ version }}/goleft_osx # [osx]
+  md5: 4a0a20bfdc1b2792ad24d7acacdfc749 # [osx]
 
 build:
   number: 0
@@ -20,6 +22,7 @@ requirements:
 test:
   commands:
     - goleft depth -h
+    - goleft indexcov -h
 
 about:
   home: https://github.com/brentp/goleft


### PR DESCRIPTION
- CNVkit to latest development with fixes for antitarget creation
  (fixes chapmanb/bcbio-nextgen#1696)
- goleft: latest release with indexcov for fast estimation of
  coverage using indexes

* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
