### PR TITLE
Require deseq2 version built with conda > 2.0. Change r to r-base

### DIFF
--- a/recipes/bioconductor-dexseq/meta.yaml
+++ b/recipes/bioconductor-dexseq/meta.yaml
@@ -3,10 +3,10 @@ package:
   version: 1.20.1
 source:
   fn: DEXSeq_1.20.1.tar.gz
-  url: http://bioconductor.org/packages/release/bioc/src/contrib/DEXSeq_1.20.1.tar.gz
+  url: https://depot.galaxyproject.org/software/bioconductor-dexseq/bioconductor-dexseq_1.20.1_src_all.tar.gz
   md5: 020cf1c4899bb19fb3854d86e72132e1
 build:
-  number: 0
+  number: 1
   skip: True # [py3k or osx]
   rpaths:
     - lib/R/lib/
@@ -18,7 +18,7 @@ requirements:
     - bioconductor-biocgenerics
     - bioconductor-biocparallel
     - bioconductor-biomart
-    - 'bioconductor-deseq2 >=1.9.11'
+    - 'bioconductor-deseq2 >=1.14.1'
     - bioconductor-genefilter
     - bioconductor-geneplotter
     - 'bioconductor-genomicranges >=1.23.7'
@@ -26,7 +26,7 @@ requirements:
     - bioconductor-rsamtools
     - bioconductor-s4vectors
     - bioconductor-summarizedexperiment
-    - r
+    - r-base
     - r-hwriter
     - r-rcolorbrewer
     - r-statmod
@@ -37,7 +37,7 @@ requirements:
     - bioconductor-biocgenerics
     - bioconductor-biocparallel
     - bioconductor-biomart
-    - 'bioconductor-deseq2 >=1.9.11'
+    - 'bioconductor-deseq2 >=1.14.1'
     - bioconductor-genefilter
     - bioconductor-geneplotter
     - 'bioconductor-genomicranges >=1.23.7'
@@ -45,7 +45,7 @@ requirements:
     - bioconductor-rsamtools
     - bioconductor-s4vectors
     - bioconductor-summarizedexperiment
-    - r
+    - r-base
     - r-hwriter
     - r-rcolorbrewer
     - r-statmod
@@ -55,7 +55,7 @@ test:
   commands:
     - '$R -e "library(''DEXSeq'')"'
 about:
-  home: http://bioconductor.org/packages/release/bioc/html/DEXSeq.html
+  home: https://bioconductor.org/packages/release/bioc/html/DEXSeq.html
   license: 'GPL (>= 3)'
   summary: 'The package is focused on finding differential exon usage using RNA-seq
     exon counts between samples with different experimental designs. It provides functions


### PR DESCRIPTION
Use depot URL, upstream is gone.

* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
