### PR TITLE
Pin the old mothur-1.36.1 to old boost version

### DIFF
--- a/boost-1.61-migration-blacklist
+++ b/boost-1.61-migration-blacklist
@@ -3,6 +3,3 @@ recipes/detonate
 
 # /boost/intrusive/list.hpp:123:22: error: ‘const bool boost::intrusive::list_impl<boost::intrusive::bhtraits<dng::pileup::Node, boost::intrusive::list_node_traits<void*>, (boost::intrusive::link_mode_type)0u, boost::intrusive::dft_tag, 1u>, long unsigned int, true, void>::safemode_or_autounlink’ is private
 recipes/denovogear
-
-# seems to be broken with newer boost
-recipes/mothur/1.36.1

--- a/recipes/mothur/1.36.1/meta.yaml
+++ b/recipes/mothur/1.36.1/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 2
-  string: boost{{CONDA_BOOST}}_{{PKG_BUILDNUM}}
+  string: boost1.60_{{PKG_BUILDNUM}}
   skip: True # [not linux64 or osx]
 
 requirements:
@@ -21,14 +21,14 @@ requirements:
     - zlib
     - ncurses
     - readline
-    - boost >=1.55,{{CONDA_BOOST}}*
+    - boost >=1.55,1.60*  # does not work with boost >1.60
     - blast-legacy
   run:
     - libgcc   # [linux]
     - zlib
     - ncurses
     - readline
-    - boost {{CONDA_BOOST}}*
+    - boost 1.60*
     - blast-legacy
 test:
   commands:

--- a/recipes/mothur/1.36.1/meta.yaml
+++ b/recipes/mothur/1.36.1/meta.yaml
@@ -10,7 +10,7 @@ source:
     - Build-Flags.patch
 
 build:
-  number: 2
+  number: 3
   string: boost1.60_{{PKG_BUILDNUM}}
   skip: True # [not linux64 or osx]
 
@@ -37,4 +37,5 @@ test:
 
 about:
   home: http://www.mothur.org
-license: GPL
+  license: GPL
+  summary: An expandable software to fill the bioinformatics needs of the microbial ecology community.


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

According to @bgruening it does not work with the newer version. Hence, I hardcoded the latest working version into this recipe. This is reasonable since it is just an old version of the recipe that won't be updated.

ping @bgruening @bebatut @shiltemann