### PR TITLE
Update: Toil, bcbio (+vm), VEP

### DIFF
--- a/recipes/bcbio-nextgen-vm/meta.yaml
+++ b/recipes/bcbio-nextgen-vm/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: '0.1.0a'
 
 build:
-  number: 95
+  number: 96
   skip: True # [not py27]
 
 source:
@@ -18,17 +18,19 @@ requirements:
 
   run:
     - python
-    - bcbio-nextgen >=1.0.3
+    - bcbio-nextgen >1.0.3
     - ipyparallel >=4.0,<5.0
     - pysam >=0.11.0
     - arvados-cwl-runner
     - cwl2wdl
     - ruamel.yaml >=0.13.0
-    - toil >=3.3.7a1
+    - toil >=3.8.0a1
     - nodejs
     - elasticluster
     - nose
     - sevenbridges-python
+    - rabix-bunny
+    - synapseclient
     - six
 
 test:

--- a/recipes/bcbio-nextgen/meta.yaml
+++ b/recipes/bcbio-nextgen/meta.yaml
@@ -3,16 +3,16 @@ package:
   version: '1.0.4a0'
 
 build:
-  number: 0
+  number: 1
   skip: True # [not py27]
 
 source:
   #fn: bcbio-nextgen-1.0.3.tar.gz
   #url: https://pypi.io/packages/source/b/bcbio-nextgen/bcbio-nextgen-1.0.3.tar.gz
   #md5: 0dcd2f02cc2d35dc00ec2acd04d7bb9e
-  fn: bcbio-nextgen-311092f.tar.gz
-  url: https://github.com/chapmanb/bcbio-nextgen/archive/311092f.tar.gz
-  md5: cbd2352682473ecf79d5ad8142205183
+  fn: bcbio-nextgen-8b54739.tar.gz
+  url: https://github.com/chapmanb/bcbio-nextgen/archive/8b54739.tar.gz
+  md5: cc9f47fd1e5f80c6dcb8203d039489ec
 
 requirements:
   build:
@@ -52,7 +52,6 @@ requirements:
     - pycrypto
     - pytest
     - pytest-cov
-    - pytest-marks
     - pytest-mock
     - progressbar
     - psutil

--- a/recipes/ensembl-vep/meta.yaml
+++ b/recipes/ensembl-vep/meta.yaml
@@ -1,15 +1,18 @@
+{% set version="88.10" %}
+
 package:
   name: ensembl-vep
-  version: '88.9'
+  version: {{ version }}
 
 source:
-  fn: vep-88.9.tar.gz
-  url: https://github.com/Ensembl/ensembl-vep/archive/release/88.9.tar.gz
-  md5: 2c088ead3a3a5245a7209e9b087666af
+  fn: vep-{{ version }}.tar.gz
+  url: https://github.com/Ensembl/ensembl-vep/archive/release/{{ version }}.tar.gz
+  md5: 9a2ba81dec8968d5f2d71988fd7abba3
 
 build:
-  number: 2
+  number: 0
   skip: True # [osx]
+  string: "htslib{{CONDA_HTSLIB}}_{{PKG_BUILDNUM}}"
 
 requirements:
   build:

--- a/recipes/perl-bio-db-hts/meta.yaml
+++ b/recipes/perl-bio-db-hts/meta.yaml
@@ -12,6 +12,7 @@ source:
 build:
   number: 0
   skip: true # [osx]
+  string: "htslib{{CONDA_HTSLIB}}_{{PKG_BUILDNUM}}"
 
 requirements:
   build:

--- a/recipes/toil/meta.yaml
+++ b/recipes/toil/meta.yaml
@@ -6,12 +6,12 @@ source:
   #fn: toil-3.6.0.tar.gz
   #url: https://pypi.python.org/packages/44/38/5554efcd059db4d67a30075204fe2051465be0031c207e51490cb550f313/toil-3.6.0.tar.gz
   #md5: 55298b33f3d246717cb87d1004fb752c
-  fn: toil-ef9f126.tar.gz
-  url: https://github.com/BD2KGenomics/toil/archive/ef9f126.tar.gz
-  md5: 5577d6d7c27802f6b09bfa6a4e894641
+  fn: toil-32337c0.tar.gz
+  url: https://github.com/BD2KGenomics/toil/archive/32337c0.tar.gz
+  md5: 9cc6cbf7c036eb52deeb74e490f92d3a
 
 build:
-  number: 0
+  number: 1
   skip: True # [not py27]
 
 requirements:


### PR DESCRIPTION
- Adds CONDA_HTSLIB version string to VEP and Bio::DB::HTS (#4793)
- bcbio: latest development and remove pytest-marks dependency
- bcbio-vm: include Rabix and Synapse support
- Toil: avoid file copying during cwltoil

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
