### PR TITLE
Update: htslib with libhts.so.1 symlink

### DIFF
--- a/recipes/htslib/build.sh
+++ b/recipes/htslib/build.sh
@@ -2,3 +2,6 @@
 
 ./configure --prefix=$PREFIX --enable-libcurl CFLAGS="-I$PREFIX/include" LDFLAGS="-L$PREFIX/lib"
 make install prefix=$PREFIX
+# Add back-compatible links for htslib.so
+cd $PREFIX/lib
+ln -s libhts.so libhts.so.1

--- a/recipes/htslib/meta.yaml
+++ b/recipes/htslib/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 0
+  number: 1
 
 source:
   fn: htslib-{{ version }}.tar.bz2


### PR DESCRIPTION
Provides back-compatibility. Fixes chapmanb/bcbio-nextgen#1873

* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
