### PR TITLE
[WIP] Non redundant builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,16 @@
 os:
   - linux
   - osx
+
 language: c
+
 sudo: required
+
 services:
   - docker
+
 install: scripts/travis-setup.sh
+
 script: travis_wait 119 scripts/travis-run.sh
 
 env:
@@ -19,3 +24,7 @@ env:
 
 matrix:
   fast_finish: true
+
+branches:
+  only:
+    - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
   global:
     - secure: WS9nwlZfrSgdU5bUw9ZXh5xD067PyUVq+UZnPazORgh5kgkTTX4EsNnXPtmUiQ9DOwVvBiCZzn6c7N+YPuUdEROOR/pBjtFA+w/APFk4ug1tcIzRH7z2we+fZaAnKK3SRqOhHkUYa8tjZFGr53RsaKaxKEc0SIqsHGbDupdBz9KC4raXyUQobcLxWbE6BQq2jhyJGqWxOrhTTrd3WCRKVTgjUlQmwimk6s9txfnEbEguE7UlRhlO0CSqgBj2oUvwtJQSkZWAFminUi2Jcmnduebu42iYX6IF3bYNLVxy8d56v2APGv6reipsD9m3l6URRtpgGygMF4EI9X6dlCjT2qMrwwuWQcZJncFkR584dL+MiPfA2RXamGQybX8HSlnrn60ZKzr5gmw4hetffUGwmOA2VlEW1Wcxcwcef+/8osWwnfLT4I3i736P71LARcBWjBaXKKCXCkCLegv0WB0V/JXyo6IfdLToB0ElAwNfoSlhK1ZtTejngMQewzh6HFcyJwbyPog8/WCL+/j+OohdLZYgiXuldeoLoTwM8YmrSV7twUg3rl2Uc9AWd6iKXC2n8t+2XXdSTwcyrLAEp5J2gZA+HPE/4R6/K1YLbILfMp+u2k8TpazSVX7oRwIcp5UJK6NGx9KDLnT5nJXFW2J5SuBdvQjOXGNSVxyAhBg2AAM=
     - SUBDAGS=1
-    - BIOCONDA_UTILS_TAG=master
+    - BIOCONDA_UTILS_TAG=filter-by-git
     - BIOCONDA_UTILS_ARGS="--loglevel=info --mulled-test"
   matrix:
     - SUBDAG=0

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
   global:
     - secure: WS9nwlZfrSgdU5bUw9ZXh5xD067PyUVq+UZnPazORgh5kgkTTX4EsNnXPtmUiQ9DOwVvBiCZzn6c7N+YPuUdEROOR/pBjtFA+w/APFk4ug1tcIzRH7z2we+fZaAnKK3SRqOhHkUYa8tjZFGr53RsaKaxKEc0SIqsHGbDupdBz9KC4raXyUQobcLxWbE6BQq2jhyJGqWxOrhTTrd3WCRKVTgjUlQmwimk6s9txfnEbEguE7UlRhlO0CSqgBj2oUvwtJQSkZWAFminUi2Jcmnduebu42iYX6IF3bYNLVxy8d56v2APGv6reipsD9m3l6URRtpgGygMF4EI9X6dlCjT2qMrwwuWQcZJncFkR584dL+MiPfA2RXamGQybX8HSlnrn60ZKzr5gmw4hetffUGwmOA2VlEW1Wcxcwcef+/8osWwnfLT4I3i736P71LARcBWjBaXKKCXCkCLegv0WB0V/JXyo6IfdLToB0ElAwNfoSlhK1ZtTejngMQewzh6HFcyJwbyPog8/WCL+/j+OohdLZYgiXuldeoLoTwM8YmrSV7twUg3rl2Uc9AWd6iKXC2n8t+2XXdSTwcyrLAEp5J2gZA+HPE/4R6/K1YLbILfMp+u2k8TpazSVX7oRwIcp5UJK6NGx9KDLnT5nJXFW2J5SuBdvQjOXGNSVxyAhBg2AAM=
     - SUBDAGS=1
-    - BIOCONDA_UTILS_TAG=filter-by-git
+    - BIOCONDA_UTILS_TAG=master
     - BIOCONDA_UTILS_ARGS="--loglevel=info --mulled-test"
   matrix:
     - SUBDAG=0

--- a/recipes/snakemake/meta.yaml
+++ b/recipes/snakemake/meta.yaml
@@ -1,5 +1,4 @@
 {% set version = "3.10.1" %}
-{% set sha256 = "7728c8ccfc464e8e624a87e3eeae04ec750bdcaf856c44a11f5057e3c51d15d5" %}
 
 package:
   name: snakemake
@@ -8,7 +7,7 @@ package:
 source:
   fn: snakemake-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/s/snakemake/snakemake-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  sha256: 7728c8ccfc464e8e624a87e3eeae04ec750bdcaf856c44a11f5057e3c51d15d5
 
 build:
   number: 1

--- a/recipes/svtools/0.3.0/meta.yaml
+++ b/recipes/svtools/0.3.0/meta.yaml
@@ -1,31 +1,19 @@
+{% set version = "0.3.0" %}
+
 package:
   name: svtools
-  version: "0.3.0"
+  version: {{ version }}
 
 source:
-  fn: svtools-0.3.0.tar.gz
-  url: https://pypi.python.org/packages/87/cc/c96af7f05d1e7b6b1a0c10e020a0733aa43d841a52faeb589e097710fea3/svtools-0.3.0.tar.gz
+  fn: svtools-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/s/svtools/svtools-{{ version }}.tar.gz
   md5: 0524f0bac826a51e46a832444460a19e
-#  patches:
-   # List any patch files here
-   # - fix.patch
 
 build:
   skip: True # [not py27 ]
-  # noarch_python: True
   preserve_egg_dir: True
   entry_points:
-    # Put any entry points (scripts to be generated automatically) here. The
-    # syntax is module:function.  For example
-    #
-    # - svtools = svtools:main
-    #
-    # Would create an entry point called svtools that calls svtools.main()
-
     - svtools=svtools.cli:main
-
-  # If this is a new build for the same version, increment the build
-  # number. If you do not include this key, it defaults to 0.
   number: 1
 
 requirements:
@@ -48,30 +36,15 @@ requirements:
     - setuptools
 
 test:
-  # Python imports
   imports:
     - svtools
     - svtools.vcf
 
   commands:
-    # You can put test commands to be run here.  Use this to test that the
-    # entry points work.
-
     - svtools --help
     - create_coordinates --help
-
-  # You can also put a file called run_test.py in the recipe that will be run
-  # at test time.
-
-  # requires:
-    # Put any additional test requirements here.  For example
-    # - nose
 
 about:
   home: https://github.com/hall-lab/svtools
   license: MIT License
   summary: 'Tools for processing and analyzing structural variants'
-
-# See
-# http://docs.continuum.io/conda/build.html for
-# more information about meta.yaml

--- a/scripts/travis-run.sh
+++ b/scripts/travis-run.sh
@@ -19,10 +19,10 @@ else
     fi
     # obtain recipes that changed in this commit
     RECIPES=$(git diff --exit-code --relative=recipes --name-only $RANGE recipes/*/meta.yaml recipes/*/*/meta.yaml)
-    echo $RECIPES
-    if [ $? -eq 1 ]
+    ANY_CHANGE=$?
+    if [ $ANY_CHANGE -eq 1 ]
     then
-        RECIPES=$(echo $RECIPES | xargs dirname)
+        RECIPES=$(echo "$RECIPES" | xargs dirname)
         echo "considering changed recipes:"
         echo "--------"
         echo $RECIPES

--- a/scripts/travis-run.sh
+++ b/scripts/travis-run.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 # determine recipes to build
 # case 1: env matrix changed or this is a cron job. In this case consider all recipes.
+set +e
 PACKAGES=""
 git diff --exit-code --name-only $TRAVIS_COMMIT_RANGE scripts/env_matrix.yml
 if [ $? -eq 1 ] || [ $TRAVIS_EVENT_TYPE == "cron" ]
@@ -31,6 +32,7 @@ else
         exit 0
     fi
 fi
+set -e
 
 
 export PATH=/anaconda/bin:$PATH

--- a/scripts/travis-run.sh
+++ b/scripts/travis-run.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 # obtain recipes that changed in this commit
 RECIPES=""
-git diff master HEAD --exit-code --name-only scripts/env_matrix.yml
+git diff --exit-code --name-only $TRAVIS_COMMIT_RANGE scripts/env_matrix.yml
 if [ $? -eq 1 ] || [ $TRAVIS_EVENT_TYPE == "cron" ]
 then
     echo "considering all recipes because either env matrix was changed or build is triggered via cron"

--- a/scripts/travis-run.sh
+++ b/scripts/travis-run.sh
@@ -22,7 +22,7 @@ else
     echo "--------"
     echo $RECIPES
     echo "--------"
-    if [ -z $RECIPES ]
+    if [ -z "$RECIPES" ]
     then
         echo "no recipe changed, exiting build"
         exit 0

--- a/scripts/travis-run.sh
+++ b/scripts/travis-run.sh
@@ -2,23 +2,24 @@
 set -euo pipefail
 
 # determine recipes to build
-# case 1: env matrix changed or this is a cron job. In this case consider all recipes.
+RANGE="$TRAVIS_BRANCH HEAD"
+if [ $TRAVIS_PULL_REQUEST == "false" ]
+then
+    RANGE="$TRAVIS_COMMIT_RANGE"
+fi
+
 RANGE_ARG=""
 set +e
-git diff --exit-code --name-only $TRAVIS_COMMIT_RANGE scripts/env_matrix.yml
+git diff --exit-code --name-only $RANGE scripts/env_matrix.yml
 ENV_CHANGE=$?
 set -e
 if [ $ENV_CHANGE -eq 1 ] || [ $TRAVIS_EVENT_TYPE == "cron" ]
 then
+    # case 1: env matrix changed or this is a cron job. In this case consider all recipes.
     echo "considering all recipes because either env matrix was changed or build is triggered via cron"
 else
     # case 2: consider only recipes that (a) changed since the last build on master, or (b) changed in this pull request compared to the target branch.
-    if [ $TRAVIS_PULL_REQUEST == "false" ]
-    then
-        RANGE_ARG="--git-range $TRAVIS_COMMIT_RANGE"
-    else
-        RANGE_ARG="--git-range $TRAVIS_BRANCH HEAD"
-    fi
+    RANGE_ARG="--git-range $RANGE"
 fi
 
 

--- a/scripts/travis-run.sh
+++ b/scripts/travis-run.sh
@@ -4,8 +4,8 @@ set -euo pipefail
 
 # obtain recipes that changed in this commit
 RECIPES=""
-ENV_MATRIX_CHANGED=$(git diff master HEAD --name-only scripts/env_matrix.yml)
-if [ -z "$ENV_MATRIX_CHANGED" ] || [ $TRAVIS_EVENT_TYPE == "cron" ]
+git diff master HEAD --exit-code --name-only scripts/env_matrix.yml
+if [ $? -eq 1 ] || [ $TRAVIS_EVENT_TYPE == "cron" ]
 then
     echo "considering all recipes because either env matrix was changed or build is triggered via cron"
 else

--- a/scripts/travis-run.sh
+++ b/scripts/travis-run.sh
@@ -5,9 +5,9 @@ set -euo pipefail
 # obtain recipes that changed in this commit
 RECIPES=""
 ENV_MATRIX_CHANGED=$(git diff master HEAD --name-only scripts/env_matrix.yml)
-if [ -z "$ENV_MATRIX_CHANGED" ]
+if [ -z "$ENV_MATRIX_CHANGED" ] || [ $TRAVIS_EVENT_TYPE == "cron" ]
 then
-    echo "env matrix changed, considering all recipes"
+    echo "considering all recipes because either env matrix was changed or build is triggered via cron"
 else
     RECIPES=$(git diff --relative=recipes --name-only $TRAVIS_COMMIT_RANGE recipes/*/meta.yaml recipes/*/*/meta.yaml | xargs dirname)
     echo "considering changed recipes:"

--- a/scripts/travis-run.sh
+++ b/scripts/travis-run.sh
@@ -19,6 +19,7 @@ else
     fi
     # obtain recipes that changed in this commit
     RECIPES=$(git diff --exit-code --relative=recipes --name-only $RANGE recipes/*/meta.yaml recipes/*/*/meta.yaml)
+    echo $RECIPES
     if [ $? -eq 1 ]
     then
         RECIPES=$(echo $RECIPES | xargs dirname)

--- a/scripts/travis-run.sh
+++ b/scripts/travis-run.sh
@@ -9,9 +9,17 @@ if [ $? -eq 1 ] || [ $TRAVIS_EVENT_TYPE == "cron" ]
 then
     echo "considering all recipes because either env matrix was changed or build is triggered via cron"
 else
-    RECIPES=$(git diff --relative=recipes --name-only $TRAVIS_COMMIT_RANGE recipes/*/meta.yaml recipes/*/*/meta.yaml | xargs dirname)
+    if [ $TRAVIS_PULL_REQUEST == "false" ]
+    then
+        RANGE=$TRAVIS_COMMIT_RANGE
+    else
+        RANGE="$TRAVIS_BRANCH HEAD"
+    fi
+    RECIPES=$(git diff --relative=recipes --name-only $RANGE recipes/*/meta.yaml recipes/*/*/meta.yaml | xargs --no-run-if-empty dirname)
     echo "considering changed recipes:"
+    echo "--------"
     echo $RECIPES
+    echo "--------"
 fi
 
 

--- a/scripts/travis-run.sh
+++ b/scripts/travis-run.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 CHANGED_FILES=$(git diff --name-only $TRAVIS_COMMIT_RANGE)
+echo "Changed files:"
 echo $CHANGED_FILES
 
 export PATH=/anaconda/bin:$PATH

--- a/scripts/travis-run.sh
+++ b/scripts/travis-run.sh
@@ -3,10 +3,12 @@ set -euo pipefail
 
 # determine recipes to build
 # case 1: env matrix changed or this is a cron job. In this case consider all recipes.
-set +e
 PACKAGES=""
+set +e
 git diff --exit-code --name-only $TRAVIS_COMMIT_RANGE scripts/env_matrix.yml
-if [ $? -eq 1 ] || [ $TRAVIS_EVENT_TYPE == "cron" ]
+ANY_CHANGE=$?
+set -e
+if [ $ANY_CHANGE -eq 1 ] || [ $TRAVIS_EVENT_TYPE == "cron" ]
 then
     echo "considering all recipes because either env matrix was changed or build is triggered via cron"
 else
@@ -18,8 +20,10 @@ else
         RANGE="$TRAVIS_BRANCH HEAD"
     fi
     # obtain recipes that changed in this commit
+    set +e
     RECIPES=$(git diff --exit-code --relative=recipes --name-only $RANGE recipes/*/meta.yaml recipes/*/*/meta.yaml)
     ANY_CHANGE=$?
+    set -e
     if [ $ANY_CHANGE -eq 1 ]
     then
         RECIPES=$(echo "$RECIPES" | xargs dirname)
@@ -33,7 +37,6 @@ else
         exit 0
     fi
 fi
-set -e
 
 
 export PATH=/anaconda/bin:$PATH

--- a/scripts/travis-run.sh
+++ b/scripts/travis-run.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 
+CHANGED_FILES=$(git diff --name-only $TRAVIS_COMMIT_RANGE)
+echo $CHANGED_FILES
+
 export PATH=/anaconda/bin:$PATH
 
 if [[ $TRAVIS_BRANCH = "master" && "$TRAVIS_PULL_REQUEST" = "false" ]]


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

Following a discussion in #3845, this is a try to get rid of the redundancy in our travis builds. For both PRs and master, we obtain the list of changed recipes and run bioconda-utils restricted to those. However, if either the env matrix changed or the current build is a cron job, we consider all recipes instead.