### PR TITLE
Do not skip khmer build on macOS

### DIFF
--- a/recipes/khmer/2.0/meta.yaml
+++ b/recipes/khmer/2.0/meta.yaml
@@ -7,7 +7,6 @@ about:
     hence the name.'
 build:
   number: 1
-  skip: True # [osx]
 package:
   name: khmer
   version: '2.0'


### PR DESCRIPTION
* [ ] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

It seems the khmer recipe was meant to work under macOS (there is an `llvm` requirement), but the `skip: True` was never removed.