### PR TITLE
increased fastxtoolkit build number(5) -  (error while planemo test w…

### DIFF
--- a/recipes/fastx_toolkit/meta.yaml
+++ b/recipes/fastx_toolkit/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   preserve_egg_dir: True
-  number: 4
+  number: 5
   skip: False
 
 requirements:


### PR DESCRIPTION
I encountered an error with fastX_toolkit within a planemo test : 
```
(.venv_planemo)[vmataigne@n56 ~]$ /tmp/mv/bin/conda create -y --name mulled-v1-72f73e688f29976c6334a4b1b612ee663169a67d04ff49f7511e997a96b9c  fastx_toolkit=0.0.14 
Fetching package metadata ...............
Solving package specifications: ..........
Warning: 2 possible package resolutions (only showing differing packages):
  - bioconda::perl-gdgraph-histogram-1.1-0.tar.bz2
  - bioconda::perl-gdgraph-histogram-1.1-pl5.22.0_0.tar.bz2
```
We updated fastxtoolkit build number with @lecorguille to check this out. 

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
