### PR TITLE
Update goleft recipe to include samtools as a run requirement

### DIFF
--- a/recipes/goleft/meta.yaml
+++ b/recipes/goleft/meta.yaml
@@ -13,7 +13,7 @@ source:
   md5: 91ef9a4274925e544cd45a3c3d2460cf # [osx]
 
 build:
-  number: 0
+  number: 1
   skip: false
   binary_relocation: false
 

--- a/recipes/goleft/meta.yaml
+++ b/recipes/goleft/meta.yaml
@@ -18,6 +18,8 @@ build:
   binary_relocation: false
 
 requirements:
+  run:
+    - samtools
 
 test:
   commands:


### PR DESCRIPTION
This is specifically for `goleft depth` that parallelizes `samtools` calls. `samtools` is not a monstrous dependency to have so better include it rather than forcing user to install it upon `depth` subcommand failures (cc: @brentp)

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
