### PR TITLE
Bump WhatsHap to version 0.14.1

### DIFF
--- a/recipes/whatshap/meta.yaml
+++ b/recipes/whatshap/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: whatshap
-  version: "0.13"
+  version: "0.14.1"
 
 about:
   home: https://whatshap.readthedocs.io/
@@ -8,32 +8,30 @@ about:
   summary: 'phase genomic variants using DNA sequencing reads (haplotype assembly)'
 
 source:
-  fn: whatshap-0.13.tar.gz
-  url: https://pypi.python.org/packages/e2/f3/c71cb4bc3ba3b1234ee0c5fe729c60440164e07437695ca09c61750e0e11/whatshap-0.13.tar.gz
-  md5: 6c9c8b7d6138b60a5a070f0de59f576f
+  fn: whatshap-0.14.1.tar.gz
+  url: https://pypi.python.org/packages/ec/d4/d6c19b716926895ee3def919ab23194212172ed5cf89ccb91c2949fb258d/whatshap-0.14.1.tar.gz
+  md5: edaaeada862844285de1fee9d76da93d
 
 requirements:
-  # To do: Pinnng of the setuptools version is a workaround. Try to remove it.
   build:
     - gcc
     - python
     - setuptools
-    - pysam <0.9.0
+    - pysam >0.11.0
     - pyvcf
     - pyfaidx
     - xopen
   run:
     - libgcc
     - python
-    - setuptools
-    - pysam <0.9.0
+    - pysam >0.11.0
     - pyvcf
     - pyfaidx
     - xopen
 
 build:
   skip: True  # [not py3k]
-  script: python3 setup.py install
+  script: $PYTHON setup.py install --single-version-externally-managed --record=record.txt
 
 test:
   imports:


### PR DESCRIPTION
Remove run dependency on setuptools. Use ``$PYTHON setup.py install --single-version-externally-managed --record=record.txt`` to avoid the problems discussed in pull request #5124.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
