### PR TITLE
Format $TRAVIS_COMMIT_RANGE properly.

### DIFF
--- a/scripts/travis-run.sh
+++ b/scripts/travis-run.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 RANGE="$TRAVIS_BRANCH HEAD"
 if [ $TRAVIS_PULL_REQUEST == "false" ]
 then
-    RANGE="$TRAVIS_COMMIT_RANGE"
+    RANGE="${TRAVIS_COMMIT_RANGE/.../ }"
 fi
 
 RANGE_ARG=""


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

Fixes a problem with non-redundant-builds in master (see PR #3891).