### PR TITLE
Enable Travis Fast Finishing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,10 @@ install: scripts/travis-setup.sh
 script: travis_wait 119 scripts/travis-run.sh
 env:
   global:
-  - secure: WS9nwlZfrSgdU5bUw9ZXh5xD067PyUVq+UZnPazORgh5kgkTTX4EsNnXPtmUiQ9DOwVvBiCZzn6c7N+YPuUdEROOR/pBjtFA+w/APFk4ug1tcIzRH7z2we+fZaAnKK3SRqOhHkUYa8tjZFGr53RsaKaxKEc0SIqsHGbDupdBz9KC4raXyUQobcLxWbE6BQq2jhyJGqWxOrhTTrd3WCRKVTgjUlQmwimk6s9txfnEbEguE7UlRhlO0CSqgBj2oUvwtJQSkZWAFminUi2Jcmnduebu42iYX6IF3bYNLVxy8d56v2APGv6reipsD9m3l6URRtpgGygMF4EI9X6dlCjT2qMrwwuWQcZJncFkR584dL+MiPfA2RXamGQybX8HSlnrn60ZKzr5gmw4hetffUGwmOA2VlEW1Wcxcwcef+/8osWwnfLT4I3i736P71LARcBWjBaXKKCXCkCLegv0WB0V/JXyo6IfdLToB0ElAwNfoSlhK1ZtTejngMQewzh6HFcyJwbyPog8/WCL+/j+OohdLZYgiXuldeoLoTwM8YmrSV7twUg3rl2Uc9AWd6iKXC2n8t+2XXdSTwcyrLAEp5J2gZA+HPE/4R6/K1YLbILfMp+u2k8TpazSVX7oRwIcp5UJK6NGx9KDLnT5nJXFW2J5SuBdvQjOXGNSVxyAhBg2AAM=
-  - SUBDAGS=1
-  - BIOCONDA_UTILS_TAG=master
-  - BIOCONDA_UTILS_ARGS="--loglevel=info --mulled-test"
+    - secure: WS9nwlZfrSgdU5bUw9ZXh5xD067PyUVq+UZnPazORgh5kgkTTX4EsNnXPtmUiQ9DOwVvBiCZzn6c7N+YPuUdEROOR/pBjtFA+w/APFk4ug1tcIzRH7z2we+fZaAnKK3SRqOhHkUYa8tjZFGr53RsaKaxKEc0SIqsHGbDupdBz9KC4raXyUQobcLxWbE6BQq2jhyJGqWxOrhTTrd3WCRKVTgjUlQmwimk6s9txfnEbEguE7UlRhlO0CSqgBj2oUvwtJQSkZWAFminUi2Jcmnduebu42iYX6IF3bYNLVxy8d56v2APGv6reipsD9m3l6URRtpgGygMF4EI9X6dlCjT2qMrwwuWQcZJncFkR584dL+MiPfA2RXamGQybX8HSlnrn60ZKzr5gmw4hetffUGwmOA2VlEW1Wcxcwcef+/8osWwnfLT4I3i736P71LARcBWjBaXKKCXCkCLegv0WB0V/JXyo6IfdLToB0ElAwNfoSlhK1ZtTejngMQewzh6HFcyJwbyPog8/WCL+/j+OohdLZYgiXuldeoLoTwM8YmrSV7twUg3rl2Uc9AWd6iKXC2n8t+2XXdSTwcyrLAEp5J2gZA+HPE/4R6/K1YLbILfMp+u2k8TpazSVX7oRwIcp5UJK6NGx9KDLnT5nJXFW2J5SuBdvQjOXGNSVxyAhBg2AAM=
+    - SUBDAGS=1
+    - BIOCONDA_UTILS_TAG=master
+    - BIOCONDA_UTILS_ARGS="--loglevel=info --mulled-test"
   matrix:
-  - SUBDAG=0
+    fast_finish: true
+    - SUBDAG=0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,19 @@
 os:
-- linux
-- osx
+  - linux
+  - osx
 language: c
 sudo: required
 services:
-- docker
+  - docker
 install: scripts/travis-setup.sh
 script: travis_wait 119 scripts/travis-run.sh
+
 env:
   global:
     - secure: WS9nwlZfrSgdU5bUw9ZXh5xD067PyUVq+UZnPazORgh5kgkTTX4EsNnXPtmUiQ9DOwVvBiCZzn6c7N+YPuUdEROOR/pBjtFA+w/APFk4ug1tcIzRH7z2we+fZaAnKK3SRqOhHkUYa8tjZFGr53RsaKaxKEc0SIqsHGbDupdBz9KC4raXyUQobcLxWbE6BQq2jhyJGqWxOrhTTrd3WCRKVTgjUlQmwimk6s9txfnEbEguE7UlRhlO0CSqgBj2oUvwtJQSkZWAFminUi2Jcmnduebu42iYX6IF3bYNLVxy8d56v2APGv6reipsD9m3l6URRtpgGygMF4EI9X6dlCjT2qMrwwuWQcZJncFkR584dL+MiPfA2RXamGQybX8HSlnrn60ZKzr5gmw4hetffUGwmOA2VlEW1Wcxcwcef+/8osWwnfLT4I3i736P71LARcBWjBaXKKCXCkCLegv0WB0V/JXyo6IfdLToB0ElAwNfoSlhK1ZtTejngMQewzh6HFcyJwbyPog8/WCL+/j+OohdLZYgiXuldeoLoTwM8YmrSV7twUg3rl2Uc9AWd6iKXC2n8t+2XXdSTwcyrLAEp5J2gZA+HPE/4R6/K1YLbILfMp+u2k8TpazSVX7oRwIcp5UJK6NGx9KDLnT5nJXFW2J5SuBdvQjOXGNSVxyAhBg2AAM=
     - SUBDAGS=1
     - BIOCONDA_UTILS_TAG=master
     - BIOCONDA_UTILS_ARGS="--loglevel=info --mulled-test"
-  matrix:
-    fast_finish: true
-    - SUBDAG=0
+matrix:
+  fast_finish: true
+   - SUBDAG=0


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

Many bioconda PRs are held up by builds from other PRs where one job in the build matrix has failed but secondary jobs within the failing build still run. This PR enables the [Travis-CI `fast_finish` feature]( https://docs.travis-ci.com/user/customizing-the-build#Fast-Finishing ), which marks a build finished as soon as a single member job has failed.  This allows other builds to continue. Since a contributor will need to submit a new commit to correct a failing job, all jobs in the build matrix will eventually be tested. @bioconda/core: Thoughts?