### PR TITLE
CNVkit: update with support for latest pysam

### DIFF
--- a/recipes/cnvkit/meta.yaml
+++ b/recipes/cnvkit/meta.yaml
@@ -4,13 +4,14 @@ package:
   version: {{ version }}
 
 source:
-  fn: cnvkit-{{ version }}.tar.gz
-  url: https://github.com/etal/cnvkit/archive/eb571bf.tar.gz
+  fn: cnvkit-4c94834.tar.gz
+  url: https://github.com/etal/cnvkit/archive/4c94834.tar.gz
+  #fn: cnvkit-{{ version }}.tar.gz
   #url: https://pypi.io/packages/source/c/cnvkit/cnvkit-{{ version }}.tar.gz
-  md5: 57f36dc93fdbda2e993c96eb4b70aa90
+  md5: ee3e12b06673a3f64a019c05e35c4993
 
 build:
-  number: 0
+  number: 1
   # Requires futures which is not available in conda for 3.6
   skip: true # [not py27 and not py35]
 


### PR DESCRIPTION
Recent pysam release has pickier requirements for
retrieving INFO fields during VCF parsing.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
