### PR TITLE
Rebuild r-mclust to build with conda-build > 2.0...

### DIFF
--- a/recipes/r-mclust/meta.yaml
+++ b/recipes/r-mclust/meta.yaml
@@ -1,7 +1,5 @@
 package:
   name: r-mclust
-  # Note that conda versions cannot contain -, so any -'s in the version have
-  # been replaced with _'s.
   version: "5.1"
 
 source:
@@ -9,21 +7,10 @@ source:
   url:
     - http://cran.r-project.org/src/contrib/mclust_5.1.tar.gz
     - http://cran.r-project.org/src/contrib/Archive/mclust/mclust_5.1.tar.gz
-
-
-  # You can add a hash for the file here, like md5 or sha1
-  # md5: 49448ba4863157652311cc5ea4fea3ea
-  # sha1: 3bcfbee008276084cbb37a2b453963c61176a322
-  # patches:
-   # List any patch files here
-   # - fix.patch
+  md5: f43b4bb255d8413fa932465a511f0c64
 
 build:
-  # If this is a new build for the same version, increment the build
-  # number. If you do not include this key, it defaults to 0.
   number: 1
-
-  # This is required to make R link correctly on Linux.
   rpaths:
     - lib/R/lib/
     - lib/
@@ -31,24 +18,16 @@ build:
 # Suggests: knitr (>= 1.8), rmarkdown (>= 0.6), mix
 requirements:
   build:
-    - r
-    - gcc # [not win]
+    - r-base
+    - gcc
 
   run:
-    - r
-    - libgcc # [not win]
+    - r-base
+    - libgcc
 
 test:
   commands:
-    # You can put additional test commands to be run here.
-    - $R -e "library('mclust')" # [not win]
-    - "\"%R%\" -e \"library('mclust')\"" # [win]
-
-  # You can also put a file called run_test.py, run_test.sh, or run_test.bat
-  # in the recipe that will be run at test time.
-
-  # requires:
-    # Put any additional test requirements here.
+    - $R -e "library('mclust')" 
 
 about:
   home: http://www.stat.washington.edu/mclust/

--- a/recipes/r-mclust/meta.yaml
+++ b/recipes/r-mclust/meta.yaml
@@ -21,7 +21,7 @@ source:
 build:
   # If this is a new build for the same version, increment the build
   # number. If you do not include this key, it defaults to 0.
-  number: 0
+  number: 1
 
   # This is required to make R link correctly on Linux.
   rpaths:


### PR DESCRIPTION
… to fix "PaddingError: Placeholder of length '80' too short in package bioconda::r-mclust-5.1-r3.3.1_0."

* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
