### PR TITLE
downloader R/CRAN package

### DIFF
--- a/recipes/r-downloader/build.sh
+++ b/recipes/r-downloader/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+mv DESCRIPTION DESCRIPTION.old
+grep -v '^Priority: ' DESCRIPTION.old > DESCRIPTION
+$R CMD INSTALL --build .
+

--- a/recipes/r-downloader/meta.yaml
+++ b/recipes/r-downloader/meta.yaml
@@ -1,0 +1,35 @@
+package:
+  name: r-downloader
+  version: 0.0.4
+
+source:
+  fn: downloader_0.4.tar.gz
+  url: https://cran.rstudio.com/src/contrib/downloader_0.4.tar.gz
+  md5: f26daf8fbeb29a1882bf102f62008594
+
+build:
+  number: 0
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - r-base
+    - r-digest
+  run:
+    - r-base
+    - r-digest
+
+test:
+  commands:
+    - $R -e "library('downloader')"
+
+about:
+  home: https://cran.rstudio.com/web/packages/downloader/index.html
+  license: GPL-2
+  summary: 'Provides a wrapper for the download.file function, making it possible to download 
+    files over HTTPS on Windows, Mac OS X, and other Unix-like platforms. The 'RCurl' package 
+    provides this functionality (and much more) but can be difficult to install because it must 
+    be compiled with external dependencies. This package has no external dependencies, so it is 
+    much easier to install.'

--- a/recipes/r-downloader/meta.yaml
+++ b/recipes/r-downloader/meta.yaml
@@ -29,7 +29,7 @@ about:
   home: https://cran.rstudio.com/web/packages/downloader/index.html
   license: GPL-2
   summary: 'Provides a wrapper for the download.file function, making it possible to download 
-    files over HTTPS on Windows, Mac OS X, and other Unix-like platforms. The 'RCurl' package 
+    files over HTTPS on Windows, Mac OS X, and other Unix-like platforms. The RCurl package 
     provides this functionality (and much more) but can be difficult to install because it must 
     be compiled with external dependencies. This package has no external dependencies, so it is 
     much easier to install.'


### PR DESCRIPTION
* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [X] This PR adds a new recipe.
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Provides a wrapper for the download.file function, making it possible to download files over HTTPS on Windows, Mac OS X, and other Unix-like platforms. The 'RCurl' package provides this functionality (and much more) but can be difficult to install because it must be compiled with external dependencies. This package has no external dependencies, so it is much easier to install.