### PR TITLE
added deps for configureHomer.pl

### DIFF
--- a/recipes/homer/meta.yaml
+++ b/recipes/homer/meta.yaml
@@ -16,7 +16,7 @@ source:
   md5: e71ff4258c8a9cfcdd419c7078848a0d
   url: http://homer.salk.edu/homer/configureHomer.pl
 build:
-  number: 4
+  number: 5
 
 # dependencies according to README.txt installed by configureHomer.pl
 # are ghostscript, weblogo v2 NOT v2.8 and blat. Note, however, that there
@@ -26,14 +26,15 @@ requirements:
     - python
     - setuptools
     - perl
-    - weblogo ==2.8.2
-    - ghostscript
-    - blat
+    - wget
+    - gcc # [linux]
+    - llvm # [osx]
+    - unzip # [linux]
+    - zip # [linux]
+
   run:
     - perl
-    - weblogo ==2.8.2
-    - ghostscript
-    - blat
+    - libgcc # [linux]
 
 test:
   requires:
@@ -43,6 +44,7 @@ test:
     #- findMotifs.pl 2>&1 | grep "findMotifs.pl" > /dev/null
     #- findMotifs.pl 2>&1 | grep "please run configureHomer.pl" > /dev/null
     - findMotifs.pl -h > /dev/null 
+    - homer2 > /dev/null
     #- GenomeOntology.pl > /dev/null
     #- homer > /dev/null
     #- makeTagDirectory > /dev/null
@@ -52,6 +54,6 @@ about:
   license: "GPL3"
   summary: 'Software for motif discovery and next generation sequencing analysis'
   license_family: GPL
-  maintainer: BioNinja, cokelaer
+  maintainer: BioNinja, cokelaer, simonvh
 
 


### PR DESCRIPTION
* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

* weblogo, blat and ghostscript are no longer dependencies
* `configureHomer.pl` depends on gcc, wget, zip and unzip which are not present in the build environment