### PR TITLE
Update meta.yml to fix incompatibility issues

### DIFF
--- a/recipes/vispr/build.sh
+++ b/recipes/vispr/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-$PYTHON setup.py install
+$PYTHON setup.py install --single-version-externally-managed --record=record.txt

--- a/recipes/vispr/meta.yaml
+++ b/recipes/vispr/meta.yaml
@@ -11,6 +11,7 @@ source:
 
 build:
   skip: True # [py27]
+  number: 1
   entry_points:
     - vispr = vispr.cli:main
 

--- a/recipes/vispr/meta.yaml
+++ b/recipes/vispr/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - setuptools
     - numpy
     - flask
-    - pandas >=0.17.1
+    - pandas >=0.17.1,<0.20
     - pyyaml
     - scipy
     - scikit-learn
@@ -29,7 +29,7 @@ requirements:
     - python
     - numpy
     - flask
-    - pandas >=0.17.1
+    - pandas >=0.17.1,<0.20
     - pyyaml
     - scipy
     - scikit-learn


### PR DESCRIPTION
Fix incompatibility issues of vispr and new panda versions >=0.20. Require panda versions to be <0.20.

* [ ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR updates an existing recipe.
