### PR TITLE
Fixes for unicycler

### DIFF
--- a/recipes/unicycler/Makefile.patch
+++ b/recipes/unicycler/Makefile.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile b/Makefile
+index 587afde..73094c0 100644
+--- a/Makefile
++++ b/Makefile
+@@ -57,7 +57,7 @@ endif
+
+
+ # CXXFLAGS can be overridden by the user.
+-CXXFLAGS    ?= -Wall -Wextra -pedantic -march=native
++CXXFLAGS    ?= -Wall -Wextra -pedantic -mtune=generic
+
+
+ # These flags are required for the build to work.

--- a/recipes/unicycler/meta.yaml
+++ b/recipes/unicycler/meta.yaml
@@ -28,7 +28,7 @@ requirements:
   - libgcc
   - spades >=3.6.2
   - pilon
-  - java-jdk
+  - openjdk
   - bowtie2
   - samtools >=1.0
   - blast

--- a/recipes/unicycler/meta.yaml
+++ b/recipes/unicycler/meta.yaml
@@ -6,35 +6,38 @@ package:
   version: {{ version }}
 
 build:
-  number: 0
+  number: 1
   skip: True # [py27]
 
 source:
   fn: {{ name|lower }}_{{ version }}.tar.gz
   url: https://github.com/rrwick/Unicycler/archive/906a3e7f314c7843bf0b4edf917593fc10baee4f.tar.gz
   md5: 5f06d2bd8ef5065c8047421db8c7895f
+  patches:
+    - Makefile.patch [linux]
+    - misc.py.patch
 
 requirements:
   build:
   - python
   - setuptools
-  - gcc 
+  - gcc
 
   run:
   - python
-  - libgcc  
+  - libgcc
   - spades >=3.6.2
   - pilon
   - java-jdk
   - bowtie2
   - samtools >=1.0
-  - blast 
+  - blast
   - freebayes
 
 test:
   commands:
-    - unicycler -h 
-    - unicycler_align -h 
+    - unicycler -h
+    - unicycler_align -h
     - unicycler_check -h
     - unicycler_polish -h
 

--- a/recipes/unicycler/misc.py.patch
+++ b/recipes/unicycler/misc.py.patch
@@ -1,0 +1,31 @@
+diff --git a/unicycler/misc.py b/unicycler/misc.py
+index d202e3d..b3ee0ab 100644
+--- a/unicycler/misc.py
++++ b/unicycler/misc.py
+@@ -767,24 +767,14 @@ def get_left_arrow():
+     """
+     This function returns either a Unicode left arrow or '<-', depending on the system encoding.
+     """
+-    try:
+-        '\u2190'.encode(sys.stdout.encoding)
+-    except (AttributeError, UnicodeEncodeError):
+-        return '<-'
+-    else:
+-        return '\u2190 '
++    return '<-'
+
+
+ def get_right_arrow():
+     """
+     This function returns either a Unicode right arrow or '->', depending on the system encoding.
+     """
+-    try:
+-        '\u2192'.encode(sys.stdout.encoding)
+-    except (AttributeError, UnicodeEncodeError):
+-        return '->'
+-    else:
+-        return '\u2192'
++    return '->'
+
+
+ def get_default_thread_count():


### PR DESCRIPTION
 - Replace `-march=native` with `-mtune=generic` to prevent the possibility of building with architecture-specific hardware instructions.
 - Remove unicode left/right arrows so that the job output handler definitely won't explode.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [x] This PR updates an existing recipe.
