### PR TITLE
Correct boost library version

### DIFF
--- a/recipes/openms/meta.yaml
+++ b/recipes/openms/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 36765c3a4c7a3277d71b9278505bd32f26c7030ffa6681a76344ca0024edf6a2
   
 build:
-    number: 0
+    number: 1
     skip: True  ## This package exceeds the travis build time, see the extra section.
 
 requirements:

--- a/recipes/openms/meta.yaml
+++ b/recipes/openms/meta.yaml
@@ -11,6 +11,7 @@ source:
   
 build:
     number: 1
+    string: boost1.62_{{PKG_BUILDNUM}}
     skip: True  ## This package exceeds the travis build time, see the extra section.
 
 requirements:
@@ -26,7 +27,7 @@ requirements:
     - libtool
     - xerces-c
     - gsl
-    - boost  ==1.62.0
+    - boost  ==1.62.*
     - eigen
     - glpk  >=4.60
     - bzip2
@@ -41,7 +42,7 @@ requirements:
     - zlib
     - xerces-c
     - gsl
-    - boost  >=1.62.0
+    - boost  ==1.62.*
     - eigen
     - glpk  >=4.60
     - bzip2

--- a/recipes/openms/meta.yaml
+++ b/recipes/openms/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - libtool
     - xerces-c
     - gsl
-    - boost  >=1.62.0
+    - boost  ==1.62.0
     - eigen
     - glpk  >=4.60
     - bzip2


### PR DESCRIPTION
Seems like openms needs the boost library as version 1.62 and doesn't work with 1.63.

* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
