### PR TITLE
nglview: use sys-prefix

### DIFF
--- a/recipes/nglview/post-link.sh
+++ b/recipes/nglview/post-link.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-"${PREFIX}/bin/jupyter-nbextension" install nglview --py --user
-"${PREFIX}/bin/jupyter-nbextension" enable nglview --py --user
+"${PREFIX}/bin/jupyter-nbextension" install nglview --py --sys-prefix
+"${PREFIX}/bin/jupyter-nbextension" enable nglview --py --sys-prefix


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Install `nglview` widget to `sys.prefix` rather than user's local directory