### PR TITLE
change snpeff version to fix conda version sorting

### DIFF
--- a/recipes/snpeff/meta.yaml
+++ b/recipes/snpeff/meta.yaml
@@ -1,3 +1,8 @@
+{% set snpeff_ver = "v4_3k" %}
+# NOTE: if the version contains a trailing letter, use the <d>.<d>.1<l> format
+{% set version = "4.3.1k" %}
+{% set sha256 = "396fadbefb4994838713c9a3e96393d16e7ec833254a962834e7cbd699b9f35e" %}
+
 about:
   home: 'http://snpeff.sourceforge.net/'
   license: "LGPLv3"
@@ -5,16 +10,16 @@ about:
 
 package:
   name: snpeff
-  version: '4.3.0k'
+  version: {{ version }}
 
 build:
   number: 0
   skip: False
 
 source:
-  fn: snpEff_v4_3k_core.zip
-  url: https://downloads.sourceforge.net/project/snpeff/snpEff_v4_3k_core.zip
-  sha256: 396fadbefb4994838713c9a3e96393d16e7ec833254a962834e7cbd699b9f35e
+  fn: snpEff_{{ snpeff_ver }}_core.zip
+  url: https://downloads.sourceforge.net/project/snpeff/snpEff_{{ snpeff_ver }}_core.zip
+  sha256: {{ sha256 }}
 
 requirements:
   run:
@@ -23,3 +28,6 @@ requirements:
 test:
     commands:
       - snpEff -version
+
+extra:
+    notes: 'Note that the package version is slightly different from upstream, this is to make sure conda will order the package versions correctly.'

--- a/recipes/snpeff/meta.yaml
+++ b/recipes/snpeff/meta.yaml
@@ -5,7 +5,7 @@ about:
 
 package:
   name: snpeff
-  version: '4.3k'
+  version: '4.3.0k'
 
 build:
   number: 0


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

snpeff current version is "4.3k" but conda is sorting it below "4.3", this PR changes the version to "4.3.0k", that seems to do the trick (see openssl versions).