### PR TITLE
Update rmblast as per #4324

### DIFF
--- a/recipes/rmblast/build.sh
+++ b/recipes/rmblast/build.sh
@@ -18,9 +18,17 @@ elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
     cd $SRC_DIR/c++
     ./configure --prefix=$PREFIX --with-mt --without-debug
 
-    make
+    make > make.log 2>&1
+
+    echo "Last 1000 lines of make log"
+    tail -1000 make.log
 
     cp $SRC_DIR/c++/GCC*-ReleaseMT*/bin/rmblastn $PREFIX/bin
 fi
 
 chmod +x $PREFIX/bin/*
+
+# if we only have libbz2.so.1.0, make a symlink to libbz2.so.1
+if [[ ! -e $PREFIX/lib/libbz2.so.1 && -e $PREFIX/lib/libbz2.so.1.0 ]] ; then
+  ln -s $PREFIX/lib/libbz2.so.1.0 $PREFIX/lib/libbz2.so.1
+fi

--- a/recipes/rmblast/meta.yaml
+++ b/recipes/rmblast/meta.yaml
@@ -1,4 +1,4 @@
-package:
+package: 
     name: rmblast
     version: 2.2.28
 source:
@@ -10,21 +10,26 @@ source:
     md5: 421c5ddf2c425800d934562c965e8706 # [osx]
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
-    - boost # [linux]
+    - boost <=1.58 # [linux]
     - gcc # [linux]
+    - bzip2 1.0.6 1 # [linux]
     - zlib # [linux]
   run:
-    - boost # [linux]
+    - boost <=1.58 # [linux]
     - libgcc # [linux]
+    - bzip2 1.0.6 1 # [linux]
     - zlib # [linux]
     - blast
+
 test:
     commands:
         - rmblastn -help > /dev/null
+        - makeblastdb -help > /dev/null
+
 about:
     home: http://www.repeatmasker.org/RMBlast.html
     license: OSL-2.1


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

This is a cleaned up version of the commits that went into PR #4324. It:

* adds the bzip2 dependency for rmblast (for makeblastdb)
* adds code to the build.sh to link bzip2.so.1.0 to bzip2.so.1 if necessary
* locks boost to <= 1.58