### PR TITLE
refactor java-jdk build script

### DIFF
--- a/recipes/java-jdk/build.sh
+++ b/recipes/java-jdk/build.sh
@@ -22,7 +22,7 @@ mv $NAME/* .
 rm -r $NAME
 
 # clean up
-rm -rf release README readme.txt Welcome.html *jli.* demo sample *.zip
+rm -rf release README readme.txt Welcome.html *jli.* demo sample *.zip *.tar.gz ASSEMBLY_EXCEPTION THIRD_PARTY_README DISCLAIMER LICENSE
 
 if [[ `uname` == "Linux" ]]
 then
@@ -42,11 +42,8 @@ then
     cd ../../..
 fi
 
-mv * $PREFIX
+mv include jre lib man $PREFIX
+# bin might already exist on $PREFIX
+mkdir -p $PREFIX/bin
+mv bin/* $PREFIX/bin
 
-# more clean up
-rm -rf $PREFIX/release $PREFIX/README $PREFIX/Welcome.html
-rm -f $PREFIX/DISCLAIMER
-rm -f $PREFIX/LICENSE
-rm -f $PREFIX/THIRD_PARTY_README
-rm -f $PREFIX/ASSEMBLY_EXCEPTION

--- a/recipes/java-jdk/meta.yaml
+++ b/recipes/java-jdk/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: 8.0.92
 
 build:
-  number: 1
+  number: 2
   skip: False
 
 test:


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

refactor java-jdk build script to makes sure only necessary files go into the package

I noticed recently that the java-jdk package had the tar.gz release in the root directory, I believe this is a mistake as it doubles the package size for no apparent reason, as it can be [seen here](https://anaconda.org/bioconda/java-jdk/files) the linux builds have double the size.

I also took this opportunity to explicit move files into the package instead of moving "everything left", to make it more clearer what is being included.