### PR TITLE
Add recipe for salmon 0.8.0.

### DIFF
--- a/recipes/salmon/0.7.2/build.sh
+++ b/recipes/salmon/0.7.2/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -eu -o pipefail
+
+# pre-built version
+if [ "$(uname)" == "Darwin" ]; then
+    outdir=$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM
+    mkdir -p $outdir
+    mkdir -p $PREFIX/bin
+    cp -r bin lib $outdir
+    ln -s $outdir/bin/salmon $PREFIX/bin
+elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+    cd $SRC_DIR
+    mkdir -p build
+    sed -i 's/Boost_USE_STATIC_LIBS ON/Boost_USE_STATIC_LIBS OFF/' CMakeLists.txt
+    sed -i 's/.\/autogen.sh/CFLAGS=-fPIC CPPFLAGS=-fPIC .\/autogen.sh/' CMakeLists.txt
+    sed -i 's/CFLAGS+=${STADEN_LIB}/CFLAGS+=${STADEN_LIB} CFLAGS+=-lz/' CMakeLists.txt
+    cd build
+    cmake -DCMAKE_INSTALL_PREFIX=${PREFIX} -DBOOST_ROOT=$PREFIX -DBoost_NO_SYSTEM_PATHS=ON -DBoost_DEBUG=ON ..
+    make install CFLAGS="-L${PREFIX}/lib -I${PREFIX}/include"
+fi

--- a/recipes/salmon/0.7.2/meta.yaml
+++ b/recipes/salmon/0.7.2/meta.yaml
@@ -1,0 +1,37 @@
+build:
+  number: 2
+  # XXX OSX currently failing due to problem with bundled shared libraries
+  skip: True # [osx]
+  string: boost{{CONDA_BOOST}}_{{PKG_BUILDNUM}}
+
+about:
+    home: https://github.com/COMBINE-lab/salmon
+    license: GPLv3
+    summary: Highly-accurate & wicked fast transcript-level quantification from RNA-seq reads using lightweight alignments
+package:
+    name: salmon
+    version: 0.7.2
+source:
+  fn: SalmonBeta-0.7.2_OSX_10.11.tar.gz # [osx]
+  url: https://github.com/COMBINE-lab/salmon/releases/download/v0.7.2/SalmonBeta-0.7.2_OSX_10.11.tar.gz # [osx]
+  sha256: 4e832696826e04f8f02c3ce2645b5aeda09fafa4ff97dc0a785ef023003e26c1 # [osx]
+  fn: salmon-v0.7.2.tar.gz # [linux]
+  url: https://github.com/COMBINE-lab/salmon/archive/v0.7.2.tar.gz # [linux]
+  sha256: d35147663d349a6c28bcabf51e85d5a45f24273be1c4cda76173ffa15bd68d0a
+
+requirements:
+  build:
+    - autoconf
+    - boost {{CONDA_BOOST}}*
+    - cmake
+    - tbb
+    - zlib
+    - bzip2
+  run:
+    - boost {{CONDA_BOOST}}*
+    - tbb
+    - zlib
+    - bzip2
+test:
+    commands:
+      - salmon --help

--- a/recipes/salmon/build.sh
+++ b/recipes/salmon/build.sh
@@ -1,20 +1,12 @@
 #!/bin/bash
 set -eu -o pipefail
 
-# pre-built version
-if [ "$(uname)" == "Darwin" ]; then
-    outdir=$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM
-    mkdir -p $outdir
-    mkdir -p $PREFIX/bin
-    cp -r bin lib $outdir
-    ln -s $outdir/bin/salmon $PREFIX/bin
-elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
-    cd $SRC_DIR
-    mkdir -p build
-    sed -i 's/Boost_USE_STATIC_LIBS ON/Boost_USE_STATIC_LIBS OFF/' CMakeLists.txt
-    sed -i 's/.\/autogen.sh/CFLAGS=-fPIC CPPFLAGS=-fPIC .\/autogen.sh/' CMakeLists.txt
-    sed -i 's/CFLAGS+=${STADEN_LIB}/CFLAGS+=${STADEN_LIB} CFLAGS+=-lz/' CMakeLists.txt
-    cd build
-    cmake -DCMAKE_INSTALL_PREFIX=${PREFIX} -DBOOST_ROOT=$PREFIX -DBoost_NO_SYSTEM_PATHS=ON -DBoost_DEBUG=ON ..
-    make install CFLAGS="-L${PREFIX}/lib -I${PREFIX}/include"
-fi
+export LD_LIBRARY_PATH=${PREFIX}/lib
+cd $SRC_DIR
+mkdir -p build
+sed -i 's/Boost_USE_STATIC_LIBS ON/Boost_USE_STATIC_LIBS OFF/' CMakeLists.txt
+sed -i 's/.\/autogen.sh/CFLAGS=-fPIC CPPFLAGS=-fPIC .\/autogen.sh/' CMakeLists.txt
+sed -i 's/CFLAGS+=${STADEN_LIB}/CFLAGS+=${STADEN_LIB} CFLAGS+=-lz/' CMakeLists.txt
+cd build
+cmake -DCMAKE_EXE_LINKER_FLAGS="-L$PREFIX/lib" -DCMAKE_INSTALL_PREFIX=${PREFIX} -DBOOST_ROOT=$PREFIX -DBoost_NO_SYSTEM_PATHS=ON -DBoost_DEBUG=ON ..
+make install CFLAGS="-L${PREFIX}/lib -I${PREFIX}/include"

--- a/recipes/salmon/meta.yaml
+++ b/recipes/salmon/meta.yaml
@@ -1,6 +1,6 @@
 build:
-  number: 2
-  # XXX OSX currently failing due to problem with bundled shared libraries
+  number: 0
+  # XXX OSX source build currently failing due to unresolved symbols at runtime
   skip: True # [osx]
   string: boost{{CONDA_BOOST}}_{{PKG_BUILDNUM}}
 
@@ -8,30 +8,36 @@ about:
     home: https://github.com/COMBINE-lab/salmon
     license: GPLv3
     summary: Highly-accurate & wicked fast transcript-level quantification from RNA-seq reads using lightweight alignments
+
 package:
     name: salmon
-    version: 0.7.2
+    version: 0.8.0
+
 source:
-  fn: SalmonBeta-0.7.2_OSX_10.11.tar.gz # [osx]
-  url: https://github.com/COMBINE-lab/salmon/releases/download/v0.7.2/SalmonBeta-0.7.2_OSX_10.11.tar.gz # [osx]
-  sha256: 4e832696826e04f8f02c3ce2645b5aeda09fafa4ff97dc0a785ef023003e26c1 # [osx]
-  fn: salmon-v0.7.2.tar.gz # [linux]
-  url: https://github.com/COMBINE-lab/salmon/archive/v0.7.2.tar.gz # [linux]
-  sha256: d35147663d349a6c28bcabf51e85d5a45f24273be1c4cda76173ffa15bd68d0a
+  fn: v0.8.0.tar.gz
+  url: https://github.com/COMBINE-lab/salmon/archive/v0.8.0.tar.gz
+  sha256: a58799eb9ac61a91d941ab23485328e1fe2e869dbc2091c86ff6eb4300f284c5
 
 requirements:
   build:
-    - autoconf
+    - autoconf 2.69 pl5.*
     - boost {{CONDA_BOOST}}*
+    - icu 56.*
     - cmake
     - tbb
     - zlib
     - bzip2
+    - unzip
+    - gcc # [linux]
+    - llvm # [osx]
   run:
     - boost {{CONDA_BOOST}}*
+    - icu 56.*
     - tbb
     - zlib
     - bzip2
+    - libgcc # [linux]
+
 test:
     commands:
       - salmon --help


### PR DESCRIPTION
* [X] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Building from source on OS X is still a WIP.  The binary is created ok, but throws symbol not found errors at runtime.  The pre-built OS X binary was built using 10.12, and gives a `lazy symbol binding failed` error when run on earlier OS versions.