### PR TITLE
perl-gdgraph-histogram - Bump build number

### DIFF
--- a/recipes/perl-gdgraph-histogram/meta.yaml
+++ b/recipes/perl-gdgraph-histogram/meta.yaml
@@ -8,7 +8,7 @@ source:
   md5: 633c97212412d0d85bb3dc7251f5bad9
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   # Explicitly list libgd 2.1.0 as a requirement to force use of the BioBuilds


### PR DESCRIPTION
* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

```
~/miniconda_galaxy/bin/conda create -n mulled-v1-e83a3e475b70bd872ec10963ee67d0896b09886f6d7b371688258b06447c4b2e fastx_toolkit
Warning: 2 possible package resolutions (only showing differing packages):
  - bioconda::perl-gdgraph-histogram-1.1-0.tar.bz2
  - bioconda::perl-gdgraph-histogram-1.1-pl5.22.0_0.tar.bz2
…
Linking packages ...
[pango               ]|#####################################################################################################################                       |  83%

PaddingError: Placeholder of length '80' too short in package conda-forge::pango-1.40.1-0.
The package must be rebuilt with conda-build > 2.0.
```

https://github.com/bioconda/bioconda-recipes/pull/5191#issuecomment-316620456

Let try a bump

ping @nsoranzo @Mataivic 