### PR TITLE
Update: rdflib-jsonld, rdflib

### DIFF
--- a/recipes/rdflib-jsonld/meta.yaml
+++ b/recipes/rdflib-jsonld/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: rdflib-jsonld
-  version: "0.3"
+  version: "0.4"
 
 source:
-  fn: rdflib-jsonld-0.3.tar.gz
-  url: https://pypi.python.org/packages/source/r/rdflib-jsonld/rdflib-jsonld-0.3.tar.gz
-  md5: 653083508e904bfd2c240b03a446d6c2
+  fn: rdflib-jsonld-0.4.tar.gz
+  url: https://pypi.python.org/packages/ba/48/edaad22fc9de34500699f0c7fc9124385dd425fd18857244f126a6f7df66/rdflib-jsonld-0.4.0.tar.gz
+  md5: 69097f57d302791a2959c07e110c47cf
 
 build:
   number: 0
@@ -15,12 +15,12 @@ requirements:
   build:
     - python
     - setuptools
-    - rdflib >=4.2
+    - rdflib >=4.2.2
 
   run:
     - python
     - setuptools
-    - rdflib >=4.2
+    - rdflib >=4.2.2
 
 test:
   imports:

--- a/recipes/rdflib/meta.yaml
+++ b/recipes/rdflib/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: rdflib
-  version: '4.2.1'
+  version: '4.2.2'
 
 source:
-  fn: rdflib-4.2.1.tar.gz
-  url: https://pypi.python.org/packages/source/r/rdflib/rdflib-4.2.1.tar.gz
-  md5: 528adaa10536d14a608507d7831711f5
+  fn: rdflib-4.2.2.tar.gz
+  url: https://pypi.python.org/packages/c5/77/1fa0f4cffd5faad496b1344ab665902bb2609f56e0fb19bcf80cff485da0/rdflib-4.2.2.tar.gz
+  md5: 534fe35b13c5857d53fa1ac5a41eca67
 
 build:
   number: 0


### PR DESCRIPTION
- FreeBayes: move to 1.1.0 release build which has a fix for Allele
  creation edge cases
- rdflib, redflib-jsonld: latest version without html5lib requirement

* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
