### PR TITLE
Fix PNG support in gnuplot 4.6.0

### DIFF
--- a/recipes/gnuplot/4.6.0/build.sh
+++ b/recipes/gnuplot/4.6.0/build.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
-./prepare
-./configure --prefix=$PREFIX
+./configure \
+    --prefix=$PREFIX \
+    --without-x \
+    --without-lua
+
 make && make install

--- a/recipes/gnuplot/4.6.0/build.sh
+++ b/recipes/gnuplot/4.6.0/build.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+./prepare
 ./configure \
     --prefix=$PREFIX \
     --without-x \

--- a/recipes/gnuplot/4.6.0/build.sh
+++ b/recipes/gnuplot/4.6.0/build.sh
@@ -1,5 +1,17 @@
 #!/bin/bash
 
+# fix automake
+sed -i.bak '1 s|^.*$|#!/usr/bin/env perl|g' $PREFIX/bin/aclocal
+sed -i.bak '1 s|^.*$|#!/usr/bin/env perl|g' $PREFIX/bin/automake
+
+# fix autoconf
+sed -i.bak '1 s|^.*$|#!/usr/bin/env perl|g' $PREFIX/bin/autom4te
+sed -i.bak '1 s|^.*$|#!/usr/bin/env perl|g' $PREFIX/bin/autoheader
+sed -i.bak '1 s|^.*$|#!/usr/bin/env perl|g' $PREFIX/bin/autoreconf
+sed -i.bak '1 s|^.*$|#!/usr/bin/env perl|g' $PREFIX/bin/ifnames
+sed -i.bak '1 s|^.*$|#!/usr/bin/env perl|g' $PREFIX/bin/autoscan
+sed -i.bak '1 s|^.*$|#!/usr/bin/env perl|g' $PREFIX/bin/autoupdate
+
 ./prepare
 ./configure \
     --prefix=$PREFIX \

--- a/recipes/gnuplot/4.6.0/meta.yaml
+++ b/recipes/gnuplot/4.6.0/meta.yaml
@@ -23,11 +23,13 @@ requirements:
     - llvm [osx]
     - pkg-config [osx]
     - libgd >=2.2
+    - libiconv
     - ncurses {{CONDA_NCURSES}}*
     - perl
   run:
     - libgcc [not osx]
     - libgd >=2.2
+    - libiconv
     - ncurses {{CONDA_NCURSES}}*
 
 about:

--- a/recipes/gnuplot/4.6.0/meta.yaml
+++ b/recipes/gnuplot/4.6.0/meta.yaml
@@ -4,26 +4,24 @@ package:
 
 build:
   number: 2
+  string: "ncurses{{CONDA_NCURSES}}_{{PKG_BUILDNUM}}"
 
 source:
   url: https://github.com/gnuplot/gnuplot/archive/Release_4_6_0.tar.gz
   sha256: c0885a5b4f5c1f64545b9852c0184ec5fd230df4c7c99e5a3cbd25dd441e5206
-  patches:
-    - fix-automake.patch
-    - fix-proto-int.patch
 
 requirements:
   build:
-    - autoconf
-    - m4
     - gcc [not osx]
     - libgcc [not osx]
     - llvm [osx]
     - pkg-config [osx]
     - libgd
+    - ncurses {{CONDA_NCURSES}}*
   run:
     - libgcc [not osx]
     - libgd
+    - ncurses {{CONDA_NCURSES}}*
 
 about:
   home: https://github.com/gnuplot/gnuplot

--- a/recipes/gnuplot/4.6.0/meta.yaml
+++ b/recipes/gnuplot/4.6.0/meta.yaml
@@ -9,9 +9,14 @@ build:
 source:
   url: https://github.com/gnuplot/gnuplot/archive/Release_4_6_0.tar.gz
   sha256: c0885a5b4f5c1f64545b9852c0184ec5fd230df4c7c99e5a3cbd25dd441e5206
+  patches:
+    - fix-automake.patch		
+    - fix-proto-int.patch
 
 requirements:
   build:
+    - autoconf
+    - m4
     - gcc [not osx]
     - libgcc [not osx]
     - llvm [osx]

--- a/recipes/gnuplot/4.6.0/meta.yaml
+++ b/recipes/gnuplot/4.6.0/meta.yaml
@@ -24,6 +24,7 @@ requirements:
     - pkg-config [osx]
     - libgd >=2.2
     - ncurses {{CONDA_NCURSES}}*
+    - perl
   run:
     - libgcc [not osx]
     - libgd >=2.2

--- a/recipes/gnuplot/4.6.0/meta.yaml
+++ b/recipes/gnuplot/4.6.0/meta.yaml
@@ -15,6 +15,7 @@ source:
 
 requirements:
   build:
+    - automake
     - autoconf
     - m4
     - gcc [not osx]

--- a/recipes/gnuplot/4.6.0/meta.yaml
+++ b/recipes/gnuplot/4.6.0/meta.yaml
@@ -22,11 +22,11 @@ requirements:
     - libgcc [not osx]
     - llvm [osx]
     - pkg-config [osx]
-    - libgd >= 2.2
+    - libgd >=2.2
     - ncurses {{CONDA_NCURSES}}*
   run:
     - libgcc [not osx]
-    - libgd >= 2.2
+    - libgd >=2.2
     - ncurses {{CONDA_NCURSES}}*
 
 about:

--- a/recipes/gnuplot/4.6.0/meta.yaml
+++ b/recipes/gnuplot/4.6.0/meta.yaml
@@ -6,8 +6,8 @@ build:
   number: 2
 
 source:
-  git_url: https://github.com/gnuplot/gnuplot.git
-  git_rev: Release_4_6_0
+  url: https://github.com/gnuplot/gnuplot/archive/Release_4_6_0.tar.gz
+  sha256: c0885a5b4f5c1f64545b9852c0184ec5fd230df4c7c99e5a3cbd25dd441e5206
   patches:
     - fix-automake.patch
     - fix-proto-int.patch

--- a/recipes/gnuplot/4.6.0/meta.yaml
+++ b/recipes/gnuplot/4.6.0/meta.yaml
@@ -18,10 +18,10 @@ requirements:
     - libgcc [not osx]
     - llvm [osx]
     - pkg-config [osx]
-    - libgd *.bioconda
+    - libgd
   run:
     - libgcc [not osx]
-    - libgd *.bioconda
+    - libgd
 
 about:
   home: https://github.com/gnuplot/gnuplot

--- a/recipes/gnuplot/4.6.0/meta.yaml
+++ b/recipes/gnuplot/4.6.0/meta.yaml
@@ -21,11 +21,11 @@ requirements:
     - libgcc [not osx]
     - llvm [osx]
     - pkg-config [osx]
-    - libgd
+    - libgd >= 2.2
     - ncurses {{CONDA_NCURSES}}*
   run:
     - libgcc [not osx]
-    - libgd
+    - libgd >= 2.2
     - ncurses {{CONDA_NCURSES}}*
 
 about:

--- a/recipes/gnuplot/4.6.0/meta.yaml
+++ b/recipes/gnuplot/4.6.0/meta.yaml
@@ -14,6 +14,8 @@ source:
 
 requirements:
   build:
+    - autoconf
+    - m4
     - gcc [not osx]
     - libgcc [not osx]
     - llvm [osx]

--- a/recipes/gnuplot/4.6.0/meta.yaml
+++ b/recipes/gnuplot/4.6.0/meta.yaml
@@ -10,7 +10,7 @@ source:
   url: https://github.com/gnuplot/gnuplot/archive/Release_4_6_0.tar.gz
   sha256: c0885a5b4f5c1f64545b9852c0184ec5fd230df4c7c99e5a3cbd25dd441e5206
   patches:
-    - fix-automake.patch		
+    - fix-automake.patch
     - fix-proto-int.patch
 
 requirements:

--- a/recipes/gnuplot/4.6.0/meta.yaml
+++ b/recipes/gnuplot/4.6.0/meta.yaml
@@ -1,25 +1,36 @@
 package:
   name: gnuplot
   version: "4.6.0"
+
 build:
-  number: 1
+  number: 2
+
 source:
   git_url: https://github.com/gnuplot/gnuplot.git
   git_rev: Release_4_6_0
   patches:
     - fix-automake.patch
     - fix-proto-int.patch
+
 requirements:
   build:
-    - autoconf
-    - m4
+    - gcc [not osx]
+    - libgcc [not osx]
+    - llvm [osx]
+    - pkg-config [osx]
+    - libgd *.bioconda
   run:
+    - libgcc [not osx]
+    - libgd *.bioconda
+
 about:
   home: https://github.com/gnuplot/gnuplot
   license: Gnuplot License + others
   summary: Gnuplot, plotting from command line
+
 test:
   files:
     - test-data.txt
   commands:
     - gnuplot -e "set terminal dumb; set style histogram; p 'test-data.txt'"
+    - gnuplot -e "set terminal png"


### PR DESCRIPTION
* [X] I have read the guidelines above.
* [ ] This PR adds a new recipe.
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Based on @croth1's merged pull request #981 for the latest gnuplot recipe, this updates the build requirements for gnuplot 4.6.0 to point at a BioConda libgd over the default channel, and includes an explicit test for PNG support.

Found while testing Galaxy Tool https://github.com/peterjc/pico_galaxy/tree/master/tools/mummer locally using planemo to install dependencies from bioconda, see also https://github.com/bioconda/bioconda-recipes/pull/4650 triggered by the same work.