### PR TITLE
Update: sambamba, gemini, bcbio

### DIFF
--- a/recipes/bcbio-nextgen/meta.yaml
+++ b/recipes/bcbio-nextgen/meta.yaml
@@ -1,15 +1,18 @@
 package:
   name: bcbio-nextgen
-  version: '1.0.2'
+  version: '1.0.3a'
 
 build:
   number: 0
   skip: True # [not py27]
 
 source:
-  fn: bcbio-nextgen-1.0.2.tar.gz
-  url: https://pypi.python.org/packages/3f/c0/f8e46f5cbc3b4f04f94670b157737c2a402f40a2a5cc6168d7f1dee58f9e/bcbio-nextgen-1.0.2.tar.gz
-  md5: 0b8e7bf553b15173aeaa06102afa021a
+  #fn: bcbio-nextgen-1.0.2.tar.gz
+  #url: https://pypi.python.org/packages/3f/c0/f8e46f5cbc3b4f04f94670b157737c2a402f40a2a5cc6168d7f1dee58f9e/bcbio-nextgen-1.0.2.tar.gz
+  #md5: 0b8e7bf553b15173aeaa06102afa021a
+  fn: bcbio-nextgen-ffc2aae.tar.gz
+  url: https://github.com/chapmanb/bcbio-nextgen/archive/ffc2aae.tar.gz
+  md5: 7674c0f68dc19c2291d9d50d75b70279
 
 requirements:
   build:
@@ -36,7 +39,7 @@ requirements:
     - libsodium >=0.4,<1.0
     - logbook
     - lxml
-    - matplotlib
+    - matplotlib >=2.0.0
     - msgpack-python
     - numpy
     - openpyxl

--- a/recipes/gemini/meta.yaml
+++ b/recipes/gemini/meta.yaml
@@ -2,14 +2,15 @@ package:
   name: gemini
   version: "0.19.2a"
 build:
-  number: 1
+  number: 2
   skip: True # [not py27]
 source:
   #url: https://github.com/arq5x/gemini/archive/v0.19.1.tar.gz
   #fn: gemini-0.19.1.tar.gz
   #md5: xxxx
-  git_url: https://github.com/arq5x/gemini
-  git_tag: b52c7e9d751ae698d701f108ea3c39c4ae199705
+  fn: gemini-820ddf68.tar.gz
+  url: https://github.com/arq5x/gemini/archive/820ddf68.tar.gz
+  md5: a96de735a46aa2c7219fd2ae65194b9f
 
 requirements:
   build:

--- a/recipes/sambamba/meta.yaml
+++ b/recipes/sambamba/meta.yaml
@@ -1,13 +1,14 @@
+{% set version='0.6.6' %}
 package:
   name: sambamba
-  version: '0.6.5'
+  version: {{ version }}
 
 source:
-  fn: sambamba_v0.6.5.tar.bz2
-  url: https://github.com/lomereiter/sambamba/releases/download/v0.6.5/sambamba_v0.6.5_linux.tar.bz2 # [linux]
-  md5: 697b8903722ec0225f378547b7bb9973 # [linux]
-  url: https://github.com/lomereiter/sambamba/releases/download/v0.6.5/sambamba_v0.6.5_osx.tar.bz2 # [osx]
-  md5: b08b8858dc6ac6b1d20f65e715845cbb # [osx]
+  fn: sambamba_v{{ version }}.tar.bz2
+  url: https://github.com/lomereiter/sambamba/releases/download/v{{ version }}/sambamba_v{{ version }}_linux.tar.bz2 # [linux]
+  md5: 6fc3b70ac32441f3a9c6aa87743c8e3c # [linux]
+  url: https://github.com/lomereiter/sambamba/releases/download/v{{ version }}/sambamba_v{{ version }}_osx.tar.bz2 # [osx]
+  md5: 07d82a2102126565e6796658face7c71 # [osx]
 
 build:
   number: 0


### PR DESCRIPTION
- sambamba: 0.6.6 with ldc fixes for some HPC architectures
- gemini: gnomad support and fixes for VEP extras in variants tables
- bcbio: clean validation plots with matplotlib 2.0

* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
