### PR TITLE
Build additional object files used by GffCompare

### DIFF
--- a/recipes/gclib/Makefile.patch
+++ b/recipes/gclib/Makefile.patch
@@ -1,0 +1,19 @@
+diff --git a/Makefile b/Makefile
+index 43a9c91..d937ddd 100644
+--- a/Makefile
++++ b/Makefile
+@@ -75,12 +75,13 @@ LIBS :=
+ OBJS := GBase.o GStr.o GArgs.o
+ 
+ .PHONY : all
+-all:    gtest threads
++all:    gtest threads gffcomparelibs
+ 
+ version: ; @echo "GCC Version is: "$(GCC_MAJOR)":"$(GCC_MINOR)":"$(GCC_SUB)
+ 	@echo "> GCC Opt. string is: "$(GCC45OPTS)
+ debug:  gtest threads
+ nodebug:  gtest threads
++gffcomparelibs: codons.o gdna.o GFaSeqGet.o GFastaIndex.o gff.o
+ gtest.o : GBase.h GArgs.h GVec.hh GList.hh GBitVec.h
+ GArgs.o : GArgs.h
+ gtest: $(OBJS) gtest.o

--- a/recipes/gclib/build.sh
+++ b/recipes/gclib/build.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-mkdir -p $PREFIX/lib $PREFIX/bin
+mkdir -p $PREFIX/lib $PREFIX/bin $PREFIX/include
 make
-install *.o $PREFIX/lib/
+install *.o -v $PREFIX/lib/
+install *.h -v $PREFIX/include/
 install gtest $PREFIX/bin/
 install threads $PREFIX/bin/
-

--- a/recipes/gclib/build.sh
+++ b/recipes/gclib/build.sh
@@ -2,7 +2,7 @@
 
 mkdir -p $PREFIX/lib $PREFIX/bin $PREFIX/include
 make
-install *.o -v $PREFIX/lib/
-install *.h -v $PREFIX/include/
+install *.o $PREFIX/lib/
+install *.h $PREFIX/include/
 install gtest $PREFIX/bin/
 install threads $PREFIX/bin/

--- a/recipes/gclib/meta.yaml
+++ b/recipes/gclib/meta.yaml
@@ -3,13 +3,15 @@ package:
   version: "0.0.1"
 
 build:
-    number: 0
+    number: 1
     skip: False
 
 source:
   fn: gclib-0.0.1.tar.gz
   url: https://github.com/gpertea/gclib/archive/907a9d6484b92ea0c357baf2da5d85bc6e6b82b1.tar.gz
   md5: 13891db103fab3457beb621ab43f8843
+  patches:
+    - Makefile.patch
 
 requirements:
   build:


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

GffCompare links with GFastaIndex.o, among others, which gclib's Makefile doesn't build. With this change, that is no longer the case. Obviously GffCompare's Makefile will also need to be patched to reflect this modification.