### PR TITLE
Update: toil, cwltool, schema-salad

### DIFF
--- a/recipes/bcbio-nextgen/meta.yaml
+++ b/recipes/bcbio-nextgen/meta.yaml
@@ -3,15 +3,15 @@ package:
   version: '1.0.1a0'
 
 build:
-  number: 2
+  number: 3
   skip: True # [not py27]
 
 source:
   #fn: bcbio-nextgen-1.0.0.tar.gz
   #url: https://pypi.python.org/packages/8d/5b/80d5b73b534e485cb0254ca8e6460f7236737937a65c1b55d0dbbc9b717b/bcbio-nextgen-1.0.0.tar.gz
   #md5: 0b78a9b725a505dbeb489c7b418afe1a
-  fn: bcbio-nextgen-ebdd7c1.tar.gz
-  url: https://github.com/chapmanb/bcbio-nextgen/archive/ebdd7c1.tar.gz
+  fn: bcbio-nextgen-4a25071.tar.gz
+  url: https://github.com/chapmanb/bcbio-nextgen/archive/4a25071.tar.gz
 
 requirements:
   build:

--- a/recipes/cwltool/build.sh
+++ b/recipes/cwltool/build.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 
-sed -i.bak 's/ruamel.yaml ==/ruamel.yaml >=/' setup.py
+#sed -i.bak 's/ruamel.yaml ==/ruamel.yaml >=/' setup.py
+sed -i.bak 's/ruamel.yaml >= 0.12.4, < 0.12.5/ruamel.yaml >= 0.12.4/' setup.py
 $PYTHON setup.py install --single-version-externally-managed --record=record.txt

--- a/recipes/cwltool/meta.yaml
+++ b/recipes/cwltool/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: cwltool
-  version: '1.0.20161123190203'
+  version: '1.0.20161221171240'
 
 source:
-  fn: cwltool-1.0.20161123190203.tar.gz
-  url: https://pypi.python.org/packages/83/79/5ad5d1b86aad5997dd0a7853101bb0091552022886471bc51b318b1fd42a/cwltool-1.0.20161123190203.tar.gz
-  md5: 3e47068883d69834ad00499466d8e265
+  fn: cwltool-1.0.20161221171240.tar.gz
+  url: https://pypi.python.org/packages/81/29/38b35011a0e557e071c3868391bfee28616919e2143c5d68b69f77cb9c57/cwltool-1.0.20161221171240.tar.gz
+  md5: 0dcbb290dc29094ff48d6c12a4c4f128
 
 build:
   number: 0
@@ -15,25 +15,27 @@ requirements:
   build:
     - python
     - setuptools
+    - pathlib2
     - requests
     - ruamel.yaml >=0.12.4
     - rdflib
     - rdflib-jsonld
     - shellescape
     - cwltest
-    - schema-salad ==1.20.20161122192122
+    - schema-salad ==2.1.20161221160224
     - typing >=3.5.2
 
   run:
     - python
     - setuptools
+    - pathlib2
     - requests
     - ruamel.yaml >=0.12.4
     - rdflib
     - rdflib-jsonld
     - shellescape
     - cwltest
-    - schema-salad ==1.20.20161122192122
+    - schema-salad ==2.1.20161221160224
     - typing >=3.5.2
 
 test:

--- a/recipes/schema-salad/build.sh
+++ b/recipes/schema-salad/build.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 
-sed -i.bak 's/ruamel.yaml ==/ruamel.yaml >=/' setup.py
+#sed -i.bak 's/ruamel.yaml ==/ruamel.yaml >=/' setup.py
+sed -i.bak 's/ruamel.yaml >= 0.12.4, < 0.12.5/ruamel.yaml >= 0.12.4/' setup.py
 $PYTHON setup.py install --single-version-externally-managed --record=record.txt

--- a/recipes/schema-salad/meta.yaml
+++ b/recipes/schema-salad/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: schema-salad
-  version: '1.20.20161122192122'
+  version: '2.1.20161221160224'
 
 source:
-  fn: schema-salad-1.20.20161122192122.tar.gz
-  url: https://pypi.python.org/packages/e7/ff/31b3d7ffb25ae9ccb3c4463be820f85e9ca1b315c50840a7061c6bed5992/schema-salad-1.20.20161122192122.tar.gz
-  md5: 48cc9562d73003509a15fef104fbe07c
+  fn: schema-salad-2.1.20161221160224.tar.gz
+  url: https://pypi.python.org/packages/c7/dc/bf6aeae219bca19383c989ea5568bb1c0922994618bdca14cf41b0454f55/schema-salad-2.1.20161221160224.tar.gz
+  md5: 0f6ec273aee9f0c87efdb7f543243148
 
 build:
   entry_points:

--- a/recipes/toil/meta.yaml
+++ b/recipes/toil/meta.yaml
@@ -5,10 +5,10 @@ package:
 source:
   git_url: https://github.com/chapmanb/toil
   #git_url: https://github.com/BD2KGenomics/toil
-  git_tag: f13f4eb90f5fa2ee270876d96e1501625f1a1a3e
+  git_tag: 80ec24f6d69781db799b9c652137728b89e01601
 
 build:
-  number: 1
+  number: 2
   skip: True # [not py27]
 
 requirements:
@@ -22,7 +22,7 @@ requirements:
     - boto
     - futures # [py27]
     - azure
-    - cwltool ==1.0.20161123190203
+    - cwltool ==1.0.20161221171240
     - gcs-oauth2-boto-plugin ==1.9
     - pynacl ==0.3.0
 
@@ -35,7 +35,7 @@ requirements:
     - boto
     - futures # [py27]
     - azure
-    - cwltool ==1.0.20161123190203
+    - cwltool ==1.0.20161221171240
     - gcs-oauth2-boto-plugin ==1.9
     - pynacl ==0.3.0
 


### PR DESCRIPTION
Latest development version of Toil supporting recent cwltool.
Synchronizes cwltoil with cwltool, fixing issues in latest CWL
development.

* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
