### PR TITLE
updated version of phylip recipe

### DIFF
--- a/recipes/phylip/drawtree.py
+++ b/recipes/phylip/drawtree.py
@@ -81,7 +81,7 @@ def main():
     this program updates files relative to the path of the jar file.
     In a multiuser setting, the option --exec_dir="exec_dir"
     can be used as the location for the phylip distribution.
-    If the exec_dir dies not exist,
+    If the exec_dir does not exist,
     we copy the jar file, lib, and resources to the exec_dir directory.
     """
     (mem_opts, prop_opts, pass_args, exec_dir) = jvm_opts(sys.argv[1:])
@@ -95,7 +95,7 @@ def main():
     
     java_args = [java] + mem_opts + prop_opts + [jar_arg] + [jar_path] + pass_args
     
-    # Trying to fix font problems phylip appears to require that fonts
+    # Trying to fix font problems. Phylip appears to require that fonts
     # are placed in the working directory Current workaround is to
     # temporarily link them there and then remove links. Far from
     # optimal solution, but I can't get anything else to work:(

--- a/recipes/phylip/font-paths.patch
+++ b/recipes/phylip/font-paths.patch
@@ -5,7 +5,7 @@
  #define INFILE "infile"
  #define OUTFILE "outfile"
 -#define FONTFILE "fontfile" /* on unix this might be /usr/local/lib/fontfile */
-+#define FONTFILE "@@prefix@@/share/phylip-3.696-0/fonts/fontfile" /* on unix this might be /usr/local/lib/fontfile */
++#define FONTFILE "@@prefix@@/share/phylip-3.696-1/fonts/fontfile" /* on unix this might be /usr/local/lib/fontfile */
  #define PLOTFILE "plotfile"
  #define INTREE "intree"
  #define INTREE2 "intree2"

--- a/recipes/phylip/maxtrees.patch
+++ b/recipes/phylip/maxtrees.patch
@@ -1,0 +1,84 @@
+diff -Naur phylip-3.696/src/dnacomp.c phylip-3.696_patched/src/dnacomp.c
+--- phylip-3.696/src/dnacomp.c	2014-09-17 05:38:54.000000000 +0200
++++ phylip-3.696_patched/src/dnacomp.c	2017-03-24 11:42:35.000000000 +0100
+@@ -31,7 +31,7 @@
+    POSSIBILITY OF SUCH DAMAGE.
+ */
+ 
+-#define maxtrees        100   /* maximum number of tied trees stored     */
++#define maxtrees        10000   /* maximum number of tied trees stored     */
+ 
+ typedef boolean *boolptr;
+ 
+diff -Naur phylip-3.696/src/dnapenny.c phylip-3.696_patched/src/dnapenny.c
+--- phylip-3.696/src/dnapenny.c	2014-09-17 05:38:54.000000000 +0200
++++ phylip-3.696_patched/src/dnapenny.c	2017-03-24 11:42:48.000000000 +0100
+@@ -30,7 +30,7 @@
+    POSSIBILITY OF SUCH DAMAGE.
+ */
+ 
+-#define maxtrees        1000  /* maximum number of trees to be printed out   */
++#define maxtrees        10000  /* maximum number of trees to be printed out   */
+ #define often           1000  /* how often to notify how many trees examined */
+ #define many            10000 /* how many multiples of howoften before stop  */
+ 
+diff -Naur phylip-3.696/src/dollop.c phylip-3.696_patched/src/dollop.c
+--- phylip-3.696/src/dollop.c	2014-09-17 05:38:54.000000000 +0200
++++ phylip-3.696_patched/src/dollop.c	2017-03-24 11:43:02.000000000 +0100
+@@ -32,7 +32,7 @@
+    POSSIBILITY OF SUCH DAMAGE.
+ */
+ 
+-#define maxtrees        100  /* maximum number of tied trees stored     */
++#define maxtrees        10000  /* maximum number of tied trees stored     */
+ 
+ #ifndef OLDC
+ /* function prototypes */
+diff -Naur phylip-3.696/src/dolpenny.c phylip-3.696_patched/src/dolpenny.c
+--- phylip-3.696/src/dolpenny.c	2014-09-17 05:38:54.000000000 +0200
++++ phylip-3.696_patched/src/dolpenny.c	2017-03-24 11:43:12.000000000 +0100
+@@ -31,7 +31,7 @@
+    POSSIBILITY OF SUCH DAMAGE.
+ */
+ 
+-#define maxtrees        1000  /* maximum number of trees to be printed out   */
++#define maxtrees        10000  /* maximum number of trees to be printed out   */
+ #define often           100   /* how often to notify how many trees examined */
+ #define many            1000  /* how many multiples of howoften before stop  */
+ 
+diff -Naur phylip-3.696/src/mix.c phylip-3.696_patched/src/mix.c
+--- phylip-3.696/src/mix.c	2014-09-17 05:38:54.000000000 +0200
++++ phylip-3.696_patched/src/mix.c	2017-03-24 11:43:24.000000000 +0100
+@@ -33,7 +33,7 @@
+ */
+ 
+ 
+-#define maxtrees        100  /* maximum number of tied trees stored     */
++#define maxtrees        10000  /* maximum number of tied trees stored     */
+ 
+ typedef long *placeptr;
+ 
+diff -Naur phylip-3.696/src/penny.c phylip-3.696_patched/src/penny.c
+--- phylip-3.696/src/penny.c	2014-09-17 05:38:54.000000000 +0200
++++ phylip-3.696_patched/src/penny.c	2017-03-24 11:43:52.000000000 +0100
+@@ -32,7 +32,7 @@
+    POSSIBILITY OF SUCH DAMAGE.
+ */
+ 
+-#define maxtrees        1000 /* maximum number of trees to be printed out   */
++#define maxtrees        10000 /* maximum number of trees to be printed out   */
+ #define often           100  /* how often to notify how many trees examined */
+ #define many            1000 /* how many multiples of howoften before stop  */
+ 
+diff -Naur phylip-3.696/src/protpars.c phylip-3.696_patched/src/protpars.c
+--- phylip-3.696/src/protpars.c	2014-09-17 05:38:55.000000000 +0200
++++ phylip-3.696_patched/src/protpars.c	2017-03-24 11:44:03.000000000 +0100
+@@ -32,7 +32,7 @@
+ */
+ 
+ 
+-#define maxtrees        100   /* maximum number of tied trees stored */
++#define maxtrees        10000   /* maximum number of tied trees stored */
+ 
+ typedef enum {
+   universal, ciliate, mito, vertmito, flymito, yeastmito

--- a/recipes/phylip/meta.yaml
+++ b/recipes/phylip/meta.yaml
@@ -15,9 +15,15 @@ source:
   patches:
     - makefile.patch
     - font-paths.patch # adapted this patch to bioconda share dir
+    - maxtrees.patch   # increased max tied trees stored for all
 
 build:
-  number: 0
+
+  # Note when changing the build-number you must also update the
+  # font-paths.patch file from
+  # /share/phylip-3.696-<oldversion>/fonts/fontfile to
+  # /share/phylip-3.696-<new version>/fonts/fontfile
+  number: 1 
   detect_binary_files_with_prefix: true
   script_env:
     - BB_ARCH_FLAGS


### PR DESCRIPTION
New version of phylip-recipe to build 1. 
(Reason for update: By default, phylip only save a maximum number of phylogenetic trees determined by the hard-coded variable maxtrees. This update applies a patch that changes maxtrees to 10000 in several programs -- previous value of 100 in several programs was way to low for biologically relevant analyses.)

* [x ] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
