### PR TITLE
Update: bcbio, bcbio-vm

### DIFF
--- a/recipes/bcbio-nextgen-vm/meta.yaml
+++ b/recipes/bcbio-nextgen-vm/meta.yaml
@@ -3,13 +3,13 @@ package:
   version: '0.1.0a'
 
 build:
-  number: 94
+  number: 95
   skip: True # [not py27]
 
 source:
-  fn: bcbio-nextgen-vm-d8cb02f.tar.gz
-  url: https://github.com/chapmanb/bcbio-nextgen-vm/archive/d8cb02f.tar.gz
-  md5: b81d2324d377f9a58c8d174834adafb2
+  fn: bcbio-nextgen-vm-4484964.tar.gz
+  url: https://github.com/chapmanb/bcbio-nextgen-vm/archive/4484964.tar.gz
+  md5: d2454ed39c750d9d9a88f03d7ce4cdf3
 
 requirements:
   build:
@@ -18,7 +18,7 @@ requirements:
 
   run:
     - python
-    - bcbio-nextgen >1.0.2
+    - bcbio-nextgen >=1.0.3
     - ipyparallel >=4.0,<5.0
     - pysam >=0.11.0
     - arvados-cwl-runner

--- a/recipes/bcbio-nextgen/meta.yaml
+++ b/recipes/bcbio-nextgen/meta.yaml
@@ -1,18 +1,18 @@
 package:
   name: bcbio-nextgen
-  version: '1.0.3a'
+  version: '1.0.3'
 
 build:
-  number: 10
+  number: 0
   skip: True # [not py27]
 
 source:
-  #fn: bcbio-nextgen-1.0.2.tar.gz
-  #url: https://pypi.python.org/packages/3f/c0/f8e46f5cbc3b4f04f94670b157737c2a402f40a2a5cc6168d7f1dee58f9e/bcbio-nextgen-1.0.2.tar.gz
-  #md5: 0b8e7bf553b15173aeaa06102afa021a
-  fn: bcbio-nextgen-13dfcb3.tar.gz
-  url: https://github.com/chapmanb/bcbio-nextgen/archive/13dfcb3.tar.gz
-  md5: c1a48b19b9c67842328416c680562edb
+  fn: bcbio-nextgen-1.0.3.tar.gz
+  url: https://pypi.io/packages/source/b/bcbio-nextgen/bcbio-nextgen-1.0.3.tar.gz
+  md5: 0dcd2f02cc2d35dc00ec2acd04d7bb9e
+  #fn: bcbio-nextgen-13dfcb3.tar.gz
+  #url: https://github.com/chapmanb/bcbio-nextgen/archive/13dfcb3.tar.gz
+  #md5: c1a48b19b9c67842328416c680562edb
 
 requirements:
   build:


### PR DESCRIPTION
New 1.0.3 release for bcbio. Ansible fix and version pinning for
bcbio-vm

* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
