### PR TITLE
Increase savage build number in order to retrigger generation of the …

### DIFF
--- a/recipes/savage/meta.yaml
+++ b/recipes/savage/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 0
+  number: 1
   string: "py{{CONDA_PY}}_boost{{CONDA_BOOST}}_{{PKG_BUILDNUM}}"
   skip: True  # [py3k or osx]
 


### PR DESCRIPTION
…corresponding docs.

* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

The savage package (PR #3652) by @jbaaijens has been built and uploaded successfully, but the corresponding entry on bioconda.github.io has never been generated. I assume there was a temporal bug in bioconda-utils. @daler would this make sense, or do you think there is a different reason?