### PR TITLE
Update requirements for bioconductor_skeleton.py.

### DIFF
--- a/scripts/bioconductor/requirements.txt
+++ b/scripts/bioconductor/requirements.txt
@@ -4,3 +4,5 @@ beautifulsoup4
 requests
 cachecontrol
 lockfile
+pyaml
+colorlog


### PR DESCRIPTION
* [ ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

tl;dr This PR adds the Python dependencies pyaml and colorlog for building Bioconductor recipes.

I followed the [directions](https://github.com/bioconda/bioconda-recipes/blob/998a13938db4b0905b9a74e9d765749921c8fccc/scripts/bioconductor/README.md) to install the Python dependencies prior to running [bioconductor_skeleton.py](https://github.com/bioconda/bioconda-recipes/blob/998a13938db4b0905b9a74e9d765749921c8fccc/scripts/bioconductor/bioconductor_skeleton.py), but [requirements.txt](https://github.com/bioconda/bioconda-recipes/blob/998a13938db4b0905b9a74e9d765749921c8fccc/scripts/bioconductor/requirements.txt) didn't list pyaml or colorlog. After I added them and updated the conda environment, I was able to run the script.

As an aside, this script was really useful. Any chance of it getting incorporated into the official `conda skeleton`?