### PR TITLE
ggthemes R/CRAN package

### DIFF
--- a/recipes/r-ggthemes/build.sh
+++ b/recipes/r-ggthemes/build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# R refuses to build packages that mark themselves as Priority: Recommended
+mv DESCRIPTION DESCRIPTION.old
+grep -v '^Priority: ' DESCRIPTION.old > DESCRIPTION
+
+$R CMD INSTALL --build .
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/recipes/r-ggthemes/meta.yaml
+++ b/recipes/r-ggthemes/meta.yaml
@@ -1,0 +1,42 @@
+package:
+  name: r-ggthemes
+  version: "3.4.0"
+
+source:
+  fn: ggthemes_3.4.0.tar.gz
+  url: https://cran.rstudio.com/src/contrib/ggthemes_3.4.0.tar.gz
+  md5: 075dde101a5415becc790dfbdcf0b862
+
+build:
+  number: 0
+  # This is required to make R link correctly on Linux.
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - r-base
+    - r-assertthat
+    - r-colorspace
+    - r-ggplot2 >=2.2.0
+    - r-scales
+
+  run:
+    - r-base
+    - r-assertthat
+    - r-colorspace
+    - r-ggplot2 >=2.2.0
+    - r-scales
+
+test:
+  commands:
+    - $R -e "library('ggthemes')"
+
+about:
+  home: https://cran.rstudio.com/web/packages/ggthemes/index.html
+  license: GPL-2
+  summary: 'Some extra themes, geoms, and scales for 'ggplot2'. Provides 'ggplot2' themes and 
+    scales that replicate the look of plots by Edward Tufte, Stephen Few, 'Fivethirtyeight', 
+    'The Economist', 'Stata', 'Excel', and 'The Wall Street Journal', among others. Provides 
+    'geoms' for Tufte's box plot and range frame.'

--- a/recipes/r-ggthemes/meta.yaml
+++ b/recipes/r-ggthemes/meta.yaml
@@ -36,7 +36,7 @@ test:
 about:
   home: https://cran.rstudio.com/web/packages/ggthemes/index.html
   license: GPL-2
-  summary: 'Some extra themes, geoms, and scales for 'ggplot2'. Provides 'ggplot2' themes and 
-    scales that replicate the look of plots by Edward Tufte, Stephen Few, 'Fivethirtyeight', 
-    'The Economist', 'Stata', 'Excel', and 'The Wall Street Journal', among others. Provides 
-    'geoms' for Tufte's box plot and range frame.'
+  summary: 'Some extra themes, geoms, and scales for ggplot2. Provides ggplot2 themes and 
+    scales that replicate the look of plots by Edward Tufte, Stephen Few, Fivethirtyeight, 
+    The Economist, Stata, Excel, and The Wall Street Journal, among others. Provides 
+    geoms for Tufte s box plot and range frame.'


### PR DESCRIPTION
* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [X] This PR adds a new recipe.
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Some extra themes, geoms, and scales for 'ggplot2'. Provides 'ggplot2' themes and scales that replicate the look of plots by Edward Tufte, Stephen Few, 'Fivethirtyeight', 'The Economist', 'Stata', 'Excel', and 'The Wall Street Journal', among others. Provides ‘geoms' for Tufte's box plot and range frame.