### PR TITLE
Add bioconductor-signer

### DIFF
--- a/recipes/bioconductor-signer/build.sh
+++ b/recipes/bioconductor-signer/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+mv DESCRIPTION DESCRIPTION.old
+grep -v '^Priority: ' DESCRIPTION.old > DESCRIPTION
+# Ensure C++11 compatibility for macOS
+if [ `uname` == "Darwin" ]; then
+	export MACOSX_DEPLOYMENT_TARGET=10.9
+fi
+$R CMD INSTALL --build .
+#

--- a/recipes/bioconductor-signer/meta.yaml
+++ b/recipes/bioconductor-signer/meta.yaml
@@ -1,0 +1,55 @@
+package:
+  name: bioconductor-signer
+  version: 1.0.1
+source:
+  fn: signeR_1.0.1.tar.gz
+  url:
+    - http://bioconductor.org/packages/3.4/bioc/src/contrib/signeR_1.0.1.tar.gz
+    - https://depot.galaxyproject.org/software/signeR/signeR_1.0.1_src_all.tar.gz
+  md5: edc96646e9c9e8f88a0a147f4662095b
+build:
+  number: 0
+  rpaths:
+    - lib/R/lib/
+    - lib/
+      # skip: True # [osx]
+requirements:
+  build:
+    - bioconductor-biocgenerics
+    - bioconductor-biostrings
+    - 'bioconductor-bsgenome >=1.36.3'
+    - bioconductor-genomicranges
+    - bioconductor-variantannotation
+    - r-base
+    - r-class
+    - r-nloptr
+    - r-nmf
+    - r-pmcmr
+    - r-rcpp
+    - r-rcpparmadillo
+    - gcc    # [not win]
+  run:
+    - bioconductor-biocgenerics
+    - bioconductor-biostrings
+    - 'bioconductor-bsgenome >=1.36.3'
+    - bioconductor-genomicranges
+    - bioconductor-variantannotation
+    - r-base
+    - r-class
+    - r-nloptr
+    - r-nmf
+    - r-pmcmr
+    - r-rcpp
+    - r-rcpparmadillo
+    - libgcc # [linux]
+test:
+  commands:
+    - '$R -e "library(''signeR'')"'
+about:
+  home: http://bioconductor.org/packages/3.4/bioc/html/signeR.html
+  license: GPL-3
+  summary: 'The signeR package provides an empirical Bayesian approach to mutational
+    signature discovery. It is designed to analyze single nucleotide variaton (SNV)
+    counts in cancer genomes, but can also be applied to other features as well. Functionalities
+    to characterize signatures or genome samples according to exposure patterns are
+    also provided.'


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [x] This PR adds a new recipe.
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

I cannot build this package on macOS using llvm nor llvmdev as an alternative solution mentioned in #1332. So I followed the way RcppArmadillo was compiled on macOS using gcc and managed to compile the package.

The compilation error i got when using llvmdev was:

```
/private/tmp/miniconda/conda-bld/bioconductor-signer_1501610880420/_b_env_blah/lib/R/library/RcppArmadillo/include/armadillo_bits/Cube_bones.hpp:288:49: note: 
      candidate template ignored: couldn't infer template argument 'functor'
  template<typename functor> inline const Cube& transform(functor F);
                                                ^
```
