### PR TITLE
GNU licenses like GPL, AGPL, LGPL are not public domain

### DIFF
--- a/recipes/biomaj/meta.yaml
+++ b/recipes/biomaj/meta.yaml
@@ -49,5 +49,5 @@ about:
   home: http://biomaj.genouest.org
   license: GNU Affero General Public License v3 or later (AGPLv3+)
   summary: 'BioMAJ'
-  license_family: Public-Domain
+  license_family: AGPL
   summary: Automates the update cycle and the supervision of the locally mirrored databank repository

--- a/recipes/biomaj/meta.yaml
+++ b/recipes/biomaj/meta.yaml
@@ -9,6 +9,9 @@ source:
   patches:
     - deps.patch
 
+build:
+  number: 1
+
 requirements:
   build:
     - python

--- a/recipes/biomaj/meta.yaml
+++ b/recipes/biomaj/meta.yaml
@@ -9,9 +9,6 @@ source:
   patches:
     - deps.patch
 
-build:
-  number: 1
-
 requirements:
   build:
     - python

--- a/recipes/circlator/meta.yaml
+++ b/recipes/circlator/meta.yaml
@@ -8,6 +8,7 @@ source:
   md5: c92bc70c40874f209e9e93378d6d0c9d
 
 build:
+  number: 1
   skip: True # [py27]
 
 requirements:

--- a/recipes/circlator/meta.yaml
+++ b/recipes/circlator/meta.yaml
@@ -8,7 +8,6 @@ source:
   md5: c92bc70c40874f209e9e93378d6d0c9d
 
 build:
-  number: 1
   skip: True # [py27]
 
 requirements:

--- a/recipes/circlator/meta.yaml
+++ b/recipes/circlator/meta.yaml
@@ -49,4 +49,4 @@ about:
   home: https://github.com/sanger-pathogens/circlator
   license: GNU General Public License v3 (GPLv3)
   summary: 'circlator: a tool to circularise genome assemblies'
-  license_family: Public-Domain
+  license_family: GPL

--- a/recipes/iva/meta.yaml
+++ b/recipes/iva/meta.yaml
@@ -44,4 +44,4 @@ about:
   home: https://github.com/sanger-pathogens/iva
   license: GNU General Public License v3 (GPLv3)
   summary: 'Iterative Virus Assembler'
-  license_family: Public-Domain
+  license_family: GPL

--- a/recipes/iva/meta.yaml
+++ b/recipes/iva/meta.yaml
@@ -8,7 +8,7 @@ source:
   md5: 45d4f46d47b3a2cd1a0ed799f266149f
 
 build:
-  number: 1
+  number: 0
   skip: True # [py2k]
 
 requirements:

--- a/recipes/iva/meta.yaml
+++ b/recipes/iva/meta.yaml
@@ -8,7 +8,7 @@ source:
   md5: 45d4f46d47b3a2cd1a0ed799f266149f
 
 build:
-  number: 0
+  number: 1
   skip: True # [py2k]
 
 requirements:

--- a/recipes/minepy/meta.yaml
+++ b/recipes/minepy/meta.yaml
@@ -31,5 +31,4 @@ about:
   home: http://minepy.readthedocs.io
   license: GNU General Public License (GPL)
   summary: 'minepy - Maximal Information-based Nonparametric Exploration'
-  license_family: Public-Domain
-
+  license_family: GPL

--- a/recipes/minepy/meta.yaml
+++ b/recipes/minepy/meta.yaml
@@ -8,7 +8,7 @@ source:
   md5: b22db1dfb5e96d909a46bacc072a77e6
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipes/minepy/meta.yaml
+++ b/recipes/minepy/meta.yaml
@@ -8,7 +8,7 @@ source:
   md5: b22db1dfb5e96d909a46bacc072a77e6
 
 build:
-  number: 1
+  number: 0
 
 requirements:
   build:

--- a/recipes/pepr/meta.yaml
+++ b/recipes/pepr/meta.yaml
@@ -71,7 +71,7 @@ about:
   home: https://github.com/shawnzhangyx/PePr/
   license: GNU General Public License v3 (GPLv3)
   summary: 'Peak-calling and Prioritization pipeline for replicated ChIP-Seq data'
-  license_family: Public-Domain
+  license_family: GPL
 
 # See
 # http://docs.continuum.io/conda/build.html for

--- a/recipes/pepr/meta.yaml
+++ b/recipes/pepr/meta.yaml
@@ -9,6 +9,7 @@ source:
   patches:
    # List any patch files here
     - setup.py.patch
+
 build:
   # noarch_python: True
   # preserve_egg_dir: True
@@ -24,9 +25,7 @@ build:
     - PePr-preprocess=PePr.PePr:pre_processing_module
     - PePr-postprocess=PePr.post_processing.post_process_PePr:post_processing_module
 
-  # If this is a new build for the same version, increment the build
-  # number. If you do not include this key, it defaults to 0.
-  # number: 1
+  number: 1
 
 requirements:
   build:

--- a/recipes/pepr/meta.yaml
+++ b/recipes/pepr/meta.yaml
@@ -9,7 +9,6 @@ source:
   patches:
    # List any patch files here
     - setup.py.patch
-
 build:
   # noarch_python: True
   # preserve_egg_dir: True
@@ -25,7 +24,9 @@ build:
     - PePr-preprocess=PePr.PePr:pre_processing_module
     - PePr-postprocess=PePr.post_processing.post_process_PePr:post_processing_module
 
-  number: 1
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
 
 requirements:
   build:

--- a/recipes/pyfasta/meta.yaml
+++ b/recipes/pyfasta/meta.yaml
@@ -24,7 +24,9 @@ build:
 
     - pyfasta = pyfasta:main
 
-  number: 1
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
 
 requirements:
   build:

--- a/recipes/pyfasta/meta.yaml
+++ b/recipes/pyfasta/meta.yaml
@@ -24,9 +24,7 @@ build:
 
     - pyfasta = pyfasta:main
 
-  # If this is a new build for the same version, increment the build
-  # number. If you do not include this key, it defaults to 0.
-  # number: 1
+  number: 1
 
 requirements:
   build:

--- a/recipes/pyfastaq/meta.yaml
+++ b/recipes/pyfastaq/meta.yaml
@@ -36,4 +36,4 @@ about:
   home: https://github.com/sanger-pathogens/Fastaq
   license: GNU General Public License v3 (GPLv3)
   summary: 'Script to manipulate FASTA and FASTQ files, plus API for developers'
-  license_family: Public-Domain
+  license_family: GPL

--- a/recipes/seqmagick/meta.yaml
+++ b/recipes/seqmagick/meta.yaml
@@ -39,4 +39,4 @@ about:
   home: http://github.com/fhcrc/seqmagick
   license: GNU General Public License (GPL)
   summary: 'Tools for converting and modifying sequence files from the command-line'
-  license_family: Public-Domain
+  license_family: GPL

--- a/recipes/seqmagick/meta.yaml
+++ b/recipes/seqmagick/meta.yaml
@@ -11,7 +11,7 @@ build:
   entry_points:
     - seqmagick = seqmagick.scripts.cli:main
   skip: True # [not py27]
-  number: 1
+  number: 0
 
 requirements:
   build:

--- a/recipes/seqmagick/meta.yaml
+++ b/recipes/seqmagick/meta.yaml
@@ -11,7 +11,7 @@ build:
   entry_points:
     - seqmagick = seqmagick.scripts.cli:main
   skip: True # [not py27]
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipes/stacks_summary/meta.yaml
+++ b/recipes/stacks_summary/meta.yaml
@@ -32,4 +32,4 @@ about:
   home: https://github.com/mariabernard/galaxy_wrappers
   license: GNU General Public License v3 or later (GPLv3+)
   summary: 'Stacks reports generator'
-  license_family: Public-Domain
+  license_family: GPL

--- a/recipes/stacks_summary/meta.yaml
+++ b/recipes/stacks_summary/meta.yaml
@@ -8,7 +8,7 @@ source:
   md5: 20e72a66a52502954894168f1cf197c3
 
 build:
-  number: 1
+  number: 0
   skip: True  # [not py27]
 
 requirements:

--- a/recipes/stacks_summary/meta.yaml
+++ b/recipes/stacks_summary/meta.yaml
@@ -8,7 +8,7 @@ source:
   md5: 20e72a66a52502954894168f1cf197c3
 
 build:
-  number: 0
+  number: 1
   skip: True  # [not py27]
 
 requirements:

--- a/recipes/xmltramp2/meta.yaml
+++ b/recipes/xmltramp2/meta.yaml
@@ -57,7 +57,7 @@ about:
   home: https://github.com/tBaxter/xmltramp2
   license: GNU General Public License v2 (GPLv2)
   summary: 'A modern refactoring of the venerable xmltramp application'
-  license_family: Public-Domain
+  license_family: GPL
 
 # See
 # http://docs.continuum.io/conda/build.html for

--- a/recipes/xmltramp2/meta.yaml
+++ b/recipes/xmltramp2/meta.yaml
@@ -6,9 +6,25 @@ source:
   fn: xmltramp2-3.1.1.tar.gz
   url: https://pypi.python.org/packages/28/56/a8628b716378b67c8536989ad9347a003328e83a52f0a5c65407331e59d3/xmltramp2-3.1.1.tar.gz
   md5: 1e803ef8c64ba619159572bd03f7b24b
+#  patches:
+   # List any patch files here
+   # - fix.patch
 
-build:
-  number: 1
+# build:
+  # noarch_python: True
+  # preserve_egg_dir: True
+  # entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - xmltramp2 = xmltramp2:main
+    #
+    # Would create an entry point called xmltramp2 that calls xmltramp2.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
 
 requirements:
   build:
@@ -21,8 +37,21 @@ requirements:
     - six
 
 test:
+  # Python imports
   imports:
     - xmltramp2
+
+  # commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
 
 about:
   home: https://github.com/tBaxter/xmltramp2

--- a/recipes/xmltramp2/meta.yaml
+++ b/recipes/xmltramp2/meta.yaml
@@ -6,25 +6,9 @@ source:
   fn: xmltramp2-3.1.1.tar.gz
   url: https://pypi.python.org/packages/28/56/a8628b716378b67c8536989ad9347a003328e83a52f0a5c65407331e59d3/xmltramp2-3.1.1.tar.gz
   md5: 1e803ef8c64ba619159572bd03f7b24b
-#  patches:
-   # List any patch files here
-   # - fix.patch
 
-# build:
-  # noarch_python: True
-  # preserve_egg_dir: True
-  # entry_points:
-    # Put any entry points (scripts to be generated automatically) here. The
-    # syntax is module:function.  For example
-    #
-    # - xmltramp2 = xmltramp2:main
-    #
-    # Would create an entry point called xmltramp2 that calls xmltramp2.main()
-
-
-  # If this is a new build for the same version, increment the build
-  # number. If you do not include this key, it defaults to 0.
-  # number: 1
+build:
+  number: 1
 
 requirements:
   build:
@@ -37,21 +21,8 @@ requirements:
     - six
 
 test:
-  # Python imports
   imports:
     - xmltramp2
-
-  # commands:
-    # You can put test commands to be run here.  Use this to test that the
-    # entry points work.
-
-
-  # You can also put a file called run_test.py in the recipe that will be run
-  # at test time.
-
-  # requires:
-    # Put any additional test requirements here.  For example
-    # - nose
 
 about:
   home: https://github.com/tBaxter/xmltramp2


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

I've not found any BioConda documentation defining the ``license_family:`` field (see also #1581), but none of the GNU licenses (i.e. any versions of the GPL and LGPL) can be considered as public domain.

It makes sense to me to class any version of the GPL as ``license_family: GPL`` as in this LGPL example:

```
about:
  home: https://pypi.python.org/pypi/xmlbuilder/1.0
  license: LGPL v3
  summary: 'pythonic way to crate xml/(x)html files'
  license_family: LGPL
```