### PR TITLE
Update: vcfanno, vcf2db, bcbio-vm

### DIFF
--- a/recipes/bcbio-nextgen-vm/build.sh
+++ b/recipes/bcbio-nextgen-vm/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 #sed -i.bak 's#!/usr/bin/env python -Es#!/usr/bin/env python#' scripts/bcbio_vm.py
-$PYTHON setup.py install --record=/dev/null
+$PYTHON setup.py install --single-version-externally-managed --record=record.txt

--- a/recipes/bcbio-nextgen-vm/meta.yaml
+++ b/recipes/bcbio-nextgen-vm/meta.yaml
@@ -3,13 +3,13 @@ package:
   version: '0.1.0a'
 
 build:
-  number: 100
+  number: 101
   skip: True # [not py27]
 
 source:
-  fn: bcbio-nextgen-vm-167c59d.tar.gz
-  url: https://github.com/chapmanb/bcbio-nextgen-vm/archive/167c59d.tar.gz
-  md5: 86996105abdd19fb7e4ea2f2689f3b9e
+  fn: bcbio-nextgen-vm-8ec80a6.tar.gz
+  url: https://github.com/chapmanb/bcbio-nextgen-vm/archive/8ec80a6.tar.gz
+  md5: d5a1b1a468cdef6ebccfcd48a84c23b5
 
 requirements:
   build:

--- a/recipes/vcf2db/meta.yaml
+++ b/recipes/vcf2db/meta.yaml
@@ -1,19 +1,20 @@
 package:
   name: vcf2db
-  version: '2017.03.01'
+  version: '2017.04.12'
 
 build:
   number: 0
   skip: True # [not py27]
  
 source:
-  git_url: https://github.com/quinlan-lab/vcf2db.git
-  git_tag: 9d5e5c0a7fbddc26453d96520a94550d1d169fc8
+  fn: vcf2db-7dfc48a.tar.gz
+  url: https://github.com/quinlan-lab/vcf2db/archive/7dfc48a.tar.gz
+  md5: c9c98b6bdf38e838214fde198fb9a7d4
 
 requirements:
   build:
     - python
-    - perl-threaded
+    - perl
     - nomkl # [unix]
     - snappy
     - python-snappy

--- a/recipes/vcfanno/meta.yaml
+++ b/recipes/vcfanno/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = '0.2.6' %}
+{% set version = '0.2.8' %}
 
 package:
   name: vcfanno
@@ -7,10 +7,10 @@ package:
 source:
   fn: vcfanno_osx # [osx]
   url: https://github.com/brentp/vcfanno/releases/download/v{{ version }}/vcfanno_osx # [osx]
-  md5: f70ee959183325a8e165bc29234f735b # [osx]
+  md5: 334f1b2f0711601306ae8ed752be4894 # [osx]
   fn: vcfanno_linux # [linux]
   url: https://github.com/brentp/vcfanno/releases/download/v{{ version }}/vcfanno_linux64 # [linux]
-  md5: 05b0d7dcfc03f10703a7908f6540c07b # [linux]
+  md5: e5c665b0ffee8cb09a732768cdaae733 # [linux]
 
 build:
   number: 0


### PR DESCRIPTION
- vcf2db: correctly handle non-string values when calculation length.
  Fixes chapmanb/bcbio-nextgen#2011
- vcfanno: Update to latest bug fix version
- bcbio-vm: Include CWL generation with local reference data. Thanks
  to @brainstorm

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
