### PR TITLE
Recipes for GhostScript 9.07 and 9.10

### DIFF
--- a/recipes/ghostscript/9.07/build.sh
+++ b/recipes/ghostscript/9.07/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+./configure --prefix=${PREFIX}
+make
+make install

--- a/recipes/ghostscript/9.07/meta.yaml
+++ b/recipes/ghostscript/9.07/meta.yaml
@@ -1,0 +1,25 @@
+package:
+  name: ghostscript
+  version: 9.07
+
+source:
+  fn: ghostscript-9.07.tar.gz
+  url: https://downloads.sourceforge.net/project/ghostscript/GPL%20Ghostscript/9.07/ghostscript-9.07.tar.gz
+  sha256: 44800d004c53f13192d1b5db413119198ddfc8a11c4d2a030aac2f2fda822ebf
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - gcc
+
+test:
+  commands:
+    - gs --version > /dev/null
+
+about:
+  home: http://ghostscript.com/
+  summary: An interpreter for the PostScript language and for PDF.
+  license: Affero GPL
+  license_file: LICENSE

--- a/recipes/ghostscript/9.07/meta.yaml
+++ b/recipes/ghostscript/9.07/meta.yaml
@@ -12,7 +12,11 @@ build:
 
 requirements:
   build:
-    - gcc
+    - gcc   # [not osx]
+    - llvm  # [osx]
+
+  run:
+    - libgcc    # [not osx]
 
 test:
   commands:

--- a/recipes/ghostscript/9.10/build.sh
+++ b/recipes/ghostscript/9.10/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+./configure --prefix=${PREFIX}
+make
+make install

--- a/recipes/ghostscript/9.10/meta.yaml
+++ b/recipes/ghostscript/9.10/meta.yaml
@@ -1,0 +1,25 @@
+package:
+  name: ghostscript
+  version: 9.10
+
+source:
+  fn: ghostscript-9.10.tar.gz
+  url: https://downloads.sourceforge.net/project/ghostscript/GPL%20Ghostscript/9.10/ghostscript-9.10.tar.gz
+  sha256: 913fc974433238ffd4e0549ce11ba2a3360d1d159cf5c3b988d72a77acb74d04
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - gcc
+
+test:
+  commands:
+    - gs --version > /dev/null
+
+about:
+  home: http://ghostscript.com/
+  summary: An interpreter for the PostScript language and for PDF.
+  license: Affero GPL
+  license_file: LICENSE

--- a/recipes/ghostscript/9.10/meta.yaml
+++ b/recipes/ghostscript/9.10/meta.yaml
@@ -12,7 +12,11 @@ build:
 
 requirements:
   build:
-    - gcc
+    - gcc   # [not osx]
+    - llvm  # [osx]
+
+  run:
+    - libgcc    # [not osx]
 
 test:
   commands:

--- a/recipes/ghostscript/meta.yaml
+++ b/recipes/ghostscript/meta.yaml
@@ -8,11 +8,15 @@ source:
   sha1: 761c9c25b9f5fe01197bd1510f527b3c1b6eb9de
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
-    - gcc
+    - gcc   # [not osx]
+    - llvm  # [osx]
+
+  run:
+    - libgcc    # [not osx]
 
 test:
   commands:


### PR DESCRIPTION
* [X] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

In order to facilitate Galaxy Admins transitioning from Galaxy's old packaging system to Conda, this pull request adds recipes for old versions of GhostScript available as packages on the Galaxy Tool Shed,

* https://toolshed.g2.bx.psu.edu/view/iuc/package_ghostscript_9_07/
* https://toolshed.g2.bx.psu.edu/view/devteam/package_ghostscript_9_10/

See also https://github.com/galaxyproject/tools-iuc/issues/1001 