### PR TITLE
Update msstitch to v2.2

### DIFF
--- a/recipes/msstitch/meta.yaml
+++ b/recipes/msstitch/meta.yaml
@@ -1,15 +1,15 @@
 package:
   name: msstitch
-  version: "1.0"
+  version: "2.2"
 
 source:
-  fn: msstitch-1.0.tar.gz
-  url: https://pypi.python.org/packages/cd/90/88a5a94dd61f6e07c590fa315ad85f5760ee4014838442c28ff321c6d250/msstitch-1.0.tar.gz
-  md5: 54bd24bc3055309c07a5b9d73d978015
+  fn: msstitch-2.2.tar.gz
+  url: https://pypi.python.org/packages/f4/e7/804e3d09d3180c7c45d49d97df1774a8b79e3c38da65acd8731f5c04e11f/msstitch-2.2.tar.gz
+  md5: bbe1a080011b7b41ebe789993ed917fe
 
 build:
   skip: True # [py2k]
-  number: 1
+  number: 0
   entry_points:
     - msspercolator=app.pycolator:main
     - msslookup=app.mslookup:main
@@ -22,13 +22,13 @@ requirements:
     - python
     - setuptools
     - numpy
-    - lxml
+    - lxml ==3.6.0
     - biopython
     - pyyaml
   run:
     - python
     - numpy
-    - lxml
+    - lxml ==3.6.0
     - biopython
     - pyyaml
     ## can be removed if the upstream package includes libgcc at some point


### PR DESCRIPTION
* [X] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Version update. I had to pin lxml because the latest 3.7.2 gave lots of errors in the tests complaining about not finding a lot of shared object files. I could solve some of those but not all (got stuck at `libicui18n`).