### PR TITLE
new recipe for CRISPResso 1.0.6

### DIFF
--- a/recipes/crispresso/build.sh
+++ b/recipes/crispresso/build.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
+CRISPRESSO_DEPENDENCIES_FOLDER=$CONDA_ROOT/share
 $PYTHON setup.py install

--- a/recipes/crispresso/meta.yaml
+++ b/recipes/crispresso/meta.yaml
@@ -1,15 +1,16 @@
 package:
   name: crispresso
-  version: 1.0
+  version: 1.0.6
 
 
 source:
-  fn: CRISPResso-1.0.zip
-  url: https://github.com/lucapinello/CRISPResso/archive/42c37b32a3740a5e0998678a1a0bb221fac69481.zip
-  md5: 3f87c9499f5a3a8a6b63e1d82b07e141
+  fn: CRISPResso-1.0.6.zip
+  url: https://github.com/lucapinello/CRISPResso/archive/09527d897f7a5ee2597c7ab9ab29335b7db3166c.zip
+  md5: 897c350e3ff18c79a04738e1f34724ae
 
 build:
-  skip: True # [not py27]
+    number: 0
+    skip: True # [not py27]
 
 requirements:
   build:
@@ -21,14 +22,15 @@ requirements:
     - matplotlib >=1.3.1
     - biopython >=1.6.5
     - argparse
-    - setuptools
     - trimmomatic
     - flash
     - emboss
-    - java-jdk >=8
+    - openjdk
     - gcc
     - samtools
     - bowtie2
+    - seaborn
+    - setuptools
 
   run:
     - python
@@ -39,14 +41,14 @@ requirements:
     - matplotlib >=1.3.1
     - biopython >=1.6.5
     - argparse
-    - setuptools
     - trimmomatic
     - flash
     - emboss
-    - java-jdk >=8
+    - openjdk >=8
     - libgcc
     - samtools
     - bowtie2
+    - seaborn
 
 test:
   commands:


### PR DESCRIPTION
* [X ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [  ] This PR adds a new recipe.
* [ X] This PR updates an existing recipe.
* [X ] This PR does something else (explain below).

There are some dep files for CRISPResso, by default they are copied in ~/CRISPREsso_dependencies, but this can be overridden by setting an env variable () before calling the setup. I have modified the build script to put those files in CONDA_ROOT/share. Please let me know if this is acceptable.

I am new to this so please let me know if I am missing something.

Thanks!