### PR TITLE
Update: bcbio, bcbio-vm to force latest pysam

### DIFF
--- a/recipes/bcbio-nextgen-vm/meta.yaml
+++ b/recipes/bcbio-nextgen-vm/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: '0.1.0a'
 
 build:
-  number: 92
+  number: 93
   skip: True # [not py27]
 
 source:
@@ -20,7 +20,7 @@ requirements:
     - python
     - bcbio-nextgen >1.0.2
     - ipyparallel >=4.0,<5.0
-    - htslib
+    - pysam >=0.11.0
     - arvados-cwl-runner
     - cwl2wdl
     - toil

--- a/recipes/bcbio-nextgen/meta.yaml
+++ b/recipes/bcbio-nextgen/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: '1.0.3a'
 
 build:
-  number: 6
+  number: 7
   skip: True # [not py27]
 
 source:
@@ -60,7 +60,7 @@ requirements:
     - psutil
     - python-dateutil
     - pybedtools
-    - pysam
+    - pysam >=0.11.0
     - pyvcf
     - pyyaml
     - pyzmq


### PR DESCRIPTION
Use latest pysam to force consistent use of htslib 1.4

* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
