### PR TITLE
Pin conda to python3.5

### DIFF
--- a/scripts/travis-setup.sh
+++ b/scripts/travis-setup.sh
@@ -26,7 +26,7 @@ curl -O https://repo.continuum.io/miniconda/Miniconda3-latest-$tag-x86_64.sh
 sudo bash Miniconda3-latest-$tag-x86_64.sh -b -p /anaconda
 sudo chown -R $USER /anaconda
 export PATH=/anaconda/bin:$PATH
-conda install -y conda=4.2.15
+conda install -y conda=4.2.15=py35_0
 
 $SCRIPT_DIR/../simulate-travis.py --set-channel-order
 $SCRIPT_DIR/../simulate-travis.py --install-requirements


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

This pins the python version used for conda to py3.5 to be internally consistent with the dependencies of bioconda_utils. See https://github.com/bioconda/bioconda-recipes/issues/3808

This is likely temporary until we can update bioconda_utils dependencies etc. to use Python 3.6.