### PR TITLE
Build r-checkmate separately.

### DIFF
--- a/recipes/r-checkmate/meta.yaml
+++ b/recipes/r-checkmate/meta.yaml
@@ -1,14 +1,18 @@
+{% set name = 'checkmate' %}
+{% set version = '1.8.2' %}
+
 package:
-  name: r-checkmate
+  name: r-{{ name|lower }}
   # Note that conda versions cannot contain -, so any -'s in the version have
   # been replaced with _'s.
-  version: "1.6.3"
+  version: {{ version|replace("-", "_") }}
 
 source:
-  fn: checkmate_1.6.3.tar.gz
+  fn: {{ name }}_{{ version }}.tar.gz
   url:
-    - http://cran.r-project.org/src/contrib/checkmate_1.6.3.tar.gz
-    - http://cran.r-project.org/src/contrib/Archive/checkmate/checkmate_1.6.3.tar.gz
+    - http://cran.r-project.org/src/contrib/{{ name }}_{{ version }}.tar.gz
+    - http://cran.r-project.org/src/contrib/Archive/{{ name }}/{{ name }}_{{ version }}.tar.gz
+  md5: 5d229b699232c6ac2b796bfd6b1caf84
 
 build:
   number: 0
@@ -23,17 +27,19 @@ build:
 requirements:
   build:
     - r
+    - r-backports
     - gcc # [not win]
 
   run:
     - r
+    - r-backports
     - libgcc # [not win]
 
 test:
   commands:
     # You can put additional test commands to be run here.
-    - $R -e "library('checkmate')" # [not win]
-    - "\"%R%\" -e \"library('checkmate')\"" # [win]
+    - $R -e "library('{{ name }}')" # [not win]
+    - "\"%R%\" -e \"library('{{ name }}')\"" # [win]
 
 about:
   home: https://github.com/mllg/checkmate


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [x] This PR updates an existing recipe.

Apparently the travis CI does not find the r-checkmate package it is supposed to build in #4688, so the recipe changes there are failing tests. This should resolve that situation.