### PR TITLE
Add option -get_jar_path to recieve the path of the MSGFPlus.jar file…

### DIFF
--- a/recipes/msgf_plus/meta.yaml
+++ b/recipes/msgf_plus/meta.yaml
@@ -8,7 +8,7 @@ package:
   version: 2016.10.26
 
 build:
-  number: 1
+  number: 2
   skip: False
 
 source:

--- a/recipes/msgf_plus/msgf_plus.py
+++ b/recipes/msgf_plus/msgf_plus.py
@@ -71,12 +71,16 @@ def main():
     jar_dir = real_dirname(sys.argv[0])
     (mem_opts, prop_opts, pass_args) = jvm_opts(sys.argv[1:])
 
+    jar_path = os.path.join(jar_dir, jar_file
+
+    if pass_args != [] and '-get_jar_path' in pass_args:
+        print(jar_path)
+        return
+
     if pass_args != [] and pass_args[0].startswith('edu'):
         jar_arg = '-cp'
     else:
         jar_arg = '-jar'
-
-    jar_path = os.path.join(jar_dir, jar_file)
 
     java_args = [java]+ mem_opts + prop_opts + [jar_arg] + [jar_path] + pass_args
 

--- a/recipes/msgf_plus/msgf_plus.py
+++ b/recipes/msgf_plus/msgf_plus.py
@@ -71,7 +71,7 @@ def main():
     jar_dir = real_dirname(sys.argv[0])
     (mem_opts, prop_opts, pass_args) = jvm_opts(sys.argv[1:])
 
-    jar_path = os.path.join(jar_dir, jar_file
+    jar_path = os.path.join(jar_dir, jar_file)
 
     if pass_args != [] and '-get_jar_path' in pass_args:
         print(jar_path)


### PR DESCRIPTION
…. This can be helpful for other tools (e.g. MSGFPlusAdapter from OpenMS).

* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
