### PR TITLE
Depend on r-base instead of r.

### DIFF
--- a/scripts/bioconductor/bioconductor_skeleton.py
+++ b/scripts/bioconductor/bioconductor_skeleton.py
@@ -313,7 +313,7 @@ class BioCProjectPage(object):
                 self.depends_on_gcc = True
 
         # Add R itself
-        results.append('r')
+        results.append('r-base')
         self._dependencies = results
         return self._dependencies
 


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

This should ensure that R-specific code in conda-build is triggered.