### PR TITLE
Bump build number for perl-gd

### DIFF
--- a/recipes/perl-gd/meta.yaml
+++ b/recipes/perl-gd/meta.yaml
@@ -7,7 +7,7 @@ source:
   md5: c4b3afd98b2c4ce3c2e1027d101a8f1e
 build:
   ##ignore_prefix_files: True
-  number: 4
+  number: 5
   skip: True  # [osx]
 
 requirements:
@@ -18,12 +18,12 @@ requirements:
     - libgd >=2.2.3
     - perl-module-build
     - perl-extutils-makemaker
-    
+
   run:
     - libgcc # [not osx]
     - perl-threaded >=5.22.0
     - libgd >=2.2.3
-    
+
 test:
   # Perl 'use' tests
   imports:
@@ -31,7 +31,7 @@ test:
     - GD::Simple ## (no version defined)
     - GD::Polygon ## (no version defined)
     # - GD::Polyline ## (version 0.2 defined?!)
-    
+
 about:
   home: http://metacpan.org/pod/GD
   license: perl_5


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Bumped build in the hope that jpeg >=9 is being recognized as runtime dependency.
Seemed to work locally.
Ping @nsoranzo 