### PR TITLE
Update: arvados-cwl-runner, gridss, bcbio-nextgen

### DIFF
--- a/recipes/arvados-cwl-runner/meta.yaml
+++ b/recipes/arvados-cwl-runner/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: arvados-cwl-runner
-  version: '1.0.20170216151734'
+  version: '1.0.20170327202303'
 
 source:
-  fn: arvados-cwl-runner-1.0.20170216151734.tar.gz
-  url: https://pypi.python.org/packages/3f/2b/104ef1fad62c96a90e136459f49d43d7b487005f1b84637a80bdbe7a9722/arvados-cwl-runner-1.0.20170216151734.tar.gz
-  md5: 290b1b626e5dafd9de993bdc2d7244a3
+  fn: arvados-cwl-runner-1.0.20170327202303.tar.gz
+  url: https://pypi.python.org/packages/66/24/4a44eaa001dd64b7c3722e322c33338044f44e9d36dec5204d368d291fd8/arvados-cwl-runner-1.0.20170327202303.tar.gz
+  md5: 3240ab87d8c313bc5f50c31d666d16d5
 
 build:
   number: 0

--- a/recipes/bcbio-nextgen/meta.yaml
+++ b/recipes/bcbio-nextgen/meta.yaml
@@ -3,16 +3,16 @@ package:
   version: '1.0.3a'
 
 build:
-  number: 3
+  number: 4
   skip: True # [not py27]
 
 source:
   #fn: bcbio-nextgen-1.0.2.tar.gz
   #url: https://pypi.python.org/packages/3f/c0/f8e46f5cbc3b4f04f94670b157737c2a402f40a2a5cc6168d7f1dee58f9e/bcbio-nextgen-1.0.2.tar.gz
   #md5: 0b8e7bf553b15173aeaa06102afa021a
-  fn: bcbio-nextgen-02f373a.tar.gz
-  url: https://github.com/chapmanb/bcbio-nextgen/archive/02f373a.tar.gz
-  md5: d74c6773e96cd3758d792250c9cb0d8d
+  fn: bcbio-nextgen-9c30509.tar.gz
+  url: https://github.com/chapmanb/bcbio-nextgen/archive/9c30509.tar.gz
+  md5: 2f470682c39127d6ca2d54f5196e4665
 
 requirements:
   build:

--- a/recipes/cwltool/meta.yaml
+++ b/recipes/cwltool/meta.yaml
@@ -8,7 +8,7 @@ source:
   md5: 899c22688bfcc5c361a6c192ab1872ef
 
 build:
-  number: 0
+  number: 1
   skip: True # [not py27]
 
 requirements:
@@ -22,11 +22,10 @@ requirements:
     - shellescape
     - cwltest
     - schema-salad ==2.2.20170216125639
-    - typing >=3.5.2
+    - typing >=3.5.2,<3.6
 
   run:
     - python
-    - setuptools
     - requests
     - ruamel.yaml >=0.12.4
     - rdflib >=4.2.2
@@ -34,7 +33,7 @@ requirements:
     - shellescape
     - cwltest
     - schema-salad ==2.2.20170216125639
-    - typing >=3.5.2
+    - typing >=3.5.2,<3.6
 
 test:
   imports:

--- a/recipes/gridss/meta.yaml
+++ b/recipes/gridss/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.3.2" %}
+{% set version = "1.3.4" %}
 
 package:
   name: gridss
@@ -7,7 +7,7 @@ package:
 source:
   fn: gridss-{{ version }}.jar
   url: https://github.com/PapenfussLab/gridss/releases/download/v{{ version }}/gridss-{{version}}-jar-with-dependencies.jar
-  sha256: 4a97971d3dff271f262a19ec1ba3bd860ad9792586e2abd1ed7a38b9e206bf06
+  md5: 6ccca8c848540e40da45407550e5db5a
 
 build:
   number: 0
@@ -15,7 +15,7 @@ build:
 
 requirements:
   run:
-    - java-jdk >=8
+    - openjdk >=8
     - python
 
 test:

--- a/recipes/schema-salad/meta.yaml
+++ b/recipes/schema-salad/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - rdflib >=4.2.0
     - rdflib-jsonld >=0.3.0
     - mistune
-    - typing >=3.5.2
+    - typing >=3.5.2,<3.6
     - ruamel.yaml >=0.12.4
     - cachecontrol
     - lockfile
@@ -34,7 +34,7 @@ requirements:
     - rdflib >=4.2.0
     - rdflib-jsonld >=0.3.0
     - mistune
-    - typing >=3.5.2
+    - typing >=3.5.2,<3.6
     - ruamel.yaml >=0.12.4
     - cachecontrol
     - lockfile


### PR DESCRIPTION
- arvados-cwl-runner -- update to latest release
- gridss -- include fix for disk space usage in latest release
- cwltool, schema-salad -- pin to correct version of typing
- bcbio-nextgen -- support for generating WDL compatible output

* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
