### PR TITLE
r-data-table: fix a path length problem

### DIFF
--- a/recipes/r-data.table/meta.yaml
+++ b/recipes/r-data.table/meta.yaml
@@ -13,7 +13,7 @@ source:
   md5: f0e08dd5ba1b3f46c59dd1574fe497c1
 
 build:
-
+  number: 1
   rpaths:
     - lib/R/lib/
     - lib/


### PR DESCRIPTION
Try rebuilding to fix a path length problem:
```
PaddingError: Placeholder of length '80' too short in package bioconda::r-data.table-1.10.0-r3.3.1_0.
The package must be rebuilt with conda-build > 2.0.
```

* [ ] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
