### PR TITLE
MIRA 4.0.2 is GPLv2+ and also available on Mac OS X

### DIFF
--- a/recipes/mira/meta.yaml
+++ b/recipes/mira/meta.yaml
@@ -6,18 +6,17 @@ about:
 
 build:
   number: 2
-  skip: True # [not linux64 and not osx]
+  # TODO - this ought to work on osx as well
+  skip: True # [not linux64]
 
 package:
   name: mira
   version: '4.0.2'
 
 # No build requirements as using the author's binaries.
-# However, these were built expecting libgcc (on Mac).
 requirements:
   build:
   run:
-  - libgcc
 
 source:
   fn: mira_4.0.2.tar.bz2

--- a/recipes/mira/meta.yaml
+++ b/recipes/mira/meta.yaml
@@ -1,25 +1,33 @@
 about:
   home: https://sourceforge.net/p/mira-assembler/wiki/Home/
-  license: GPLv2
+  license: 'GNU General Public License v2 or later (GPLv2+)'
+  license_file: LICENCE
   summary: 'MIRA is a whole genome shotgun and EST sequence assembler for Sanger, 454, Solexa (Illumina), IonTorrent data and PacBio (the later at the moment only CCS and error-corrected CLR reads)'
 
 build:
-  number: 1
-  skip: True # [osx]
+  number: 2
+  skip: True # [not linux64 and not osx]
 
 package:
   name: mira
   version: '4.0.2'
 
+# No build requirements as using the author's binaries.
+# However, these were built expecting libgcc (on Mac).
 requirements:
   build:
   run:
+  - libgcc
 
 source:
   fn: mira_4.0.2.tar.bz2
-  url: https://sourceforge.net/projects/mira-assembler/files/MIRA/stable/mira_4.0.2_linux-gnu_x86_64_static.tar.bz2/download
-  md5: 1defc8b9a398691d9aab640cba41e36e
+  url: https://downloads.sourceforge.net/project/mira-assembler/MIRA/stable/mira_4.0.2_linux-gnu_x86_64_static.tar.bz2 # [linux64]
+  md5: 1defc8b9a398691d9aab640cba41e36e # [linux64]
+  sha256: d3c74a6b402192e01d10adb8dbdc3450d4033fa0e7662ce5ce5de4f8c1967813 # [linux64]
+  url: https://downloads.sourceforge.net/project/mira-assembler/MIRA/stable/mira_4.0.2_darwin13.1.0_x86_64_static.tar.bz2 # [osx]
+  md5: 4ced4dc1fd412b3f8a5a802c076d2724 # [osx]
+  sha256: 3cdfba4be7bde1a97b15259b9fd3216c4369d906ea20f5f360f30dc0d83e7b8e # [osx]
 
 test:
-    commands:
-        - mira --help
+  commands:
+  - mira --help


### PR DESCRIPTION
* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Following existing recipe approach and using the pre-compiled binaries from MIRA author Bastien Chevreux for either 64 bit Linux or Mac OS X (Darwin).
