### PR TITLE
Stacks: fix runtime errors

### DIFF
--- a/recipes/stacks/build.sh
+++ b/recipes/stacks/build.sh
@@ -4,6 +4,9 @@ export CPATH=${PREFIX}/include
 export CFLAGS="-I${PREFIX}/include"
 export LDFLAGS="-L${PREFIX}/lib"
 
+# This is required until gcc>4.8 is available in conda
+export LDFLAGS="-lboost_regex $LDFLAGS"
+
 ./configure --prefix=$PREFIX --enable-sparsehash --enable-bam --includedir=${PREFIX}/include/bam --libdir=${PREFIX}/lib
 cp Makefile Makefile.bk
 sed "s|^LIBS=.*$|LIBS=\"-I$PREFIX/include/ -L$PREFIX/lib/ -lz -lgomp\"|" Makefile.bk > Makefile

--- a/recipes/stacks/gcc48.patch
+++ b/recipes/stacks/gcc48.patch
@@ -98,3 +98,55 @@
  # For test harness
  for ac_prog in gawk mawk nawk awk
  do
+--- a/src/sstacks.cc	2017-04-20 19:43:55.274105934 +0200
++++ b/src/sstacks.cc	2017-04-20 19:40:00.930177547 +0200
+@@ -22,7 +22,7 @@
+ // sstacks -- search for occurances of stacks in a catalog of stacks.
+ //
+ 
++#include <boost/regex.hpp>
+-#include <regex>
+ 
+ #include "catalog_utils.h"
+ #include "MetaPopInfo.h"
+@@ -30,6 +30,7 @@
+ #include "sstacks.h"
+ 
+ using namespace std;
++using namespace boost;
+ 
+ // Global variables to hold command-line options.
+ queue<string> samples;
+--- a/src/constants.cc	2017-04-20 19:43:32.793399833 +0200
++++ b/src/constants.cc	2017-04-20 19:41:33.523959091 +0200
+@@ -1,10 +1,11 @@
++#include <boost/regex.hpp>
+-#include <regex>
+ #include <cassert>
+ #include <map>
+ 
+ #include "constants.h"
+ 
+ using namespace std;
++using namespace boost;
+ 
+ const
+ map<string, FileT> known_extensions = {
+--- a/src/catalog_utils.cc	2017-04-20 19:44:48.203413967 +0200
++++ b/src/catalog_utils.cc	2017-04-20 19:44:21.373764722 +0200
+@@ -25,13 +25,14 @@
+ // jcatchen@uoregon.edu
+ // University of Oregon
+ //
++#include <boost/regex.hpp>
+-#include <regex>
+ 
+ #include "utils.h"
+ 
+ #include "catalog_utils.h"
+ 
+ using namespace std;
++using namespace boost;
+ 
+ const regex catalog_tags_regex ("^batch_([0-9]+).catalog.tags.tsv(.gz)?$");
+ 

--- a/recipes/stacks/meta.yaml
+++ b/recipes/stacks/meta.yaml
@@ -3,8 +3,9 @@ package:
   version: "1.46"
 
 build:
-  number: 0
+  number: 1
   skip: True # [osx]
+  string: boost{{CONDA_BOOST}}_{{PKG_BUILDNUM}}
 
 source:
   fn: stacks-1.46.tar.gz
@@ -21,12 +22,14 @@ requirements:
     - gcc # [linux]
     - zlib
     - sparsehash
+    - boost {{CONDA_BOOST}}*
   run:
     - perl
     - velvet
     - libgcc # [linux]
     - zlib
     - sparsehash
+    - boost {{CONDA_BOOST}}*
 
 test:
   commands:


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Now uses boost::regex instead of std::regex
It should fix runtime errors due to std::regex not being available in gcc 4.8