### PR TITLE
New: extract-sv-reads

### DIFF
--- a/recipes/extract-sv-reads/build.sh
+++ b/recipes/extract-sv-reads/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+mkdir -p build
+cd build
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$PREFIX ..
+make
+make install

--- a/recipes/extract-sv-reads/meta.yaml
+++ b/recipes/extract-sv-reads/meta.yaml
@@ -1,0 +1,30 @@
+build:
+  number: 0
+  skip: True # [osx]
+
+package:
+  name: extract-sv-reads
+  version: '1.1.0'
+source:
+  fn: extract-sv-reads-1.1.0.tar.gz
+  url: https://github.com/hall-lab/extract_sv_reads/archive/v1.1.0.tar.gz
+  md5: f7f4d113e32090404ffd9d7204b4f052
+
+requirements:
+  build:
+    - gcc
+    - cmake
+    - perl
+    - zlib
+  run:
+    - libgcc
+    - zlib
+
+test:
+  commands:
+    - extract-sv-reads -h
+
+about:
+  home: https://github.com/hall-lab/extract_sv_reads
+  license: MIT
+  summary:  Tool for extracting splitter or discordant reads from a BAM or CRAM file.

--- a/recipes/fgbio/meta.yaml
+++ b/recipes/fgbio/meta.yaml
@@ -4,13 +4,13 @@ about:
     summary: A set of tools for working with genomic and high throughput sequencing data, including UMIs
 package:
     name: fgbio
-    version: 0.1.2a
+    version: 0.1.3a
 build:
   number: 0
   skip: true # [not py27]
 source:
-    fn: fgbio-4c4a68181.tar.gz
-    url: https://github.com/fulcrumgenomics/fgbio/archive/4c4a68181.tar.gz
+    fn: fgbio-d4d8c22.tar.gz
+    url: https://github.com/fulcrumgenomics/fgbio/archive/d4d8c22.tar.gz
 requirements:
   build:
     - java-jdk >=8

--- a/recipes/goleft/meta.yaml
+++ b/recipes/goleft/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.1.9" %}
+{% set version = "0.1.10" %}
 
 package:
   name: goleft
@@ -7,10 +7,10 @@ package:
 source:
   fn: goleft-v{{ version }}-linux # [linux]
   url: https://github.com/brentp/goleft/releases/download/v{{ version }}/goleft_linux64 # [linux]
-  md5: 9df0a1f98bd7eca3d47b63c5b2d2dc1e # [linux]
+  md5: 9c5c801b163e07b65a583f705120301c # [linux]
   fn: goleft-v{{ version }}-osx # [osx]
   url: https://github.com/brentp/goleft/releases/download/v{{ version }}/goleft_osx # [osx]
-  md5: 86071da63b22c0b7a6121a4bb1cd919b # [osx]
+  md5: 3846e6dc62e911d3e3e705ee690dc8cb # [osx]
 
 build:
   number: 0


### PR DESCRIPTION
Allows extraction of split and discordant reads from sorted BAM
files for better lumpy preparation chapmanb/bcbio-nextgen#1738
chapmanb/bcbio-nextgen#1664 chapmanb/bcbio-nextgen#1526

* [x] I have read the guidelines above.
* [x] This PR adds a new recipe.
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
