### PR TITLE
{AH} add pysam 0.10.0 build recipe

### DIFF
--- a/recipes/pysam/0.9.1.4/build.sh
+++ b/recipes/pysam/0.9.1.4/build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Remove gcc statements that do not work on older compilers for CentOS5
+# support, from https://github.com/chapmanb/bcbio-conda/blob/master/pysam/build.sh
+sed -i'' -e 's/"-Wno-error=declaration-after-statement",//g' setup.py
+sed -i'' -e 's/"-Wno-error=declaration-after-statement"//g' setup.py
+# linking htslib, see:
+# http://pysam.readthedocs.org/en/latest/installation.html#external
+# https://github.com/pysam-developers/pysam/blob/v0.9.0/setup.py#L79
+export CFLAGS="-I$PREFIX/include"
+export CPPFLAGS="-I$PREFIX/include"
+export LDFLAGS="-L$PREFIX/lib"
+
+export HTSLIB_LIBRARY_DIR=$PREFIX/lib
+export HTSLIB_INCLUDE_DIR=$PREFIX/include
+$PYTHON setup.py install

--- a/recipes/pysam/0.9.1.4/meta.yaml
+++ b/recipes/pysam/0.9.1.4/meta.yaml
@@ -1,16 +1,15 @@
 package:
     name: pysam
-    version: 0.10.0
+    version: 0.9.1.4
 
 source:
-    fn: pysam-0.10.0.tar.gz
-    url: https://pypi.python.org/packages/87/8e/d2d8238558970df37c7aa01ddec63057a98042334e939b4c1c69cb9a2504/pysam-0.10.0.tar.gz
-    md5: a1f3333ce60f8de542624cb07c792fc0
+    fn: pysam-0.9.1.4.tar.gz
+    url: https://pypi.python.org/packages/de/03/02934438b204565bc5231f38a11da840a3c3e4b2beac8c8770d675770668/pysam-0.9.1.4.tar.gz
+    md5: a7e0e9cbc972618cde7aea54894067d6
 
 build:
     number: 1
     skip: False
-    binary_relocation: False
 
 requirements:
     build:


### PR DESCRIPTION
* [x ] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Minor modification to recipe to build pysam 0.10.0:
```build:
    binary_relocation: False
```

CI seems to pass:
```
INFO bioconda_utils.build:build(145): BIOCONDA TEST SUCCESS recipes/pysam, CONDA_BOOST=1.60;CONDA_GMP=5.1;CONDA_GSL=1.16;CONDA_HDF5=1.8.17;CONDA_NCURSES=5.9;CONDA_NPY=110;CONDA_PERL=5.22.0;CONDA_PY=27;CONDA_R=3.3.1

INFO bioconda_utils.build:build_recipes(396): BIOCONDA BUILD SUMMARY: successfully built 1 of 1 recipes
```

but then fails at upload stage, presumably because of missing permissions.
```
File "/anaconda/lib/python3.5/site-packages/bioconda_utils/upload.py", line 37, in upload

    raise ValueError("Env var ANACONDA_TOKEN not found")

ValueError: Env var ANACONDA_TOKEN not found
```

Full log is here: https://travis-ci.org/pysam-developers/bioconda-recipes/jobs/198895421
