### PR TITLE
New: DKFZBiasFilter, Update: VarDict, VarDictJava

### DIFF
--- a/recipes/dkfz-bias-filter/build.sh
+++ b/recipes/dkfz-bias-filter/build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+OUTDIR=$PREFIX/share/dkfz-bias-filter
+mkdir -p $OUTDIR
+cp -r scripts/* $OUTDIR
+
+for $file in biasFilter.py dkfzbiasfilter_summarize.py
+do
+    chmod a+x $OUTDIR/$file
+    sed -i.bak 's#!/usr/bin/env python#!/opt/anaconda1anaconda2anaconda3/bin/python#' $OUTDIR/$file
+    rm -f $OUTDIR/$file.bak
+done
+
+mkdir -p $PREFIX/bin
+ln -s $OUTDIR/biasFilter.py $PREFIX/bin/dkfzbiasfilter.py
+ln -s $OUTDIR/dkfzbiasfilter_summarize.py $PREFIX/bin/dkfzbiasfilter_summarize.py

--- a/recipes/dkfz-bias-filter/meta.yaml
+++ b/recipes/dkfz-bias-filter/meta.yaml
@@ -1,0 +1,31 @@
+package:
+  name: dkfz-bias-filter
+  version: '1.2.3a'
+
+source:
+  git_url: https://github.com/chapmanb/DKFZBiasFilter.git
+  git_tag: 7a7dbd75b402c82d8758a171b8c5d8d78ca9833c
+
+build:
+  number: 0
+  skip: true # [not py27]
+
+requirements:
+  build:
+    - python
+
+  run:
+    - python
+    - matplotlib
+    - numpy
+    - pysam
+    - scipy
+
+test:
+  commands:
+    - dkfzbiasfilter.py -h
+
+about:
+  home: https://github.com/eilslabs/DKFZBiasFilter
+  license: GPLv3
+  summary: The DKFZ bias filter flags SNVs that appear to be biased based on the variant read support

--- a/recipes/vardict-java/meta.yaml
+++ b/recipes/vardict-java/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.4.8" %}
+{% set version = "1.4.9" %}
 
 package:
   name: vardict-java
@@ -6,9 +6,8 @@ package:
 
 source:
   fn: VarDict-{{ version }}.zip
-  #url: https://github.com/AstraZeneca-NGS/VarDictJava/releases/download/v{{ version }}/VarDict-{{ version }}.zip
-  url: https://github.com/AstraZeneca-NGS/VarDictJava/blob/master/dist/VarDict-{{ version }}.zip?raw=true
-  md5: ce4fc1bbf1b6b4d76c7f046d6b4dbc0d
+  url: https://github.com/AstraZeneca-NGS/VarDictJava/files/748361/VarDict-{{ version }}.zip
+  md5: a0f1b6311b3fbdb48ba437223427e7c3
 
 build:
   number: 0

--- a/recipes/vardict/meta.yaml
+++ b/recipes/vardict/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: vardict
-  version: '2017.01.27'
+  version: '2017.02.01'
 
 source:
   git_url: https://github.com/AstraZeneca-NGS/VarDict
-  git_tag: e59f72e1025b23ed6a5352ed58e7fe2cacad3541
+  git_tag: 0752bad985cdb1b499f87a5ce32c7a486e0fcc63
 
 build:
   number: 0


### PR DESCRIPTION
- VarDictJava: update to 1.4.9 with fixes for overlapping reads
- VarDict: support reference calls AstraZeneca-NGS/VarDict#37
- DDFZBiasFilter: new recipe supporting filtering of DNA damage events
  (oxoG, FFPE) and strand bias.

* [x] I have read the guidelines above.
* [x] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
