### PR TITLE
add kernsmooth dep to dupradar

### DIFF
--- a/recipes/bioconductor-dupradar/meta.yaml
+++ b/recipes/bioconductor-dupradar/meta.yaml
@@ -13,9 +13,11 @@ build:
 requirements:
   build:
     - 'bioconductor-rsubread >=1.14.1'
+    - r-kernsmooth
     - r-base
   run:
     - 'bioconductor-rsubread >=1.14.1'
+    - r-kernsmooth
     - r-base
 test:
   commands:


### PR DESCRIPTION
* [ ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

I found in some cases bioconductor-dupradar has a runtime error because it can't load `KernSmooth` in some functions. `KernSmooth` is one of the packages no longer included by default in R so this adds the dependency.