### PR TITLE
Update: Toil and VarDict

### DIFF
--- a/recipes/cgcloud-lib/meta.yaml
+++ b/recipes/cgcloud-lib/meta.yaml
@@ -1,26 +1,27 @@
 package:
   name: cgcloud-lib
-  version: "1.4a1.dev195"
+  version: "1.6.0"
 
 source:
-  fn: cgcloud-lib-1.4a1.dev195.tar.gz
-  url: https://pypi.python.org/packages/ab/ab/b383710d03962b8f60a89b021ee3db01809676aeee70c2f4879c00448e85/cgcloud-lib-1.4a1.dev195.tar.gz
-  md5: aec110dd333ed8624dd33ba58db6e7bf
+  fn: cgcloud-lib-1.6.0.tar.gz
+  url: https://pypi.python.org/packages/71/e3/0ce3f6b3e3f11f37a51634cd84fa5d95bcee418843ef9b30239de4df0160/cgcloud-lib-1.6.0.tar.gz
+  md5: 76cb2e9b3b6f716c0790bf7a55594c94
 
 build:
   number: 0
+  skip: True # [not py27]
 
 requirements:
   build:
     - python
     - setuptools
     - bd2k-python-lib
-    - boto
+    - boto ==2.38.0
 
   run:
     - python
     - bd2k-python-lib
-    - boto
+    - boto ==2.38.0
 
 test:
   imports:

--- a/recipes/toil/meta.yaml
+++ b/recipes/toil/meta.yaml
@@ -1,24 +1,26 @@
 package:
   name: toil
-  version: '3.5.0a1'
+  version: '3.6.0'
 
 source:
-  git_url: https://github.com/BD2KGenomics/toil
-  git_tag: b21bb494359398bf5ad85fc6fe9c4b007a797597
+  fn: toil-3.6.0.tar.gz
+  url: https://pypi.python.org/packages/44/38/5554efcd059db4d67a30075204fe2051465be0031c207e51490cb550f313/toil-3.6.0.tar.gz
+  md5: 55298b33f3d246717cb87d1004fb752c
 
 build:
-  number: 3
+  number: 0
   skip: True # [not py27]
 
 requirements:
   build:
     - python
     - setuptools
+    - six
     - bd2k-python-lib ==1.14a1.dev37
     - dill
     - psutil
     - cgcloud-lib
-    - boto
+    - boto ==2.38.0
     - futures # [py27]
     - azure
     - cwltool ==1.0.20161227200419
@@ -27,11 +29,12 @@ requirements:
 
   run:
     - python
+    - six
     - bd2k-python-lib ==1.14a1.dev37
     - dill
     - psutil
     - cgcloud-lib
-    - boto
+    - boto ==2.38.0
     - futures # [py27]
     - azure
     - cwltool ==1.0.20161227200419

--- a/recipes/vardict/meta.yaml
+++ b/recipes/vardict/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: vardict
-  version: '2017.02.01'
+  version: '2017.02.10'
 
 source:
   git_url: https://github.com/AstraZeneca-NGS/VarDict
-  git_tag: 0752bad985cdb1b499f87a5ce32c7a486e0fcc63
+  git_tag: 4db3330b86f260e6c513c1fe0c0300dcafb238fa
 
 build:
   number: 0


### PR DESCRIPTION
- toil, cgcloud-lib: update to latest 3.6.0 release and dependencies
- vardict: fix for empty paired inputs

* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
