### PR TITLE
fix build.sh; bump build

### DIFF
--- a/recipes/gffutils/build.sh
+++ b/recipes/gffutils/build.sh
@@ -1,9 +1,2 @@
 #!/bin/bash
-
-$PYTHON setup.py install
-
-# Add more build steps here, if they are necessary.
-
-# See
-# http://docs.continuum.io/conda/build.html
-# for a list of environment variables that are set during the build process.
+$PYTHON setup.py install --single-version-externally-managed --record /tmp/$PKG_NAME.log

--- a/recipes/gffutils/meta.yaml
+++ b/recipes/gffutils/meta.yaml
@@ -3,8 +3,7 @@ package:
   version: "0.8.7.1"
 
 build:
-    number: 0
-    skip: False
+    number: 1
 
 source:
   fn: gffutils-0.8.7.1.tar.gz


### PR DESCRIPTION
* [ ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Fixes the build error `RuntimeError: Setuptools downloading is disabled in conda build. Be sure to add all dependencies in the meta.yaml  url=https://files.pythonhosted.org/packages/source/c/certifi/certifi-2016.9.26.tar.gz`