### PR TITLE
rebuild a number of packages under conda-build 2

### DIFF
--- a/recipes/bamtools/meta.yaml
+++ b/recipes/bamtools/meta.yaml
@@ -12,7 +12,7 @@ source:
     - bamtools_lib.diff
 
 build:
-  number: 3
+  number: 4
 
 requirements:
   build:

--- a/recipes/bcftools/1.2/meta.yaml
+++ b/recipes/bcftools/1.2/meta.yaml
@@ -2,7 +2,7 @@ package:
   name: bcftools
   version: "1.2"
 build:
-  number: 2
+  number: 3
 source:
   fn: bcftools-1.2.tar.bz2
   url: https://github.com/samtools/bcftools/releases/download/1.2/bcftools-1.2.tar.bz2

--- a/recipes/bedtools/2.26.0/meta.yaml
+++ b/recipes/bedtools/2.26.0/meta.yaml
@@ -10,7 +10,7 @@ source:
       - 2.26.0_postrelease.patch
 
 build:
-    number: 0
+    number: 1
 
 requirements:
   build:

--- a/recipes/biopython/meta.yaml
+++ b/recipes/biopython/meta.yaml
@@ -14,7 +14,7 @@ source:
   md5: 078e915185485a5327937029b7577ddc
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipes/bmfilter/meta.yaml
+++ b/recipes/bmfilter/meta.yaml
@@ -8,7 +8,7 @@ source:
     fn: bmfilter # [osx]
     url: ftp://ftp.ncbi.nlm.nih.gov/pub/agarwala/bmtagger/mac-os/bmfilter # [osx]
 build:
-  number: 1
+  number: 2
   skip: False
 requirements:
   build:

--- a/recipes/bmtagger/meta.yaml
+++ b/recipes/bmtagger/meta.yaml
@@ -10,7 +10,7 @@ source:
     patches:
       - bmtagger.sh.osxpatch # [osx]
 build:
-  number: 3
+  number: 4
   skip: False
 requirements:
   build:

--- a/recipes/bmtool/meta.yaml
+++ b/recipes/bmtool/meta.yaml
@@ -8,7 +8,7 @@ source:
     fn: bmtool # [osx]
     url: ftp://ftp.ncbi.nlm.nih.gov/pub/agarwala/bmtagger/mac-os/bmtool # [osx]
 build:
-  number: 1
+  number: 2
   skip: False
 requirements:
   build:

--- a/recipes/bwa/meta.yaml
+++ b/recipes/bwa/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: "0.7.15"
 
 build:
-  number: 0
+  number: 1
 
 source:
   fn: v0.7.15.tar.gz

--- a/recipes/curl/meta.yaml
+++ b/recipes/curl/meta.yaml
@@ -4,7 +4,7 @@ about:
   summary: curl is an open source command line tool and library for transferring data with URL syntax
 
 build:
-  number: 2
+  number: 3
   binary_has_prefix_files:
     - lib/libcurl.so.4.4.0 # [not osx]
     - lib/libcurl.4.dylib # [not linux]

--- a/recipes/diamond/0.8.22/meta.yaml
+++ b/recipes/diamond/0.8.22/meta.yaml
@@ -1,5 +1,5 @@
 build:
-  number: 2
+  number: 3
 
 package:
   name: diamond

--- a/recipes/dropbox/meta.yaml
+++ b/recipes/dropbox/meta.yaml
@@ -8,7 +8,7 @@ source:
   md5: ccc5cbf0bf7fde85f10cae418a5e6044
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipes/extract_fullseq/meta.yaml
+++ b/recipes/extract_fullseq/meta.yaml
@@ -9,7 +9,7 @@ source:
     url: ftp://ftp.ncbi.nlm.nih.gov/pub/agarwala/bmtagger/mac-os/extract_fullseq # [osx]
 
 build:
-    number: 2
+    number: 3
     skip: False
 
 requirements:

--- a/recipes/fastqc/meta.yaml
+++ b/recipes/fastqc/meta.yaml
@@ -6,7 +6,7 @@ about:
 
 build:
   detect_binary_files_with_prefix: true
-  number: 1
+  number: 2
   skip: False
 
 requirements:

--- a/recipes/filechunkio/meta.yaml
+++ b/recipes/filechunkio/meta.yaml
@@ -1,5 +1,5 @@
 build:
-  number: 0
+  number: 1
 
 package:
   name: filechunkio
@@ -9,25 +9,6 @@ source:
   fn: filechunkio-1.6.tar.gz
   url: https://pypi.python.org/packages/source/f/filechunkio/filechunkio-1.6.tar.gz
   md5: c168a11ad94cd2ec42a219f0f8869a7b
-#  patches:
-   # List any patch files here
-   # - fix.patch
-
-# build:
-  # noarch_python: True
-  # preserve_egg_dir: True
-  # entry_points:
-    # Put any entry points (scripts to be generated automatically) here. The
-    # syntax is module:function.  For example
-    #
-    # - filechunkio = filechunkio:main
-    #
-    # Would create an entry point called filechunkio that calls filechunkio.main()
-
-
-  # If this is a new build for the same version, increment the build
-  # number. If you do not include this key, it defaults to 0.
-  # number: 1
 
 requirements:
   build:
@@ -37,27 +18,11 @@ requirements:
     - python
 
 test:
-  # Python imports
   imports:
     - filechunkio
 
-  # commands:
-    # You can put test commands to be run here.  Use this to test that the
-    # entry points work.
-
-
-  # You can also put a file called run_test.py in the recipe that will be run
-  # at test time.
-
-  # requires:
-    # Put any additional test requirements here.  For example
-    # - nose
 
 about:
   home: http://bitbucket.org/fabian/filechunkio
   license: MIT license
   summary: 'FileChunkIO represents a chunk of an OS-level file containing bytes data'
-
-# See
-# http://docs.continuum.io/conda/build.html for
-# more information about meta.yaml

--- a/recipes/ftputil/meta.yaml
+++ b/recipes/ftputil/meta.yaml
@@ -8,7 +8,7 @@ source:
   md5: e714790766b753bfdd712955bf3584f8
 
 build:
-  number: 0
+  number: 1
   skip: False
 
 requirements:

--- a/recipes/gatk/meta.yaml
+++ b/recipes/gatk/meta.yaml
@@ -8,7 +8,7 @@ package:
   version: '3.7'
 
 build:
-  number: 0
+  number: 1
   skip: False
 
 requirements:

--- a/recipes/gettext/meta.yaml
+++ b/recipes/gettext/meta.yaml
@@ -3,7 +3,7 @@ about:
   license: "GPL"
   summary: "GNU gettext"
 build:
-  number: 0
+  number: 1
   skip: False
 package: 
   name: gettext

--- a/recipes/gnu-getopt/meta.yaml
+++ b/recipes/gnu-getopt/meta.yaml
@@ -3,7 +3,7 @@ about:
     license: "GPLv2"
     summary: "Command-line option parsing library"
 build:
-  number: 3
+  number: 4
   skip: True # [not osx]
 package: 
   name: gnu-getopt

--- a/recipes/htslib/meta.yaml
+++ b/recipes/htslib/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 0
+  number: 1
 
 source:
   fn: htslib-{{ version }}.tar.bz2

--- a/recipes/java-jdk/meta.yaml
+++ b/recipes/java-jdk/meta.yaml
@@ -4,7 +4,7 @@ package:
   version: 8.0.112
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   run:

--- a/recipes/jpeg/meta.yaml
+++ b/recipes/jpeg/meta.yaml
@@ -8,7 +8,7 @@ source:
   md5: 6a9996ce116ec5c52b4870dbcd6d3ddb
 
 build:
-  number: 0
+  number: 1
 
 about:
   home: http://www.ijg.org/

--- a/recipes/krona/meta.yaml
+++ b/recipes/krona/meta.yaml
@@ -4,7 +4,7 @@ about:
   summary: 'Krona Tools is a set of scripts to create Krona charts from several Bioinformatics
             tools as well as from text and XML files.'
 build:
-  number: 1
+  number: 2
 package:
   name: krona
   version: 2.7

--- a/recipes/last/meta.yaml
+++ b/recipes/last/meta.yaml
@@ -1,19 +1,21 @@
+{% set version = "719" %}
+
 about:
     home: 'http://last.cbrc.jp/'
     license: GPLv3
     summary: "LAST finds similar regions between sequences, and aligns them. It is designed for comparing large datasets to each other (e.g. vertebrate genomes and/or large numbers of DNA reads)."
 package:
   name: last
-  version: '719'
+  version: '{{ version }}'
 source:
-  fn: last-719.zip
+  fn: last-{{ version }}.zip
+  url: http://last.cbrc.jp/last-{{ version }}.zip
   md5: 2fd486b6cf8738ba3121fc3a0256487d
-  url: http://last.cbrc.jp/last-719.zip
   patches:
     - maf-convert.23patch
 
 build:
-  number: 2
+  number: 3
   skip: False
 
 requirements:

--- a/recipes/libffi/meta.yaml
+++ b/recipes/libffi/meta.yaml
@@ -3,7 +3,7 @@ about:
     license: "https://raw.githubusercontent.com/atgreen/libffi/master/LICENSE"
     summary: "A Portable Foreign Function Interface Library"
 build:
-  number: 1
+  number: 2
   skip: True # [not osx]
 package:
   name: libffi

--- a/recipes/mafft/meta.yaml
+++ b/recipes/mafft/meta.yaml
@@ -1,3 +1,5 @@
+{% set version = "7.308" %}
+
 about:
     home: 'http://mafft.cbrc.jp/alignment/software/'
     license: BSD
@@ -5,16 +7,16 @@ about:
 
 package:
   name: mafft
-  version: '7.305'
+  version: '{{ version }}'
 
 build:
   number: 0
   skip: False
 
 source:
-  fn: mafft-7.305-without-extensions-src.tgz
-  md5: 4f645f32df0d0b2edfa3ead7c4486815
-  url: http://mafft.cbrc.jp/alignment/software/mafft-7.305-without-extensions-src.tgz
+  fn: mafft-{{ version }}-without-extensions-src.tgz
+  md5: 80e9b960533a313f3ea5cc816178dd28
+  url: http://mafft.cbrc.jp/alignment/software/mafft-{{ version }}-without-extensions-src.tgz
   patches:
     - osx-makefile.patch # [osx]
     - linux-makefile.patch # [linux]

--- a/recipes/mmtf-python/meta.yaml
+++ b/recipes/mmtf-python/meta.yaml
@@ -15,7 +15,7 @@ source:
   sha256: 121ce4555915e16e5009db0e22d33b57df4aeebad2cc358e5be7ec064630fb68
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipes/mummer/meta.yaml
+++ b/recipes/mummer/meta.yaml
@@ -3,7 +3,7 @@ about:
     license: "The Artistic License"
     summary: "MUMmer is a system for rapidly aligning entire genomes"
 build:
-  number: 4
+  number: 5
   skip: False
 package:
   name: mummer

--- a/recipes/muscle/meta.yaml
+++ b/recipes/muscle/meta.yaml
@@ -13,7 +13,7 @@ source:
     - osx-makefile.patch 
 
 build:
-  number: 2
+  number: 3
 
 requirements:
   build:

--- a/recipes/mvicuna/meta.yaml
+++ b/recipes/mvicuna/meta.yaml
@@ -8,7 +8,7 @@ package:
 source:
   git_url: https://github.com/broadinstitute/mvicuna.git
 build:
-  number: 4
+  number: 5
   # rpaths:
   #   - "$PREFIX/opt/$PKG_NAME-$PKG_VERSION"
   #   - lib/

--- a/recipes/novoalign/meta.yaml
+++ b/recipes/novoalign/meta.yaml
@@ -1,12 +1,14 @@
+{% set version = "3.07.00" %}
+
 package:
   name: novoalign
-  version: '3.06.05'
+  version: '{{ version }}'
 source:
-  fn: novocraftV3.06.05.tar.gz
-  url: http://www.novocraft.com/homebrew/novocraftV3.06.05.Linux2.6.tar.gz # [linux]
-  md5: 60b5454f9610fac30a292c48671b4aab # [linux]
-  url: http://www.novocraft.com/homebrew/novocraftV3.06.05.MacOSX.tar.gz # [osx]
-  md5: baa2f1c3de84d7cd7095e8052b0b1b22 # [osx]
+  fn: novocraftV{{ version }}.tar.gz
+  url: http://www.novocraft.com/homebrew/novocraftV{{ version }}.Linux2.6.tar.gz # [linux]
+  md5: d0cd7d20cf6f10f1da8db1e875356aa3 # [linux]
+  url: http://www.novocraft.com/homebrew/novocraftV{{ version }}.MacOSX.tar.gz # [osx]
+  md5: 1a0f98015fe0bf7c8e135132063b312f # [osx]
 
 build:
   number: 0

--- a/recipes/picard/2.7.1/meta.yaml
+++ b/recipes/picard/2.7.1/meta.yaml
@@ -1,14 +1,14 @@
 package:
   name: picard
-  version: "2.7.1"
+  version: "2.9.0"
 
 source:
   fn: picard.jar
-  url: https://github.com/broadinstitute/picard/releases/download/2.7.1/picard.jar
-  md5: 323c048b5c33ce4cccfd8b481539968b
+  url: https://github.com/broadinstitute/picard/releases/download/2.9.0/picard.jar
+  md5: b711d492f16dfe0084d33e684dca2202
 
 build:
-  number: 2
+  number: 0
   skip: False
 
 requirements:

--- a/recipes/prinseq/meta.yaml
+++ b/recipes/prinseq/meta.yaml
@@ -6,7 +6,7 @@ package:
   name: prinseq
   version: '0.20.4'
 build:
-  number: 2
+  number: 3
   skip: False
 source:
   fn: prinseq-lite-0.20.4.tar.gz

--- a/recipes/pybedtools/meta.yaml
+++ b/recipes/pybedtools/meta.yaml
@@ -8,7 +8,7 @@ source:
   md5: 498a9cf0bb6eaf1e6342463da2baa855
 
 build:
-  number: 0
+  number: 1
   skip: False
 
 requirements:

--- a/recipes/pycodestyle/meta.yaml
+++ b/recipes/pycodestyle/meta.yaml
@@ -8,6 +8,7 @@ source:
   md5: 733291d308def897c0c48c7840b7f6bc
 
 build:
+  number: 1
   entry_points:
     - pycodestyle = pycodestyle:_main
 

--- a/recipes/pysam/meta.yaml
+++ b/recipes/pysam/meta.yaml
@@ -8,7 +8,7 @@ source:
     md5: a1f3333ce60f8de542624cb07c792fc0
 
 build:
-    number: 1
+    number: 2
     skip: False
     binary_relocation: False
 

--- a/recipes/pysftp/meta.yaml
+++ b/recipes/pysftp/meta.yaml
@@ -3,12 +3,12 @@ build:
 
 package:
   name: pysftp
-  version: "0.2.8"
+  version: "0.2.9"
 
 source:
-  fn: pysftp-0.2.8.tar.gz
-  url: https://pypi.python.org/packages/source/p/pysftp/pysftp-0.2.8.tar.gz
-  md5: 10bd5452aee5684871f434f5cfc8e07b
+  fn: pysftp-0.2.9.tar.gz
+  url: https://pypi.python.org/packages/36/60/45f30390a38b1f92e0a8cf4de178cd7c2bc3f874c85430e40ccf99df8fe7/pysftp-0.2.9.tar.gz
+  md5: abc55b7122de3e86f0d547301f4ddf0c
 requirements:
   build:
     - python

--- a/recipes/python-dateutil/meta.yaml
+++ b/recipes/python-dateutil/meta.yaml
@@ -1,16 +1,19 @@
+{% set version = "2.6.0" %}
+
 package:
   name: python-dateutil
-  version: "2.3"
+  version: "{{ version }}"
 
 source:
-  fn: python-dateutil-2.3.tar.gz
-  url: https://pypi.python.org/packages/source/p/python-dateutil/python-dateutil-2.3.tar.gz
-  md5: 14dae5a51d11802cc1e8828c5f797358
+  fn: python-dateutil-{{ version }}.tar.gz
+  url: https://pypi.python.org/packages/51/fc/39a3fbde6864942e8bb24c93663734b74e281b984d1b8c4f95d64b0c21f6/python-dateutil-{{ version }}.tar.gz
+  md5: 6e38f91e8c94c15a79ce22768dfeca87
 #  patches:
    # List any patch files here
    # - fix.patch
 
 build:
+  number: 1
   skip: False
   # noarch_python: True
   # preserve_egg_dir: True

--- a/recipes/samtools/meta.yaml
+++ b/recipes/samtools/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 5
+  number: 6
   skip: False
 
 source:

--- a/recipes/snakemake/meta.yaml
+++ b/recipes/snakemake/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 7728c8ccfc464e8e624a87e3eeae04ec750bdcaf856c44a11f5057e3c51d15d5
 
 build:
-  number: 1
+  number: 2
   skip: True # [py27]
   script: python setup.py install --single-version-externally-managed --record record.txt
   entry_points:

--- a/recipes/snpeff/meta.yaml
+++ b/recipes/snpeff/meta.yaml
@@ -8,7 +8,7 @@ package:
   version: '4.3i'
 
 build:
-  number: 0
+  number: 1
   skip: False
 
 source:

--- a/recipes/srprism/meta.yaml
+++ b/recipes/srprism/meta.yaml
@@ -5,7 +5,7 @@ about:
     home: 'ftp://ftp.ncbi.nlm.nih.gov/pub/agarwala/srprism/'
     summary: "SRPRISM - Short Read Alignment Tool"
 build:
-  number: 2
+  number: 3
   skip: False
 
 source:

--- a/recipes/trimmomatic/meta.yaml
+++ b/recipes/trimmomatic/meta.yaml
@@ -8,7 +8,7 @@ package:
   version: '0.36'
 
 build:
-  number: 3
+  number: 4
   skip: False
 
 source:

--- a/recipes/urllib3/meta.yaml
+++ b/recipes/urllib3/meta.yaml
@@ -6,25 +6,9 @@ source:
   fn: urllib3-1.12.tar.gz
   url: https://pypi.python.org/packages/source/u/urllib3/urllib3-1.12.tar.gz
   md5: befd9dbb2c373681bd88710ba96abbdb
-#  patches:
-   # List any patch files here
-   # - fix.patch
 
 build:
-  # noarch_python: True
-  # preserve_egg_dir: True
-  # entry_points:
-    # Put any entry points (scripts to be generated automatically) here. The
-    # syntax is module:function.  For example
-    #
-    # - urllib3 = urllib3:main
-    #
-    # Would create an entry point called urllib3 that calls urllib3.main()
-
-
-  # If this is a new build for the same version, increment the build
-  # number. If you do not include this key, it defaults to 0.
-  # number: 1
+  number: 1
   skip: False
 
 requirements:
@@ -36,7 +20,6 @@ requirements:
     - python
 
 test:
-  # Python imports
   imports:
     - urllib3
     - urllib3.contrib
@@ -44,26 +27,13 @@ test:
     - urllib3.packages.ssl_match_hostname
     - urllib3.util
 
-  # commands:
-    # You can put test commands to be run here.  Use this to test that the
-    # entry points work.
-
-
-  # You can also put a file called run_test.py in the recipe that will be run
-  # at test time.
-
   requires:
     - mock
     - nose
     - tornado
-    # Put any additional test requirements here.  For example
-    # - nose
 
 about:
   home: http://urllib3.readthedocs.org/
   license: MIT License
   summary: 'HTTP library with thread-safe connection pooling, file post, and more.'
-
-# See
-# http://docs.continuum.io/conda/build.html for
-# more information about meta.yaml
+  

--- a/recipes/vphaser2/meta.yaml
+++ b/recipes/vphaser2/meta.yaml
@@ -8,7 +8,7 @@ package:
 source:
   git_url: https://github.com/broadinstitute/v-phaser2.git #[osx or linux64]
 build:
-  number: 3
+  number: 4
   rpaths:
     - "$PREFIX/opt/$PKG_NAME-$PKG_VERSION"
     - lib/


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

This is to rebuild a number of viral-ngs dependencies with certainty under conda-build 2 to support longer path prefixes. also update novoalign, picard, and python-dateutil versions.