### PR TITLE
Preserve the original JAR filename: clinod-1.3.jar

### DIFF
--- a/recipes/clinod/clinod.py
+++ b/recipes/clinod/clinod.py
@@ -13,7 +13,7 @@ import shutil
 from os import access
 from os import getenv
 from os import X_OK
-jar_file = 'clinod_1.3_src_all.jar'
+jar_file = 'clinod-1.3.jar'
 
 default_jvm_mem_opts = ['-Xms512m', '-Xmx1g']
 

--- a/recipes/clinod/meta.yaml
+++ b/recipes/clinod/meta.yaml
@@ -4,12 +4,12 @@ package:
 
 build:
   skip: True  # [not linux]
-  number: 0
+  number: 1
 
 source:
   # Original URL http://www.compbio.dundee.ac.uk/www-nod/downloads/clinod-1.3.jar
   url: https://depot.galaxyproject.org/software/clinod/clinod_1.3_src_all.jar
-  fn: clinod_1.3_src_all.jar
+  fn: clinod-1.3.jar
   sha256: 45d80662ba109a7af28aeafcfb2ca417a7d575ac3700f69bd40965a69d41e072
 
 requirements:


### PR DESCRIPTION
* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

The original recipe accidentally used the Galaxy cache's filename ``clinod_1.3_src_all.jar`` rather than the original filename, ``clinod-1.3.jar``.

This restores the original JAR filename.