### PR TITLE
fgbio: update to latest devel with duplex support

### DIFF
--- a/recipes/fgbio/meta.yaml
+++ b/recipes/fgbio/meta.yaml
@@ -1,25 +1,27 @@
+{% set tag="8b2bc12" %}
 about:
     home: https://github.com/fulcrumgenomics/fgbio
     license: MIT
     summary: A set of tools for working with genomic and high throughput sequencing data, including UMIs
 package:
     name: fgbio
-    version: 0.1.3a
+    version: 0.1.5a
 build:
   number: 0
   skip: true # [not py27]
 source:
-    fn: fgbio-d4d8c22.tar.gz
-    url: https://github.com/fulcrumgenomics/fgbio/archive/d4d8c22.tar.gz
+    fn: fgbio-{{ tag }}.tar.gz
+    url: https://github.com/fulcrumgenomics/fgbio/archive/{{ tag }}.tar.gz
+    md5: 292b817c31ce2fbca21911169774ae98
 requirements:
   build:
-    - java-jdk >=8
+    - openjdk >=8
     - sbt
     - scala
   run:
-    - java-jdk >=8
+    - openjdk >=8
     - python
 
 test:
     commands:
-      - fgbio 2>&1 | grep "CallMolecularConsensusReads"
+      - 'fgbio 2>&1 | grep "CallMolecularConsensusReads"'


### PR DESCRIPTION
Latest development version supports duplex UMIs with a fix to handle
strand changes from 0.1.4

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
