### PR TITLE
Remove .patch extension from gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ cached_bioconductor_tarballs
 
 #Ignore patches and any original files created by patch command
 *.diff
-*.patch
 *.orig
 *.rej
 


### PR DESCRIPTION
* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] This PR updates an existing recipe.
* [X] This PR does something else (explain below).

Remove `.patch` from `.gitignore` since it's commonly used when adding patch files to a recipe.  Xref: #4591.