### PR TITLE
Make link to contributing guidelines explicit

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-* [ ] I have read the [contributing guidelines](https://bioconda.github.io/contributing.html).
+* [ ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
 * [ ] This PR adds a new recipe.
 * [ ] This PR updates an existing recipe.
 * [ ] This PR does something else (explain below).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-* [ ] I have read the guidelines above.
+* [ ] I have read the [contributing guidelines](https://bioconda.github.io/contributing.html).
 * [ ] This PR adds a new recipe.
 * [ ] This PR updates an existing recipe.
 * [ ] This PR does something else (explain below).


### PR DESCRIPTION
* [X] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [ ] This PR updates an existing recipe.
* [X] This PR does something else (explain below).

While writing a pull request GitHub shows the following above the text box:

> Before you create a pull request, please review [the guidelines for contributing](https://github.com/bioconda/bioconda-recipes/blob/master/CONTRIBUTING.md) to this repository.

However, the ``CONTRIBUTING.md`` file just points you at https://bioconda.github.io/contributing.htm

Moreover, once a pull request is created, "above" becomes meaningless, so I think it is better to make this explicit in the template, as in this pull request.