### PR TITLE
Blasr - update version, skip some linting

### DIFF
--- a/recipes/blasr/meta.yaml
+++ b/recipes/blasr/meta.yaml
@@ -1,18 +1,24 @@
 {% set name = "blasr" %}
-{% set version = "5.3.f8bfa9c" %}
+{% set version = "5.3.574e1c2" %}
 
 package:
   name: {{ name }}
   version: {{ version }}
 
 build:
-  number: 1
+  number: 0
   skip: True # [not py27 or osx]
 
 source:
   git_url: https://github.com/PacificBiosciences/blasr.git
-  git_rev: f8bfa9c5565ae01ea669af872edaae5e55471d98
-    
+  git_rev: 574e1c2ab1fadea49774c61c2c2374006e941ec1
+
+
+extra:
+  skip-lints:
+    - uses_git_url
+    - missing_hash
+
 requirements:
   build:
     - llvm # [osx]

--- a/recipes/blasr/meta.yaml
+++ b/recipes/blasr/meta.yaml
@@ -1,12 +1,12 @@
 {% set name = "blasr" %}
-{% set version = "5.3.574e1c2" %}
+{% set version = "5.3.post1.574e1c2" %}
 
 package:
   name: {{ name }}
   version: {{ version }}
 
 build:
-  number: 0
+  number: 1
   skip: True # [not py27 or osx]
 
 source:

--- a/recipes/blasr/meta.yaml
+++ b/recipes/blasr/meta.yaml
@@ -23,14 +23,14 @@ requirements:
   build:
     - llvm # [osx]
     - gcc # [linux]
-    - hdf5
+    - hdf5 1.8.18|1.8.18.*
     - python
     - pbbam
     - blasr_libcpp
 
   run:
     - libgcc # [linux]
-    - hdf5
+    - hdf5 1.8.18|1.8.18.*
     - pbbam
     - blasr_libcpp
 

--- a/recipes/blasr/meta.yaml
+++ b/recipes/blasr/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 0
+  number: 1
   skip: True # [not py27 or osx]
 
 source:


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

This is now failing the build for a new reason, which seems to be discussed here: https://github.com/PacificBiosciences/blasr/issues/355. Unfortunately, the issue was closed without fixing it (atm). Hoping to get it fixed upstream, otherwise we may have to fall back to an earlier version of HDF5.