### PR TITLE
bcbio: update and remove matplotlib pinning

### DIFF
--- a/recipes/bcbio-nextgen/meta.yaml
+++ b/recipes/bcbio-nextgen/meta.yaml
@@ -3,16 +3,16 @@ package:
   version: '1.0.3a'
 
 build:
-  number: 0
+  number: 1
   skip: True # [not py27]
 
 source:
   #fn: bcbio-nextgen-1.0.2.tar.gz
   #url: https://pypi.python.org/packages/3f/c0/f8e46f5cbc3b4f04f94670b157737c2a402f40a2a5cc6168d7f1dee58f9e/bcbio-nextgen-1.0.2.tar.gz
   #md5: 0b8e7bf553b15173aeaa06102afa021a
-  fn: bcbio-nextgen-ffc2aae.tar.gz
-  url: https://github.com/chapmanb/bcbio-nextgen/archive/ffc2aae.tar.gz
-  md5: 7674c0f68dc19c2291d9d50d75b70279
+  fn: bcbio-nextgen-3ebbeec.tar.gz
+  url: https://github.com/chapmanb/bcbio-nextgen/archive/3ebbeec.tar.gz
+  md5: 9d63c66eee1cb3549856e1c735a81735
 
 requirements:
   build:
@@ -39,7 +39,7 @@ requirements:
     - libsodium >=0.4,<1.0
     - logbook
     - lxml
-    - matplotlib >=2.0.0
+    - matplotlib
     - msgpack-python
     - numpy
     - openpyxl


### PR DESCRIPTION
matplotlib pin causes issues with other pinned tools, breaking upgrades
and causing incompatibilities with icu. Fixes chapmanb/bcbio-nextgen#1865

* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
