### PR TITLE
Qiime

### DIFF
--- a/recipes/qiime/1.9.1/meta.yaml
+++ b/recipes/qiime/1.9.1/meta.yaml
@@ -6,9 +6,11 @@ source:
   fn: qiime-1.9.1.tar.gz
   url: https://pypi.python.org/packages/source/q/qiime/qiime-1.9.1.tar.gz
   md5: 32d4db2b2c888dbbfc6aa33f02725526
+  sha1: 2ab4ac9beb745ed3eca3243312cc9ce14e8a20d8
+  sha256: c12dcdae1fe44762a49668276d7e93f487d87a0dc2ff8ca696ac0eff9d92a8a8
 
 build:
-  number: 0
+  number: 1
   skip: True # [not py27]
 
 requirements:
@@ -19,13 +21,13 @@ requirements:
     - scipy >=0.14.0
     - cogent ==1.5.3
     - natsort <4.0.0
-    - matplotlib >=1.1.0,!=1.4.2,<1.5.0
     - pynast ==1.2.2
     - qcli >=0.1.1,<0.2.0
     - gdata
     - biom-format >=2.1.4,<2.2.0
     - emperor >=0.9.51,<1.0.0
     - scikit-bio >=0.2.3,<0.3.0
+    - matplotlib >=1.1.0,!=1.4.2,<1.5.0
     - burrito-fillings >=0.1.1,<0.2.0
     - pandas >=0.13.1
     - burrito >=0.9.1,<1.0.0
@@ -39,19 +41,26 @@ requirements:
     - scipy >=0.14.0
     - cogent ==1.5.3
     - natsort <4.0.0
-    - matplotlib >=1.1.0,!=1.4.2,<1.5.0
     - pynast ==1.2.2
     - qcli >=0.1.1,<0.2.0
     - gdata
     - biom-format >=2.1.4,<2.2.0
     - emperor >=0.9.51,<1.0.0
     - scikit-bio >=0.2.3,<0.3.0
+    - matplotlib >=1.1.0,!=1.4.2,<1.5.0
     - burrito-fillings >=0.1.1,<0.2.0
     - pandas >=0.13.1
     - burrito >=0.9.1,<1.0.0
     - qiime-default-reference >=0.1.2,<0.2.0
     - mock
     - nose
+    - libgcc
+    - glib
+    - xorg-libxext
+    - xorg-libxdmcp
+    - xorg-libsm
+    - xorg-libxrender
+    - xorg-libxau
 
 test:
   # Python imports
@@ -60,6 +69,165 @@ test:
     - qiime.util
     - qiime.check_id_map
     - qiime.sort
+
+  commands:
+    - add_alpha_to_mapping_file.py -h
+    - add_qiime_labels.py -h
+    - adjust_seq_orientation.py -h
+    - align_seqs.py -h
+    - alpha_diversity.py -h
+    - alpha_rarefaction.py -h
+    - amplicon_contingency_table.py # no option
+    - ampliconnoise.py -h
+    - assign_taxonomy.py -h
+    - beta_diversity.py -h
+    - beta_diversity_through_plots.py -h
+    - beta_significance.py -h
+    - blast_wrapper.py -h
+    - categorized_dist_scatterplot.py -h
+    - check_id_map.py -h
+    - clean_raxml_parsimony_tree.py -h
+    - cluster_quality.py -h
+    - collapse_samples.py -h
+    - collate_alpha.py -h
+    - compare_alpha_diversity.py -h
+    - compare_categories.py -h
+    - compare_distance_matrices.py -h
+    - compare_taxa_summaries.py -h
+    - compare_trajectories.py -h
+    - compute_core_microbiome.py -h
+    - compute_taxonomy_ratios.py -h
+    - conditional_uncovered_probability.py -h
+    - consensus_tree.py -h
+    - convert_fastaqual_fastq.py -h
+    - convert_unifrac_sample_mapping_to_otu_table.py -h
+    - core_diversity_analyses.py -h
+    - count_seqs.py -h
+    - demultiplex_fasta.py -h
+    - denoise_wrapper.py -h
+    - denoiser.py -h
+    - denoiser_preprocess.py -h
+    - denoiser_worker.py -h
+    - detrend.py -h
+    - differential_abundance.py -h
+    - dissimilarity_mtx_stats.py -h
+    - distance_matrix_from_mapping.py -h
+    - estimate_observation_richness.py -h
+    - exclude_seqs_by_blast.py -h
+    - extract_barcodes.py -h
+    - extract_reads_from_interleaved_file.py -h
+    - extract_seqs_by_sample_id.py -h
+    - filter_alignment.py -h
+    - filter_distance_matrix.py -h
+    - filter_fasta.py -h
+    - filter_otus_by_sample.py -h
+    - filter_otus_from_otu_table.py -h
+    - filter_samples_from_otu_table.py -h
+    - filter_taxa_from_otu_table.py -h
+    - filter_tree.py -h
+    - fix_arb_fasta.py -h
+    - group_significance.py -h
+    - identify_chimeric_seqs.py -h
+    - identify_missing_files.py -h
+    - identify_paired_differences.py -h
+    - inflate_denoiser_output.py -h
+    - jackknifed_beta_diversity.py -h
+    - join_paired_ends.py -h
+    - load_remote_mapping_file.py -h
+    - make_2d_plots.py -h
+    - make_bipartite_network.py -h
+    - make_bootstrapped_tree.py -h
+    - make_distance_boxplots.py -h
+    - make_distance_comparison_plots.py -h
+    - make_fastq.py -h
+    - make_library_id_lists.py -h
+    - make_otu_heatmap.py -h
+    - make_otu_heatmap_html.py -h
+    - make_otu_network.py -h
+    - make_otu_table.py -h
+    - make_per_library_sff.py -h
+    - make_phylogeny.py -h
+    - make_prefs_file.py -h
+    - make_qiime_py_file.py -h
+    - make_rarefaction_plots.py -h
+    - make_tep.py -h
+    - map_reads_to_reference.py -h
+    - merge_mapping_files.py -h
+    - merge_otu_maps.py -h
+    - merge_otu_tables.py -h
+    - multiple_extract_barcodes.py -h
+    - multiple_join_paired_ends.py -h
+    - multiple_rarefactions.py -h
+    - multiple_rarefactions_even_depth.py -h
+    - multiple_split_libraries_fastq.py -h
+    - neighbor_joining.py -h
+    - nmds.py -h
+    - normalize_table.py -h
+    - observation_metadata_correlation.py -h
+    - otu_category_significance.py -h
+    - parallel_align_seqs_pynast.py -h
+    - parallel_alpha_diversity.py -h
+    - parallel_assign_taxonomy_blast.py -h
+    - parallel_assign_taxonomy_rdp.py -h
+    - parallel_assign_taxonomy_uclust.py -h
+    - parallel_beta_diversity.py -h
+    - parallel_blast.py -h
+    - parallel_identify_chimeric_seqs.py -h
+    - parallel_map_reads_to_reference.py -h
+    - parallel_merge_otu_tables.py -h
+    - parallel_multiple_rarefactions.py -h
+    - parallel_pick_otus_blast.py -h
+    - parallel_pick_otus_sortmerna.py -h
+    - parallel_pick_otus_trie.py -h
+    - parallel_pick_otus_uclust_ref.py -h
+    - parallel_pick_otus_usearch61_ref.py -h
+    - pick_closed_reference_otus.py -h
+    - pick_de_novo_otus.py -h
+    - pick_open_reference_otus.py -h
+    - pick_otus.py -h
+    - pick_rep_set.py -h
+    - plot_rank_abundance_graph.py -h
+    - plot_semivariogram.py -h
+    - plot_taxa_summary.py -h
+    - poller.py -h
+    - principal_coordinates.py -h
+    - print_metadata_stats.py -h
+    - print_qiime_config.py -h
+    - process_iseq.py -h
+    - process_qseq.py -h
+    - process_sff.py -h
+    - quality_scores_plot.py -h
+    - relatedness.py -h
+    - shared_phylotypes.py -h
+    - simsam.py -h
+    - single_rarefaction.py -h
+    - sort_otu_table.py -h
+    - split_libraries.py -h
+    - split_libraries_fastq.py -h
+    - split_libraries_lea_seq.py -h
+    - split_otu_table.py -h
+    - split_otu_table_by_taxonomy.py -h
+    - split_sequence_file_on_sample_ids.py -h
+    - start_parallel_jobs.py -h
+    - start_parallel_jobs_sc.py -h
+    - start_parallel_jobs_slurm.py -h
+    - start_parallel_jobs_torque.py -h
+    - subsample_fasta.py -h
+    - summarize_otu_by_cat.py -h
+    - summarize_taxa.py -h
+    - summarize_taxa_through_plots.py -h
+    - supervised_learning.py -h
+    - swarm_breaker.py -h
+    - transform_coordinate_matrices.py -h
+    - tree_compare.py -h
+    - trflp_file_to_otu_table.py -h
+    - trim_sff_primers.py -h
+    - truncate_fasta_qual_files.py -h
+    - truncate_reverse_primer.py -h
+    - unweight_fasta.py -h
+    - upgma_cluster.py -h
+    - validate_demultiplexed_fasta.py -h
+    - validate_mapping_file.py -h
 
 about:
   home: http://www.qiime.org


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

The current qiime recipe fails because the matplotlib requirement in the recipe is overwrited by the matplotlib requirement of the scikit-bio recipe (scikit-bio installs the last matplotlib version which is the version 2.0.0 when redacting this message)
Moving the matplotlib requirement after the scikit-bio requirement solves the issue.

Following additional libs are required to pass the travis tests. The related issues are detailled in parenthesis:
    - libgcc (ImportError: libstdc++.so.6:: cannot open shared object file: No such file or directory)
    - glib (ImportError: libgthread-2.0.so.0: cannot open shared object file: No such file or directory)
    - xorg-libxext (ImportError: libXext.so.6: cannot open shared object file: No such file or directory)
    - xorg-libxdmcp (ImportError: libXdmcp.so.6: cannot open shared object file: No such file or directory)
    - xorg-libsm (ImportError: libSM.so.6: cannot open shared object file: No such file or directory)
    - xorg-libxrender (ImportError: libXrender.so.1: cannot open shared object file: No such file or directory)
    - xorg-libxau (ImportError: libXau.so.6: cannot open shared object file: No such file or directory)

The import tests are completed by the command tests (they are thoses that lead me to the initial matplotlib issue).

@bgruening: is it the normal conda behavior to overwrite constraints on requirements like the matplotlib issues solved by this PR? A safe behavior will be: (1) make the (recursive) union of all constraints of the requirement, (2) check the constraints consistency to tell if the installation is possible, and (3) when requirement contraints are satisfied, install a right version of each requirement.