### PR TITLE
Update shell wrappers: gatk-framework, picard, snpeff

### DIFF
--- a/recipes/gatk-framework/gatk-framework
+++ b/recipes/gatk-framework/gatk-framework
@@ -21,7 +21,7 @@ ENV_PREFIX="$(dirname $(dirname $DIR))"
 # Use Java installed with Anaconda to ensure correct version
 java="$ENV_PREFIX/bin/java"
 
-if [ -z "${JAVA_HOME:=}" ]; then
+if [ -n "${JAVA_HOME:=}" ]; then
   if [ -e "$JAVA_HOME/bin/java" ]; then
       java="$JAVA_HOME/bin/java"
   fi

--- a/recipes/gatk-framework/meta.yaml
+++ b/recipes/gatk-framework/meta.yaml
@@ -8,7 +8,7 @@ package:
   version: '3.6.24'
 
 build:
-  number: 3
+  number: 4
   skip: False
 
 source:

--- a/recipes/picard/meta.yaml
+++ b/recipes/picard/meta.yaml
@@ -8,17 +8,17 @@ source:
   md5: 0449279a6a89830917e8bcef3a976ef7
 
 build:
-  number: 0
+  number: 1
   skip: False
 
 requirements:
   run:
-    - java-jdk >=8
+    - openjdk >=8
     - python
 
 test:
   commands:
-    - "picard 2>&1 | grep 'USAGE: PicardCommandLine'"
+    - "picard 2>&1 | grep USAGE:"
 
 about:
   home: "http://broadinstitute.github.io/picard/"

--- a/recipes/picard/picard.sh
+++ b/recipes/picard/picard.sh
@@ -21,7 +21,7 @@ ENV_PREFIX="$(dirname $(dirname $DIR))"
 java="$ENV_PREFIX/bin/java"
 
 # if JAVA_HOME is set (non-empty), use it. Otherwise keep "java"
-if [ ! -z "${JAVA_HOME:=}" ]; then
+if [ -n "${JAVA_HOME:=}" ]; then
   if [ -e "$JAVA_HOME/bin/java" ]; then
       java="$JAVA_HOME/bin/java"
   fi

--- a/recipes/snpeff/meta.yaml
+++ b/recipes/snpeff/meta.yaml
@@ -13,7 +13,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 0
+  number: 1
   skip: False
 
 source:

--- a/recipes/snpeff/snpeff.sh
+++ b/recipes/snpeff/snpeff.sh
@@ -21,7 +21,7 @@ JAR_DIR=$DIR
 
 java=java
 
-if [ -z "${JAVA_HOME:=}" ]; then
+if [ -n "${JAVA_HOME:=}" ]; then
   if [ -e "$JAVA_HOME/bin/java" ]; then
       java="$JAVA_HOME/bin/java"
   fi


### PR DESCRIPTION
The shell wrapper scripts had inconsistent ways of checking for
JAVA_HOME which were incorrect on gatk-framework and snpeff and would
pick up a java installed in `/bin/java` even if unset.
chapmanb/bcbio-nextgen#1968

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
