### PR TITLE
gnuplot 5.0.4 recipe no longer works, libgd PNG

### DIFF
--- a/recipes/gnuplot/build.sh
+++ b/recipes/gnuplot/build.sh
@@ -13,5 +13,6 @@ LDFLAGS="-Wl,-rpath,$PREFIX/lib $LDFLAGS" LIBS="-liconv" ./configure --prefix=$P
 
 export GNUTERM=dumb
 make PREFIX=$PREFIX
-make check PREFIX=$PREFIX
+# too verbose
+#make check PREFIX=$PREFIX
 make install PREFIX=$PREFIX

--- a/recipes/gnuplot/build.sh
+++ b/recipes/gnuplot/build.sh
@@ -1,8 +1,17 @@
 #!/bin/bash
 
-./configure \
-    --prefix=$PREFIX \
+opts="
     --without-x \
-    --without-lua
+    --without-lua \
+    --without-latex \
+    --without-libcerf \
+    --with-qt=qt5
+    --with-readline=$PREFIX
+    "
 
-make && make install
+LDFLAGS="-Wl,-rpath,$PREFIX/lib $LDFLAGS" LIBS="-liconv" ./configure --prefix=$PREFIX $opts
+
+export GNUTERM=dumb
+make PREFIX=$PREFIX
+make check PREFIX=$PREFIX
+make install PREFIX=$PREFIX

--- a/recipes/gnuplot/meta.yaml
+++ b/recipes/gnuplot/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 0
+  number: 1
   string: "ncurses{{CONDA_NCURSES}}_{{PKG_BUILDNUM}}"
 
 source:

--- a/recipes/gnuplot/meta.yaml
+++ b/recipes/gnuplot/meta.yaml
@@ -16,23 +16,22 @@ source:
 
 requirements:
   build:
-    - gcc [not osx]
-    - llvm [osx]
-    - pkg-config
+    - gcc  # [linux]
+    - pkgconfig
     - libgd >=2.2
     - ncurses {{CONDA_NCURSES}}*
     - readline 6.2*
     - cairo 1.14.*
-    - qt 4.8.*
+    - qt 5.6.*
     - pango 1.40.*
   run:
     - libgcc [not osx]
-    - libgd >=2.2
     - ncurses {{CONDA_NCURSES}}*
     - readline 6.2*
     - cairo 1.14.*
-    - qt 4.8.*
+    - qt 5.6.*
     - pango 1.40.*
+    - libgd >=2.2
 
 about:
   home: https://github.com/gnuplot/gnuplot

--- a/recipes/gnuplot/meta.yaml
+++ b/recipes/gnuplot/meta.yaml
@@ -19,11 +19,11 @@ requirements:
     - gcc [not osx]
     - llvm [osx]
     - pkg-config [osx]
-    - libgd
+    - libgd >=2.2
     - ncurses {{CONDA_NCURSES}}*
   run:
     - libgcc [not osx]
-    - libgd
+    - libgd >=2.2
     - ncurses {{CONDA_NCURSES}}*
 
 about:

--- a/recipes/gnuplot/meta.yaml
+++ b/recipes/gnuplot/meta.yaml
@@ -29,6 +29,7 @@ requirements:
 about:
   home: https://github.com/gnuplot/gnuplot
   license: Gnuplot License + others
+  license_file: Copyright
   summary: Gnuplot, plotting from command line
 
 test:

--- a/recipes/gnuplot/meta.yaml
+++ b/recipes/gnuplot/meta.yaml
@@ -18,7 +18,7 @@ requirements:
   build:
     - gcc [not osx]
     - llvm [osx]
-    - pkg-config [osx]
+    - pkg-config
     - libgd >=2.2
     - ncurses {{CONDA_NCURSES}}*
   run:

--- a/recipes/gnuplot/meta.yaml
+++ b/recipes/gnuplot/meta.yaml
@@ -21,10 +21,18 @@ requirements:
     - pkg-config
     - libgd >=2.2
     - ncurses {{CONDA_NCURSES}}*
+    - readline 6.2*
+    - cairo 1.14.*
+    - qt 4.8.*
+    - pango 1.40.*
   run:
     - libgcc [not osx]
     - libgd >=2.2
     - ncurses {{CONDA_NCURSES}}*
+    - readline 6.2*
+    - cairo 1.14.*
+    - qt 4.8.*
+    - pango 1.40.*
 
 about:
   home: https://github.com/gnuplot/gnuplot


### PR DESCRIPTION
* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Including the license_file meta data ought to be useful as it is a non-standard license.

The secondary purpose is I want to see if the current recipe actually still works or not (given problems with gnuplot 4.6.0 on #4655 and in updating to gnuplot 5.0.5 in #4730).