### PR TITLE
Disable march=native for beagle-lib.

### DIFF
--- a/recipes/beagle-lib/build.sh
+++ b/recipes/beagle-lib/build.sh
@@ -2,6 +2,6 @@
 
 export LDFLAGS="-L${PREFIX}/lib"
 ./autogen.sh
-./configure --prefix=${PREFIX} --with-jdk=${PREFIX}
+./configure --prefix=${PREFIX} --with-jdk=${PREFIX} --disable-march-native
 make
 make install

--- a/recipes/beagle-lib/meta.yaml
+++ b/recipes/beagle-lib/meta.yaml
@@ -11,7 +11,7 @@ source:
     - osx_ltdl.patch # [osx]
 
 build:
-  number: 6
+  number: 7
 
 requirements:
   build:


### PR DESCRIPTION
By default, using march=native is enabled.  This causes SIGILL
crashes on hardware sufficiently different than the build
environment.

* [X] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
