### PR TITLE
[ci skip] Better error reporting when generating docs. Fix notes section of openms.

### DIFF
--- a/recipes/openms/meta.yaml
+++ b/recipes/openms/meta.yaml
@@ -60,8 +60,7 @@ about:
   summary: OpenMS is an open-source software C++ library for LC-MS data management and analyses
 
 extra:
-    notes:
-        - |
-          This package exceeds the travis build time. Hence, this package was build by @bioconda/core locally via
-          simulate-travis.py and pushed directly. If you need an update for this package please make your changes,
-          create a PR and contact @bioconda/core.
+    notes: |
+           This package exceeds the travis build time. Hence, this package was build by @bioconda/core locally via
+           simulate-travis.py and pushed directly. If you need an update for this package please make your changes,
+           create a PR and contact @bioconda/core.


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

Since some time, the docs were not properly updated any more. This was because of an undetected error in the openms recipe (the notes section contained a list). This PR improves the error messages of our doc script (they now point to the failing recipe) and fixes the problem with openms.