### PR TITLE
Update: svtyper, bcbio-nextgen

### DIFF
--- a/recipes/bcbio-nextgen/meta.yaml
+++ b/recipes/bcbio-nextgen/meta.yaml
@@ -3,16 +3,16 @@ package:
   version: '1.0.3a'
 
 build:
-  number: 8
+  number: 9
   skip: True # [not py27]
 
 source:
   #fn: bcbio-nextgen-1.0.2.tar.gz
   #url: https://pypi.python.org/packages/3f/c0/f8e46f5cbc3b4f04f94670b157737c2a402f40a2a5cc6168d7f1dee58f9e/bcbio-nextgen-1.0.2.tar.gz
   #md5: 0b8e7bf553b15173aeaa06102afa021a
-  fn: bcbio-nextgen-3a998f7.tar.gz
-  url: https://github.com/chapmanb/bcbio-nextgen/archive/3a998f7.tar.gz
-  md5: c2f1e011bafac45cf7baa700aec694af
+  fn: bcbio-nextgen-713bf71.tar.gz
+  url: https://github.com/chapmanb/bcbio-nextgen/archive/713bf71.tar.gz
+  md5: 2080a64daad0674ea8ac12d556f24f75
 
 requirements:
   build:
@@ -37,7 +37,6 @@ requirements:
     - htslib
     - ipyparallel >=4.0,<5.0
     - ipython-cluster-helper >=0.5.2
-    - ipywidgets
     - joblib
     - libsodium >=0.4,<1.0
     - logbook

--- a/recipes/svtyper/meta.yaml
+++ b/recipes/svtyper/meta.yaml
@@ -1,11 +1,13 @@
+{% set version="0.1.4" %}
+
 package:
   name: svtyper
-  version: 0.1.1
+  version: {{ version }}
 
 source:
-  fn: svtyper-0.1.1.tar.gz
-  url: https://github.com/hall-lab/svtyper/archive/v0.1.1.tar.gz
-  md5sum: nope
+  fn: svtyper-{{ version }}.tar.gz
+  url: https://github.com/hall-lab/svtyper/archive/v{{ version }}.tar.gz
+  md5: cd1b7a73a6cbf002c6398caef5bfa79a
 
 build:
   number: 0


### PR DESCRIPTION
- svtyper: support for --max_reads to downsample in complex regions
- bcbio-nextgen: Improved install size by removing mkl libraries
  and ipython notebook html with associated dependencies like pandoc.

* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
