### PR TITLE
Compile hmmer with --enable-portable-binary

### DIFF
--- a/recipes/hmmer/build.sh
+++ b/recipes/hmmer/build.sh
@@ -4,7 +4,9 @@
 CC=${PREFIX}/bin/gcc
 CXX=${PREFIX}/bin/g++
 
-./configure --prefix=$PREFIX
+# Fix broken configure option
+sed -i.bak -e 's/acx_maxopt_portable=$withval/acx_maxopt_portable=$enableval/' configure
+# --enable-portable-binary should be removed for the next HMMER release where this should be unnecessary
+./configure --enable-portable-binary --prefix=$PREFIX
 make -j4
 make install
-

--- a/recipes/hmmer/meta.yaml
+++ b/recipes/hmmer/meta.yaml
@@ -8,7 +8,7 @@ source:
   md5: c8c141018bc0ccd7fc37b33f2b945d5f
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:


### PR DESCRIPTION
Disable compiler optimizations that produce unportable binaries.

* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
