### PR TITLE
update meme 4.11.2

### DIFF
--- a/recipes/meme/build.sh
+++ b/recipes/meme/build.sh
@@ -1,15 +1,21 @@
 #!/bin/bash
-#
+set -e
 MEME_ETC_DIR=${PREFIX}/etc
-cpanm YAML
 cpanm HTML::PullParser
-cpanm XML::Simple
-cpanm CGI
-cpanm HTML::Template
 cpanm HTML::Parse
 cpanm CGI::Application
 cpanm XML::Parser::Expat --configure-args "EXPATLIBPATH=$PREFIX/lib" --configure-args "EXPATHINCPATH=$PREFIX/include"
-./configure --prefix="$PREFIX" --with-gnu-ld # --enable-build-libxml2 --enable-build-libxslt
+perl scripts/dependencies.pl
+
+./configure --prefix="$PREFIX"
+
 make clean
 make AM_CFLAGS='-DNAN="(0.0/0.0)"'
+
+# tests will only work inside the build dir, but
+# https://github.com/conda/conda-build/issues/1453
+# so you need `conda build --prefix-length 1`
+# for it to work properly
+# make test
+
 make install

--- a/recipes/meme/meta.yaml
+++ b/recipes/meme/meta.yaml
@@ -6,28 +6,33 @@ about:
 
 package:
     name: meme
-    version: 4.11.1
+    version: 4.11.2
 
 build:
-    number: 1
-    skip: True  # [osx]
+    number: 0
+    skip: True  # [not py27]
     detect_binary_files_with_prefix: True
 
 requirements:
     build:
-        - gcc
+        - gcc # [not osx]
+        - llvm # [osx]
         - yaml
-        - python >=2.7,<3
+        - python
         - perl
-        - ghostscript   #[linux]
+        - ghostscript
         - zlib
         - libxslt
         - libxml2
         - expat
-        - perl-xml-parser #[linux]
+        - perl-xml-parser
         - perl-app-cpanminus
+        - perl-yaml
+        - perl-xml-simple
+        - perl-html-template
+        - perl-cgi
     run:
-        - gcc
+        - libgcc # [not osx]
         - yaml
         - expat
         - python
@@ -35,18 +40,22 @@ requirements:
         - zlib
         - libxslt
         - libxml2
-        - ghostscript   #[linux]
-        - perl-xml-parser #[linux]
+        - ghostscript
+        - perl-xml-parser
+        - perl-yaml
+        - perl-xml-simple
+        - perl-html-template
+        - perl-cgi
 source:
-    fn: meme_4.11.1.tar.gz
-    url: http://alternate.meme-suite.org/meme-software/4.11.1/meme_4.11.1.tar.gz
-    md5: 8d04213c4feddf31d4f620060fdc6b97
+    fn: meme_4.11.2.tar.gz
+    url: http://alternate.meme-suite.org/meme-software/4.11.2/meme_4.11.2.tar.gz
+    sha1: 317c230772b62ae3a44d2e7dcc2466eadedf6662
     patches:
         - mast.patch
 
-
 test:
     commands:
-        - "meme -h 2>&1 | grep fraction > /dev/null"
-        - "meme-chip 2>&1 | grep FIMO > /dev/null"
-        - "centrimo 2>&1 | grep maxreg > /dev/null"
+        - meme -version
+        - mast -version
+        - meme-chip 2>&1 | grep FIMO > /dev/null
+        - centrimo 2>&1 | grep maxreg > /dev/null


### PR DESCRIPTION
also fixed the build to python 2 only,
this fixes issues #2272 and #1840

* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

as stated in the docs: http://meme-suite.org/doc/install.html, meme doesn't support python3 so I'm changing it to build on python 2 only.

unfortunately, I could not integrate the tests meme ships with because of this bug: https://github.com/conda/conda-build/issues/1453, the tests need to be executed from the build dir, however when build the shebangs strings exceed the linux maximum length and that makes the tests fail.

as a local workaround, the tests can be run if conda-build is executed with the `--prefix-length 1` option.
