### PR TITLE
Increase build number for affyio to rebuild with conda > 2.0

### DIFF
--- a/recipes/bioconductor-affyio/meta.yaml
+++ b/recipes/bioconductor-affyio/meta.yaml
@@ -6,7 +6,7 @@ source:
   url: https://bioarchive.galaxyproject.org/affyio_1.42.0.tar.gz
   md5: aa52c3eacb3401eaf7bdaefea62e6c06
 build:
-  number: 0
+  number: 1
   rpaths:
     - lib/R/lib/
     - lib/


### PR DESCRIPTION
* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

In https://github.com/bioconda/bioconda-recipes/pull/4898 I am getting:

```
conda.CondaMultiError: Placeholder of length '80' too short in package /opt/conda/conda-bld/recipe_1496762523369/_b_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placeh/lib/R/library/affyio/libs/affyio.so.
The package must be rebuilt with conda-build > 2.0.
```

I was advised that increasing the build number would cause the package to be rebuilt. However doing so within that PR wasn't sufficient because it doesn't rebuild affyio first causing a failure before it happens. Therefore I'm going to do it in this PR so it is available for that one.