### PR TITLE
Update wkhtmltopdf to 0.12.4

### DIFF
--- a/recipes/wkhtmltopdf/meta.yaml
+++ b/recipes/wkhtmltopdf/meta.yaml
@@ -4,15 +4,16 @@ build:
 
 package:
   name: wkhtmltopdf
-  version: "0.12.3"
+  version: "0.12.4"
 source:
-  fn: wkhtmltox-0.12.3_linux-generic-amd64.tar.xz  # [linux]
-  url: http://download.gna.org/wkhtmltopdf/0.12/0.12.3/wkhtmltox-0.12.3_linux-generic-amd64.tar.xz  # [linux]
+  fn: wkhtmltox-0.12.4_linux-generic-amd64.tar.xz  # [linux]
+  url: https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.4/wkhtmltox-0.12.4_linux-generic-amd64.tar.xz  # [linux]
+  sha256: 049b2cdec9a8254f0ef8ac273afaf54f7e25459a273e27189591edc7d7cf29db  # [linux]
 requirements:
 #test:  # Skip test for now due to glibc version
   #commands:
     #- wkhtmltopdf -h
 about:
-  home: http://wkhtmltopdf.org/
+  home: https://wkhtmltopdf.org/
   license: LGPLv3
   summary: 'wkhtmltopdf and wkhtmltoimage are open source (LGPLv3) command line tools to render HTML into PDF and various image formats using the Qt WebKit rendering engine'

--- a/recipes/wkhtmltopdf/meta.yaml
+++ b/recipes/wkhtmltopdf/meta.yaml
@@ -10,9 +10,9 @@ source:
   url: https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.4/wkhtmltox-0.12.4_linux-generic-amd64.tar.xz  # [linux]
   sha256: 049b2cdec9a8254f0ef8ac273afaf54f7e25459a273e27189591edc7d7cf29db  # [linux]
 requirements:
-#test:  # Skip test for now due to glibc version
-  #commands:
-    #- wkhtmltopdf -h
+test:
+  commands:
+    - wkhtmltopdf --version
 about:
   home: https://wkhtmltopdf.org/
   license: LGPLv3


### PR DESCRIPTION
This is the first time I've worked with a conda recipe, so please review carefully and let me know if I'm missing anything.

I was not able to build locally due to https://github.com/conda/conda-build/issues/1482, so I'll have to use the Travis builds for feedback.

The goal is to upgrade `wkhtmltopdf` to 0.12.4. In addition, enabling installation tests as well as support for other OSes besides Linux would be ideal.