### PR TITLE
WIP initial work to upgrade bowtie to 2.3.1

### DIFF
--- a/recipes/bowtie2/meta.yaml
+++ b/recipes/bowtie2/meta.yaml
@@ -5,12 +5,12 @@ about:
 
 package:
   name: bowtie2
-  version: 2.3.0
+  version: 2.3.1
 
 source:
-  fn: bowtie2-2.3.0-source.zip
-  url: http://downloads.sourceforge.net/project/bowtie-bio/bowtie2/2.3.0/bowtie2-2.3.0-source.zip
-  sha256: f9f841e780e78b1ae24b17981e2469e6d5add90ec22ef563af23ae2dd5ca003c
+  fn: bowtie2-2.3.1-source.zip
+  url: https://sourceforge.net/projects/bowtie-bio/files/bowtie2/2.3.1/bowtie2-2.3.1-source.zip
+  sha256: 33bd54f5041a31878e7e450cdcf0afba08345fa1133ce8ac6fd00bf7e521a443
   patches:
     - bowtie2.patch
 
@@ -23,11 +23,15 @@ requirements:
     - llvm  # [osx]
     - python
     - tbb
+    - ncurses
+    - readline
   run:
     - python
-    - perl-threaded
+    - perl
     - libgcc    # [linux]
     - tbb
+    - ncurses
+    - readline
 
 test:
   commands:


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Don't pull this in yet - it does not build properly. @bgruening asked me to start this PR so we can try to handle the new readline dependency that seems to require termcap.

Here's the error I get locally when I run:
./simulate-travis.py --packages bowtie2
```
+ source /opt/conda/bin/activate /opt/conda/conda-bld/_b_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placeho
+ set -eu -o pipefail
+ make 'EXTRA_FLAGS=-I/opt/conda/conda-bld/_b_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placeho/include -L/opt/conda/conda-bld/_b_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placeho/lib'
g++ -O3 -m64 -msse2 -funroll-loops -g3 -DCOMPILER_OPTIONS="\"-O3 -m64 -msse2 -funroll-loops -g3 -I/opt/conda/conda-bld/_b_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placeho/include -L/opt/conda/conda-bld/_b_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placeho/lib -DPOPCNT_CAPABILITY -DWITH_TBB -DNO_SPINLOCK -DWITH_QUEUELOCK=1\"" -I/opt/conda/conda-bld/_b_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placeho/include -L/opt/conda/conda-bld/_b_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placeho/lib -DPOPCNT_CAPABILITY -DWITH_TBB -DNO_SPINLOCK -DWITH_QUEUELOCK=1 \
		-fno-strict-aliasing -DBOWTIE2_VERSION="\"`cat VERSION`\"" -DBUILD_HOST="\"`hostname`\"" -DBUILD_TIME="\"`date`\"" -DCOMPILER_VERSION="\"`g++ -v 2>&1 | tail -1`\"" -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE  -DBOWTIE_MM  -DBOWTIE2 -DNDEBUG -Wall \
		 -I third_party \
		-o bowtie2-build-s bt2_build.cpp \
		ccnt_lut.cpp ref_read.cpp alphabet.cpp shmem.cpp edit.cpp bt2_idx.cpp bt2_io.cpp bt2_util.cpp reference.cpp ds.cpp multikey_qsort.cpp limit.cpp random_source.cpp diff_sample.cpp bowtie_build_main.cpp \
		-lreadline -ltermcap -lz -lpthread -ltbb -ltbbmalloc_proxy
/opt/rh/devtoolset-2/root/usr/bin/ld: cannot find -ltermcap
collect2: error: ld returned 1 exit status
```