### PR TITLE
Bump Picopore to v1.1.4

### DIFF
--- a/recipes/picopore/meta.yaml
+++ b/recipes/picopore/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: picopore
-  version: "1.1.2"
+  version: "1.1.4"
 
 source:
-  fn: picopore-1.1.2.tar.gz
-  url: https://pypi.python.org/packages/0c/a3/06b6630153eb8d9a868c9377a7c489ace77f75925f461cf8ff92991138f0/picopore-1.1.2.tar.gz
-  md5: bd16455fd1065bb6dbb200ae5994982b
+  fn: picopore-1.1.4.zip
+  url: https://pypi.python.org/packages/bb/7e/87cc180009254d68bd70ce3467d1cf13ddae2f1dcdf4edd49133108bce70/picopore-1.1.4.zip
+  md5: 6703677292ff144304ae29af60a81961
 
 build:
   entry_points:


### PR DESCRIPTION
Not sure why I keep swapping between tar.gz and zip... probably to do with what dist I use to build+push.

* [Y] I have read the guidelines above.
* [N] This PR adds a new recipe.
* [Y] This PR updates an existing recipe.
* [N] This PR does something else (explain below).
