### PR TITLE
Fix3510

### DIFF
--- a/recipes/tophat2/build.sh
+++ b/recipes/tophat2/build.sh
@@ -26,12 +26,5 @@ tophat_reports \
 directories="sortedcontainers intervaltree"
 pythonfiles="tophat bed_to_juncs contig_to_chr_coords sra_to_solid tophat-fusion-post"
 
-PY3_BUILD="${PY_VER%.*}"
-
-if [ $PY3_BUILD -eq 3 ]
-then
-    for i in $pythonfiles; do 2to3 --write $i; done
-fi
-
 for i in $binaries; do cp $i $PREFIX/bin && chmod +x $PREFIX/bin/$i; done
 for d in $directories; do cp -r $d $PREFIX/bin; done

--- a/recipes/tophat2/meta.yaml
+++ b/recipes/tophat2/meta.yaml
@@ -10,11 +10,14 @@ package:
     name: tophat
     version: 2.1.1
 
+build:
+    skip: True # [py3k]
+
 requirements:
     build:
-        - python # [not py3k]
+        - python
     run:
-        - python # [not py3k]
+        - python
         - bowtie2 <=2.2.5
 
 test:
@@ -23,5 +26,7 @@ test:
 
 source:
   fn: tophat-2.1.1.Linux_x86_64.tar.gz
-  url: http://ccb.jhu.edu/software/tophat/downloads/tophat-2.1.1.Linux_x86_64.tar.gz
-  md5: 97fe58465a01cb0a860328fdb1993660
+  url: http://ccb.jhu.edu/software/tophat/downloads/tophat-2.1.1.Linux_x86_64.tar.gz # [linux]
+  md5: 97fe58465a01cb0a860328fdb1993660 # [linux]
+  url: https://ccb.jhu.edu/software/tophat/downloads/tophat-2.1.1.OSX_x86_64.tar.gz # [osx]
+  md5: 1e4e7f8d08f182d2db3202975f284294 # [osx]

--- a/recipes/tophat2/meta.yaml
+++ b/recipes/tophat2/meta.yaml
@@ -1,5 +1,5 @@
 build:
-  number: 0
+  number: 1
 
 about:
     home: http://ccb.jhu.edu/software/tophat/index.shtml
@@ -12,9 +12,10 @@ package:
 
 requirements:
     build:
-        - python
+        - python # [not py3k]
     run:
-        - python
+        - python # [not py3k]
+        - bowtie2 <=2.2.5
 
 test:
     commands:


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

@bioconda/core: This should fix #3510, which was also reported [here](https://www.biostars.org/p/232228/). It also appears that the recipe was never compatible with OSX (the test would work, but the binaries wouldn't have). I'm not sure what to do about the existing python3 versions of this package that are already available. They won't work and this update won't fix them. Should they just be removed so people can't inadvertently install them?