### PR TITLE
Add minimum version 2.3.0 to bowtie2 requirement for Trinity

### DIFF
--- a/recipes/trinity/meta.yaml
+++ b/recipes/trinity/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 3
+  number: 4
   skip: True  # [osx]
 
 source:
@@ -37,7 +37,7 @@ requirements:
 
   run:
     - bowtie
-    - bowtie2
+    - bowtie2 >=2.3.0
     - collectl
     - fastool
     - jellyfish >=2.2.6


### PR DESCRIPTION
Otherwise the completely broken bowtie2 2.2.5-0 is chosen by conda when creating a new environment.

* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
