### PR TITLE
samtools 0.1.19: update permissions for vcfutils.pl

### DIFF
--- a/recipes/samtools/0.1.19/build.sh
+++ b/recipes/samtools/0.1.19/build.sh
@@ -1,8 +1,9 @@
 #!/bin/sh
-make
+make INCLUDES="-I. -I$PREFIX/include -I$PREFIX/include/ncurses" LIBCURSES="-L$PREFIX/lib -lncurses"
 mkdir -p $PREFIX/bin
 mv samtools $PREFIX/bin
 mv bcftools/bcftools $PREFIX/bin
+chmod a+rx bcftools/vcfutils.pl
 mv bcftools/vcfutils.pl $PREFIX/bin
 mkdir -p $PREFIX/lib
 mv libbam.a $PREFIX/lib

--- a/recipes/samtools/0.1.19/meta.yaml
+++ b/recipes/samtools/0.1.19/meta.yaml
@@ -3,15 +3,18 @@ about:
   license: MIT
   summary: Tools for dealing with SAM and BAM files
 build:
-  number: 1
+  number: 2
 package:
   name: samtools
   version: 0.1.19
 requirements:
   build:
+  - gcc  # [not osx]
+  - llvm # [osx]
   - ncurses
   - zlib
   run:
+  - libgcc # [not osx]
   - ncurses
   - zlib
 source:
@@ -20,4 +23,4 @@ source:
   url: http://depot.galaxyproject.org/package/source/samtools/samtools-0.1.19.tar.bz2
 test:
   commands:
-    - "samtools view --help 2>&1 | grep Notes > /dev/null"
+    - "samtools view --help 2>&1 | grep Notes"


### PR DESCRIPTION
In #3900 we run into failures during the mulled build
when unpacking the samtools 0.1.19 package. It complains about
permissions when installing `vcfutils.pl`:

https://travis-ci.org/bioconda/bioconda-recipes/jobs/209609560#L1767
```
[Mar 10 03:48:15] DEBU Packing failed due to open build/dist/bin/vcfutils.pl: permission denied
[Mar 10 03:48:15] WARN Local execution errorred with error [open build/dist/bin/vcfutils.pl: permission denied], retrying with remote execution
```
The cause appears to be that `vcfutils.pl` does not have read
and execute permissions set for non-root users:
```
/anaconda/pkgs/samtools-0.1.19-1/bin:
total 2.4M
-rwxr-xr-x 1 root root 643K Apr 20  2016 bcftools
-rwxr-xr-x 1 root root 1.8M Apr 20  2016 samtools
-rwxrwx--- 1 root root  16K Apr 20  2016 vcfutils.pl
```
This updates the samtools 0.1.19 recipe to fix permissions on vcfutils.pl,
requiring some modernization of the recipe to build.

* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
