### PR TITLE
Update: bcbio, goleft

### DIFF
--- a/recipes/bcbio-nextgen/alignprep.diff
+++ b/recipes/bcbio-nextgen/alignprep.diff
@@ -1,0 +1,10 @@
+--- a/bcbio/ngsalign/alignprep.py	2017-01-09 20:01:37.000000000 -0500
++++ b/bcbio/ngsalign/alignprep.py	2017-01-23 09:45:20.824621275 -0500
+@@ -548,6 +548,7 @@
+     """Determine if a gzipped input file is blocked gzip or standard.
+ 
+     """
++    return True, True
+     if not needs_convert and is_bgzf(in_file):
+         return False, False
+     else:

--- a/recipes/bcbio-nextgen/meta.yaml
+++ b/recipes/bcbio-nextgen/meta.yaml
@@ -3,13 +3,16 @@ package:
   version: '1.0.1'
 
 build:
-  number: 0
+  number: 1
   skip: True # [not py27]
 
 source:
   fn: bcbio-nextgen-1.0.1.tar.gz
   url: https://pypi.python.org/packages/77/ba/29c493ef6f10eff436102d19f75989d6cd970cb2e7f915f246fbaa945b14/bcbio-nextgen-1.0.1.tar.gz
   md5: b0734f467cd511ca629ed739fb08495c
+  # Avoids bug in 1.0.1 which checks for bgzip and causes hangs on Illumina bgzip inputs for grabix
+  patches:
+    - alignprep.diff
   #fn: bcbio-nextgen-0f9d85a.tar.gz
   #url: https://github.com/chapmanb/bcbio-nextgen/archive/0f9d85a.tar.gz
 

--- a/recipes/goleft/meta.yaml
+++ b/recipes/goleft/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.1.11" %}
+{% set version = "0.1.12" %}
 
 package:
   name: goleft
@@ -6,11 +6,11 @@ package:
 
 source:
   fn: goleft-v{{ version }}-linux # [linux]
-  url: https://github.com/brentp/goleft/releases/download/v{{ version }}/goleft_linux64 # [linux]
-  md5: 466deb690ffc663aa12a4cfc5ac2074a # [linux]
+  url: https://github.com/brentp/goleft/releases/download/v{{ version }}-dev/goleft_linux64 # [linux]
+  md5: c4b3b5c524a91f3cb86d88ab24f6a66b # [linux]
   fn: goleft-v{{ version }}-osx # [osx]
-  url: https://github.com/brentp/goleft/releases/download/v{{ version }}/goleft_osx # [osx]
-  md5: f51cc158409df095a3a349afdeaca8ee # [osx]
+  url: https://github.com/brentp/goleft/releases/download/v{{ version }}-dev/goleft_osx # [osx]
+  md5: 01d1355e81c3eccb316987b912cdb2c4 # [osx]
 
 build:
   number: 0


### PR DESCRIPTION
- bcbio: Fixes bug where bcbio 1.0.1 release can hang when grabix
  indexing bgzip files (chapmanb/bcbio-nextgen#1779)
- goleft: update to 0.1.12-dev with fixes for hg38 BAMs

* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
