### PR TITLE
New: gatk4 wrapper, Update: gatk-framework

### DIFF
--- a/recipes/gatk-framework/gatk-framework
+++ b/recipes/gatk-framework/gatk-framework
@@ -21,9 +21,10 @@ ENV_PREFIX="$(dirname $(dirname $DIR))"
 # Use Java installed with Anaconda to ensure correct version
 java="$ENV_PREFIX/bin/java"
 
-if [ -e "$JAVA_HOME/bin/java" ]
-then
-java="$JAVA_HOME/bin/java"
+if [ -z "${JAVA_HOME:=}" ]; then
+  if [ -e "$JAVA_HOME/bin/java" ]; then
+      java="$JAVA_HOME/bin/java"
+  fi
 fi
 
 # extract memory and system property Java arguments from the list of provided arguments

--- a/recipes/gatk-framework/meta.yaml
+++ b/recipes/gatk-framework/meta.yaml
@@ -8,12 +8,13 @@ package:
   version: '3.6.24'
 
 build:
-  number: 1
+  number: 2
   skip: False
 
 source:
   fn: gatk-framework-3.6-24.tar.gz
   url: https://github.com/chapmanb/gatk/releases/download/v3.6-24-framework/gatk-framework-3.6-24.tar.gz
+  md5: 91f783c78569384ba8eccc747220adb2
 
 requirements:
   run:

--- a/recipes/gatk4/build.sh
+++ b/recipes/gatk4/build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+BINARY_HOME=$PREFIX/bin
+PACKAGE_HOME=$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM
+
+mkdir -p $PREFIX/bin
+mkdir -p $PACKAGE_HOME
+
+SCRIPT_HASH=7332d10f1cd19a46f6f5b072be1031884f47b5a2
+wget --no-check-certificate https://raw.githubusercontent.com/broadinstitute/gatk/$SCRIPT_HASH/gatk-launch
+wget --no-check-certificate https://raw.githubusercontent.com/broadinstitute/gatk/$SCRIPT_HASH/settings.gradle
+sed -i.bak 's#!/usr/bin/env python#!/opt/anaconda1anaconda2anaconda3/bin/python#' gatk-launch
+chmod +x gatk-launch
+cp gatk-launch $PACKAGE_HOME
+cp settings.gradle $PACKAGE_HOME
+cp gatk-*.jar $PACKAGE_HOME
+
+ln -s $PACKAGE_HOME/gatk-launch $PREFIX/bin

--- a/recipes/gatk4/meta.yaml
+++ b/recipes/gatk4/meta.yaml
@@ -1,0 +1,32 @@
+{% set version="4.0a1.2.7.2" %}
+
+about:
+  home: https://www.broadinstitute.org/gatk/
+  license: BSD
+  summary: Genome Analysis Toolkit (GATK4), currently in alpha
+
+package:
+  name: gatk4
+  version: {{ version }}
+
+build:
+  number: 0
+  skip: False
+
+source:
+  fn: gatk-package-{{ version }}-local.jar
+  url: https://github.com/broadinstitute/gatk-protected/releases/download/1.0.0.0-alpha1.2.7.2/gatk-protected-local.jar
+  md5: 632eddb1413774a294c6f3a7388aed85
+
+requirements:
+  build:
+    - gnu-wget
+  run:
+    - java-jdk >=8,<9
+    - python
+
+test:
+  commands:
+    - gatk-launch -h
+    - gatk-launch --list
+    - gatk-launch HaplotypeCaller --help

--- a/recipes/multiqc-bcbio/meta.yaml
+++ b/recipes/multiqc-bcbio/meta.yaml
@@ -3,25 +3,25 @@ package:
   version: "0.2.0dev"
 
 source:
-  git_url: https://github.com/lpantano/MultiQC_bcbio
-  git_tag: 89a998a01d4d1301c079e623636bdd917c52ab02
+  fn: multiqc-bcbio-3a1e773.tar.gz
+  url: https://github.com/MultiQC/MultiQC_bcbio/archive/3a1e773.tar.gz
+  md5: fc2378804bb413ccb1d41a70877b8da1
 
 build:
-  number: 3
+  number: 4
   preserve_egg_dir: True
-  skip: False
+  # multiqc currently not compatible with py3 due to click locale issues
+  skip: true # [not py27]
 
 requirements:
   build:
     - python
     - setuptools
-    - multiqc >=0.9
-    - git
+    - multiqc >=1.0
 
   run:
     - python
-    - setuptools
-    - multiqc >=0.9
+    - multiqc >=1.0
 
 test:
   # Python imports


### PR DESCRIPTION
- gatk4 -- initial wrapper for gatk4 alpha release. This is BSD licensed
  and fully open source. Uses the Broad team's gatk-launch wrapper
  script instead of a custom bioconda wrapper. Only supports local
  execution for now.
- gatk-framework -- Fix problem where we detect java in `/bin/java` even
  if JAVA_HOME is unset. Thanks to Tanner Koomar.
  https://groups.google.com/d/msg/biovalidation/-HzLgUnK2eA/ugmqnPGjAwAJ

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [x] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
