### PR TITLE
Update: ensembl-vep, perl-bio-db-hts with htslib

### DIFF
--- a/recipes/ensembl-vep/meta.yaml
+++ b/recipes/ensembl-vep/meta.yaml
@@ -8,21 +8,21 @@ source:
   md5: 2c088ead3a3a5245a7209e9b087666af
 
 build:
-  number: 1
+  number: 2
   skip: True # [osx]
 
 requirements:
   build:
     - curl
+    - perl
     - perl-archive-zip
     - perl-lwp-simple
-    - perl-threaded >=5.2*
     - unzip
-    - zlib
   run:
-    - htslib 1.3.*
+    - perl
+    - htslib {{CONDA_HTSLIB}}*
     - perl-bioperl
-    - perl-bio-db-hts
+    - perl-bio-db-hts >=2.7
     - perl-cgi
     - perl-dbi
     - perl-dbd-mysql
@@ -31,9 +31,7 @@ requirements:
     - perl-perlio-gzip
     - perl-sereal
     - perl-set-intervaltree
-    - perl-threaded >=5.2*
     - unzip
-
 
 test:
   commands:

--- a/recipes/perl-bio-db-hts/build.sh
+++ b/recipes/perl-bio-db-hts/build.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-#cpanm -i --configure-args "CFLAGS=-I$prefix/include" .
 
 perl Build.PL --extra_compiler_flags "-I$PREFIX/include"
 perl ./Build

--- a/recipes/perl-bio-db-hts/meta.yaml
+++ b/recipes/perl-bio-db-hts/meta.yaml
@@ -1,10 +1,13 @@
+{% set version="2.7" %}
+
 package:
   name: perl-bio-db-hts
-  version: '2.4'
+  version: {{ version }}
 
 source:
-  fn: Bio-DB-HTS-2.4.tar.gz
-  url: https://cpan.metacpan.org/authors/id/R/RI/RISHIDEV/Bio-DB-HTS-2.4.tar.gz
+  fn: Bio-DB-HTS-{{ version }}.tar.gz
+  url: https://cpan.metacpan.org/authors/id/R/RI/RISHIDEV/Bio-DB-HTS-{{ version }}.tar.gz
+  md5: a09468d02a7e58673b177e60915f28b0
 
 build:
   number: 0
@@ -12,19 +15,16 @@ build:
 
 requirements:
   build:
-    - gcc
     - zlib
-    - perl-threaded
-    - perl-app-cpanminus
+    - perl
     - perl-module-build
     - perl-bioperl
-    - htslib
+    - htslib {{CONDA_HTSLIB}}*
   run:
-    - libgcc
     - zlib
-    - perl-threaded
+    - perl
     - perl-bioperl
-    - htslib
+    - htslib {{CONDA_HTSLIB}}*
 
 test:
   imports:


### PR DESCRIPTION
Upgrades to htslib 1.4 and current perl in conda-forge. Avoids using
package gcc for compilation because of fstack-protector-strong error,
instead using gcc in condaforge/linux-anvil container.

Fixes #4703
Fixes chapmanb/bcbio-nextgen#1911

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
