### PR TITLE
Update SnpEff and SnpSift to v4.3p. Re-add scripts/ and snpEff.config to snpsift

### DIFF
--- a/recipes/snpeff/build.sh
+++ b/recipes/snpeff/build.sh
@@ -4,7 +4,7 @@ outdir=$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM
 mkdir -p "$outdir"
 mkdir -p "$PREFIX/bin"
 cd snpEff/
-cp -R scripts/ snpEff.config snpEff.jar "$outdir/"
+mv scripts/ snpEff.config snpEff.jar "$outdir/"
 cp "$RECIPE_DIR/snpeff.sh" "$outdir/snpEff"
 chmod +x "$outdir/snpEff"
 

--- a/recipes/snpeff/meta.yaml
+++ b/recipes/snpeff/meta.yaml
@@ -1,7 +1,7 @@
-{% set snpeff_ver = "v4_3o" %}
+{% set snpeff_ver = "v4_3p" %}
 # NOTE: if the version contains a trailing letter, use the <d>.<d>.1<l> format
-{% set version = "4.3.1o" %}
-{% set sha256 = "a2a098afc7434596092a1c0c0eb9d9e56628a56e1451fb4a4ca459311d331638" %}
+{% set version = "4.3.1p" %}
+{% set sha256 = "61f52d2105230ddf74ca810062b6b98473515fa403012cb8fd6498d63d9863f5" %}
 
 about:
   home: 'http://snpeff.sourceforge.net/'
@@ -23,11 +23,11 @@ source:
 
 requirements:
   run:
-      - openjdk
+    - openjdk
 
 test:
-    commands:
-      - snpEff -version
+  commands:
+    - snpEff -version
 
 extra:
-    notes: 'Note that the package version is slightly different from upstream, this is to make sure conda will order the package versions correctly.'
+  notes: 'Note that the package version is slightly different from upstream, this is to make sure conda will order the package versions correctly.'

--- a/recipes/snpsift/build.sh
+++ b/recipes/snpsift/build.sh
@@ -4,8 +4,8 @@ outdir=$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM
 mkdir -p "$outdir"
 mkdir -p "$PREFIX/bin"
 cd snpEff/
-cp -R SnpSift.jar "$outdir/"
-cp $RECIPE_DIR/snpsift.py $outdir/SnpSift
+mv scripts/ snpEff.config SnpSift.jar "$outdir/"
+cp "$RECIPE_DIR/snpsift.py" "$outdir/SnpSift"
 chmod +x "$outdir/SnpSift"
 
 ln -s "$outdir/SnpSift" "$PREFIX/bin"

--- a/recipes/snpsift/meta.yaml
+++ b/recipes/snpsift/meta.yaml
@@ -13,7 +13,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 0
+  number: 1
   skip: False
 
 source:

--- a/recipes/snpsift/meta.yaml
+++ b/recipes/snpsift/meta.yaml
@@ -1,7 +1,7 @@
-{% set snpeff_ver = "v4_3o" %}
+{% set snpeff_ver = "v4_3p" %}
 # NOTE: if the version contains a trailing letter, use the <d>.<d>.1<l> format
-{% set version = "4.3.1o" %}
-{% set sha256 = "a2a098afc7434596092a1c0c0eb9d9e56628a56e1451fb4a4ca459311d331638" %}
+{% set version = "4.3.1p" %}
+{% set sha256 = "61f52d2105230ddf74ca810062b6b98473515fa403012cb8fd6498d63d9863f5" %}
 
 about:
   home: 'http://snpeff.sourceforge.net/SnpSift.html'
@@ -13,12 +13,12 @@ package:
   version: {{ version }}
 
 build:
-  number: 1
+  number: 0
   skip: False
 
 source:
   fn: snpEff_{{ snpeff_ver }}_core.zip
-  url: http://downloads.sourceforge.net/project/snpeff/snpEff_{{ snpeff_ver }}_core.zip
+  url: https://downloads.sourceforge.net/project/snpeff/snpEff_{{ snpeff_ver }}_core.zip
   sha256: {{ sha256 }}
 
 requirements:

--- a/recipes/snpsift/meta.yaml
+++ b/recipes/snpsift/meta.yaml
@@ -23,13 +23,14 @@ source:
 
 requirements:
   run:
-      - openjdk
-      - python
+    - openjdk
+    - python
 
 test:
-    commands:
-      - SnpSift 2>&1 > /dev/null | grep "SnpSift version 4.3"
-      - echo | SnpSift filter "(CHROM == '2')" >/dev/null 2>&1
+  commands:
+    - SnpSift 2>&1 > /dev/null | grep "SnpSift version 4.3"
+    - echo | SnpSift filter "(CHROM == '2')" >/dev/null 2>&1
+    - touch a.vcf && echo | SnpSift annotate a.vcf
 
 extra:
   notes: 'Note that the package version is slightly different from upstream, this is to make sure conda will order the package versions correctly.'


### PR DESCRIPTION
`snpEff.config` is needed by SnpSift annotate
`scripts/vcfEffOnePerLine.pl` is mentioned in the SnpSift documentation

Broken in abbda6ea25c4342d15d5c494ba1bcdd86cce5de0

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
