### PR TITLE
[ci skip] Setup buildkite configuration as a submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".buildkite"]
+	path = .buildkite
+	url = https://github.com/bioconda/bioconda-buildkite.git


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

Buildkite might at some point replace our travis setup. It allows us to host CI agents ourselves. By that, we can scale our build system with the community size. We keep the whole configuration in public (via bioconda/bioconda-buildkite), such that transparency is ensured.