### PR TITLE
Bump Bioconductor methylkit to 1.0.0 and enable OSX build

### DIFF
--- a/recipes/bioconductor-methylkit/build.sh
+++ b/recipes/bioconductor-methylkit/build.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-CC=${PREFIX}/bin/gcc
-CXX=${PREFIX}/bin/g++
-
 # R refuses to build packages that mark themselves as
 # "Priority: Recommended"
 mv DESCRIPTION DESCRIPTION.old

--- a/recipes/bioconductor-methylkit/meta.yaml
+++ b/recipes/bioconductor-methylkit/meta.yaml
@@ -1,15 +1,19 @@
 package:
   name: bioconductor-methylkit
-  version: 0.99.2
+  version: 1.0.0
+
 source:
-  git_url: https://github.com/al2na/methylKit.git
-  git_rev: v0.99.2
+  fn: methylKit_1.0.0.tar.gz
+  url: https://bioarchive.galaxyproject.org/methylKit_1.0.0.tar.gz
+  md5: 3612ce6bf0b748d8869a4a16c57265dc
+
 build:
   skip: True  # [osx]
   number: 0
   rpaths:
     - lib/R/lib/
     - lib/
+
 requirements:
   build:
     - bioconductor-fastseg

--- a/recipes/bioconductor-methylkit/meta.yaml
+++ b/recipes/bioconductor-methylkit/meta.yaml
@@ -6,9 +6,10 @@ source:
   fn: methylKit_1.0.0.tar.gz
   url: https://bioarchive.galaxyproject.org/methylKit_1.0.0.tar.gz
   md5: 3612ce6bf0b748d8869a4a16c57265dc
+  patches: # [osx]
+    - rpath.patch # [osx]
 
 build:
-  skip: True  # [osx]
   number: 0
   rpaths:
     - lib/R/lib/

--- a/recipes/bioconductor-methylkit/rpath.patch
+++ b/recipes/bioconductor-methylkit/rpath.patch
@@ -1,0 +1,19 @@
+--- Makevars	2016-10-12 18:25:26.000000000 -0500
++++ Makevars	2017-03-09 01:00:27.000000000 -0600
+@@ -1,6 +1,9 @@
+-RHTSLIB_LIBS=`echo 'Rhtslib::pkgconfig("PKG_LIBS")'|\
+-    "${R_HOME}/bin/R" --vanilla --slave`
+-PKG_LIBS=$(RHTSLIB_LIBS)
+-CXX?=g++-4.8
+-CC?=gcc-4.8
+-CXX_STD= CXX11
+\ No newline at end of file
++# RHTSLIB_LIBS=`echo 'Rhtslib::pkgconfig("PKG_LIBS")'|\
++#    "${R_HOME}/bin/R" --vanilla --slave`
++# PKG_LIBS=$(RHTSLIB_LIBS)
++PKG_LIBS = -lz -pthread
++# CXX?=g++-4.8
++# CC?=gcc-4.8
++# CXX_STD= CXX11
++PKG_CXXFLAGS+= ${PREFIX}/lib/R/library/Rhtslib/lib/libhts.a -std=c++11 -stdlib=libc++
++

--- a/recipes/bioconductor-methylkit/rpath.patch
+++ b/recipes/bioconductor-methylkit/rpath.patch
@@ -1,5 +1,5 @@
---- Makevars	2016-10-12 18:25:26.000000000 -0500
-+++ Makevars	2017-03-09 01:00:27.000000000 -0600
+--- src/Makevars	2016-10-12 18:25:26.000000000 -0500
++++ src/Makevars	2017-03-09 01:00:27.000000000 -0600
 @@ -1,6 +1,9 @@
 -RHTSLIB_LIBS=`echo 'Rhtslib::pkgconfig("PKG_LIBS")'|\
 -    "${R_HOME}/bin/R" --vanilla --slave`

--- a/recipes/bioconductor-methylkit/rpath.patch
+++ b/recipes/bioconductor-methylkit/rpath.patch
@@ -1,19 +1,12 @@
 --- src/Makevars	2016-10-12 18:25:26.000000000 -0500
-+++ src/Makevars	2017-03-09 01:00:27.000000000 -0600
-@@ -1,6 +1,9 @@
++++ src/Makevars	2017-03-10 13:34:07.000000000 -0600
+@@ -1,6 +1,2 @@
 -RHTSLIB_LIBS=`echo 'Rhtslib::pkgconfig("PKG_LIBS")'|\
 -    "${R_HOME}/bin/R" --vanilla --slave`
 -PKG_LIBS=$(RHTSLIB_LIBS)
--CXX?=g++-4.8
+-CXX?=g++-4.8		
 -CC?=gcc-4.8
 -CXX_STD= CXX11
 \ No newline at end of file
-+# RHTSLIB_LIBS=`echo 'Rhtslib::pkgconfig("PKG_LIBS")'|\
-+#    "${R_HOME}/bin/R" --vanilla --slave`
-+# PKG_LIBS=$(RHTSLIB_LIBS)
-+PKG_LIBS = -lz -pthread
-+# CXX?=g++-4.8
-+# CC?=gcc-4.8
-+# CXX_STD= CXX11
-+PKG_CXXFLAGS+= ${PREFIX}/lib/R/library/Rhtslib/lib/libhts.a -std=c++11 -stdlib=libc++
-+
++PKG_LIBS= ${PREFIX}/lib/R/library/Rhtslib/lib/libhts.a -lz -pthread
++PKG_CXXFLAGS+= -std=c++11 -stdlib=libc++


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

This upgrades [methylKit](https://bioconductor.org/packages/release/bioc/html/methylKit.html) to 1.0.0, the current version in Bioconductor release channel.  

Also, a patch is included to enable OSX build by passing the correct library paths and C++11 flags. This is my first attempt at creating patch for bioconda so @bioconda/core please review my patch. Any feedback is highly welcomed. Thanks!