### PR TITLE
Update: kraken to fix missing `.bak` files

### DIFF
--- a/recipes/kraken/0.10.5beta/build.sh
+++ b/recipes/kraken/0.10.5beta/build.sh
@@ -5,6 +5,8 @@ mkdir -p "$PREFIX/libexec" "$PREFIX/bin"
 chmod u+x install_kraken.sh
 ./install_kraken.sh "$PREFIX/libexec"
 for bin in kraken kraken-build kraken-filter kraken-mpa-report kraken-report kraken-translate; do
+    sed -i.bak 's|#!/usr/bin/perl|#!/usr/bin/env perl|' $PREFIX/libexec/$bin
+    rm -f $PREFIX/libexec/$bin.bak
     chmod +x "$PREFIX/libexec/$bin"
     ln -s "$PREFIX/libexec/$bin" "$PREFIX/bin/$bin"
 done

--- a/recipes/kraken/0.10.5beta/meta.yaml
+++ b/recipes/kraken/0.10.5beta/meta.yaml
@@ -4,6 +4,7 @@ package:
 source:
   fn: kraken-0.10.5-beta.tar.gz
   url: https://github.com/DerrickWood/kraken/archive/v0.10.5-beta.tar.gz
+  md5: 0231a7bfc067f564ad28fa91e9f71606
 
 build:
   skip: True # [osx]
@@ -14,6 +15,13 @@ build:
     - libexec/kraken-mpa-report
     - libexec/kraken-report
     - libexec/kraken-translate
+
+requirements:
+  build:
+    - perl
+  run:
+    - perl
+
 test:
   commands:
     - kraken --version 2>&1 > /dev/null

--- a/recipes/kraken/build.sh
+++ b/recipes/kraken/build.sh
@@ -5,8 +5,9 @@ mkdir -p "$PREFIX/libexec" "$PREFIX/bin"
 chmod u+x install_kraken.sh
 ./install_kraken.sh "$PREFIX/libexec"
 for bin in kraken kraken-build kraken-filter kraken-mpa-report kraken-report kraken-translate; do
+    sed -i.bak 's|#!/usr/bin/perl|#!/usr/bin/env perl|' $PREFIX/libexec/$bin
+    rm -f $PREFIX/libexec/$bin.bak
     chmod +x "$PREFIX/libexec/$bin"
     ln -s "$PREFIX/libexec/$bin" "$PREFIX/bin/$bin"
 done
 
-sed -i.bak 's|#!/usr/bin/perl|#!/usr/bin/env perl|' $PREFIX/bin/*

--- a/recipes/kraken/meta.yaml
+++ b/recipes/kraken/meta.yaml
@@ -7,7 +7,7 @@ source:
   sha256: 0425fb88ce1d66ca5187cf348970d1dd2cec61d69bd53c466ca43f957de71ffd
 
 build:
-  number: 3
+  number: 4
   skip: True # [osx]
   has_prefix_files:
     - libexec/kraken


### PR DESCRIPTION
kraken had a global sed to fix perl files that created `.bak` files
for internal anaconda files (like activate) that causes install
issues.
https://groups.google.com/d/msg/biovalidation/hZBLfeOqMDc/SGr6Gxv7AgAJ

* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
