### PR TITLE
Add recipe for PASTA version 0.2

### DIFF
--- a/recipes/pasta/0.2/build.sh
+++ b/recipes/pasta/0.2/build.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+out_dir=$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM
+pasta_tools_dev_dir=$PREFIX/share
+share_dir=$PREFIX/share
+
+mkdir -p $out_dir
+mkdir -p $PREFIX/bin
+mkdir -p $PREFIX/pasta
+
+cp -R ./* $out_dir
+
+unamestr=`uname`
+if [ $unamestr == 'Linux' ];
+then
+    wget --no-check-certificate https://github.com/smirarab/sate-tools-linux/archive/a3e6f56.tar.gz
+    tar -xzf a3e6f56.tar.gz
+    mv sate-tools-linux-a3e6f56372599ffacf1bd43adb2d67cf361228e2 sate-tools-linux
+    mv sate-tools-linux $pasta_tools_dev_dir
+    cd $out_dir
+    $PYTHON setup.py install
+    cp -R $share_dir/sate-tools-linux/* $PREFIX/bin
+elif [ $unamestr == 'Darwin' ];
+then
+    export DYLD_LIBRARY_PATH=$PREFIX/lib
+    wget --no-check-certificate https://github.com/smirarab/sate-tools-mac/archive/0712214.tar.gz
+    tar -xzf 0712214.tar.gz
+    mv sate-tools-mac-0712214e20152b2ec989fc102602afa53d3a7b1a sate-tools-mac
+    mv sate-tools-mac $pasta_tools_dev_dir
+    cd $out_dir
+    $PYTHON setup.py install
+    cp -R $share_dir/sate-tools-mac/* $PREFIX/bin
+fi
+
+# There seemes to be a bug in this version of Pasta.  Executing the following
+# with a valid input dataset:
+#
+# $python run_pasta.py -i input_fasta [-t starting_tree]
+#
+# produces the following error:
+#
+# PASTA ERROR: PASTA is exiting because of an error:
+# '~/pasta/bin/hmmeralign' not found. Please install 'hmmeralign' and/or configure its location...
+#
+# Here is a work-around:
+ln -s $PREFIX/bin/hmmalign $PREFIX/bin/hmmeralign
+ln -s $PREFIX/bin/hmmbuild $PREFIX/bin/hmmerbuild
+
+cp $out_dir/pasta/*.py $PREFIX/pasta
+cp $out_dir/run*.py $PREFIX
+
+# Allow for calling "pasta" from the command line.
+ln -s $PREFIX/run_pasta.py $PREFIX/bin/pasta
+

--- a/recipes/pasta/0.2/meta.yaml
+++ b/recipes/pasta/0.2/meta.yaml
@@ -1,0 +1,62 @@
+package:
+  name: pasta
+  version: "0.2"
+
+source:
+    fn: 6d52da1.tar.gz
+    url: https://github.com/smirarab/pasta/archive/6d52da1.tar.gz
+    md5: 69430d77b13f53505c3c9dc14bc1c4e2
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - certifi
+    - dendropy <=3.13
+    - gcc  # [linux]
+    - gnu-wget
+    - java-jdk >=6
+    - llvm  # [osx]
+    - pcre
+    - python >=2.7,<3
+    - pymongo
+    - setuptools
+
+  run:
+    - dendropy <=3.13
+    - java-jdk >=6
+    - libgcc  # [linux]
+    - pcre
+    - python >=2.7,<3
+    - pymongo
+
+test:
+  imports:
+    - pasta.alignment
+    - pasta.configure
+    - pasta.errors
+    - pasta.filemgr
+    - pasta.mainpasta
+    - pasta.pastaalignerjob
+    - pasta.pastajob
+    - pasta.scheduler
+    - pasta.settings
+    - pasta.tools
+    - pasta.treeholder
+    - pasta.tree
+    - pasta.usersettingclasses
+    - pasta.utility
+  commands:
+    - clustalw2 -help | grep OPTIONS
+    - hmmalign -h | grep HMMER
+    - hmmbuild -h | grep HMMER
+    - muscle -version | grep MUSCLE
+    - prank -help | grep prank
+    - raxml -h | grep raxmlHPC
+    - raxmlp -h | grep raxmlHPC
+
+about:
+  home: https://github.com/smirarab/pasta
+  license: GNU General Public License v3 or later (GPLv3+)
+  summary: 'An implementation of the PASTA (Practical Alignment using Sate and TrAnsitivity) algorithm'


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [x] This PR adds a new recipe.
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

@bgruening The additional github repositories retrieved using wget in the build script (e.g., https://github.com/smirarab/sate-tools-linux/archive/a3e6f56.tar.gz) are necessary for this recipe.  They cannot be retrieved using a separate recipe and then required by this one because the Python pasta components wrap the various sate tools that are included in the separate repositories and the setup.py script requires them in a specified location (relative to the script) for proper installation.  I've corrected a problem with the pasta code (https://github.com/smirarab/pasta/issues/17) which was causing tests to fail in previous attempts for this recipe, so I'm hopeful that this will pass all tests and be acceptable.