### PR TITLE
JSON Collect Data Source

### DIFF
--- a/recipes/json-collect-data-source/build.sh
+++ b/recipes/json-collect-data-source/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+python setup.py install

--- a/recipes/json-collect-data-source/meta.yaml
+++ b/recipes/json-collect-data-source/meta.yaml
@@ -14,7 +14,7 @@ about:
 
 source:
   git_url: https://github.com/fabio-cumbo/galaxy-json-collect-data-source.git
-  git_rev: 644d746
+  git_rev: 1.0.0
 
 build:
   number: 0

--- a/recipes/json-collect-data-source/meta.yaml
+++ b/recipes/json-collect-data-source/meta.yaml
@@ -23,7 +23,8 @@ build:
 
 test:
   # Python imports
-  imports: json_collect_data_source
+  imports: 
+    - json_collect_data_source
 
 requirements:
   build:

--- a/recipes/json-collect-data-source/meta.yaml
+++ b/recipes/json-collect-data-source/meta.yaml
@@ -13,7 +13,7 @@ about:
   license: BSD
 
 source:
-  git_url: https://github.com/fabio-cumbo/galaxy-json-collect-data-source
+  git_url: https://github.com/fabio-cumbo/galaxy-json-collect-data-source.git
   git_rev: 644d746
 
 build:

--- a/recipes/json-collect-data-source/meta.yaml
+++ b/recipes/json-collect-data-source/meta.yaml
@@ -13,8 +13,9 @@ about:
   license: BSD
 
 source:
-  git_url: https://github.com/fabio-cumbo/galaxy-json-collect-data-source.git
-  git_rev: 1.0.0
+  fn: package_galaxy_json_collect_data_source-1.0.0.tar.gz
+  url: https://github.com/fabio-cumbo/package_galaxy_json_collect_data_source/archive/1.0.0.tar.gz
+  md5: 5ac73f57117d759056aea19cdcd9ad89
 
 build:
   number: 0

--- a/recipes/json-collect-data-source/meta.yaml
+++ b/recipes/json-collect-data-source/meta.yaml
@@ -1,0 +1,31 @@
+package:
+  name: json_collect_data_source
+  version: "1.0.0"
+
+about:
+  home: https://github.com/fabio-cumbo/galaxy-json-collect-data-source
+  summary: 'This tool is able to receive multiple datasets 
+  (optionally with their metadata) in a single query. 
+  As an extension of the galaxy-json-data-source tool
+  (https://github.com/mdshw5/galaxy-json-data-source), 
+  it allows to handle archives (gz, bz2, tar, and zip) 
+  organizing their content in a collection.'
+  license: BSD
+
+source:
+  git_url: https://github.com/fabio-cumbo/galaxy-json-collect-data-source
+  git_rev: 644d746
+
+build:
+  number: 0
+  skip: False
+
+test:
+  # Python imports
+  imports: json_collect_data_source
+
+requirements:
+  build:
+    - python
+  run:
+    - python


### PR DESCRIPTION
Extension of the [json_data_source](https://github.com/mdshw5/galaxy-json-data-source) tool.
It allows to handle archives (gz, bz2, tar, and zip) organizing their content in a collection.
Reference [https://github.com/fabio-cumbo/galaxy-json-collect-data-source](https://github.com/fabio-cumbo/galaxy-json-collect-data-source)

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [x] This PR adds a new recipe.
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
