### PR TITLE
Update for Genepop 4.6, works on Mac

### DIFF
--- a/recipes/genepop/build.sh
+++ b/recipes/genepop/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-
+cd Cpp
 g++ -DNO_MODULES -o Genepop GenepopS.cpp -O3
 
 mkdir -p $PREFIX/bin

--- a/recipes/genepop/meta.yaml
+++ b/recipes/genepop/meta.yaml
@@ -27,4 +27,4 @@ about:
 test:
   commands:
     # Expected output verion and prompt for a file or press ENTER to quit:
-    - echo -e '\n' | Genepop
+    - bash -c "echo -e '\n' | Genepop"

--- a/recipes/genepop/meta.yaml
+++ b/recipes/genepop/meta.yaml
@@ -24,7 +24,8 @@ about:
   license: CeCILL
   summary: The Genepop population genetics package.
 
-test:
-  commands:
-    # Expected output verion and prompt for a file or press ENTER to quit:
-    - bash -c "echo -e '\n' | Genepop"
+#Potential test commented out as could not get it to work in framework...
+#test:
+#  commands:
+#    # Expected output verion and prompt for a file or press ENTER to quit:
+#    - bash -c "echo -e '\n' | Genepop"

--- a/recipes/genepop/meta.yaml
+++ b/recipes/genepop/meta.yaml
@@ -1,15 +1,24 @@
 package:
   name: genepop
-  version: "4.5.1"
+  version: "4.6"
+
 build:
   number: 0
-  skip: True # [osx]
+
 source:
+  # Sadly they reuse the same URL and filename for each release
+  # so the checksum is our fall back for coping with this.
   fn: sources.tar.gz
   url: http://kimura.univ-montp2.fr/~rousset/sources.tar.gz
+  sha256: 9a87c9f5401d9de5a9a675e8c4db64ae6f63e83e7924d678c7da12a2210c9475
+
 requirements:
   build:
+    - gcc # [linux]
+    - llvm # [osx]
   run:
+    - libgcc # [linux]
+
 about:
   home: http://kimura.univ-montp2.fr/~rousset/Genepop.htm
   license: CeCILL

--- a/recipes/genepop/meta.yaml
+++ b/recipes/genepop/meta.yaml
@@ -24,8 +24,7 @@ about:
   license: CeCILL
   summary: The Genepop population genetics package.
 
-#Potential test commented out as could not get it to work in framework...
-#test:
-#  commands:
-#    # Expected output verion and prompt for a file or press ENTER to quit:
-#    - bash -c "echo -e '\n' | Genepop"
+test:
+  commands:
+    # Expected output is the version and an error message
+    - echo 'does_not_exist.txt' | Genepop | grep 'Genepop version'

--- a/recipes/genepop/meta.yaml
+++ b/recipes/genepop/meta.yaml
@@ -23,3 +23,8 @@ about:
   home: http://kimura.univ-montp2.fr/~rousset/Genepop.htm
   license: CeCILL
   summary: The Genepop population genetics package.
+
+test:
+  commands:
+    # Expected output verion and prompt for a file or press ENTER to quit:
+    - echo -e '\n' | Genepop

--- a/recipes/genepop/meta.yaml
+++ b/recipes/genepop/meta.yaml
@@ -27,4 +27,4 @@ about:
 test:
   commands:
     # Expected output is the version and an error message
-    - echo 'does_not_exist.txt' | Genepop | grep 'Genepop version'
+    - echo does_not_exist.txt | Genepop | grep "Genepop version"


### PR DESCRIPTION
* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Original recipe by @tiagoantao 

It looks like @bgruening restricted this to exclude Mac, not sure why - it compiles for me locally and my tests passed.

I have also made the compilation requirements explicit in line with evolving BioConda best practises, and added a minimal test.

Note the authors seem to reuse their filenames and URL, meaning older releases are not cached. I have added a checksum, but this is a concern as sources for the old releases are no longer available.