### PR TITLE
Update: cwl2wdl, bcbio-nextgen, bcbio-vm

### DIFF
--- a/recipes/bcbio-nextgen-vm/meta.yaml
+++ b/recipes/bcbio-nextgen-vm/meta.yaml
@@ -3,13 +3,13 @@ package:
   version: '0.1.0a'
 
 build:
-  number: 97
+  number: 98
   skip: True # [not py27]
 
 source:
-  fn: bcbio-nextgen-vm-06dbe09.tar.gz
-  url: https://github.com/chapmanb/bcbio-nextgen-vm/archive/06dbe09.tar.gz
-  md5: 707650583c973d62a715db8c6c96c965
+  fn: bcbio-nextgen-vm-acf219a.tar.gz
+  url: https://github.com/chapmanb/bcbio-nextgen-vm/archive/acf219a.tar.gz
+  md5: a99110c5406cc8be0f11fdccc7c12e0b
 
 requirements:
   build:

--- a/recipes/bcbio-nextgen/meta.yaml
+++ b/recipes/bcbio-nextgen/meta.yaml
@@ -3,16 +3,16 @@ package:
   version: '1.0.4a0'
 
 build:
-  number: 1
+  number: 2
   skip: True # [not py27]
 
 source:
   #fn: bcbio-nextgen-1.0.3.tar.gz
   #url: https://pypi.io/packages/source/b/bcbio-nextgen/bcbio-nextgen-1.0.3.tar.gz
   #md5: 0dcd2f02cc2d35dc00ec2acd04d7bb9e
-  fn: bcbio-nextgen-8b54739.tar.gz
-  url: https://github.com/chapmanb/bcbio-nextgen/archive/8b54739.tar.gz
-  md5: cc9f47fd1e5f80c6dcb8203d039489ec
+  fn: bcbio-nextgen-d7af4dd.tar.gz
+  url: https://github.com/chapmanb/bcbio-nextgen/archive/d7af4dd.tar.gz
+  md5: 0682729a887f219e2189708cd68c43dc
 
 requirements:
   build:

--- a/recipes/cwl2wdl/meta.yaml
+++ b/recipes/cwl2wdl/meta.yaml
@@ -3,13 +3,13 @@ package:
   version: "0.1dev44"
 
 source:
-  fn: cwl2wdl-b6dbaea.tar.gz
-  url: https://github.com/chapmanb/cwl2wdl/archive/b6dbaea.tar.gz
-  md5: 747d7d6047706da03b8648de05a58fa6
+  fn: cwl2wdl-c242b63.tar.gz
+  url: https://github.com/chapmanb/cwl2wdl/archive/c242b63.tar.gz
+  md5: de4c77b6b6c035ab8dc388c405541de0
 
 build:
   skip: False
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
Updates cwl2wdl and bcbio to support generation of WDL proposed structs.
Updates bcbio-vm to support AWS runs on non us-east regions.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
