### PR TITLE
Biopython License Agreement, not MIT.

### DIFF
--- a/recipes/biopython/meta.yaml
+++ b/recipes/biopython/meta.yaml
@@ -15,17 +15,18 @@ source:
 
 build:
   number: 1
+  skip: True # [py34]
 
 requirements:
   build:
     - python
-    - numpy
+    - numpy x.x
     - reportlab
     - mmtf-python
 
   run:
     - python
-    - numpy
+    - numpy x.x
     - reportlab
     - mmtf-python
 

--- a/recipes/biopython/meta.yaml
+++ b/recipes/biopython/meta.yaml
@@ -14,7 +14,7 @@ source:
   md5: 078e915185485a5327937029b7577ddc
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipes/biopython/meta.yaml
+++ b/recipes/biopython/meta.yaml
@@ -4,9 +4,9 @@ package:
 
 about:
   home: http://www.biopython.org/
-  license: MIT
+  license: Biopython License Agreement
+  license_file: LICENSE
   summary: 'Freely available tools for computational molecular biology.'
-  license_family: MIT
 
 source:
   fn: biopython-1.68.tar.gz


### PR DESCRIPTION
This should resolve #4399 (but does not pick a license family for the metadata)

* [ ] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Note I recommend applying this prior to #4403 in order to fix the Biopython 1.68 recipe.

Then, as part of supporting Biopython 1.69, update the ``license_file:`` to point at ``LICENSE.rst`` to reflect this being renamed in Biopython 1.69