### PR TITLE
Update r-ggrepel 0.5 to 0.6.5

### DIFF
--- a/recipes/r-ggrepel/meta.yaml
+++ b/recipes/r-ggrepel/meta.yaml
@@ -2,14 +2,13 @@ package:
   name: r-ggrepel
   # Note that conda versions cannot contain -, so any -'s in the version have
   # been replaced with _'s.
-  version: "0.5"
+  version: "0.6.5"
 
 source:
-  fn: ggrepel_0.5.tar.gz
+  fn: ggrepel_0.6.5.tar.gz
   url:
-    - http://cran.r-project.org/src/contrib/ggrepel_0.5.tar.gz
-    - http://cran.r-project.org/src/contrib/Archive/ggrepel/ggrepel_0.5.tar.gz
-
+    - http://cran.r-project.org/src/contrib/ggrepel_0.6.5.tar.gz
+    - http://cran.r-project.org/src/contrib/Archive/ggrepel/ggrepel_0.6.5.tar.gz
 
   # You can add a hash for the file here, like md5 or sha1
   # md5: 49448ba4863157652311cc5ea4fea3ea
@@ -57,7 +56,7 @@ test:
 about:
   home: http://github.com/slowkow/ggrepel
   license: GPL-2
-  summary: ' Provides text and label geoms for ''ggplot2'' that help to avoid overlapping text
+  summary: 'Provides text and label geoms for ''ggplot2'' that help to avoid overlapping text
     labels. Labels repel away from each other and away from the data points.'
 
 

--- a/recipes/r-ggrepel/meta.yaml
+++ b/recipes/r-ggrepel/meta.yaml
@@ -8,12 +8,10 @@ source:
   fn: ggrepel_0.6.5.tar.gz
   url:
     - http://cran.r-project.org/src/contrib/ggrepel_0.6.5.tar.gz
-    # ggrepel_0.6.5 not available in Archive
-    #- http://cran.r-project.org/src/contrib/Archive/ggrepel/ggrepel_0.6.5.tar.gz
 
   # You can add a hash for the file here, like md5 or sha1
-  # md5: 49448ba4863157652311cc5ea4fea3ea
-  # sha1: 3bcfbee008276084cbb37a2b453963c61176a322
+  md5: 7e2732cd4840efe2dc9e4bc689cf1ee5
+  sha1: 73316bb68042eafc04bc21473e414f220dd403b1
   # patches:
    # List any patch files here
    # - fix.patch

--- a/recipes/r-ggrepel/meta.yaml
+++ b/recipes/r-ggrepel/meta.yaml
@@ -8,7 +8,8 @@ source:
   fn: ggrepel_0.6.5.tar.gz
   url:
     - http://cran.r-project.org/src/contrib/ggrepel_0.6.5.tar.gz
-    - http://cran.r-project.org/src/contrib/Archive/ggrepel/ggrepel_0.6.5.tar.gz
+    # ggrepel_0.6.5 not available in Archive
+    #- http://cran.r-project.org/src/contrib/Archive/ggrepel/ggrepel_0.6.5.tar.gz
 
   # You can add a hash for the file here, like md5 or sha1
   # md5: 49448ba4863157652311cc5ea4fea3ea


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

This is a simple update of the package r-ggrepel which does not work in the version 0.5 with the current ggplot version (2.2.2).
One simple example of the error produced with v0.5:
```
> library(ggrepel)
Loading required package: ggplot2
> ggplot(mtcars, aes(wt, mpg)) +
+   geom_point(color = 'red') +
+   geom_text_repel(aes(label = rownames(mtcars))) +
+   theme_classic(base_size = 16)
Error: GeomTextRepel was built with an incompatible version of ggproto.
Please reinstall the package that provides this extension.
```

This is my first pull request so I have to ask @bioconda/core for a review. Please tell me if it means something more than just what I did in the previous sentence.

