### PR TITLE
Increment to test missing libICU

### DIFF
--- a/recipes/perl-gd/meta.yaml
+++ b/recipes/perl-gd/meta.yaml
@@ -7,7 +7,7 @@ source:
   md5: c4b3afd98b2c4ce3c2e1027d101a8f1e
 build:
   ##ignore_prefix_files: True
-  number: 6
+  number: 7
   skip: True  # [osx]
 
 requirements:


### PR DESCRIPTION
* [ ] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

Per some brief discussion with @bgruening, I believe the GD module may be missing a dependency on libicu and I'm trying to test that. He suggested making a PR and waiting for the build to fail.

Currently when running circos I see:

```console
missing GD
  error Can't load '/home/hxr/miniconda2/envs/mulled-v1-e266dde3021cea30342fb68f5dc2db89a867f725287b998875b3c86b81715e46/lib/perl5/site_perl/5.22.0/x86_64-linux-thread-multi/auto/GD/GD.so' for module GD: libicui18n.so.56: cannot open shared object file: Fila eller mappa finnes ikke at /home/hxr/miniconda2/envs/mulled-v1-e266dde3021cea30342fb68f5dc2db89a867f725287b998875b3c86b81715e46/lib/perl5/5.22.0/x86_64-linux-thread-multi/DynaLoader.pm line 193. at (eval 24) line 1.Compilation failed in require at (eval 24) line 1.
missing GD::Polyline
  error Attempt to reload GD.pm aborted.Compilation failed in require at /home/hxr/miniconda2/envs/mulled-v1-e266dde3021cea30342fb68f5dc2db89a867f725287b998875b3c86b81715e46/lib/perl5/site_perl/5.22.0/x86_64-linux-thread-multi/GD/Polyline.pm line 45.
```

The important error being `for module GD: libicui18n.so.56: cannot open shared object file: Fila eller mappa finnes ikke at ...` (norwegian error message reads "File or folder not found")

A quick ldd shows

```console
[hxr@castor:~/arbeid/tools-cpt]$ ldd /home/hxr/miniconda2/envs/mulled-v1-e266dde3021cea30342fb68f5dc2db89a867f725287b998875b3c86b81715e46/lib/perl5/site_perl/5.22.0/x86_64-linux-thread-multi/auto/GD/GD.so | grep not
        libicui18n.so.56 => not found
        libicuuc.so.56 => not found
        libicudata.so.56 => not found
```