### PR TITLE
BioConda recipes for Biopython 1.65 and 1.66

### DIFF
--- a/recipes/biopython/1.65/build.sh
+++ b/recipes/biopython/1.65/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$PYTHON setup.py install 

--- a/recipes/biopython/1.65/meta.yaml
+++ b/recipes/biopython/1.65/meta.yaml
@@ -1,0 +1,113 @@
+{% set name = "biopython" %}
+{% set version = "1.65" %}
+{% set sha256 = "6d591523ba4d07a505978f6e1d7fac57e335d6d62fb5b0bcb8c40bdde5c8998e" %}
+
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.python.org/packages/4e/77/8590d61dcda439d83f378106954e748db1a71e565335168a966642133ef8/biopython-1.65.tar.gz
+  sha256: {{ sha256 }}
+
+about:
+  home: http://www.biopython.org/
+  license: Biopython License Agreement
+  license_file: LICENSE
+  summary: 'Freely available tools for computational molecular biology.'
+
+build:
+  number: 0
+  skip: True # [py34]
+
+requirements:
+  build:
+    - python
+    - numpy x.x
+    - reportlab
+    - mmtf-python
+
+  run:
+    - python
+    - numpy x.x
+    - reportlab
+    - mmtf-python
+
+test:
+  imports:
+    - Bio
+    - Bio.Align
+    - Bio.Align.Applications
+    - Bio.AlignIO
+    - Bio.Alphabet
+    - Bio.Application
+    - Bio.Blast
+    - Bio.CAPS
+    - Bio.Compass
+    - Bio.Crystal
+    - Bio.Data
+    - Bio.Emboss
+    - Bio.Entrez
+    - Bio.ExPASy
+    - Bio.FSSP
+    - Bio.GA
+    - Bio.GA.Crossover
+    - Bio.GA.Mutation
+    - Bio.GA.Repair
+    - Bio.GA.Selection
+    - Bio.GenBank
+    - Bio.Geo
+    - Bio.Graphics
+    - Bio.Graphics.GenomeDiagram
+    - Bio.HMM
+    - Bio.KEGG
+    - Bio.KEGG.Compound
+    - Bio.KEGG.Enzyme
+    - Bio.KEGG.KGML
+    - Bio.KEGG.Map
+    - Bio.Medline
+    - Bio.NMR
+    - Bio.NeuralNetwork
+    - Bio.NeuralNetwork.BackPropagation
+    - Bio.NeuralNetwork.Gene
+    - Bio.Nexus
+    - Bio.PDB
+    - Bio.PDB.QCPSuperimposer
+    # - Bio.PDB.mmtf  Introduced in 1.68
+    - Bio.Pathway
+    - Bio.Pathway.Rep
+    - Bio.Phylo
+    - Bio.Phylo.Applications
+    - Bio.Phylo.PAML
+    - Bio.PopGen
+    - Bio.PopGen.Async
+    - Bio.PopGen.FDist
+    - Bio.PopGen.GenePop
+    - Bio.PopGen.SimCoal
+    - Bio.Restriction
+    - Bio.SCOP
+    - Bio.SVDSuperimposer
+    - Bio.SearchIO
+    - Bio.SearchIO.BlastIO
+    - Bio.SearchIO.ExonerateIO
+    - Bio.SearchIO.HmmerIO
+    - Bio.SearchIO._model
+    - Bio.SeqIO
+    - Bio.SeqUtils
+    - Bio.Sequencing
+    - Bio.Sequencing.Applications
+    - Bio.Statistics
+    - Bio.SubsMat
+    - Bio.SwissProt
+    - Bio.TogoWS
+    - Bio.UniGene
+    - Bio.UniProt
+    - Bio.Wise
+    - Bio._py3k
+    - Bio.codonalign
+    - Bio.motifs
+    - Bio.motifs.applications
+    - Bio.motifs.jaspar
+    - BioSQL

--- a/recipes/biopython/1.66/build.sh
+++ b/recipes/biopython/1.66/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$PYTHON setup.py install 

--- a/recipes/biopython/1.66/meta.yaml
+++ b/recipes/biopython/1.66/meta.yaml
@@ -1,0 +1,113 @@
+{% set name = "biopython" %}
+{% set version = "1.66" %}
+{% set sha256 = "171ad726f50528b514f9777e6ea54138f6e35792c5b128c4ab91ce918a48bbbd" %}
+
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.python.org/packages/42/68/908c5f122b9453c789923dc551af210b738b41b48b5bf9a7d0d85377984f/biopython-1.66.tar.gz
+  sha256: {{ sha256 }}
+
+about:
+  home: http://www.biopython.org/
+  license: Biopython License Agreement
+  license_file: LICENSE
+  summary: 'Freely available tools for computational molecular biology.'
+
+build:
+  number: 0
+  skip: True # [py34]
+
+requirements:
+  build:
+    - python
+    - numpy x.x
+    - reportlab
+    - mmtf-python
+
+  run:
+    - python
+    - numpy x.x
+    - reportlab
+    - mmtf-python
+
+test:
+  imports:
+    - Bio
+    - Bio.Align
+    - Bio.Align.Applications
+    - Bio.AlignIO
+    - Bio.Alphabet
+    - Bio.Application
+    - Bio.Blast
+    - Bio.CAPS
+    - Bio.Compass
+    - Bio.Crystal
+    - Bio.Data
+    - Bio.Emboss
+    - Bio.Entrez
+    - Bio.ExPASy
+    - Bio.FSSP
+    - Bio.GA
+    - Bio.GA.Crossover
+    - Bio.GA.Mutation
+    - Bio.GA.Repair
+    - Bio.GA.Selection
+    - Bio.GenBank
+    - Bio.Geo
+    - Bio.Graphics
+    - Bio.Graphics.GenomeDiagram
+    - Bio.HMM
+    - Bio.KEGG
+    - Bio.KEGG.Compound
+    - Bio.KEGG.Enzyme
+    - Bio.KEGG.KGML
+    - Bio.KEGG.Map
+    - Bio.Medline
+    - Bio.NMR
+    - Bio.NeuralNetwork
+    - Bio.NeuralNetwork.BackPropagation
+    - Bio.NeuralNetwork.Gene
+    - Bio.Nexus
+    - Bio.PDB
+    - Bio.PDB.QCPSuperimposer
+    # - Bio.PDB.mmtf  Introduced in 1.68
+    - Bio.Pathway
+    - Bio.Pathway.Rep
+    - Bio.Phylo
+    - Bio.Phylo.Applications
+    - Bio.Phylo.PAML
+    - Bio.PopGen
+    - Bio.PopGen.Async
+    - Bio.PopGen.FDist
+    - Bio.PopGen.GenePop
+    - Bio.PopGen.SimCoal
+    - Bio.Restriction
+    - Bio.SCOP
+    - Bio.SVDSuperimposer
+    - Bio.SearchIO
+    - Bio.SearchIO.BlastIO
+    - Bio.SearchIO.ExonerateIO
+    - Bio.SearchIO.HmmerIO
+    - Bio.SearchIO._model
+    - Bio.SeqIO
+    - Bio.SeqUtils
+    - Bio.Sequencing
+    - Bio.Sequencing.Applications
+    - Bio.Statistics
+    - Bio.SubsMat
+    - Bio.SwissProt
+    - Bio.TogoWS
+    - Bio.UniGene
+    - Bio.UniProt
+    - Bio.Wise
+    - Bio._py3k
+    - Bio.codonalign
+    - Bio.motifs
+    - Bio.motifs.applications
+    - Bio.motifs.jaspar
+    - BioSQL


### PR DESCRIPTION
* [ ] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

We now have BioConda packages for Biopython 1.67 onwards, with 1.67 added as a legacy package in #4462 to help with Galaxy tool dependencies.

Older versions of Biopython 1.65 and 1.66 are still being used by one or more of the IUC maintained Galaxy Tools, and therefore it is expedient to have them available on BioConda as well.

See https://github.com/galaxyproject/tools-iuc/

```
$ grep biopython tools/*/*.xml
tools/jbrowse/macros.xml:      <requirement type="package" version="1.66">biopython</requirement>
tools/kraken_taxonomy_report/kraken_taxonomy_report.xml:        <requirement type="package" version="1.66">biopython</requirement>
tools/ncbi_entrez_eutils/macros.xml:      <requirement type="package" version="1.68">biopython</requirement>
tools/ncbi_entrez_eutils/tool_dependencies.xml:  <package name="biopython" version="1.66">
tools/ncbi_entrez_eutils/tool_dependencies.xml:    <repository name="package_biopython_1_66" owner="biopython"/>
tools/progressivemauve/macros.xml:      <requirement type="package" version="1.65">biopython</requirement>
tools/progressivemauve/tool_dependencies.xml:  <package name="biopython" version="1.65">
tools/progressivemauve/tool_dependencies.xml:    <repository name="package_biopython_1_65" owner="biopython"/>
tools/transtermhp/macros.xml:      <requirement type="package" version="1.65">biopython</requirement>
tools/transtermhp/tool_dependencies.xml:  <package name="biopython" version="1.65">
tools/transtermhp/tool_dependencies.xml:    <repository name="package_biopython_1_65" owner="biopython"/>
```
