### PR TITLE
Add jellyfish 1 as run requirement for kraken

### DIFF
--- a/recipes/kraken/meta.yaml
+++ b/recipes/kraken/meta.yaml
@@ -4,9 +4,10 @@ package:
 source:
   fn: kraken-eaf8fb68.tar.gz
   url: https://github.com/DerrickWood/kraken/archive/eaf8fb68.tar.gz
+  sha256: 0425fb88ce1d66ca5187cf348970d1dd2cec61d69bd53c466ca43f957de71ffd
 
 build:
-  number: 2
+  number: 3
   skip: True # [osx]
   has_prefix_files:
     - libexec/kraken
@@ -18,12 +19,15 @@ build:
 
 requirements:
   build:
+    - perl
   run:
-    - perl-threaded
+    - jellyfish 1.*
+    - perl
 
 test:
   commands:
     - kraken --version 2>&1 > /dev/null
+    - kraken-build --version
 
 about:
   home: http://ccb.jhu.edu/software/kraken/


### PR DESCRIPTION
It is required for `kraken-build`.
Also add `perl` as build requirement.
Change `perl-threaded` to `perl`.

* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
