### PR TITLE
Disable linting when building master branch.

### DIFF
--- a/scripts/travis-run.sh
+++ b/scripts/travis-run.sh
@@ -65,13 +65,14 @@ fi
 # in bioconda-utils and will be pushing containers to quay.io.
 if [[ $TRAVIS_BRANCH = "master" && "$TRAVIS_PULL_REQUEST" = "false" ]]
 then
-   echo "Create Container push commands file: ${TRAVIS_BUILD_DIR}/container_push_commands.sh"
-   export CONTAINER_PUSH_COMMANDS_PATH=${TRAVIS_BUILD_DIR}/container_push_commands.sh
-   touch $CONTAINER_PUSH_COMMANDS_PATH
+    echo "Create Container push commands file: ${TRAVIS_BUILD_DIR}/container_push_commands.sh"
+    export CONTAINER_PUSH_COMMANDS_PATH=${TRAVIS_BUILD_DIR}/container_push_commands.sh
+    touch $CONTAINER_PUSH_COMMANDS_PATH
+else
+    # if building master branch, do not lint
+    set -x; bioconda-utils lint recipes config.yml $RANGE_ARG $BIOCONDA_UTILS_LINT_ARGS; set +x
 fi
 
-
-set -x; bioconda-utils lint recipes config.yml $RANGE_ARG $BIOCONDA_UTILS_LINT_ARGS; set +x
 
 if [[ $DISABLE_BIOCONDA_UTILS_BUILD_GIT_RANGE_CHECK = "true" ]]
 then


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

When building the master branch, we don't want to lint. 
1. This should have happened before.
2. We have periodic cron jobs that consider all recipes. We don't want failures due to failing lints in old stuff. Further, we can't deactivate lints by commit messages in such cases.