### PR TITLE
Update ant to 1.10.0

### DIFF
--- a/recipes/ant/meta.yaml
+++ b/recipes/ant/meta.yaml
@@ -1,22 +1,28 @@
+{% set name = "ant" %}
+{% set version = "1.10.0" %}
+{% set sha256 = "a666b7aee7608739c3ec2a27d7aab5a95ef66e7cc53de91c2738f184edf72b2f" %}
+{% set md5 = "0a55520f578a4d0990965bee49674247" %}
+
 package:
-  name: ant
-  version: 1.9.6
+  name: {{ name|lower }}
+  version: {{ version }}
 
 source:
-  fn: apache-ant-1.9.6-src.tar.gz
-  url: http://apache.mirrors.spacedump.net//ant/source/apache-ant-1.9.6-src.tar.gz
-  md5: 29b7507c9053e301d2b85091f2aec6f0
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: http://apache.mirrors.spacedump.net/{{ name }}/source/apache-{{ name }}-{{ version }}-src.tar.bz2
+  sha256: {{ sha256 }}
+  md5: {{ md5 }}
 
 build:
-  number: 1
+  number: 0
   skip: True # [osx]
 
 requirements:
   build:
-    - java-jdk
+    - openjdk
 
   run:
-    - java-jdk
+    - openjdk
 
 test:
   commands:


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Now use `openjdk` instead of `java-jdk`