### PR TITLE
Update: bcbio and bcbio-vm

### DIFF
--- a/recipes/bcbio-nextgen-vm/meta.yaml
+++ b/recipes/bcbio-nextgen-vm/meta.yaml
@@ -3,13 +3,13 @@ package:
   version: '0.1.0a'
 
 build:
-  number: 93
+  number: 94
   skip: True # [not py27]
 
 source:
-  fn: bcbio-nextgen-vm-b555c36.tar.gz
-  url: https://github.com/chapmanb/bcbio-nextgen-vm/archive/b555c36.tar.gz
-  md5: e68737569ee343b9562beb012436e017
+  fn: bcbio-nextgen-vm-d8cb02f.tar.gz
+  url: https://github.com/chapmanb/bcbio-nextgen-vm/archive/d8cb02f.tar.gz
+  md5: b81d2324d377f9a58c8d174834adafb2
 
 requirements:
   build:
@@ -23,10 +23,12 @@ requirements:
     - pysam >=0.11.0
     - arvados-cwl-runner
     - cwl2wdl
-    - toil
+    - ruamel.yaml >=0.13.0
+    - toil >=3.3.7a1
     - nodejs
     - elasticluster
     - nose
+    - sevenbridges-python
     - six
 
 test:

--- a/recipes/bcbio-nextgen/meta.yaml
+++ b/recipes/bcbio-nextgen/meta.yaml
@@ -3,16 +3,16 @@ package:
   version: '1.0.3a'
 
 build:
-  number: 9
+  number: 10
   skip: True # [not py27]
 
 source:
   #fn: bcbio-nextgen-1.0.2.tar.gz
   #url: https://pypi.python.org/packages/3f/c0/f8e46f5cbc3b4f04f94670b157737c2a402f40a2a5cc6168d7f1dee58f9e/bcbio-nextgen-1.0.2.tar.gz
   #md5: 0b8e7bf553b15173aeaa06102afa021a
-  fn: bcbio-nextgen-713bf71.tar.gz
-  url: https://github.com/chapmanb/bcbio-nextgen/archive/713bf71.tar.gz
-  md5: 2080a64daad0674ea8ac12d556f24f75
+  fn: bcbio-nextgen-13dfcb3.tar.gz
+  url: https://github.com/chapmanb/bcbio-nextgen/archive/13dfcb3.tar.gz
+  md5: c1a48b19b9c67842328416c680562edb
 
 requirements:
   build:


### PR DESCRIPTION
- Pins toil and ruamel.yaml versions to avoid getting old
  installs.
- Includes support for interacting with Seven Bridges and the Cancer
  Genomics Cloud

* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
