### PR TITLE
Update: htslib, samtools, bcftools to 1.5

### DIFF
--- a/recipes/bcftools/build.sh
+++ b/recipes/bcftools/build.sh
@@ -8,4 +8,6 @@ cd htslib*
 make
 cd ..
 
+./configure --prefix=$PREFIX --enable-libcurl CPPFLAGS="-I$PREFIX/include" LDFLAGS="-L$PREFIX/lib"
+make prefix=$PREFIX CPPFLAGS=$CPPFLAGS LDFLAGS=$LDFLAGS
 make prefix=$PREFIX CPPFLAGS=$CPPFLAGS LDFLAGS=$LDFLAGS plugins install

--- a/recipes/bcftools/meta.yaml
+++ b/recipes/bcftools/meta.yaml
@@ -1,4 +1,4 @@
-{% set version="1.4.1" %}
+{% set version="1.5" %}
 about:
   home: https://github.com/samtools/bcftools
   license: MIT
@@ -32,7 +32,7 @@ requirements:
 source:
   fn: bcftools-{{ version }}.tar.bz2
   url: https://github.com/samtools/bcftools/releases/download/{{ version }}/bcftools-{{ version }}.tar.bz2
-  md5: 103729569ca3e265b13d2fed5775016e
+  md5: e43efe3df5f9c55acb4b48cee214d281
 test:
   commands:
     - bcftools -h

--- a/recipes/htslib/meta.yaml
+++ b/recipes/htslib/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.4.1" %}
+{% set version = "1.5" %}
 
 package:
   name: htslib
@@ -10,7 +10,7 @@ build:
 source:
   fn: htslib-{{ version }}.tar.bz2
   url: https://github.com/samtools/htslib/releases/download/{{ version }}/htslib-{{ version }}.tar.bz2
-  md5: e549fee04d95c1cf8f46347e9e9bbd93
+  md5: e7c269d519a0c01de680bbc72fc76a57
 
 requirements:
   build:

--- a/recipes/pysam/meta.yaml
+++ b/recipes/pysam/meta.yaml
@@ -10,7 +10,7 @@ source:
       - osx_rpath.patch [osx]
 
 build:
-    number: 0
+    number: 1
     skip: False
     binary_relocation: False # [linux]
 
@@ -18,9 +18,9 @@ requirements:
     build:
         - gcc  # [linux]
         - llvm # [osx]
-        - htslib >=1.4.1,<1.5
-        - samtools >=1.4.1,<1.5
-        - bcftools >=1.4.1,<1.5
+        - htslib >=1.4.1
+        - samtools >=1.4.1
+        - bcftools >=1.4.1
         - cython
         - python
         - setuptools
@@ -29,9 +29,9 @@ requirements:
 
     run:
         - libgcc # [linux]
-        - htslib >=1.4.1,<1.5
-        - samtools >=1.4.1,<1.5
-        - bcftools >=1.4.1,<1.5
+        - htslib >=1.4.1
+        - samtools >=1.4.1
+        - bcftools >=1.4.1
         - python
         - zlib
         - curl

--- a/recipes/samtools/meta.yaml
+++ b/recipes/samtools/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.4.1" %}
+{% set version = "1.5" %}
 
 package:
   name: samtools
@@ -11,7 +11,7 @@ build:
 source:
   fn: samtools-{{ version }}.tar.bz2
   url: https://github.com/samtools/samtools/releases/download/{{ version }}/samtools-{{ version }}.tar.bz2
-  md5: 60186f7817813baf99abc4b802f61138
+  md5: 56239b2ede8d0571d0af2065e62eb777
 
 requirements:
   build:
@@ -27,6 +27,7 @@ requirements:
   - libgcc # [not osx]
     #- ncurses {{CONDA_NCURSES}}*
   - zlib
+  - bzip2
   - curl
   - xz
 


### PR DESCRIPTION
Update samtools, bcftools and htslib to latest 1.5 release, including
fixes for samtools multithread index problems. Bumps pysam requirements
to be compatible with latest release.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
