### PR TITLE
Update: samtools, bcftools, htslib, sailfish

### DIFF
--- a/recipes/bcftools/1.2/meta.yaml
+++ b/recipes/bcftools/1.2/meta.yaml
@@ -6,6 +6,7 @@ build:
 source:
   fn: bcftools-1.2.tar.bz2
   url: https://github.com/samtools/bcftools/releases/download/1.2/bcftools-1.2.tar.bz2
+  md5: 8044bed8fce62f7072fc6835420f0906
 requirements:
   build:
   run:

--- a/recipes/bcftools/build.sh
+++ b/recipes/bcftools/build.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+export CPPFLAGS="-I$PREFIX/include"
+export LDFLAGS="-L$PREFIX/lib"
+
+cd htslib*
+./configure --prefix=$PREFIX --enable-libcurl CPPFLAGS="-I$PREFIX/include" LDFLAGS="-L$PREFIX/lib"
+make
+cd ..
+
+make prefix=$PREFIX CPPFLAGS=$CPPFLAGS LDFLAGS=$LDFLAGS plugins install

--- a/recipes/bcftools/meta.yaml
+++ b/recipes/bcftools/meta.yaml
@@ -1,0 +1,40 @@
+{% set version="1.4" %}
+about:
+  home: https://github.com/samtools/bcftools
+  license: MIT
+  summary: BCFtools is a set of utilities that manipulate variant calls in the Variant
+    Call Format (VCF) and its binary counterpart BCF. All commands work transparently
+    with both VCFs and BCFs, both uncompressed and BGZF-compressed.  Most commands
+    accept VCF, bgzipped VCF and BCF with filetype detected automatically even when
+    streaming from a pipe. Indexed VCF and BCF will work in all situations. Un-indexed
+    VCF and BCF and streams will work in most, but not all situations.
+
+build:
+  number: 0
+package:
+  name: bcftools
+  version: {{ version }}
+requirements:
+  build:
+  - gcc  # [not osx]
+  - llvm # [osx]
+  - gcc
+  - zlib
+  - bzip2
+  - curl
+  - xz
+  run:
+  - libgcc # [not osx]
+  - zlib
+  - bzip2
+  - curl
+  - xz
+source:
+  fn: bcftools-{{ version }}.tar.bz2
+  url: https://github.com/samtools/bcftools/releases/download/{{ version }}/bcftools-{{ version }}.tar.bz2
+  md5: 50ccf0a073bd70e99cdb3c8be830416e
+test:
+  commands:
+    - bcftools -h
+    - bcftools --version
+    - bcftools plugin -lv

--- a/recipes/htslib/meta.yaml
+++ b/recipes/htslib/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.3.2" %}
+{% set version = "1.4" %}
 
 package:
   name: htslib
@@ -10,13 +10,17 @@ build:
 source:
   fn: htslib-{{ version }}.tar.bz2
   url: https://github.com/samtools/htslib/releases/download/{{ version }}/htslib-{{ version }}.tar.bz2
-  md5: 64742a2a812da1bb6eb4417128be6944
+  md5: 2a22ff382654c033c40e4ec3ea880050
 
 requirements:
   build:
     - curl
+    - bzip2
+    - xz
   run:
     - curl
+    - bzip2
+    - xz
 
 about:
   home: https://github.com/samtools/htslib

--- a/recipes/sailfish/meta.yaml
+++ b/recipes/sailfish/meta.yaml
@@ -1,7 +1,6 @@
 build:
-  number: 0
+  number: 1
   skip: True # [osx]
-  string: boost{{CONDA_BOOST}}_{{PKG_BUILDNUM}}
 
 about:
     home: http://www.cs.cmu.edu/~ckingsf/software/sailfish/
@@ -15,23 +14,24 @@ package:
 source:
     fn: sailfish-0.10.1.tar.gz
     url: https://github.com/kingsfordgroup/sailfish/archive/v0.10.1.tar.gz
+    md5: e6dab4cf3a39f346df7c28f40eb58cad
 
 requirements:
   build:
-    - boost {{CONDA_BOOST}}*
-    - cmake
-    - tbb
     - gcc # [linux]
     - llvm # [osx]
+    - boost ==1.63.0
+    - cmake
+    - tbb
     - autoconf
     - unzip
     - perl
-    - icu ==56.1
+    - icu 58.*
   run:
-    - boost {{CONDA_BOOST}}*
-    - tbb
-    - icu ==56.1
     - libgcc # [linux]
+    - boost ==1.63.0
+    - tbb
+    - icu 58.*
 
 test:
     commands:

--- a/recipes/samtools/0.1.17/meta.yaml
+++ b/recipes/samtools/0.1.17/meta.yaml
@@ -29,3 +29,8 @@ about:
   license: MIT
   license_file: COPYING
   summary: "Library for manipulating alignments in the SAM/BAM format"
+
+test:
+  commands:
+    - samtools --help
+

--- a/recipes/samtools/build.sh
+++ b/recipes/samtools/build.sh
@@ -12,7 +12,7 @@ sed -i.bak 's#misc/varfilter.py##g' Makefile
 # Remove rdynamic which can cause build issues on OSX
 # https://sourceforge.net/p/samtools/mailman/message/34699333/
 sed -i.bak 's/ -rdynamic//g' Makefile
-sed -i.bak 's/ -rdynamic//g' htslib-1.3.1/configure
+sed -i.bak 's/ -rdynamic//g' htslib-$PKG_VERSION/configure
 
 export CPPFLAGS="-I$PREFIX/include"
 export LDFLAGS="-L$PREFIX/lib"

--- a/recipes/samtools/meta.yaml
+++ b/recipes/samtools/meta.yaml
@@ -1,36 +1,40 @@
-{% set version = "1.3.1" %}
+{% set version = "1.4" %}
 
 package:
   name: samtools
   version: {{ version }}
 
 build:
-  number: 5
+  number: 0
   skip: False
 
 source:
   fn: samtools-{{ version }}.tar.bz2
   url: https://github.com/samtools/samtools/releases/download/{{ version }}/samtools-{{ version }}.tar.bz2
-  md5: a7471aa5a1eb7fc9cc4c6491d73c2d88
+  md5: 8cbd7d2a0ec16d834babcd6c6d85d691
 
 requirements:
   build:
   - gcc  # [not osx]
   - llvm # [osx]
+    # ncurses not compatible with samtools, see note in build.sh
     #- ncurses {{CONDA_NCURSES}}*
   - zlib
+  - bzip2
   - curl
+  - xz
   run:
   - libgcc # [not osx]
-    # curses from default channel fails, see note in build.sh
     #- ncurses {{CONDA_NCURSES}}*
   - zlib
   - curl
+  - xz
 
 about:
   home: https://github.com/samtools/samtools
   license: MIT
   summary: Tools for dealing with SAM, BAM and CRAM files
+
 test:
   commands:
     - samtools --help


### PR DESCRIPTION
- samtools, bcftools, htslib: latest 1.4 release
- sailfish: avoid pinning to older icu 56, which is
  incompatible with lxml

* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
