### PR TITLE
Handle case of a new branch with a single commit on forks.

### DIFF
--- a/scripts/travis-run.sh
+++ b/scripts/travis-run.sh
@@ -29,7 +29,12 @@ then
     RANGE="$TRAVIS_BRANCH HEAD"
     if [ $TRAVIS_PULL_REQUEST == "false" ]
     then
-        RANGE="${TRAVIS_COMMIT_RANGE/.../ }"
+        if [ -z "$TRAVIS_COMMIT_RANGE" ]
+        then
+            RANGE="HEAD~1 HEAD"
+        else
+            RANGE="${TRAVIS_COMMIT_RANGE/.../ }"
+        fi
     fi
 
     # If the environment vars changed (e.g., boost, R, perl) then there's no


### PR DESCRIPTION
* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] This PR updates an existing recipe.
* [X] This PR does something else (explain below).

Fixes #4553.  As @ivirshup nicely explained there, when pushing a new branch with a single commit to your fork, the build will always fail as the `TRAVIS_COMMIT_RANGE` variable is empty for that case.  This change checks for that, and sets the range to pick up the last commit.  When multiple commits are made locally to a new branch and then pushed, `TRAVIS_COMMIT_RANGE` has the proper value, so we should only ever need to look at the last commit when it's empty.

Ping @bioconda/core since this is a change to a build script.