### PR TITLE
Do not symlink subdirectories of util/

### DIFF
--- a/recipes/trinity/build.sh
+++ b/recipes/trinity/build.sh
@@ -23,8 +23,6 @@ export LD_LIBRARY_PATH="${PREFIX}/lib"
 export LDFLAGS="-L${PREFIX}/lib"
 export CPPFLAGS="-I${PREFIX}/include"
 
-
-BINARY=Trinity
 BINARY_HOME=$PREFIX/bin
 TRINITY_HOME=$PREFIX/opt/trinity-$PKG_VERSION
 
@@ -46,8 +44,9 @@ mkdir -p $PREFIX/bin
 mkdir -p $TRINITY_HOME
 cp -R $SRC_DIR/* $TRINITY_HOME/
 cd $TRINITY_HOME && chmod +x Trinity
-cd $BINARY_HOME && ln -s $TRINITY_HOME/Trinity $BINARY
-ln -s $TRINITY_HOME/util/* .
+cd $BINARY_HOME
+ln -s $TRINITY_HOME/Trinity
+ln -s $TRINITY_HOME/util/*.pl .
 ln -s $TRINITY_HOME/Analysis/DifferentialExpression/PtR
 ln -s $TRINITY_HOME/Analysis/DifferentialExpression/run_DE_analysis.pl
 ln -s $TRINITY_HOME/Analysis/DifferentialExpression/analyze_diff_expr.pl

--- a/recipes/trinity/meta.yaml
+++ b/recipes/trinity/meta.yaml
@@ -6,13 +6,13 @@ package:
   version: {{ version }}
 
 build:
-  number: 1
+  number: 2
   skip: True  # [osx]
 
 source:
   fn: {{ name|lower }}_{{ version }}.tar.gz
   url: https://github.com/trinityrnaseq/trinityrnaseq/archive/Trinity-v{{ version }}.tar.gz
-  md5sum: 397cc93d75701ec681ea7af1a7837ed8
+  md5: 397cc93d75701ec681ea7af1a7837ed8
   patches:
     - makefile.clean.patch
     - trinity-plugins.makefile.clean.patch
@@ -32,7 +32,7 @@ requirements:
     - fastool
     - parafly
     - slclust
-    - autoconf 
+    - autoconf
     - automake
 
   run:


### PR DESCRIPTION
In particular, symlinking `util/R/` prevents creating an environment containing also any R package.

Also fix md5 key name.

* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
