### PR TITLE
better dependincies for anvio

### DIFF
--- a/recipes/anvio/meta.yaml
+++ b/recipes/anvio/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - scikit-learn >=0.17.1
     - django >=1.9.7
     - h5py >=2.6.0
-    - cherrypy >=6.0.2
+    - cherrypy >=6.0.2,<9
     - requests >=2.10.0
     - gsl
 
@@ -40,13 +40,15 @@ requirements:
     - scikit-learn >=0.17.1
     - django >=1.9.7
     - h5py >=2.6.0
-    - cherrypy >=6.0.2
+    - cherrypy >=6.0.2,<9
     - requests >=2.10.0
     - gsl
     - diamond
     - blast
+    - prodigal
     - mcl
     - muscle
+    - hmmer
 
 test:
   commands:


### PR DESCRIPTION
I updated the anvio dependencies slightly:

 * Anvio's built-in test (`anvi-self-test`, used to verify installation) requires prodigal and hmmer to run successfully.
 * The most recent version of cherrypy (>=9) conflicts with the bottle.

Checklist:
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
