### PR TITLE
Fix runtime requirements for khmer

### DIFF
--- a/recipes/sourmash/meta.yaml
+++ b/recipes/sourmash/meta.yaml
@@ -14,7 +14,7 @@ source:
 build:
   entry_points:
     - sourmash = sourmash_lib.__main__:main
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipes/sourmash/meta.yaml
+++ b/recipes/sourmash/meta.yaml
@@ -40,7 +40,7 @@ requirements:
     - numpy
     - matplotlib
     - scipy
-    - khmer
+    - khmer >=2.1
 
 test:
   imports:


### PR DESCRIPTION
sourmash won't work with khmer < 2.1

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
