### PR TITLE
Use zlib for gmap & update tests

### DIFF
--- a/recipes/gmap/2014.12.23/build.sh
+++ b/recipes/gmap/2014.12.23/build.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
-env MAX_READLENGTH=500 ./configure --prefix=$PREFIX
+env MAX_READLENGTH=500 ./configure --prefix=$PREFIX --enable-zlib
 make
 make install prefix=$PREFIX

--- a/recipes/gmap/2014.12.23/build.sh
+++ b/recipes/gmap/2014.12.23/build.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
-env MAX_READLENGTH=500 ./configure --prefix=$PREFIX --enable-zlib
+env MAX_READLENGTH=500 ./configure --prefix=$PREFIX --enable-zlib --disable-simd
 make
 make install prefix=$PREFIX

--- a/recipes/gmap/2014.12.23/meta.yaml
+++ b/recipes/gmap/2014.12.23/meta.yaml
@@ -40,5 +40,5 @@ build:
     - bin/gtf_splicesites
 test:
   commands: 
-    - gmap --version
-    - gsnap --version
+    - gmap --version && gmap --version
+    - gsnap --version && gsnap --version

--- a/recipes/gmap/2014.12.23/meta.yaml
+++ b/recipes/gmap/2014.12.23/meta.yaml
@@ -17,7 +17,7 @@ about:
   license: Non-commercial
   summary: Genomic mapping and alignment program for mRNA and EST sequences
 build:
-  number: 1
+  number: 2
   skip: True # [osx]
   binary_has_prefix_files:
     - bin/atoiindex

--- a/recipes/gmap/2014.12.23/meta.yaml
+++ b/recipes/gmap/2014.12.23/meta.yaml
@@ -8,8 +8,10 @@ source:
 requirements:
   build:
     - perl
+    - zlib
   run:
     - perl
+    - zlib
 about:
   home: http://research-pub.gene.com/gmap/
   license: Non-commercial


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

This PR adds explicit zlib support for gmap (first tried on version 2014.12.23). It also adds the `--check` flag for testing. I also want to test the use of `--disable-sse*` flag for `--configure` since the default setting seems to break in some installations.