### PR TITLE
Bump umis to 0.5.0a.

### DIFF
--- a/recipes/umis/meta.yaml
+++ b/recipes/umis/meta.yaml
@@ -3,12 +3,12 @@ package:
   version: '0.5.0a'
 
 build:
-  number: 1
+  number: 2
   skip: true # [not py27]
 
 source:
-  fn: bb4b444.tar.gz
-  url: https://github.com/vals/umis/archive/bb4b444.tar.gz
+  fn: 06024e9.tar.gz
+  url: https://github.com/vals/umis/archive/06024e9.tar.gz
 
 requirements:
   build:


### PR DESCRIPTION
re-implements streaming bamtagging.

* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
