### PR TITLE
Build and copy vcflib files for freebayes-parallel.

### DIFF
--- a/recipes/freebayes/build.sh
+++ b/recipes/freebayes/build.sh
@@ -1,30 +1,46 @@
 #!/bin/bash
 
-# MacOSX Build fix: https://github.com/chapmanb/homebrew-cbl/issues/14
 if [ "$(uname)" == "Darwin" ]; then
-   sed -i.bak 's/LDFLAGS=-Wl,-s/LDFLAGS=/' vcflib/smithwaterman/Makefile
-   export CXXFLAGS="${CXXFLAGS} -std=c++11 -stdlib=libc++"
+    # MacOSX Build fix: https://github.com/chapmanb/homebrew-cbl/issues/14.
+    sed -i.bak 's/LDFLAGS=-Wl,-s/LDFLAGS=/g' vcflib/smithwaterman/Makefile
+    export CXXFLAGS="${CXXFLAGS} -std=c++11 -stdlib=libc++"
+
+    # Patch vcflib: fix for missing <thread> include.
+    sed -i.bak 's/-std=c++0x/-std=c++11 -stdlib=libc++/g' vcflib/intervaltree/Makefile
+    sed -i.bak 's/-std=c++0x/-std=c++11 -stdlib=libc++/g' vcflib/Makefile
 fi
 
-export C_INCLUDE_PATH=$PREFIX/include
-export CFLAGS="-I$PREFIX/include"
+# Patch vcflib.
+# Tabix missing library https://github.com/ekg/tabixpp/issues/5.
+# Uses newline trick for OSX from: http://stackoverflow.com/a/24299845/252589.
+sed -i.bak 's/SUBDIRS=./SUBDIRS=.\'$'\n''LOBJS=tabix.o/' vcflib/tabixpp/Makefile
+sed -i.bak 's/-ltabix//' vcflib/Makefile
 
-# bamtools/cmake for zlib
+# Set exports.
+export CFLAGS="-I$PREFIX/include"
+export C_INCLUDE_PATH=$PREFIX/include
 export CPLUS_INCLUDE_PATH=${PREFIX}/include
 export LIBRARY_PATH=${PREFIX}/lib
 
-
+# Make bamtools.
 mkdir -p bamtools/build
 cd bamtools/build
 cmake ..
 cd ../..
 
+# Make autoversion.
 cd src
 make autoversion
 make CPPFLAGS="-I$PREFIX/include" LDFLAGS="-L$PREFIX/lib"
 cd ..
 
-pythonfiles="scripts/fasta_generate_regions.py scripts/coverage_to_regions.py"
+# Make vcflib (needed for freebayes-parallel).
+cd vcflib
+make
+cd ..
+
+# Translate for Python 3 if needed.
+pythonfiles="scripts/fasta_generate_regions.py scripts/coverage_to_regions.py vcflib/scripts/vcffirstheader"
 
 PY3_BUILD="${PY_VER%.*}"
 
@@ -33,10 +49,19 @@ then
     for i in $pythonfiles; do 2to3 --write $i; done
 fi
 
+# Copy executables.
 mkdir -p $PREFIX/bin
 cp -r bin/* $PREFIX/bin
+
+sed -i.bak 's/..\/vcflib\/scripts\///g; s/..\/vcflib\/bin\///g' scripts/freebayes-parallel
 cp scripts/freebayes-parallel $PREFIX/bin
+
 sed -i.bak 's@#!/usr/bin/python@#!/usr/bin/env python@g' scripts/fasta_generate_regions.py
 cp scripts/fasta_generate_regions.py $PREFIX/bin
+
 cp scripts/coverage_to_regions.py $PREFIX/bin
 cp scripts/generate_freebayes_region_scripts.sh $PREFIX/bin
+
+cp vcflib/bin/vcfstreamsort $PREFIX/bin
+cp vcflib/bin/vcfuniq $PREFIX/bin
+cp vcflib/scripts/vcffirstheader $PREFIX/bin

--- a/recipes/freebayes/meta.yaml
+++ b/recipes/freebayes/meta.yaml
@@ -3,8 +3,8 @@ package:
   version: '1.1.0'
 
 source:
-  git_url: https://github.com/walaj/freebayes.git
-  git_tag: 09d4ecff4eb3fdde2965a4af1512ab541d3122d0
+  url: https://github.com/ekg/freebayes/archive/v1.1.0.tar.gz
+  sha256: 6e1500346b0cc739334b6c21747e9f2a9ed3811d93cd6e8111ad45fb4d7fcc01
 
 build:
   number: 2

--- a/recipes/freebayes/meta.yaml
+++ b/recipes/freebayes/meta.yaml
@@ -7,8 +7,8 @@ source:
   git_tag: 09d4ecff4eb3fdde2965a4af1512ab541d3122d0
 
 build:
-  number: 1
-  skip: False
+  number: 2
+  skip: true  # [osx]
 
 requirements:
   build:
@@ -21,10 +21,12 @@ requirements:
     - zlib
     - python
     - libgcc    # [not osx]
+    - htslib <1.4
 
 test:
   commands:
     - freebayes --version
+    - vcfstreamsort -h
 
 about:
   home: https://github.com/ekg/freebayes

--- a/recipes/freebayes/meta.yaml
+++ b/recipes/freebayes/meta.yaml
@@ -3,8 +3,8 @@ package:
   version: '1.1.0'
 
 source:
-  url: https://github.com/ekg/freebayes/archive/v1.1.0.tar.gz
-  sha256: 6e1500346b0cc739334b6c21747e9f2a9ed3811d93cd6e8111ad45fb4d7fcc01
+  git_url: https://github.com/ekg/freebayes.git
+  git_tag: 39e5e4bcb801556141f2da36aba1df5c5c60701f
 
 build:
   number: 2


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Update of previous PR (#2588), which no longer pointed to a valid branch. Fixes issues mentioned in #2148. Essentially, the modified recipe now also builds the vcflib submodule and copies the required scripts + library from the vcflib directory for freebayes-parallel.

I am still having some trouble building for OSX. My initial problems with intervaltree are fixed after replacing ``-std=c++0x`` with ``-std=c++11 -stdlib=libc++``. However, I still run into the following error:

```
  "std::basic_ostream<char, std::char_traits<char> >& std::endl<char, std::char_traits<char> >(std::basic_ostream<char, std::char_traits<char> >&)", referenced from:
      FastaIndex::entry(std::string) in libvcflib.a(Fasta.o)
      FastaReference::open(std::string) in libvcflib.a(Fasta.o)
  "std::basic_istream<char, std::char_traits<char> >& std::getline<char, std::char_traits<char>, std::allocator<char> >(std::basic_istream<char, std::char_traits<char> >&, std::basic_string<char, std::char_traits<char>, std::allocator<char> >&, char)", referenced from:
      FastaIndex::readIndexFile(std::string) in libvcflib.a(Fasta.o)
      FastaIndex::indexReference(std::string) in libvcflib.a(Fasta.o)
  "std::basic_ostream<char, std::char_traits<char> >& std::operator<<<std::char_traits<char> >(std::basic_ostream<char, std::char_traits<char> >&, char const*)", referenced from:
      FastaIndex::entry(std::string) in libvcflib.a(Fasta.o)
      FastaReference::open(std::string) in libvcflib.a(Fasta.o)
  "std::basic_ostream<char, std::char_traits<char> >& std::operator<<<char, std::char_traits<char>, std::allocator<char> >(std::basic_ostream<char, std::char_traits<char> >&, std::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)", referenced from:
      FastaIndex::entry(std::string) in libvcflib.a(Fasta.o)
      FastaReference::open(std::string) in libvcflib.a(Fasta.o)
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [bin/vcfprimers] Error 1
```

Any ideas on how to fix this are welcome. Otherwise I propose skipping the OSX build (which the vcflib recipe also does).