### PR TITLE
Enable Python 3.6 in the env matrix

### DIFF
--- a/scripts/env_matrix.yml
+++ b/scripts/env_matrix.yml
@@ -1,7 +1,7 @@
 CONDA_PY:
   - 27
-  - 34
   - 35
+  - 36
 CONDA_HTSLIB: "1.4"
 CONDA_BOOST: "1.61"
 CONDA_R: "3.3.1"


### PR DESCRIPTION
such that new PRs don't build against 3.5 only while we are still doing the bulk update.

* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).
