### PR TITLE
Bump PlantTribes AssemblyPostProcessor to version 1.0.1

### DIFF
--- a/recipes/plant_tribes_assembly_post_processor/1.0.1/build.sh
+++ b/recipes/plant_tribes_assembly_post_processor/1.0.1/build.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+mkdir -p $PREFIX/bin
+mkdir -p $PREFIX/config
+mkdir -p $PREFIX/data
+mkdir -p $PREFIX/pipelines
+mkdir -p $PREFIX/scripts
+
+cp ./pipelines/AssemblyPostProcessor $PREFIX/bin
+chmod +x $PREFIX/bin/AssemblyPostProcessor
+ln -s $PREFIX/bin/AssemblyPostProcessor $PREFIX/pipelines/AssemblyPostProcessor
+cp ./config/* $PREFIX/config
+cp ./data/* $PREFIX/data
+cp ./scripts/* $PREFIX/scripts

--- a/recipes/plant_tribes_assembly_post_processor/1.0.1/meta.yaml
+++ b/recipes/plant_tribes_assembly_post_processor/1.0.1/meta.yaml
@@ -1,0 +1,33 @@
+package:
+  name: plant_tribes_assembly_post_processor
+  version: "1.0.1"
+
+source:
+  fn: v1.0.1.tar.gz
+  url: https://github.com/dePamphilis/PlantTribes/archive/v1.0.1.tar.gz
+  md5: dcef43b19ed8057212e8cb44994c7d37
+
+build:
+  number: 0
+  # Requires genometools which is not supported on osx
+  skip: True # [osx]
+
+requirements:
+  run:
+    - cap3
+    - genometools-genometools >=1,<2
+    - hmmer >=3
+    - mafft >=7,<8
+    - perl >=5.22
+    - perl-estscan2 2.1 pl5.22.0_1
+    - transdecoder >=3,<4
+    - trimal >=1.4,<2
+
+test:
+  commands:
+    - AssemblyPostProcessor 2>&1 | grep Usage
+
+about:
+  home: 'https://github.com/dePamphilis/PlantTribes'
+  summary: 'Transcriptome assembly post processing pipeline'
+  license: GNU General Public License v3 (GPLv3)


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [x] This PR adds a new recipe.
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

The enhancements to the AssemblyPostProcessor script are necessary as a work-around for issues in the current version of TransDecoder related to fasta accessions.  In our work, we discovered that the format of the fasta IDs in the TransDecoder output changes depending on the input fasta ID string.  These issues have been reported to the TransDecoder folks and will be addressed in an upcoming release.  In the meantime, the enhancements we've made to this version of AssemblyPostProcessor should be sufficient.