### PR TITLE
Tries to solve dependency problem: pysam 0.10.0 + htslib

### DIFF
--- a/recipes/pysam/0.10.0/meta.yaml
+++ b/recipes/pysam/0.10.0/meta.yaml
@@ -18,9 +18,9 @@ requirements:
     build:
         - gcc  # [linux]
         - llvm # [osx]
-        - htslib >=1.3,<1.4
-        - samtools >=1.3,<1.4
-        - bcftools >=1.3,<1.4
+        - htslib ==1.3
+        - samtools ==1.3
+        - bcftools ==1.3
         - cython
         - python
         - setuptools
@@ -29,9 +29,9 @@ requirements:
 
     run:
         - libgcc # [linux]
-        - htslib >=1.3,<1.4
-        - samtools >=1.3,<1.4
-        - bcftools >=1.3,<1.4
+        - htslib ==1.3
+        - samtools ==1.3
+        - bcftools ==1.3
         - python
         - zlib
         - curl


### PR DESCRIPTION
Loading pysam 0.10.0 with htslib-1.4 this returns the following error:
```
  File "/home/<user>/anaconda2/envs/pysam0100/lib/python2.7/site-packages/pysam/__init__.py", line 5, in <module>
    from pysam.libchtslib import *
ImportError: libhts.so.1: cannot open shared object file: No such file or directory
```
This makes sense since pysam 0.10.0 was built against htslib 1.3.

Is there a possiblity to rebuild pysam 0.10.0 also with htslib 1.4 (e.g. by increasing the built nr.) or does it require to pin to htslib 1.3 or 1.4 explicitly? Could you please comment on this @chapmanb @kyleabeauchamp ? 
