### PR TITLE
bbmap 37.10 -> 37.17

### DIFF
--- a/recipes/bbmap/37.10/build.sh
+++ b/recipes/bbmap/37.10/build.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+BINARY_HOME=$PREFIX/bin
+BBMAP_HOME=$PREFIX/opt/bbmap-$PKG_VERSION
+
+cd $SRC_DIR
+
+# copy source to bin
+mkdir -p $PREFIX/bin
+mkdir -p $BBMAP_HOME
+cp -R $SRC_DIR/* $BBMAP_HOME/
+cd $BBMAP_HOME && chmod a+x *.sh
+
+#cd $BINARY_HOME
+cd $BBMAP_HOME
+find *.sh -type f -exec ln -s $BBMAP_HOME/{} $BINARY_HOME/{} \;

--- a/recipes/bbmap/37.10/meta.yaml
+++ b/recipes/bbmap/37.10/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "BBMap" %}
-{% set version = "37.17" %}
-{% set sha256 = "e51fc727b14ecd79bd323088903813eb02c70cc213c893d3d28e6a9cbd82b563" %}
+{% set version = "37.10" %}
+{% set sha256 = "61213d7898947e41f903b2629204d826fded2f19eadb48fcc0678b44326e88eb" %}
 
 about:
   home: 'https://sourceforge.net/projects/bbmap'


### PR DESCRIPTION
Also remove no_osx flag, it builds successfully on osx and the docs say osx is supported.

* [X] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
