### PR TITLE
bcftools: remove tex and matplotlib deps

### DIFF
--- a/recipes/bcftools/meta.yaml
+++ b/recipes/bcftools/meta.yaml
@@ -10,7 +10,7 @@ about:
     VCF and BCF and streams will work in most, but not all situations.
 
 build:
-  number: 2
+  number: 3
 package:
   name: bcftools
   version: {{ version }}
@@ -26,8 +26,9 @@ requirements:
   - libgcc # [not osx]
   - bzip2
   - curl
-  - matplotlib # for plot-vcfstats
-  - texlive-core # for plot-vcfstats
+  # Currently removed due to size and dependency issues
+  #- matplotlib # for plot-vcfstats
+  #- texlive-core # for plot-vcfstats
   - xz
   - zlib
 
@@ -42,4 +43,4 @@ test:
     - bcftools -h
     - bcftools --version
     - bcftools plugin -lv
-    - plot-vcfstats -h 2>&1 | grep -q "Plots output of "
+    #- plot-vcfstats -h 2>&1 | grep -q "Plots output of "


### PR DESCRIPTION
Temporary workaround for issues with perl dependency resolution and
large dependencies in bcftools

chapmanb/bcbio-nextgen#2004

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
