### PR TITLE
Hmmer2

### DIFF
--- a/recipes/hmmer2/Makefile.in.patch
+++ b/recipes/hmmer2/Makefile.in.patch
@@ -1,11 +1,11 @@
---- Makefile.in.bak	2017-03-09 11:49:34.000000000 -0500
-+++ Makefile.in	2017-03-09 12:06:52.000000000 -0500
+--- Makefile.in
++++ Makefile.in
 @@ -112,7 +112,7 @@
  	mkdir -p ${BINDIR}
  	-mkdir -p ${MANDIR}/man${MANSUFFIX}
  	for file in $(PROGS) $(PVMPROGS); do\
--	   cp src/$$file $(BINDIR)/$$file;\
-+	   cp src/$$file $(BINDIR)/$${file//2};\
+-	   cp src/$$file $(BINDIR)/;\
++	   cp src/$$file $(BINDIR)/"$${file}2";\
  	done
  	-for file in hmmer $(PROGS); do\
  	   $(INSTMAN) documentation/man/$$file.man $(MANDIR)/man$(MANSUFFIX)/$$file.$(MANSUFFIX);\

--- a/recipes/hmmer2/Makefile.in.patch
+++ b/recipes/hmmer2/Makefile.in.patch
@@ -1,0 +1,11 @@
+--- Makefile.in.bak	2017-03-09 11:49:34.000000000 -0500
++++ Makefile.in	2017-03-09 12:06:52.000000000 -0500
+@@ -112,7 +112,7 @@
+ 	mkdir -p ${BINDIR}
+ 	-mkdir -p ${MANDIR}/man${MANSUFFIX}
+ 	for file in $(PROGS) $(PVMPROGS); do\
+-	   cp src/$$file $(BINDIR)/$$file;\
++	   cp src/$$file $(BINDIR)/$${file//2};\
+ 	done
+ 	-for file in hmmer $(PROGS); do\
+ 	   $(INSTMAN) documentation/man/$$file.man $(MANDIR)/man$(MANSUFFIX)/$$file.$(MANSUFFIX);\

--- a/recipes/hmmer2/build.sh
+++ b/recipes/hmmer2/build.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+#strictly use anaconda build environment
+CC=${PREFIX}/bin/gcc
+CXX=${PREFIX}/bin/g++
+
+# Fix broken configure option
+sed -i.bak -e 's/acx_maxopt_portable=$withval/acx_maxopt_portable=$enableval/' configure
+# --enable-portable-binary should be removed for the next HMMER release where this should be unnecessary
+./configure --enable-portable-binary --prefix=$PREFIX
+make -j4
+make install

--- a/recipes/hmmer2/build.sh
+++ b/recipes/hmmer2/build.sh
@@ -5,8 +5,6 @@ CC=${PREFIX}/bin/gcc
 CXX=${PREFIX}/bin/g++
 
 # Fix broken configure option
-sed -i.bak -e 's/acx_maxopt_portable=$withval/acx_maxopt_portable=$enableval/' configure
-# --enable-portable-binary should be removed for the next HMMER release where this should be unnecessary
-./configure --enable-portable-binary --prefix=$PREFIX
-make -j4
-make install
+./configure  --prefix=$PREFIX
+make
+make install --always-make

--- a/recipes/hmmer2/meta.yaml
+++ b/recipes/hmmer2/meta.yaml
@@ -6,7 +6,6 @@ source:
   fn: hmmer-2.3.2.tar.gz
   url: http://eddylab.org/software/hmmer/2.3.2/hmmer-2.3.2.tar.gz
   md5: 5f073340c0cf761288f961a73821228a
-
   patches:
     - Makefile.in.patch
 

--- a/recipes/hmmer2/meta.yaml
+++ b/recipes/hmmer2/meta.yaml
@@ -12,7 +12,6 @@ source:
 
 build:
   number: 0
-  skip: False # [osx]
 
 requirements:
   build:

--- a/recipes/hmmer2/meta.yaml
+++ b/recipes/hmmer2/meta.yaml
@@ -12,11 +12,12 @@ source:
 
 build:
   number: 0
-  skip: True # [osx]
+  skip: False # [osx]
 
 requirements:
   build:
     - gcc
+    - llvm # [osx]
   run:
 
 test:

--- a/recipes/hmmer2/meta.yaml
+++ b/recipes/hmmer2/meta.yaml
@@ -6,7 +6,7 @@ source:
   fn: hmmer-2.3.2.tar.gz
   url: http://eddylab.org/software/hmmer/2.3.2/hmmer-2.3.2.tar.gz
   md5: 5f073340c0cf761288f961a73821228a
-	
+
   patches:
     - Makefile.in.patch
 
@@ -15,16 +15,17 @@ build:
 
 requirements:
   build:
-    - gcc
+    - gcc  # [not osx]
     - llvm # [osx]
   run:
+    - libgcc  # [not osx]
 
 test:
   commands:
-    - hmmalign2 -h 2>&1 | grep Usage > /dev/null
+    - hmmalign2 -h 2>&1 | grep Usage
 
 about:
-  summary: Biosequence analysis using profile hidden Markov models
+  summary: 'Biosequence analysis using profile hidden Markov models'
   home: http://hmmer.janelia.org/
   license: GPL3
   license_file: LICENSE

--- a/recipes/hmmer2/meta.yaml
+++ b/recipes/hmmer2/meta.yaml
@@ -1,0 +1,30 @@
+package:
+  name: hmmer
+  version: "2.3.2"
+
+source:
+  fn: hmmer-2.3.2.tar.gz
+  url: http://eddylab.org/software/hmmer/2.3.2/hmmer-2.3.2.tar.gz
+  md5: 5f073340c0cf761288f961a73821228a
+	
+  patches:
+    - Makefile.in.patch
+
+build:
+  number: 0
+  skip: True # [osx]
+
+requirements:
+  build:
+    - gcc
+  run:
+
+test:
+  commands:
+    - hmmalign -h 2>&1 | grep Usage > /dev/null
+
+about:
+  summary: Biosequence analysis using profile hidden Markov models
+  home: http://hmmer.janelia.org/
+  license: GPL3
+  license_file: LICENSE

--- a/recipes/hmmer2/meta.yaml
+++ b/recipes/hmmer2/meta.yaml
@@ -1,5 +1,5 @@
 package:
-  name: hmmer
+  name: hmmer2
   version: "2.3.2"
 
 source:
@@ -10,7 +10,7 @@ source:
     - Makefile.in.patch
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipes/hmmer2/meta.yaml
+++ b/recipes/hmmer2/meta.yaml
@@ -21,7 +21,7 @@ requirements:
 
 test:
   commands:
-    - hmmalign -h 2>&1 | grep Usage > /dev/null
+    - hmmalign2 -h 2>&1 | grep Usage > /dev/null
 
 about:
   summary: Biosequence analysis using profile hidden Markov models


### PR DESCRIPTION
* [X] I have read the guidelines above.
* [X] This PR adds a new recipe.
* [ ] This PR updates an existing recipe.
* [X] This PR does something else (explain below).

This pull request installs hmmer2 by appending a "2" to all executables. This allows the simultaneous installation of hmmer2 and hmmer3.  This change is desirable because the API/ABI of hmmer2/3 is not identical. Currently there is no way to use both HMMER2 and HMMER3 at the same time. The impetus to include this package in this manner is to facilitate the packaging of the Antismash program that utilizes this convention. Because it will not clash with the HMMMER program I believe it will be okay to use in this way but I will file an issue asking for suggestions/criticism.

Thanks,
zach cp