### PR TITLE
Rebuild with conda-build > 2.0

### DIFF
--- a/recipes/treebest/meta.yaml
+++ b/recipes/treebest/meta.yaml
@@ -7,7 +7,7 @@ source:
   sha256: 1bdb036e88afb366555d0edf15ae935dcb7fe33acdd3b1c3ee01a06093ac0bca
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
Fix for:
```
PaddingError: Placeholder of length '80' too short in package bioconda::treebest-1.9.2_ep78-0.
```

* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
