### PR TITLE
Recipe for v0.98.1 of w4mclassfilter

### DIFF
--- a/recipes/w4mclassfilter/0.98.0/build.sh
+++ b/recipes/w4mclassfilter/0.98.0/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+mv DESCRIPTION DESCRIPTION.old
+grep -v '^Priority: ' DESCRIPTION.old > DESCRIPTION
+
+$R CMD INSTALL --build .

--- a/recipes/w4mclassfilter/0.98.0/meta.yaml
+++ b/recipes/w4mclassfilter/0.98.0/meta.yaml
@@ -1,13 +1,13 @@
 package:
   name: w4mclassfilter
-  version: 0.98.1
+  version: 0.98.0
 source:
-  fn: w4mclassfilter_0.98.1.tar.gz
-  url: https://github.com/HegemanLab/w4mclassfilter/releases/download/v0.98.1/w4mclassfilter_0.98.1.tar.gz
-  md5: e25e7842d96bf25ff50ecea551321dea
+  fn: w4mclassfilter_0.98.0.tar.gz
+  url: https://github.com/HegemanLab/w4mclassfilter/releases/download/v0.98.0/w4mclassfilter_0.98.0.tar.gz
+  md5: 2f3ef13570c3d033bd3e24ada5d52e71
 build:
   number: 0
-  string: 0.98.1
+  string: 0.98.0
   rpaths:
     - lib/R/lib/
     - lib/


### PR DESCRIPTION
* [x] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

This recipe-change built and passed its test in [build 11.1 of eschen42/bioconda-recipes](https://travis-ci.org/eschen42/bioconda-recipes/jobs/229590498). Most of my travis builds are terminating in an error that I cannot trace to any of my changes.

```
13:38:59 BIOCONDA INFO BUILD START recipes/w4mclassfilter, env: CONDA_BOOST=1.61;CONDA_GMP=5.1;CONDA_GSL=1.16;CONDA_HDF5=1.8.17;CONDA_HTSLIB=1.4;CONDA_NCURSES=5.9;CONDA_NPY=110;CONDA_PERL=5.22.0;CONDA_PY=27;CONDA_R=3.3.1

13:39:59 BIOCONDA INFO BUILD SUCCESS /anaconda/conda-bld/linux-64/w4mclassfilter-0.98.1-0.98.1.tar.bz2, CONDA_BOOST=1.61;CONDA_GMP=5.1;CONDA_GSL=1.16;CONDA_HDF5=1.8.17;CONDA_HTSLIB=1.4;CONDA_NCURSES=5.9;CONDA_NPY=110;CONDA_PERL=5.22.0;CONDA_PY=27;CONDA_R=3.3.1

13:39:59 BIOCONDA INFO TEST START via mulled-build recipes/w4mclassfilter, CONDA_BOOST=1.61;CONDA_GMP=5.1;CONDA_GSL=1.16;CONDA_HDF5=1.8.17;CONDA_HTSLIB=1.4;CONDA_NCURSES=5.9;CONDA_NPY=110;CONDA_PERL=5.22.0;CONDA_PY=27;CONDA_R=3.3.1

updating index in: /anaconda/conda-bld/linux-64

13:41:12 BIOCONDA INFO TEST SUCCESS recipes/w4mclassfilter, CONDA_BOOST=1.61;CONDA_GMP=5.1;CONDA_GSL=1.16;CONDA_HDF5=1.8.17;CONDA_HTSLIB=1.4;CONDA_NCURSES=5.9;CONDA_NPY=110;CONDA_PERL=5.22.0;CONDA_PY=27;CONDA_R=3.3.1
```