### PR TITLE
Du Novo: Update bowtie2 dependency version

### DIFF
--- a/recipes/dunovo/meta.yaml
+++ b/recipes/dunovo/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - python
     - mafft 7.221
     - samtools 0.1.18
-    - bowtie2 2.2.4
+    - bowtie2 2.2.5
     - networkx
     - paste
     - gawk


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

This just updates the version of bowtie2 from 2.2.4 to 2.2.5, so it's compatible with the version in the Galaxy Toolshed.

It passes both Travis tests.