### PR TITLE
newer version proBAMconvert

### DIFF
--- a/recipes/probamconvert/meta.yaml
+++ b/recipes/probamconvert/meta.yaml
@@ -19,7 +19,7 @@ requirements:
   run:
     - python
     - cogent
-    - pysam > 0.9
+    - pysam >=0.9
     - mysql-python
     - lxml
     - numpy

--- a/recipes/probamconvert/meta.yaml
+++ b/recipes/probamconvert/meta.yaml
@@ -8,8 +8,8 @@ about:
   license: Apache License
 
 source:
-  url: https://github.com/Biobix/proBAMconvert/archive/0504665126486b4d4a03ce863c447891dc051ee7.tar.gz
-  md5: 7646cbbc70333517850453c678ccbe6c
+  url: https://github.com/Biobix/proBAMconvert/archive/6e9080412b500bcb52aa0576afc50575a25fb4f3.tar.gz
+  md5: d3cbf80f8ce900c85b26a90c9cd220c1
 
 build:
   number: 0
@@ -19,7 +19,7 @@ requirements:
   run:
     - python
     - cogent
-    - pysam ==0.9
+    - pysam > 0.9
     - mysql-python
     - lxml
     - numpy


### PR DESCRIPTION
My first attempt to modify the conda package for proBAMconvert, i'm still pretty amateur at this.
I've updated to a newer proBAMconvert version, compatible with pysam 0.10.0, also, the previous version did have some errors in galaxy which should be fixed now.

Also, I'm no quite sure but should the usage of python2 not be a requirement ? proBAMconvert is not made compatible with python 3.

Also, is there away to adjust the galaxy xml file to use a fork of the bioconda recipe so I could test it out before requesting a pull?

Thank you for all your work, I'm still in the progress of figuring Conda out !

* [ ] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
