### PR TITLE
Update vcf2maf recipe to v1.6.12

### DIFF
--- a/recipes/vcf2maf/meta.yaml
+++ b/recipes/vcf2maf/meta.yaml
@@ -4,12 +4,12 @@ build:
 
 package:
   name: vcf2maf
-  version: 1.6.8
+  version: 1.6.12
 
 source:
-  fn: v1.6.8.tar.gz
-  url: https://github.com/mskcc/vcf2maf/archive/v1.6.8.tar.gz
-  md5: 69eef38b218efd719bb78950549ee94e
+  fn: v1.6.12.tar.gz
+  url: https://github.com/mskcc/vcf2maf/archive/v1.6.12.tar.gz
+  md5: ebdba06c46650b3f185d237f6819a209
 
 requirements:
   build:
@@ -26,7 +26,7 @@ test:
     - vcf2maf.pl --help
 
 about:
-  home: https://github.com/mskcc/vcf2maf 
+  home: https://github.com/mskcc/vcf2maf
   license: Apache
   summary: Convert a VCF into a MAF where each variant is annotated to only one of all possible gene isoforms
 

--- a/recipes/vcf2maf/meta.yaml
+++ b/recipes/vcf2maf/meta.yaml
@@ -16,10 +16,12 @@ requirements:
     - perl-threaded
     - variant-effect-predictor
     - samtools
+    - htslib
   run:
     - perl-threaded
     - variant-effect-predictor
     - samtools
+    - htslib
 
 test:
   commands:


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

 ----

The changes are simple. Other than updating the link, I had to add `htslib` as a requirement, because `vcf2maf` now depends on `tabix` (part of `htslib`). 