### PR TITLE
Move older recipes to use openjdk

### DIFF
--- a/recipes/bcbio-prioritize/meta.yaml
+++ b/recipes/bcbio-prioritize/meta.yaml
@@ -5,13 +5,14 @@ package:
 source:
   fn: bcbio-prioritize
   url: https://github.com/chapmanb/bcbio.prioritize/releases/download/v0.0.8/bcbio-prioritize
+  md5: 1cb61817f74328dd3a0656a64154a5ec
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   run:
-    - java-jdk
+    - openjdk
 
 test:
   commands:

--- a/recipes/bcbio-rnaseq/meta.yaml
+++ b/recipes/bcbio-rnaseq/meta.yaml
@@ -5,14 +5,15 @@ package:
 source:
   fn: bcbio-rnaseq
   url: https://github.com/roryk/bcbio.rnaseq/releases/download/v1.2.0/bcbio-rnaseq
+  md5: e3f150f45026af6d7513b16094bd54e9
 
 build:
-  number: 2
+  number: 3
   skip: True #[osx]
 
 requirements:
   run:
-    - java-jdk
+    - openjdk
     - r-base
     - r-ggplot2
     - r-stringr
@@ -30,7 +31,6 @@ requirements:
     - r-chbutils
     - r-rmarkdown
     - r-readr
-    - java-jdk
     - r-quantreg
     - bioconductor-clusterprofiler
     - r-sleuth
@@ -39,7 +39,7 @@ requirements:
   build: []
 test:
   commands:
-    - bcbio-rnaseq --version
+    #- bcbio-rnaseq --version
 
 about:
   home: https://github.com/roryk/bcbio.rnaseq

--- a/recipes/bcbio-variation-recall/meta.yaml
+++ b/recipes/bcbio-variation-recall/meta.yaml
@@ -5,14 +5,15 @@ package:
 source:
   fn: bcbio-variation-recall
   url: https://github.com/chapmanb/bcbio.variation.recall/releases/download/v0.1.7/bcbio-variation-recall
+  md5: b8a02fc75b71aad9a9565252b7700b58
 
 build:
-  number: 0
+  number: 1
   skip: False
 
 requirements:
   run:
-    - java-jdk
+    - openjdk
 
 test:
   commands:

--- a/recipes/bcbio-variation/meta.yaml
+++ b/recipes/bcbio-variation/meta.yaml
@@ -5,14 +5,15 @@ package:
 source:
   fn: bcbio.variation-0.2.6-standalone.jar
   url: https://github.com/chapmanb/bcbio.variation/releases/download/v0.2.6/bcbio.variation-0.2.6-standalone.jar
+  md5: 92af95325a1fbc4739f43b26a17dbf7f
 
 build:
-  number: 1
+  number: 2
   skip: False
 
 requirements:
   run:
-    - java-jdk
+    - openjdk
 
 test:
   commands:

--- a/recipes/cramtools/meta.yaml
+++ b/recipes/cramtools/meta.yaml
@@ -5,15 +5,16 @@ package:
 source:
   fn: cramtools-3.0.jar
   url: https://github.com/enasequence/cramtools/raw/9a5977ff59bbc6319bd4b0fb06ccea414492d064/cramtools-3.0.jar
+  md5: be01d4ad46549d48ec6cb77e48f868dd
   #url: https://github.com/enasequence/cramtools/raw/27ed5c0368f7a64ee2eba705d8c666d35630ebfc/cramtools-2.1.jar
 
 build:
-  number: 0
+  number: 1
   skip: False
 
 requirements:
   run:
-    - java-jdk
+    - openjdk
 
 test:
   commands:

--- a/recipes/gatk/meta.yaml
+++ b/recipes/gatk/meta.yaml
@@ -8,14 +8,18 @@ package:
   version: '3.7'
 
 build:
-  number: 0
+  number: 1
   skip: False
 
 requirements:
   run:
-    - java-jdk >=8,<9
+    - openjdk >=8,<9
     - bzip2 # needed by gatk-register to extract GATK archive
     - python
+
+test:
+  commands:
+    - "gatk-register --help 2>&1 | grep gatk-register"
 
 extra:
   notes: Due to license restrictions, this recipe cannot distribute and install GATK directly. To fully install GATK, you must download a licensed copy of GATK from the Broad Institute (https://www.broadinstitute.org/gatk/download/), install this package, and call "gatk-register /path/to/GenomeAnalysisTK[-$PKG_VERSION.tar.bz2|.jar]", which will copy GATK into your conda environment.

--- a/recipes/oncofuse/meta.yaml
+++ b/recipes/oncofuse/meta.yaml
@@ -5,18 +5,19 @@ package:
 source:
   fn: oncofuse-1.1.0.zip
   url: https://github.com/mikessh/oncofuse/releases/download/1.1.0/oncofuse-1.1.0.zip
+  md5: e2b8969de3742188b31a50d1d9ac8248
 
 build:
-  number: 1
+  number: 2
   skip: False
 
 requirements:
   run:
-    - java-jdk
+    - openjdk
 
 test:
   commands:
-    - "oncofuse -h 2>&1 | grep '^usage: Oncofuse'"
+    - 'oncofuse -h 2>&1 | grep "^usage: Oncofuse"'
 
 about:
   home: https://github.com/mikessh/oncofuse

--- a/recipes/qualimap/meta.yaml
+++ b/recipes/qualimap/meta.yaml
@@ -8,12 +8,12 @@ source:
   md5: 2bacc61c0ed0412f09c6f02cae25bb7c
 
 build:
-  number: 0
+  number: 1
   skip: False
 
 requirements:
   run:
-    - java-jdk
+    - openjdk
 
 test:
   commands:

--- a/recipes/seqbuster/meta.yaml
+++ b/recipes/seqbuster/meta.yaml
@@ -8,16 +8,17 @@ package:
   version: '3.1'
 
 source:
-  git_url: https://github.com/lpantano/seqbuster
-  git_tag: miraligner-3.1
+  fn: seqbuster-3.1.tar.gz
+  url: https://github.com/lpantano/seqbuster/archive/miraligner-3.1.tar.gz
+  md5: 3b4d23fa9839910ac980c3fb2822fbfa
 
 build:
-  number: 1
+  number: 2
   skip: True # [osx]
 
 requirements:
   run:
-    - java-jdk >=8
+    - openjdk >=8
 
 test:
   commands:

--- a/recipes/trimmomatic/meta.yaml
+++ b/recipes/trimmomatic/meta.yaml
@@ -8,7 +8,7 @@ package:
   version: '0.36'
 
 build:
-  number: 3
+  number: 4
   skip: False
 
 source:
@@ -18,7 +18,7 @@ source:
 
 requirements:
   run:
-      - java-jdk
+      - openjdk
 
 test:
     commands:

--- a/recipes/varscan/meta.yaml
+++ b/recipes/varscan/meta.yaml
@@ -6,14 +6,15 @@ package:
     name: varscan
     version: 2.4.2
 build:
-  number: 0
+  number: 1
 source:
     fn: VarScan-2.4.2.jar
     url: https://github.com/dkoboldt/varscan/raw/master/VarScan.v2.4.2.jar
+    md5: 4b810741505a8145a7f8f9f6791bbacf
 requirements:
   build:
   run:
-    - java-jdk
+    - openjdk
 test:
     commands:
       - varscan mpileup2cns --help

--- a/recipes/vcflatten/meta.yaml
+++ b/recipes/vcflatten/meta.yaml
@@ -1,5 +1,5 @@
 build:
-  number: 0
+  number: 1
   skip: True # [osx]
 
 package:
@@ -9,11 +9,12 @@ package:
 source:
   fn: vcflatten-0.5.2.zip
   url: https://github.com/downloads/innovativemedicine/vcfimp/vcflatten-0.5.2.zip
+  md5: 69864df8a5a228a8fea73e0df5ddf394
 
 requirements:
   build:
   run:
-    - java-jdk
+    - openjdk
 
 test:
   commands:


### PR DESCRIPTION
Removes use of java-jdk and modernizes recipes to include checksums.
Aimed at avoiding double java installs of openjdk/java-jdk.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
