### PR TITLE
gap2seq: re-enabled multi-threading on osx; cleaned up recipe

### DIFF
--- a/recipes/gap2seq/0002-renamed-lock-to-Gap2Seq_lock-to-avoid-name-conflicts.patch
+++ b/recipes/gap2seq/0002-renamed-lock-to-Gap2Seq_lock-to-avoid-name-conflicts.patch
@@ -1,0 +1,179 @@
+From 02ed602ef70daf7f375cf40feb8d130094e1406d Mon Sep 17 00:00:00 2001
+From: Ilya Shlyakhter <ilya_shl@alum.mit.edu>
+Date: Tue, 23 May 2017 18:57:33 -0400
+Subject: [PATCH 2/2] renamed lock to Gap2Seq_lock to avoid name conflicts when
+ compiling with clang on osx
+
+---
+ src/Gap2Seq.cpp | 36 ++++++++++++++++++------------------
+ 1 file changed, 18 insertions(+), 18 deletions(-)
+
+diff --git a/src/Gap2Seq.cpp b/src/Gap2Seq.cpp
+index 9142484..2967db1 100755
+--- a/src/Gap2Seq.cpp
++++ b/src/Gap2Seq.cpp
+@@ -87,7 +87,7 @@ Gap2Seq::Gap2Seq ()  : Tool ("Gap2Seq")
+ 
+ #ifndef SINGLE_THREAD
+ // Synchronizer for access to global variables
+-ISynchronizer *lock;
++ISynchronizer *Gap2Seq_lock;
+ #endif
+ 
+ /*********************************************************************
+@@ -181,7 +181,7 @@ void Gap2Seq::execute ()
+ 
+ #ifndef SINGLE_THREAD
+   // Synchronization for output (both file and stdout)
+-  lock = System::thread().newSynchronizer();
++  Gap2Seq_lock = System::thread().newSynchronizer();
+   IDispatcher *d = getDispatcher();
+   // Default group size is too big (one thread will do all the work...)
+   d->setGroupSize(1);
+@@ -208,7 +208,7 @@ void Gap2Seq::execute ()
+     std::string seq = "";
+     std::string comment = "";
+     {
+-      LocalSynchronizer local(lock);
++      LocalSynchronizer local(Gap2Seq_lock);
+       if (!itSeq.isDone()) {
+ 	seq = itSeq->toString();
+ 	comment = itSeq->getComment();
+@@ -237,7 +237,7 @@ void Gap2Seq::execute ()
+ //     std::cout << comment << std::endl;
+ // #else
+ //     {
+-//       LocalSynchronizer local(lock);
++//       LocalSynchronizer local(Gap2Seq_lock);
+ //       std::cout << comment << std::endl;
+ 
+ // #ifdef DEBUG
+@@ -252,7 +252,7 @@ void Gap2Seq::execute ()
+       if (seq[i] == 'N' || seq[i] == 'n') {
+ #ifndef SINGLE_THREAD
+ 	{
+-	  LocalSynchronizer local(lock);
++	  LocalSynchronizer local(Gap2Seq_lock);
+ #endif
+ 	  gapcount++;
+ #ifndef SINGLE_THREAD
+@@ -291,7 +291,7 @@ void Gap2Seq::execute ()
+ 
+ #ifndef SINGLE_THREAD
+ 	  {
+-	    LocalSynchronizer local(lock);
++	    LocalSynchronizer local(Gap2Seq_lock);
+ #endif
+ 
+ 	    if (s > 0 && (!unique_paths || s == 1)) {
+@@ -374,7 +374,7 @@ void Gap2Seq::execute ()
+     s._comment = comment;
+ #ifndef SINGLE_THREAD
+     {
+-      LocalSynchronizer local(lock);
++      LocalSynchronizer local(Gap2Seq_lock);
+ #endif
+       output.insert(s);
+       output.flush();
+@@ -422,7 +422,7 @@ public:
+     long long id = System::thread().getThreadSelf();
+ #ifndef SINGLE_THREAD
+     {
+-      LocalSynchronizer local(lock);
++      LocalSynchronizer local(Gap2Seq_lock);
+ #endif
+       memuse[id] += n*sizeof(T);
+ #ifndef SINGLE_THREAD
+@@ -438,7 +438,7 @@ public:
+     long long id = System::thread().getThreadSelf();
+ #ifndef SINGLE_THREAD
+     {
+-      LocalSynchronizer local(lock);
++      LocalSynchronizer local(Gap2Seq_lock);
+ #endif
+       memuse[id] -= n*sizeof(T);
+ #ifndef SINGLE_THREAD
+@@ -872,7 +872,7 @@ int Gap2Seq::fill_gap(Graph graph, std::string kmer_left, std::string kmer_right
+   long long id = System::thread().getThreadSelf();
+ #ifndef SINGLE_THREAD
+   {
+-      LocalSynchronizer local(lock);
++      LocalSynchronizer local(Gap2Seq_lock);
+ #endif
+       memuse[id] = 0;
+ #ifndef SINGLE_THREAD
+@@ -927,7 +927,7 @@ int Gap2Seq::fill_gap(Graph graph, std::string kmer_left, std::string kmer_right
+   long long mymemuse;
+ #ifndef SINGLE_THREAD
+   {
+-      LocalSynchronizer local(lock);
++      LocalSynchronizer local(Gap2Seq_lock);
+ #endif
+       mymemuse = memuse[id];
+ #ifndef SINGLE_THREAD
+@@ -951,7 +951,7 @@ int Gap2Seq::fill_gap(Graph graph, std::string kmer_left, std::string kmer_right
+     for (boost::unordered_set<Node, node_hash, equal_to<Node>, count_allocator<Node> >::iterator it = border.begin(); it != border.end(); ++ it) {
+ #ifndef SINGLE_THREAD
+       {
+-	LocalSynchronizer local(lock);
++	LocalSynchronizer local(Gap2Seq_lock);
+ #endif
+ 	mymemuse = memuse[id];
+ #ifndef SINGLE_THREAD
+@@ -1043,7 +1043,7 @@ int Gap2Seq::fill_gap(Graph graph, std::string kmer_left, std::string kmer_right
+ 
+ #ifndef SINGLE_THREAD
+     {
+-      LocalSynchronizer local(lock);
++      LocalSynchronizer local(Gap2Seq_lock);
+ #endif
+       mymemuse = memuse[id];
+ #ifndef SINGLE_THREAD
+@@ -1104,7 +1104,7 @@ int Gap2Seq::fill_gap(Graph graph, std::string kmer_left, std::string kmer_right
+ 
+ #ifndef SINGLE_THREAD
+   {
+-      LocalSynchronizer local(lock);
++      LocalSynchronizer local(Gap2Seq_lock);
+ #endif
+       mymemuse = memuse[id];
+ #ifndef SINGLE_THREAD
+@@ -1126,7 +1126,7 @@ int Gap2Seq::fill_gap(Graph graph, std::string kmer_left, std::string kmer_right
+     for (boost::unordered_set<Node, node_hash, equal_to<Node>, count_allocator<Node> >::iterator it = border.begin(); it != border.end(); ++ it) {
+ #ifndef SINGLE_THREAD
+       {
+-	LocalSynchronizer local(lock);
++	LocalSynchronizer local(Gap2Seq_lock);
+ #endif
+ 	mymemuse = memuse[id];
+ #ifndef SINGLE_THREAD
+@@ -1177,7 +1177,7 @@ int Gap2Seq::fill_gap(Graph graph, std::string kmer_left, std::string kmer_right
+     
+ #ifndef SINGLE_THREAD
+     {
+-      LocalSynchronizer local(lock);
++      LocalSynchronizer local(Gap2Seq_lock);
+ #endif
+       mymemuse = memuse[id];
+ #ifndef SINGLE_THREAD
+@@ -1580,7 +1580,7 @@ int Gap2Seq::fill_gap(Graph graph, std::string kmer_left, std::string kmer_right
+ 
+ #ifndef SINGLE_THREAD
+     {
+-      LocalSynchronizer local(lock);
++      LocalSynchronizer local(Gap2Seq_lock);
+ #endif
+       mymemuse = memuse[id];
+ #ifndef SINGLE_THREAD
+@@ -1640,7 +1640,7 @@ int Gap2Seq::fill_gap(Graph graph, std::string kmer_left, std::string kmer_right
+ #ifdef STATS
+ #ifndef SINGLE_THREAD
+   {
+-      LocalSynchronizer local(lock);
++      LocalSynchronizer local(Gap2Seq_lock);
+ #endif
+       std::cout << "Nodes: " << n << " Nonzeros: " << nz << " Total memory: " << memuse[id] << std::endl; 
+ #ifndef SINGLE_THREAD
+-- 
+2.6.4
+

--- a/recipes/gap2seq/build.sh
+++ b/recipes/gap2seq/build.sh
@@ -2,22 +2,11 @@
 
 set -ef -o pipefail
 
-echo BUILDING GAP2SEQ bldvar 1
-echo uname is:
-uname -a
-echo env is:
-env
-echo ======================================== end of env =================================
-
-if [ -z "$CPPFLAGS" ]; then export CPPFLAGS=""; fi
-if [ -z "$LDFLAGS" ]; then export LDFLAGS=""; fi
-
 export CPPFLAGS="$CPPFLAGS -I${PREFIX}/include"
 export LDFLAGS="$LDFLAGS -L${PREFIX}/lib"
 
 mkdir -p build
 pushd build
-
 
 mkdir -p $PREFIX/bin
 
@@ -26,19 +15,12 @@ if [ "$(uname)" == "Darwin" ]; then
 
     # c++11 compatibility
 
-		if [ -z "$CXXFLAGS" ]; then export CXXFLAGS=""; fi
-		if [ -z "${CXX_FLAGS}" ]; then export CXX_FLAGS=""; fi
-		if [ -z "${CMAKE_CXX_FLAGS}" ]; then export CMAKE_CXX_FLAGS=""; fi
-		if [ -z "${LDFLAGS}" ]; then export LDFLAGS=""; fi
-		if [ -z "${LD_FLAGS}" ]; then export LD_FLAGS=""; fi
-		if [ -z "${CMAKE_LD_FLAGS}" ]; then export CMAKE_LD_FLAGS=""; fi
-
 		CXXFLAGS="$CXXFLAGS";
 		LDFLAGS="$LDFLAGS -Wl,-rpath ${PREFIX}/lib";
 
-    export CXXFLAGS="$CXXFLAGS -stdlib=libc++ -std=c++11 -I${PREFIX}/include -DSINGLE_THREAD"
-    export CXX_FLAGS="${CXX_FLAGS} -stdlib=libc++ -std=c++11 -I${PREFIX}/include -DSINGLE_THREAD"
-    export CMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS} -stdlib=libc++ -std=c++11 -I${PREFIX}/include -DSINGLE_THREAD"
+    export CXXFLAGS="$CXXFLAGS -stdlib=libc++ -std=c++11 -I${PREFIX}/include"
+    export CXX_FLAGS="${CXX_FLAGS} -stdlib=libc++ -std=c++11 -I${PREFIX}/include"
+    export CMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS} -stdlib=libc++ -std=c++11 -I${PREFIX}/include"
     export LDFLAGS="$LDFLAGS -stdlib=libc++"
     export LD_FLAGS="${LD_FLAGS} -stdlib=libc++"
     export CMAKE_LDFLAGS="${CMAKE_LDFLAGS} -stdlib=libc++"
@@ -55,6 +37,5 @@ fi
 cmake -DCMAKE_INSTALL_PREFIX=$PREFIX ${SRC_DIR}
 make Gap2Seq GapCutter GapMerger
 chmod u+x Gap2Seq.sh
-echo copying files: Gap2Seq.sh Gap2Seq GapCutter GapMerger $PREFIX/bin
 cp Gap2Seq.sh Gap2Seq GapCutter GapMerger $PREFIX/bin
 popd

--- a/recipes/gap2seq/meta.yaml
+++ b/recipes/gap2seq/meta.yaml
@@ -1,37 +1,41 @@
-build:
-  number: 4
-  string: boost{{CONDA_BOOST}}_{{PKG_BUILDNUM}}
-
 package:
   name: gap2seq
   version: "2.0"
+
+build:
+  number: 5
+  string: boost{{CONDA_BOOST}}_{{PKG_BUILDNUM}}
+
 source:
   fn: Gap2Seq-2.0.tar.gz
   url: https://www.cs.helsinki.fi/u/lmsalmel/Gap2Seq/Gap2Seq-2.0.tar.gz
   md5: 67af9e2ac4171dbbeff569115705405c
   patches: # [osx]
     - 0001-use-boost-unordered-map-and-set-in-lieu-of-standard.patch # [osx]
+    - 0002-renamed-lock-to-Gap2Seq_lock-to-avoid-name-conflicts.patch # [osx]
 requirements:
   build:
     # linux build
     - gcc >=4.7 # [linux]
+    - libgcc
     - boost {{CONDA_BOOST}}* # [linux]
     # osx build
-    - llvm # [osx]
     - llvmdev ==3.9.1 # [osx]
     - libcxx # [osx]
     - boost ==1.63.0 # [osx]
-    # general requirements
-    - libgcc
+    # general build
     - zlib
     - cmake
     - make
   run:
-    - zlib
+    # linux run
     - libgcc # [linux]
-    - libcxx # [osx]
     - boost {{CONDA_BOOST}}* # [linux]
+    # osx run
+    - libcxx # [osx]
     - boost ==1.63.0 # [osx]
+    # general run
+    - zlib
 test:
   commands:
      - GapMerger 2>&1 | grep "USAGE for"  > /dev/null
@@ -44,3 +48,9 @@ about:
   license: GPLv3
   license_file: LICENCE
   summary: Gap2Seq is a tool for filling gaps between contigs in genome assemblies.
+
+extra:
+  notes: "Gap2Seq is only tested on Linux x86_64 by its author."
+  recipe-maintainers:
+    - notestaff
+


### PR DESCRIPTION
gap2seq: re-enabled multi-threading on osx; cleaned up recipe

* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
