### PR TITLE
bringing back metameta v1.0

### DIFF
--- a/recipes/metameta/1.0/build.sh
+++ b/recipes/metameta/1.0/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+mkdir -p $PREFIX/bin
+mkdir -p $PREFIX/opt/metameta/
+
+# Full path to the Snakefile
+sed -i "s|Snakefile|$PREFIX/opt/metameta/Snakefile|g" metameta
+
+cp -r * $PREFIX/opt/metameta/
+ln -s $PREFIX/opt/metameta/metameta $PREFIX/bin/
+

--- a/recipes/metameta/1.0/meta.yaml
+++ b/recipes/metameta/1.0/meta.yaml
@@ -5,7 +5,7 @@ package:
 source:
   fn: v1.0.tar.gz
   url: https://github.com/pirovc/metameta/archive/v1.0.tar.gz
-  md5: 0214502abbb8b6e9c4d49b74f2e1d58f
+  md5: d4d22d24329ac0c4cf597ca5fb29fe03
 
 build:
   number: 1
@@ -17,8 +17,7 @@ requirements:
 
 test:
   commands:
-    - touch "metameta_dummy_file_test"
-    - metameta --configfile $PREFIX/opt/metameta/scripts/metameta_dummy_file_test.yaml -n
+    - metameta --configfile $PREFIX/opt/metameta/scripts/metameta_dummy_file_test.yaml --config workdir="$PREFIX/opt/metameta/" -n
 
 about:
   home: https://github.com/pirovc/metameta/

--- a/recipes/metameta/1.0/meta.yaml
+++ b/recipes/metameta/1.0/meta.yaml
@@ -1,0 +1,26 @@
+package:
+  name: metameta
+  version: 1.0
+
+source:
+  fn: v1.0.tar.gz
+  url: https://github.com/pirovc/metameta/archive/v1.0.tar.gz
+  md5: 0214502abbb8b6e9c4d49b74f2e1d58f
+
+build:
+  number: 1
+  skip: True # [osx]  
+  
+requirements:
+  run:
+    - snakemake ==3.9.1
+
+test:
+  commands:
+    - touch "metameta_dummy_file_test"
+    - metameta --configfile $PREFIX/opt/metameta/scripts/metameta_dummy_file_test.yaml -n
+
+about:
+  home: https://github.com/pirovc/metameta/
+  license: "The MIT License (MIT)"
+  summary: "MetaMeta - pipeline for integrating metagenome analysis tools to improve taxonomic profiling"


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

As stated in the PR #5132 I needed the new version of the metameta tool (1.1) on bioconda but the folder with the version 1.0 was giving a strange error on travis ("permission denied" error trying to delete the "locks" file). I kept just the new version and passed the tests and now I'm bringing the old version back to keep it there.
