### PR TITLE
Update: Toil, VariantBam

### DIFF
--- a/recipes/toil/meta.yaml
+++ b/recipes/toil/meta.yaml
@@ -1,17 +1,17 @@
 package:
   name: toil
-  version: '3.8.0a1'
+  version: '3.9.0a1'
 
 source:
   #fn: toil-3.6.0.tar.gz
   #url: https://pypi.python.org/packages/44/38/5554efcd059db4d67a30075204fe2051465be0031c207e51490cb550f313/toil-3.6.0.tar.gz
   #md5: 55298b33f3d246717cb87d1004fb752c
-  fn: toil-32337c0.tar.gz
-  url: https://github.com/BD2KGenomics/toil/archive/32337c0.tar.gz
-  md5: 9cc6cbf7c036eb52deeb74e490f92d3a
+  fn: toil-ff0404e.tar.gz
+  url: https://github.com/BD2KGenomics/toil/archive/ff0404e.tar.gz
+  md5: 644aadbf5c09f8968d071def3674dd90
 
 build:
-  number: 1
+  number: 0
   skip: True # [not py27]
 
 requirements:

--- a/recipes/variantbam/meta.yaml
+++ b/recipes/variantbam/meta.yaml
@@ -1,4 +1,5 @@
-{% set version="1.4.3" %}
+{% set version="1.4.4a" %}
+{% set revision="1522c5c" %}
 package:
   name: variantbam
   version: {{ version }}
@@ -10,19 +11,22 @@ build:
 source:
   # Needs to do recursive Git clone to get sub modules
   # [lint skip uses_git_url for recipes/variantbam]
-  # [lint skip missing_hash for recipes/variantbam]
   git_url: https://github.com/walaj/VariantBam.git
-  git_rev: {{ version }}
+  git_rev: {{ revision }}
+  md5: unused
   #fn: variantbam-{{ version }}.tar.gz
   #url: https://github.com/walaj/VariantBam/archive/{{ version }}.tar.gz
-  #md5: 514bb5ef4a0c3ae4b82bac1bd67f7d67
 
 requirements:
   build:
     - gcc # [not osx]
+    - xz
+    - bzip2
     - zlib
   run:
     - libgcc # [not osx]
+    - xz
+    - bzip2
     - zlib
 
 test:


### PR DESCRIPTION
- Toil: include fixes for PBSPro, AWS and local symlink runs
- VariantBam: QC flagging downsampled reads (walaj/VariantBam#9)
  and large VCF line support (walaj/VariantBam#10)

[lint skip uses_git_url for recipes/variantbam]

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
