### PR TITLE
New recipe galaxy-w4m-r-classfilter

### DIFF
--- a/recipes/galaxy-w4m-r-classfilter/build.sh
+++ b/recipes/galaxy-w4m-r-classfilter/build.sh
@@ -1,0 +1,17 @@
+
+#!/bin/bash
+
+# R refuses to build packages that mark themselves as
+# "Priority: Recommended"
+mv DESCRIPTION DESCRIPTION.old
+grep -v '^Priority: ' DESCRIPTION.old > DESCRIPTION
+#
+$R CMD INSTALL --build .
+#
+# # Add more build steps here, if they are necessary.
+#
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build
+# process.
+# 

--- a/recipes/galaxy-w4m-r-classfilter/build.sh
+++ b/recipes/galaxy-w4m-r-classfilter/build.sh
@@ -1,17 +1,6 @@
-
 #!/bin/bash
 
-# R refuses to build packages that mark themselves as
-# "Priority: Recommended"
 mv DESCRIPTION DESCRIPTION.old
 grep -v '^Priority: ' DESCRIPTION.old > DESCRIPTION
-#
+
 $R CMD INSTALL --build .
-#
-# # Add more build steps here, if they are necessary.
-#
-# See
-# http://docs.continuum.io/conda/build.html
-# for a list of environment variables that are set during the build
-# process.
-# 

--- a/recipes/galaxy-w4m-r-classfilter/meta.yaml
+++ b/recipes/galaxy-w4m-r-classfilter/meta.yaml
@@ -1,0 +1,28 @@
+package:
+  name: w4mclassfilter
+  version: 0.98.0
+source:
+  fn: w4mclassfilter_0.98.0.tar.gz
+  url: https://github.com/HegemanLab/w4mclassfilter/releases/download/v0.98.0/w4mclassfilter_0.98.0.tar.gz
+  md5: 2f3ef13570c3d033bd3e24ada5d52e71
+build:
+  number: 0
+  string: 0.98.0
+  rpaths:
+    - lib/R/lib/
+    - lib/
+requirements:
+  build:
+    - r
+  run:
+    - r
+test:
+  commands:
+    - '$R -e "library(w4mclassfilter)"'
+about:
+  home: https://github.com/HegemanLab/w4mclassfilter
+  license: MIT
+  summary: 'Filter Workflow4Metabolomics dataMatrix, sampleMetadata, and 
+    variableMetadata files by sample-class, imputing zero for NA values and 
+    eliminating zero-variance rows and columns from the data-matrix.
+    MIT Licence allows redistribution.'

--- a/recipes/galaxy-w4m-r-classfilter/meta.yaml
+++ b/recipes/galaxy-w4m-r-classfilter/meta.yaml
@@ -13,9 +13,9 @@ build:
     - lib/
 requirements:
   build:
-    - r
+    - r-base
   run:
-    - r
+    - r-base
 test:
   commands:
     - '$R -e "library(w4mclassfilter)"'


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [x] This PR adds a new recipe.
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Please review and provide suggestions for improvement if appropriate.

This is a new recipe for an R package that will implement processing for a new tool for the Workflow4Metabolomics flavor of Galaxy.  My intent is to add just two files:
  - recipes/galaxy-w4m-r-classfilter/build.sh
  - recipes/galaxy-w4m-r-classfilter/meta.yaml

This is my first pull request (ever), so, if there are more files than these two, that's a problem that I didn't detect!

The travis build failed for the commit that added them (which is what I believe is the basis of this pull request); however, [in that build](https://travis-ci.org/eschen42/bioconda-recipes/jobs/228312460), **this recipe succeeded**, viz:
> 14:27:31 BIOCONDA INFO BUILD START recipes/galaxy-w4m-r-classfilter, env: CONDA_BOOST=1.61;CONDA_GMP=5.1;CONDA_GSL=1.16;CONDA_HDF5=1.8.17;CONDA_HTSLIB=1.4;CONDA_NCURSES=5.9;CONDA_NPY=110;CONDA_PERL=5.22.0;CONDA_PY=27;CONDA_R=3.3.1
>
> 14:28:53 BIOCONDA INFO BUILD SUCCESS /anaconda/conda-bld/linux-64/w4mclassfilter-0.98.0-0.98.0.tar.bz2, CONDA_BOOST=1.61;CONDA_GMP=5.1;CONDA_GSL=1.16;CONDA_HDF5=1.8.17;CONDA_HTSLIB=1.4;CONDA_NCURSES=5.9;CONDA_NPY=110;CONDA_PERL=5.22.0;CONDA_PY=27;CONDA_R=3.3.1
>
> 14:28:53 BIOCONDA INFO TEST START via mulled-build recipes/galaxy-w4m-r-classfilter, CONDA_BOOST=1.61;CONDA_GMP=5.1;CONDA_GSL=1.16;CONDA_HDF5=1.8.17;CONDA_HTSLIB=1.4;CONDA_NCURSES=5.9;CONDA_NPY=110;CONDA_PERL=5.22.0;CONDA_PY=27;CONDA_R=3.3.1
>
> updating index in: /anaconda/conda-bld/linux-64
>
> 14:30:32 BIOCONDA INFO TEST SUCCESS recipes/galaxy-w4m-r-classfilter, CONDA_BOOST=1.61;CONDA_GMP=5.1;CONDA_GSL=1.16;CONDA_HDF5=1.8.17;CONDA_HTSLIB=1.4;CONDA_NCURSES=5.9;CONDA_NPY=110;CONDA_PERL=5.22.0;CONDA_PY=27;CONDA_R=3.3.1

The next travis build succeeded, but did not build this recipe. ugh.