### PR TITLE
updated to latest release of Kaptive

### DIFF
--- a/recipes/kaptive/meta.yaml
+++ b/recipes/kaptive/meta.yaml
@@ -1,22 +1,21 @@
 package:
   name: kaptive
-  version: "0.2"
+  version: "0.3"
 
 source:
-  url: https://github.com/katholt/Kaptive/archive/0.2.tar.gz
-  md5: f001e9be1c25acf6bda1b1a9bc7e6d87
+  url: https://github.com/katholt/Kaptive/archive/0.3.tar.gz
+  md5: c68074382cc8eb0c86c914f66405a546
 
 build:
   number: 0
-  skip: True  # [py3k]
 
 requirements:
   build:
     - biopython ==1.68
-    - blast ==2.5.0
+    - blast ==2.2.31
 
   run:
-    - blast ==2.5.0
+    - blast ==2.2.31
     - biopython ==1.68
     - python
 


### PR DESCRIPTION
Tool only works for blast 2.30 or lower if you want multiple threading. Also now has support for python 3 so removed those restriction

* [ ] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
