### PR TITLE
Using older CPU architecture for minialign

### DIFF
--- a/recipes/minialign/build.sh
+++ b/recipes/minialign/build.sh
@@ -4,6 +4,7 @@ export LDFLAGS="-L$PREFIX/lib"
 export CPATH=${PREFIX}/include
 
 mkdir -p $PREFIX/bin
+sed -i -e 's/march=native/march=corei7/g' Makefile
 make
 make install PREFIX=$PREFIX
 

--- a/recipes/minialign/build.sh
+++ b/recipes/minialign/build.sh
@@ -4,7 +4,7 @@ export LDFLAGS="-L$PREFIX/lib"
 export CPATH=${PREFIX}/include
 
 mkdir -p $PREFIX/bin
-sed -i -e 's/march=native/march=corei7/g' Makefile
+sed -i -e 's/-march=native/-msse4.2 -mpopcnt/g' Makefile
 make
 make install PREFIX=$PREFIX
 

--- a/recipes/minialign/meta.yaml
+++ b/recipes/minialign/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 0
+  number: 1
 
 source:
   fn: {{ name|lower }}_{{ version }}.tar.gz


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

@ocxtal I am using an older platform string here. The `-march=native` makes the built package use features that some not bleeding edge CPUs (e.g., our cluster with `Intel(R) Xeon(R) CPU E5-2650 v2 @ 2.60GHz` CPUs) do not support. This is a *proposal* only.

@bgruening @johanneskoester is there a policy of backwards compatibility in terms of CPU instruction set?