### PR TITLE
Fix incorrect gemini version

### DIFF
--- a/recipes/gemini/meta.yaml
+++ b/recipes/gemini/meta.yaml
@@ -1,13 +1,10 @@
 package:
   name: gemini
-  version: "0.19.2a"
+  version: "0.20.0a0"
 build:
-  number: 2
+  number: 0
   skip: True # [not py27]
 source:
-  #url: https://github.com/arq5x/gemini/archive/v0.19.1.tar.gz
-  #fn: gemini-0.19.1.tar.gz
-  #md5: xxxx
   fn: gemini-820ddf68.tar.gz
   url: https://github.com/arq5x/gemini/archive/820ddf68.tar.gz
   md5: a96de735a46aa2c7219fd2ae65194b9f


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Not sure how to deal with reproducibility on this, but there is not gemini release for version 0.19.2a