### PR TITLE
trinity: date.2011_11_26 fix for OS X

### DIFF
--- a/recipes/trinity/date.2011_11_26/Chrysalis_stacksize.patch
+++ b/recipes/trinity/date.2011_11_26/Chrysalis_stacksize.patch
@@ -1,0 +1,10 @@
+--- Chrysalis/Makefile_g++_x86_64	2017-02-15 18:12:39.000000000 -0500
++++ Chrysalis/Makefile_g++_x86_64	2017-02-15 18:12:49.000000000 -0500
+@@ -15,7 +15,7 @@
+ 
+ SYS_INCS	+=
+ 
+-SYS_LINK	+= 
++SYS_LINK	+= -Wl,-stack_size,0x40000000
+ 
+ SYS_LIBS	+= 

--- a/recipes/trinity/date.2011_11_26/build.sh
+++ b/recipes/trinity/date.2011_11_26/build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# Mach-O format for custom stack size changed in Mountain Lion (10.8)
+MACOSX_DEPLOYMENT_TARGET=10.9
 BINARY=Trinity
 BINARY_HOME=$PREFIX/bin
 TRINITY_HOME=$PREFIX/opt/trinity-$PKG_VERSION

--- a/recipes/trinity/date.2011_11_26/headerpad.patch
+++ b/recipes/trinity/date.2011_11_26/headerpad.patch
@@ -1,0 +1,11 @@
+--- trinity-plugins/RSEM-mod/makefile	2017-02-16 15:35:26.000000000 -0500
++++ trinity-plugins/RSEM-mod/makefile	2017-02-15 19:06:41.000000000 -0500
+@@ -52,7 +52,7 @@
+ 
+ 
+ rsem-parse-alignments : parseIt.o sam/libbam.a
+-	$(CC) -o rsem-parse-alignments parseIt.o sam/libbam.a -lz 
++	$(CC) -o rsem-parse-alignments parseIt.o sam/libbam.a -lz -Wl,-headerpad_max_install_names
+ 
+ parseIt.o : utils.h GroupInfo.h Read.h SingleRead.h SingleReadQ.h PairedEndRead.h PairedEndReadQ.h SingleHit.h PairedEndHit.h HitContainer.h SamParser.h RefSeq.h Refs.h sam/sam.h sam/bam.h parseIt.cpp
+ 	$(CC) $(COFLAGS) parseIt.cpp

--- a/recipes/trinity/date.2011_11_26/meta.yaml
+++ b/recipes/trinity/date.2011_11_26/meta.yaml
@@ -3,7 +3,7 @@ about:
     license: "https://raw.githubusercontent.com/trinityrnaseq/trinityrnaseq/master/LICENSE.txt"
     summary: "Trinity assembles transcript sequences from Illumina RNA-Seq data"
 build:
-  number: 5
+  number: 6
   string: ncurses{{CONDA_NCURSES}}_{{PKG_BUILDNUM}}
 package:
   name: trinity
@@ -16,6 +16,10 @@ source:
     - RunButterfly.cc.patch # this file is missing a header include
     - Trinity.pl.patch # Trinity requires exactly Java 1.6, but works fine >1.6, so adjust to be more permissive
     - samtools_makefile.patch # patch samtools Makefile due to missing curses.h
+    # Adjust compilation to allow 1GB stack size
+    - Chrysalis_stacksize.patch  # [osx]
+    # Allow conda's rpath rewriting to work for an RSEM binary
+    - headerpad.patch  # [osx]
 requirements:
   build:
     - perl-threaded


### PR DESCRIPTION
Chrysalis relies on unlimited stack size but OS X can only set stack size during compilations. Which we set to 1GB.

* [ ] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
