### PR TITLE
Bump matrixstats

### DIFF
--- a/recipes/r-matrixstats/meta.yaml
+++ b/recipes/r-matrixstats/meta.yaml
@@ -7,7 +7,10 @@ source:
   url:
     - http://cran.r-project.org/src/contrib/matrixStats_0.51.0.tar.gz
     - http://cran.r-project.org/src/contrib/Archive/matrixStats/matrixStats_0.51.0.tar.gz
+  sha256: f2b22c2dab2f28e9bcae9e5e744fd2a9f969230ed8ba7aa84debcd024ca74a2f
+
 build:
+  number: 1
   rpaths:
     - lib/R/lib/
     - lib/


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [x]  This PR does something else (explain below).

bump build of r-matrixstats to trigger a rebuild with conda-build > 2

```
WARNING conda_build.build:create_env(699): Build prefix failed with prefix length 255
WARNING conda_build.build:create_env(700): Error was: 
WARNING conda_build.build:create_env(701): Placeholder of length '80' too short in package bioconda::r-matrixstats-0.51.0-r3.3.1_0.
The package must be rebuilt with conda-build > 2.0.
WARNING conda_build.build:create_env(702): One or more of your package dependencies needs to be rebuilt with a longer prefix length.
WARNING conda_build.build:create_env(704): Falling back to legacy prefix length of 80 characters.
WARNING conda_build.build:create_env(705): Your package will not install into prefixes > 80 characters.
[...]
Placeholder of length '80' too short in package bioconda::r-matrixstats-0.51.0-r3.3.1_0.
The package must be rebuilt with conda-build > 2.0.
```