### PR TITLE
Downgrading matplotlib dependency

### DIFF
--- a/recipes/kiwidist/meta.yaml
+++ b/recipes/kiwidist/meta.yaml
@@ -7,9 +7,12 @@ source:
   url: https://pypi.python.org/packages/30/e8/b66db4aa5f84b02705d814411ca2fd3e5810b7bb93c3090aa57d5ecc90bc/KiwiDist-0.3.5.tar.gz
   md5: 5c6bb43204a7392fa287a4af7d083425
 
+build:
+  skip: True  # [not py27]
+
 requirements:
   build:
-    - python 2.7
+    - python
     - matplotlib 1.4.3
     - mygene >=2.1.0
     - networkx >=1.8.1
@@ -18,7 +21,7 @@ requirements:
     - scipy >=0.13.3
 
   run:
-    - python 2.7
+    - python
     - matplotlib 1.4.3
     - mygene >=2.1.0
     - networkx >=1.8.1

--- a/recipes/kiwidist/meta.yaml
+++ b/recipes/kiwidist/meta.yaml
@@ -10,7 +10,7 @@ source:
 requirements:
   build:
     - python
-    - matplotlib =1.4.3
+    - matplotlib 1.4
     - mygene >=2.1.0
     - networkx >=1.8.1
     - numpy >=1.8.0
@@ -19,7 +19,7 @@ requirements:
 
   run:
     - python
-    - matplotlib =1.4.3
+    - matplotlib 1.4
     - mygene >=2.1.0
     - networkx >=1.8.1
     - numpy >=1.8.0

--- a/recipes/kiwidist/meta.yaml
+++ b/recipes/kiwidist/meta.yaml
@@ -10,7 +10,7 @@ source:
 requirements:
   build:
     - python
-    - matplotlib 1.4
+    - matplotlib 1.4.3
     - mygene >=2.1.0
     - networkx >=1.8.1
     - numpy >=1.8.0
@@ -19,7 +19,7 @@ requirements:
 
   run:
     - python
-    - matplotlib 1.4
+    - matplotlib 1.4.3
     - mygene >=2.1.0
     - networkx >=1.8.1
     - numpy >=1.8.0

--- a/recipes/kiwidist/meta.yaml
+++ b/recipes/kiwidist/meta.yaml
@@ -10,7 +10,7 @@ source:
 requirements:
   build:
     - python
-    - matplotlib =1.4
+    - matplotlib =1.4.3
     - mygene >=2.1.0
     - networkx >=1.8.1
     - numpy >=1.8.0
@@ -19,7 +19,7 @@ requirements:
 
   run:
     - python
-    - matplotlib =1.4
+    - matplotlib =1.4.3
     - mygene >=2.1.0
     - networkx >=1.8.1
     - numpy >=1.8.0

--- a/recipes/kiwidist/meta.yaml
+++ b/recipes/kiwidist/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: kiwidist
-  version: "0.3.4"
+  version: "0.3.5"
 
 source:
-  fn: KiwiDist-0.3.4.tar.gz
-  url: https://pypi.python.org/packages/f9/b0/ef48f275c86a7233859236000e8d5b43d645a4d1c8d12877d177e6df532d/KiwiDist-0.3.4.tar.gz
-  md5: be3baa1e2a7525c4fc2e89dcd8e187ac
+  fn: KiwiDist-0.3.5.tar.gz
+  url: https://pypi.python.org/packages/30/e8/b66db4aa5f84b02705d814411ca2fd3e5810b7bb93c3090aa57d5ecc90bc/KiwiDist-0.3.5.tar.gz
+  md5: 5c6bb43204a7392fa287a4af7d083425
 
 requirements:
   build:

--- a/recipes/kiwidist/meta.yaml
+++ b/recipes/kiwidist/meta.yaml
@@ -10,7 +10,7 @@ source:
 requirements:
   build:
     - python
-    - matplotlib >=1.3.1
+    - matplotlib =1.4
     - mygene >=2.1.0
     - networkx >=1.8.1
     - numpy >=1.8.0
@@ -19,7 +19,7 @@ requirements:
 
   run:
     - python
-    - matplotlib >=1.3.1
+    - matplotlib =1.4
     - mygene >=2.1.0
     - networkx >=1.8.1
     - numpy >=1.8.0

--- a/recipes/kiwidist/meta.yaml
+++ b/recipes/kiwidist/meta.yaml
@@ -9,7 +9,7 @@ source:
 
 requirements:
   build:
-    - python
+    - python 2.7
     - matplotlib 1.4.3
     - mygene >=2.1.0
     - networkx >=1.8.1
@@ -18,7 +18,7 @@ requirements:
     - scipy >=0.13.3
 
   run:
-    - python
+    - python 2.7
     - matplotlib 1.4.3
     - mygene >=2.1.0
     - networkx >=1.8.1


### PR DESCRIPTION
This is to deal with a mismatch with libpng on OSX Sierra 10.12.

* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
