### PR TITLE
Update: CNVkit, ipython-cluster-helper, VariantBam

### DIFF
--- a/recipes/cnvkit/meta.yaml
+++ b/recipes/cnvkit/meta.yaml
@@ -1,15 +1,18 @@
+{% set version="0.8.6a0" %}
 package:
   name: cnvkit
-  version: '0.8.5'
+  version: {{ version }}
 
 source:
-  fn: cnvkit-0.8.5.tar.gz
-  url: https://pypi.python.org/packages/bb/05/336b14341a942aeb40e4692f75e05d8cc35dc6ef5c8524df6c91a56b1eba/CNVkit-0.8.5.tar.gz
-  md5: eb73600ad48daadc7db11bae10e77c4a
+  fn: cnvkit-{{ version }}.tar.gz
+  url: https://github.com/etal/cnvkit/archive/eb571bf.tar.gz
+  #url: https://pypi.io/packages/source/c/cnvkit/cnvkit-{{ version }}.tar.gz
+  md5: 57f36dc93fdbda2e993c96eb4b70aa90
 
 build:
   number: 0
-  skip: False
+  # Requires futures which is not available in conda for 3.6
+  skip: true # [not py27 and not py35]
 
 requirements:
   build:
@@ -35,6 +38,7 @@ requirements:
 test:
   imports:
     - cnvlib
+    - skgenome
   commands:
     - cnvkit.py -h
 

--- a/recipes/ipython-cluster-helper/meta.yaml
+++ b/recipes/ipython-cluster-helper/meta.yaml
@@ -1,11 +1,12 @@
+{% set version="0.5.5" %}
 package:
   name: ipython-cluster-helper
-  version: 0.5.4
+  version: {{ version }}
 
 source:
-  fn: ipython-cluster-helper-0.5.4.tar.gz
-  url: https://pypi.python.org/packages/a5/fa/026aa9d1face6ca63c6802f500bf719ab847c6d4cc7388562a805874a2ee/ipython-cluster-helper-0.5.4.tar.gz
-  md5: e3f43fa72e3e0c1f65d01f1e2dbeceff
+  fn: ipython-cluster-helper-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/i/ipython-cluster-helper/ipython-cluster-helper-{{ version }}.tar.gz
+  md5: 7c4e290e52ff25e393cb1922abaaefe2
 
 build:
   number: 0
@@ -21,7 +22,6 @@ requirements:
 
   run:
     - python
-    - setuptools
     - ipyparallel >=4.0,<5.0
     - pyzmq
     - netifaces

--- a/recipes/variantbam/meta.yaml
+++ b/recipes/variantbam/meta.yaml
@@ -1,26 +1,33 @@
+{% set version="1.4.3" %}
 package:
   name: variantbam
-  version: 1.3.0
+  version: {{ version }}
 
 build:
   number: 0
   skip: True # [osx]
 
 source:
-  #fn: variantbam-1.3.0.tar.gz
-  #url: https://github.com/jwalabroad/VariantBam/archive/1.3.0.tar.gz
-  git_url: https://github.com/jwalabroad/VariantBam.git
-  git_rev: 1.3.0
+  # Needs to do recursive Git clone to get sub modules
+  # [lint skip uses_git_url for recipes/variantbam]
+  # [lint skip missing_hash for recipes/variantbam]
+  git_url: https://github.com/walaj/VariantBam.git
+  git_rev: {{ version }}
+  #fn: variantbam-{{ version }}.tar.gz
+  #url: https://github.com/walaj/VariantBam/archive/{{ version }}.tar.gz
+  #md5: 514bb5ef4a0c3ae4b82bac1bd67f7d67
 
 requirements:
   build:
+    - gcc # [not osx]
     - zlib
   run:
+    - libgcc # [not osx]
     - zlib
 
 test:
     commands:
-      - "variant --help 2>&1 | grep 'Usage: variant'"
+      - 'variant --help 2>&1 | grep "Usage: variant"'
 
 about:
     home: https://github.com/jwalabroad/VariantBam


### PR DESCRIPTION
- ipython-cluster-helper -- v0.5.5 with fix for multiple interfaces
  (chapmanb/bcbio-nextgen#1960)
- CNVkit -- latest development with fix for `--filter cn` problems
  (etal/cnvkit#217)
- VariantBam -- upgrade to latest version with SeqLib support

VariantBam needs recursive Git retrieval

[lint skip uses_git_url for recipes/variantbam]
[lint skip missing_hash for recipes/variantbam]

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
