### PR TITLE
Bulk update support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ env:
     - BIOCONDA_UTILS_TAG=master
     - BIOCONDA_UTILS_BUILD_ARGS="--loglevel=info --mulled-test"
     - BIOCONDA_UTILS_LINT_ARGS=
+    - MINICONDA_VER="4.2.12"
   matrix:
     - SUBDAG=0
 

--- a/scripts/travis-run.sh
+++ b/scripts/travis-run.sh
@@ -24,7 +24,7 @@ SKIP_LINTING=false
 # determine recipes to build. If building locally, build anything that changed
 # since master. If on travis, only build the commit range included in the push
 # or the pull request.
-if [[ $TRAVIS = "true" ]]
+if [[ $TRAVIS == "true" ]]
 then
     RANGE="$TRAVIS_BRANCH HEAD"
     if [ $TRAVIS_PULL_REQUEST == "false" ]
@@ -34,22 +34,22 @@ then
 
     # If the environment vars changed (e.g., boost, R, perl) then there's no
     # good way of knowing which recipes need rebuilding so we check them all.
-    #
-    # For cron jobs we always want to check everything.
     set +e
     git diff --exit-code --name-only $RANGE scripts/env_matrix.yml
     ENV_CHANGE=$?
     set -e
-    if [ $ENV_CHANGE -eq 1 ] || [ $TRAVIS_EVENT_TYPE = "cron" ]
+
+    if [[ $ENV_CHANGE -eq 1 && $TRAVIS_BRANCH == bulk/* && $TRAVIS_PULL_REQUEST == "false" ]] || [[ $TRAVIS_EVENT_TYPE == "cron" ]]
     then
-        # case 1: env matrix changed or this is a cron job. In this case
-        # consider all recipes.
+        # Case 1: env matrix changed and we are on a bulk/*-branch.
+        # Case 2: this is a cron job that shall collect all missing builds.
+        # In such cases, consider all recipes.
         RANGE_ARG=""
 	# skip linting: we don't want to fix all recipes if we just update the env matrix
 	SKIP_LINTING=true
         echo "considering all recipes because either env matrix was changed or build is triggered via cron"
     else
-        # case 2: consider only recipes that (a) changed since the last build
+        # Case 3: consider only recipes that (a) changed since the last build
         # on master, or (b) changed in this pull request compared to the target
         # branch.
         RANGE_ARG="--git-range $RANGE"
@@ -60,16 +60,16 @@ export PATH=/anaconda/bin:$PATH
 
 # On travis we always run on docker for linux. This may not always be the case
 # for local testing.
-if [[ $TRAVIS_OS_NAME = "linux" && $TRAVIS = "true" ]]
+if [[ $TRAVIS_OS_NAME == "linux" && $TRAVIS == "true" ]]
 then
     DOCKER_ARG="--docker"
 fi
 
 # If this build corresponds to the merge into master, we will be detecting this
 # in bioconda-utils and will be pushing containers to quay.io.
-if [[ $TRAVIS_BRANCH = "master" && "$TRAVIS_PULL_REQUEST" = "false" ]]
+if [[ ( $TRAVIS_BRANCH == "master" || $TRAVIS_BRANCH == bulk/* ) && "$TRAVIS_PULL_REQUEST" == "false" ]]
 then
-    if [[ $TRAVIS_OS_NAME = "linux" ]]
+    if [[ $TRAVIS_OS_NAME == "linux" ]]
     then
         UPLOAD_ARG="--anaconda-upload --mulled-upload-target biocontainers"
     else
@@ -78,7 +78,7 @@ then
 else
     UPLOAD_ARG=""
     # if building master branch, do not lint
-    if [ $SKIP_LINTING = false  ]
+    if [[ $SKIP_LINTING == "false"  ]]
     then
         set -x; bioconda-utils lint recipes config.yml $RANGE_ARG $BIOCONDA_UTILS_LINT_ARGS; set +x
     fi
@@ -86,7 +86,7 @@ else
 fi
 
 
-if [[ $DISABLE_BIOCONDA_UTILS_BUILD_GIT_RANGE_CHECK = "true" ]]
+if [[ $DISABLE_BIOCONDA_UTILS_BUILD_GIT_RANGE_CHECK == "true" ]]
 then
     echo
     echo "DISABLE_BIOCONDA_UTILS_BUILD_GIT_RANGE_CHECK is true."

--- a/scripts/travis-run.sh
+++ b/scripts/travis-run.sh
@@ -39,6 +39,16 @@ then
     ENV_CHANGE=$?
     set -e
 
+    if [[ $ENV_CHANGE -eq 1 && $TRAVIS_BRANCH == "master" && $TRAVIS_PULL_REQUEST != "false" ]]
+    then
+        echo ""
+	echo "Env matrix was modified but this pull request does not target a bulk/* branch."
+	echo "Please target a branch named bulk/<reasonable-name>. Rebuild and PR against that branch until all builds succeed."
+	echo "Then, contact @bioconda/core in order to merge the branch into master."
+	echo ""
+	exit 1
+    fi
+
     if [[ $ENV_CHANGE -eq 1 && $TRAVIS_BRANCH == bulk/* && $TRAVIS_PULL_REQUEST == "false" ]] || [[ $TRAVIS_EVENT_TYPE == "cron" ]]
     then
         # Case 1: env matrix changed and we are on a bulk/*-branch.

--- a/scripts/travis-setup.sh
+++ b/scripts/travis-setup.sh
@@ -2,8 +2,6 @@
 set -e
 set -x
 
-MINICONDA_VER="4.2.12"
-
 if [[ $TRAVIS_BRANCH != "master" && $TRAVIS_PULL_REQUEST == "false" && $TRAVIS_REPO_SLUG == "bioconda/bioconda-recipes" ]]
 then
     echo ""


### PR DESCRIPTION
Consider env matrix updates only when on a branch called "bulk/*".
    
Together with PR #96, this allows us to perform bulk updates in an iterative way,
without using blacklist. The workflow is as follows:
    
1. Create a PR with an updated env matrix, with a target branch called "bulk/*".
2. The PR will be tested, but bioconda-utils will only build recipes that have changed in addition to the env matrix.
3. Once the PR is merged, bioconda-utils will build the changes induced by the new env matrix. Whenever a recipe has been successfully built, the package will be immediately uploaded to anaconda and biocontainers (mulled).
4. If errors occur, they can be fixed in a PR against the bulk branch. In such a case, we start again at step 1. Importantly, since successfully built packages have been already uploaded, we won't do redundant work and the list of packages will become shorter with each iteration.
    
If a timeout occurs during above process, once can simply restart the build job of the bulk branch, and bioconda-utils will go on with the still missing recipes.
    
For these changes to work, PR #96 has to be merged first.

@bioconda/core please check this out. I think it will solve our bulk update issues, so that we can finally update to Python 3.6 and R 3.4 (for R 3.4 we need to take care of conda-forge first).