### PR TITLE
Add missing dependencies.

### DIFF
--- a/recipes/pindel/meta.yaml
+++ b/recipes/pindel/meta.yaml
@@ -8,7 +8,7 @@ build:
   number: 1
   skip: True # [osx]
 
-  source:
+source:
   fn: pindel-{{ version }}.tar.gz
   url: https://github.com/genome/pindel/archive/v{{ version }}.tar.gz
   sha256: 7f21fda0b751d420831724d96e60873ce332139cfd24396e81c7f1ae2f707a19

--- a/recipes/pindel/meta.yaml
+++ b/recipes/pindel/meta.yaml
@@ -1,18 +1,25 @@
+{% set version = "0.2.5b8" %}
+
 package:
   name: pindel
-  version: '0.2.5b8'
+  version: {{ version }}
+
 build:
-  number: 0
+  number: 1
   skip: True # [osx]
-source:
-  fn: pindel-0.2.5b8.tar.gz
-  url: https://github.com/genome/pindel/archive/v0.2.5b8.tar.gz
+
+  source:
+  fn: pindel-{{ version }}.tar.gz
+  url: https://github.com/genome/pindel/archive/v{{ version }}.tar.gz
+  sha256: 7f21fda0b751d420831724d96e60873ce332139cfd24396e81c7f1ae2f707a19
 
 requirements:
   build:
     - htslib
+    - gcc
   run:
     - htslib
+    - libgcc
 
 test:
   commands:


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

The pindel package was broken, because it fails to find libgomp.so in stripped down containers. That library is part of libgcc, hence, this PR adds gcc/libgcc as dependencies to fix pindel.