### PR TITLE
Update: toil/arvados/cwltool, vcf2db, vawk

### DIFF
--- a/recipes/arvados-cwl-runner/meta.yaml
+++ b/recipes/arvados-cwl-runner/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: arvados-cwl-runner
-  version: '1.0.20161123235904'
+  version: '1.0.20161230191227'
 
 source:
-  fn: arvados-cwl-runner-1.0.20161123235904.tar.gz
-  url: https://pypi.python.org/packages/ef/80/16ee5cfdb1b0ae02b3f12b42ddab2854aae116daa9141df1f285a81e82ec/arvados-cwl-runner-1.0.20161123235904.tar.gz
-  md5: 9289ea42d84be93727a694bf2688dab2
+  fn: arvados-cwl-runner-1.0.20161230191227.tar.gz
+  url: https://pypi.python.org/packages/76/08/a31aa0d7ace8d21f9e627c78f27a89eb6726a8178997543198e1f110c3b7/arvados-cwl-runner-1.0.20161230191227.tar.gz
+  md5: fbe46f2b7301c640a4b82c0082f89d7f
 
 build:
   number: 0
@@ -15,12 +15,12 @@ requirements:
   build:
     - python
     - setuptools
-    - cwltool ==1.0.20161123190203
+    - cwltool ==1.0.20161227200419
     - arvados-python-client >=0.1.20161123074954
 
   run:
     - python
-    - cwltool ==1.0.20161123190203
+    - cwltool ==1.0.20161227200419
     - arvados-python-client >=0.1.20161123074954
 
 test:

--- a/recipes/bcbio-nextgen/meta.yaml
+++ b/recipes/bcbio-nextgen/meta.yaml
@@ -3,15 +3,15 @@ package:
   version: '1.0.1a0'
 
 build:
-  number: 3
+  number: 4
   skip: True # [not py27]
 
 source:
   #fn: bcbio-nextgen-1.0.0.tar.gz
   #url: https://pypi.python.org/packages/8d/5b/80d5b73b534e485cb0254ca8e6460f7236737937a65c1b55d0dbbc9b717b/bcbio-nextgen-1.0.0.tar.gz
   #md5: 0b78a9b725a505dbeb489c7b418afe1a
-  fn: bcbio-nextgen-4a25071.tar.gz
-  url: https://github.com/chapmanb/bcbio-nextgen/archive/4a25071.tar.gz
+  fn: bcbio-nextgen-0f9d85a.tar.gz
+  url: https://github.com/chapmanb/bcbio-nextgen/archive/0f9d85a.tar.gz
 
 requirements:
   build:

--- a/recipes/cwltool/meta.yaml
+++ b/recipes/cwltool/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: cwltool
-  version: '1.0.20161221171240'
+  version: '1.0.20161227200419'
 
 source:
-  fn: cwltool-1.0.20161221171240.tar.gz
-  url: https://pypi.python.org/packages/81/29/38b35011a0e557e071c3868391bfee28616919e2143c5d68b69f77cb9c57/cwltool-1.0.20161221171240.tar.gz
-  md5: 0dcbb290dc29094ff48d6c12a4c4f128
+  fn: cwltool-1.0.20161227200419.tar.gz
+  url: https://pypi.python.org/packages/e8/e8/c0556020f5e2b241610ee5813c00dd86dbbb35b468f4c9f25c422f2065a6/cwltool-1.0.20161227200419.tar.gz
+  md5: e0db6bd936d20e1f8beb654e891e1dde
 
 build:
   number: 0
@@ -22,7 +22,7 @@ requirements:
     - rdflib-jsonld
     - shellescape
     - cwltest
-    - schema-salad ==2.1.20161221160224
+    - schema-salad ==2.1.20161227191302
     - typing >=3.5.2
 
   run:
@@ -35,7 +35,7 @@ requirements:
     - rdflib-jsonld
     - shellescape
     - cwltest
-    - schema-salad ==2.1.20161221160224
+    - schema-salad ==2.1.20161227191302
     - typing >=3.5.2
 
 test:

--- a/recipes/peddy/meta.yaml
+++ b/recipes/peddy/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: peddy
-  version: "0.2.5"
+  version: "0.2.9"
 
 source:
-  fn: peddy-0.2.5.tar.gz
-  url: https://pypi.python.org/packages/fc/66/acc5dc46d6380b93fa3742035feaf750d1ff832bf22ad6b634a84599e4a9/peddy-0.2.5.tar.gz
-  md5: f2da7eef26c0a80fbce3279b7fb9d2eb
+  fn: peddy-0.2.9.tar.gz
+  url: https://pypi.python.org/packages/52/da/6afa439499143ac509eb2eceb217e9d6c4665e0c3d0e5efc5c088edf34f5/peddy-0.2.9.tar.gz
+  md5: 7870c4eb11fc359c02df5b7f22b6b467
 
 build:
   number: 0

--- a/recipes/schema-salad/meta.yaml
+++ b/recipes/schema-salad/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: schema-salad
-  version: '2.1.20161221160224'
+  version: '2.1.20161227191302'
 
 source:
-  fn: schema-salad-2.1.20161221160224.tar.gz
-  url: https://pypi.python.org/packages/c7/dc/bf6aeae219bca19383c989ea5568bb1c0922994618bdca14cf41b0454f55/schema-salad-2.1.20161221160224.tar.gz
-  md5: 0f6ec273aee9f0c87efdb7f543243148
+  fn: schema-salad-2.1.20161227191302.tar.gz
+  url: https://pypi.python.org/packages/59/b4/fed4e8227dd910933bc8fb8e5b5a70f0338d010cf0e35fd8772e28320ee8/schema-salad-2.1.20161227191302.tar.gz
+  md5: 87f7423940699d51d7be4fc8a8112e95
 
 build:
   entry_points:
@@ -25,6 +25,7 @@ requirements:
     - ruamel.yaml >=0.12.4
     - cachecontrol
     - lockfile
+    - pathlib2
     - avro-python2 # [py27]
     - avro-python3 # [not py27]
 
@@ -38,6 +39,7 @@ requirements:
     - ruamel.yaml >=0.12.4
     - cachecontrol
     - lockfile
+    - pathlib2
     - avro-python2 # [py27]
     - avro-python3 # [not py27]
 

--- a/recipes/toil/meta.yaml
+++ b/recipes/toil/meta.yaml
@@ -3,12 +3,11 @@ package:
   version: '3.5.0a1'
 
 source:
-  git_url: https://github.com/chapmanb/toil
-  #git_url: https://github.com/BD2KGenomics/toil
-  git_tag: 80ec24f6d69781db799b9c652137728b89e01601
+  git_url: https://github.com/BD2KGenomics/toil
+  git_tag: b21bb494359398bf5ad85fc6fe9c4b007a797597
 
 build:
-  number: 2
+  number: 3
   skip: True # [not py27]
 
 requirements:
@@ -22,7 +21,7 @@ requirements:
     - boto
     - futures # [py27]
     - azure
-    - cwltool ==1.0.20161221171240
+    - cwltool ==1.0.20161227200419
     - gcs-oauth2-boto-plugin ==1.9
     - pynacl ==0.3.0
 
@@ -35,7 +34,7 @@ requirements:
     - boto
     - futures # [py27]
     - azure
-    - cwltool ==1.0.20161221171240
+    - cwltool ==1.0.20161227200419
     - gcs-oauth2-boto-plugin ==1.9
     - pynacl ==0.3.0
 

--- a/recipes/vawk/meta.yaml
+++ b/recipes/vawk/meta.yaml
@@ -3,11 +3,11 @@ package:
   version: 0.0.2
 
 source:
-  fn: vawk-a63b6b2.tar.gz
-  url: https://github.com/cc2qe/vawk/archive/a63b6b2.tar.gz
+  fn: vawk-bab8237.tar.gz
+  url: https://github.com/cc2qe/vawk/archive/bab8237.tar.gz
 
 build:
-  number: 0
+  number: 1
   skip: True # [not py27 or osx]
 
 requirements:
@@ -16,6 +16,7 @@ requirements:
 
   run:
     - python
+    - gawk
 
 test:
   commands:

--- a/recipes/vcf2db/meta.yaml
+++ b/recipes/vcf2db/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: '2016.12.09'
 
 build:
-  number: 0
+  number: 1
   skip: True # [not py27]
  
 source:
@@ -20,7 +20,7 @@ requirements:
     - sqlalchemy
     - cyvcf2
     - numpy
-    - peddy
+    - peddy >=0.2.9
     - geneimpacts >0.2.0
   run:
     - python
@@ -30,7 +30,7 @@ requirements:
     - sqlalchemy
     - cyvcf2
     - numpy
-    - peddy
+    - peddy >=0.2.9
     - geneimpacts >0.2.0
 
 test:


### PR DESCRIPTION
- toil, arvados-cwl-runner, cwltool, schema-salad -- synchronize CWL
  runners on single version of cwltool
- vawk -- Use bioconda installed gawk (fixes
  chapmanb/bcbio-nextgen#1723)
- vcf2db, peddy -- support for database creation with latest peddy
  containing headers

* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
