### PR TITLE
Du Novo: Fix missing scripts in bin directory

### DIFF
--- a/recipes/dunovo/build.sh
+++ b/recipes/dunovo/build.sh
@@ -2,4 +2,4 @@
 
 make
 mv *.so $PREFIX/lib
-mv *.py *.sh $PREFIX/bin
+mv *.awk *.sh *.py utils/outconv.py $PREFIX/bin

--- a/recipes/dunovo/meta.yaml
+++ b/recipes/dunovo/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - python
     - mafft 7.221
     - samtools 0.1.18
-    - bowtie2 2.2.4
+    - bowtie2 2.2.5
     - networkx
     - paste
     - gawk

--- a/recipes/dunovo/meta.yaml
+++ b/recipes/dunovo/meta.yaml
@@ -1,12 +1,12 @@
 
 package:
   name: dunovo
-  version: 0.7
+  version: 0.7.1
 
 source:
-  fn: v0.7.tar.gz
-  url: https://github.com/galaxyproject/dunovo/archive/v0.7.tar.gz
-  sha256: 9d5092490772c43c73f7c85ea883d6a18f5df030fb4eac7310ac40694495b7c8
+  fn: v0.7.1.tar.gz
+  url: https://github.com/galaxyproject/dunovo/archive/v0.7.1.tar.gz
+  sha256: c10c54bd2b33929bbd7c78b9d9d98818793f8da3d59bfe4ed7499587bfdef24d
 
 build:
   number: 0


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

I'd forgotten a few scripts that need to be in `$PREFIX/bin`. `meta.yaml` also had to be edited to pull down new code which can find the scripts in `$PREFIX/bin`.

P.S. Sorry, I screwed up by pushing my changes before syncing with upstream. Also, I committed on `master`, not the `dunovo` branch. I'll make sure to do it right next time!