### PR TITLE
patch bowtie2 to work across filesystems

### DIFF
--- a/recipes/bowtie2/bowtie2.patch
+++ b/recipes/bowtie2/bowtie2.patch
@@ -1,0 +1,17 @@
+--- bowtie2.orig        2017-01-20 19:41:25.706765000 -0500
++++ bowtie2     2017-01-20 16:23:38.574188000 -0500
+@@ -38,10 +38,10 @@
+  my ($vol,$script_path,$prog);
+  $prog = File::Spec->rel2abs( __FILE__ );
+
+-while (-f $prog && -l $prog){
+-    my (undef, $dir, undef) = File::Spec->splitpath($prog);
+-    $prog = File::Spec->rel2abs(readlink($prog), $dir);
+-}
++#while (-f $prog && -l $prog){
++#    my (undef, $dir, undef) = File::Spec->splitpath($prog);
++#    $prog = File::Spec->rel2abs(readlink($prog), $dir);
++#}
+
+  ($vol,$script_path,$prog)
+                  = File::Spec->splitpath($prog);

--- a/recipes/bowtie2/meta.yaml
+++ b/recipes/bowtie2/meta.yaml
@@ -11,9 +11,11 @@ source:
   fn: bowtie2-2.3.0-source.zip
   url: http://downloads.sourceforge.net/project/bowtie-bio/bowtie2/2.3.0/bowtie2-2.3.0-source.zip
   sha256: f9f841e780e78b1ae24b17981e2469e6d5add90ec22ef563af23ae2dd5ca003c
+  patches:
+    - bowtie2.patch
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
* [ ] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

This PR patches the `bowtie2` Perl wrapper script which under some conditions failed with the following error: 

```
/anaconda/pkgs/bowtie2-2.3.0-py27_0/bin/bowtie2-align-s:
error while loading shared libraries:libtbbmalloc_proxy.so.2: cannot open shared object file: No such file or directory.
```

Specifically this was happening on a cluster where conda was installed on one filesystem and the environment containing bowtie2 was on another filesystem. The patch removes the part of the wrapper that attempts to resolve symlinks. 

This does not happen in previous versions of bowtie2, but according to the release notes there was substantial refactoring in 2.3.0 which could be why we're only seeing this now.

I think that removing the symlink resolution here is OK, since the bowtie2 perl wrapper installed in a conda environment is unlikely to be symlinked elsewhere. This seems to fix the problem and tests pass, but @bioconda/core does anyone foresee issues with this?

Also @bgruening would there be any way to test this sort of cross-filesystem issue from within mulled-build?

Thanks @wresch and @jfear for working this out.