### PR TITLE
Update: salmon 0.8.1 with pre-compiled binaries

### DIFF
--- a/recipes/salmon/build.sh
+++ b/recipes/salmon/build.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
 set -eu -o pipefail
 
-export LD_LIBRARY_PATH=${PREFIX}/lib
-cd $SRC_DIR
-mkdir -p build
-sed -i 's/Boost_USE_STATIC_LIBS ON/Boost_USE_STATIC_LIBS OFF/' CMakeLists.txt
-sed -i 's/.\/autogen.sh/CFLAGS=-fPIC CPPFLAGS=-fPIC .\/autogen.sh/' CMakeLists.txt
-sed -i 's/CFLAGS+=${STADEN_LIB}/CFLAGS+=${STADEN_LIB} CFLAGS+=-lz/' CMakeLists.txt
-cd build
-cmake -DCMAKE_EXE_LINKER_FLAGS="-L$PREFIX/lib" -DCMAKE_INSTALL_PREFIX=${PREFIX} -DBOOST_ROOT=$PREFIX -DBoost_NO_SYSTEM_PATHS=ON -DBoost_DEBUG=ON ..
-make install CFLAGS="-L${PREFIX}/lib -I${PREFIX}/include"
+TGT="$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM"
+[ -d "$TGT" ] || mkdir -p "$TGT"
+[ -d "${PREFIX}/bin" ] || mkdir -p "${PREFIX}/bin"
+
+cd "${SRC_DIR}"
+
+mv bin lib $TGT
+ln -s $TGT/bin/salmon $PREFIX/bin

--- a/recipes/salmon/meta.yaml
+++ b/recipes/salmon/meta.yaml
@@ -1,8 +1,10 @@
+{% set version="0.8.1" %}
 build:
   number: 0
-  # XXX OSX source build currently failing due to unresolved symbols at runtime
-  skip: True # [osx]
-  string: boost{{CONDA_BOOST}}_{{PKG_BUILDNUM}}
+  # OSX failing due to libary issues even though shipping with Salmon binary
+  # dyld: Library not loaded: /usr/local/opt/tbb/lib/libtbbmalloc_proxy.dylib
+  # https://travis-ci.org/bioconda/bioconda-recipes/jobs/211785820#L295
+  skip: true # [osx]
 
 about:
     home: https://github.com/COMBINE-lab/salmon
@@ -11,32 +13,20 @@ about:
 
 package:
     name: salmon
-    version: 0.8.0
+    version: {{ version }}
 
 source:
-  fn: v0.8.0.tar.gz
-  url: https://github.com/COMBINE-lab/salmon/archive/v0.8.0.tar.gz
-  sha256: a58799eb9ac61a91d941ab23485328e1fe2e869dbc2091c86ff6eb4300f284c5
+  fn: Salmon-{{ version }}_linux_x86_64.tar.gz # [linux]
+  url: https://github.com/COMBINE-lab/salmon/releases/download/v{{ version }}/Salmon-{{ version }}_linux_x86_64.tar.gz # [linux]
+  md5: a0e2d72b33fc571c28a6ce8aef1201fd # [linux]
+  fn: Salmon-{{ version }}_macOS_10.12.tar.gz # [osx]
+  url: https://github.com/COMBINE-lab/salmon/releases/download/v{{ version }}/Salmon-{{ version }}_macOS_10.12.tar.gz # [osx]
+  md5: 28473afefa199a4bb0b7a3625ff48793 # [osx]
+
 
 requirements:
   build:
-    - autoconf 2.69 pl5.*
-    - boost {{CONDA_BOOST}}*
-    - icu 56.*
-    - cmake
-    - tbb
-    - zlib
-    - bzip2
-    - unzip
-    - gcc # [linux]
-    - llvm # [osx]
   run:
-    - boost {{CONDA_BOOST}}*
-    - icu 56.*
-    - tbb
-    - zlib
-    - bzip2
-    - libgcc # [linux]
 
 test:
     commands:


### PR DESCRIPTION
- Avoids compiling from source due to incompatibilities between autoconf
  and lxml. autoconf requires icu 56.* and lxml uses icu 58.*
- Re-adds OSX support with binary install

* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
