### PR TITLE
Add python binding genometools

### DIFF
--- a/recipes/genometools-genometools/build.sh
+++ b/recipes/genometools-genometools/build.sh
@@ -1,15 +1,16 @@
 #!/bin/bash
 
 
-cp -R gtpython/gt ${PREFIX}/lib/python${CONDA_PY:0:1}.${CONDA_PY:1:2}/site-packages/
+#cp -R gtpython/gt ${PREFIX}/lib/python${CONDA_PY:0:1}.${CONDA_PY:1:2}/site-packages/
 
 #sed -i.bak "s/DEPLIBS:=/DEPLIBS:=-lsupc++ /g" Makefile
 
 #make -n > log.txt 
 #grep "lsupc++" log.txt
-make useshared=yes
+make
 export prefix=$PREFIX
 make install 
 
-
+cd gtpython
+$PYTHON setup.py install
 

--- a/recipes/genometools-genometools/build.sh
+++ b/recipes/genometools-genometools/build.sh
@@ -1,26 +1,6 @@
 #!/bin/bash
 
 
-#cp -R gtpython/gt ${PREFIX}/lib/python${CONDA_PY:0:1}.${CONDA_PY:1:2}/site-packages/
-
-#sed -i.bak "s/DEPLIBS:=/DEPLIBS:=-lsupc++ /g" Makefile
-
-#make -n > log.txt 
-#grep "lsupc++" log.txt
-
-#sed -i.bak 's/^\#include "md5.h"/#include <openssl\/md5.h>/' src/core/md5_fingerprint.c
-
-#sed -i.bak 's/^\#include "md5.h"/#include <openssl\/md5.h>/' src/extended/md5set.c
-
-#sed -i.bak 's/\(^\#include "extended\/reverse_api.h"\)/\1\nvoid md5 (const char *message, long len, char *output);/' src/extended/md5set.c
-
-#sed -i.bak 's/\(^struct GtR {\)/int luaopen_md5_core (lua_State *L);\n\1/' src/gtr.c
-
-
-
-
-
-
 make cairo=no
 export prefix=$PREFIX
 make cairo=no install 

--- a/recipes/genometools-genometools/build.sh
+++ b/recipes/genometools-genometools/build.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
-make
+
+
+cp -R gtpython/gt ${PREFIX}/lib/python${CONDA_PY:0:1}.${CONDA_PY:1:2}/site-packages/
+
+make 
 export prefix=$PREFIX
-make install
+make install 
+
+
+

--- a/recipes/genometools-genometools/build.sh
+++ b/recipes/genometools-genometools/build.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 
-make cairo=no
+make 
 export prefix=$PREFIX
-make cairo=no install 
+make install 
 
 cd gtpython
 $PYTHON setup.py install

--- a/recipes/genometools-genometools/build.sh
+++ b/recipes/genometools-genometools/build.sh
@@ -21,9 +21,9 @@
 
 
 
-make
+make cairo=no
 export prefix=$PREFIX
-make install 
+make cairo=no install 
 
 cd gtpython
 $PYTHON setup.py install

--- a/recipes/genometools-genometools/build.sh
+++ b/recipes/genometools-genometools/build.sh
@@ -3,7 +3,11 @@
 
 cp -R gtpython/gt ${PREFIX}/lib/python${CONDA_PY:0:1}.${CONDA_PY:1:2}/site-packages/
 
-make 
+#sed -i.bak "s/DEPLIBS:=/DEPLIBS:=-lsupc++ /g" Makefile
+
+#make -n > log.txt 
+#grep "lsupc++" log.txt
+make useshared=yes
 export prefix=$PREFIX
 make install 
 

--- a/recipes/genometools-genometools/build.sh
+++ b/recipes/genometools-genometools/build.sh
@@ -7,6 +7,20 @@
 
 #make -n > log.txt 
 #grep "lsupc++" log.txt
+
+#sed -i.bak 's/^\#include "md5.h"/#include <openssl\/md5.h>/' src/core/md5_fingerprint.c
+
+#sed -i.bak 's/^\#include "md5.h"/#include <openssl\/md5.h>/' src/extended/md5set.c
+
+#sed -i.bak 's/\(^\#include "extended\/reverse_api.h"\)/\1\nvoid md5 (const char *message, long len, char *output);/' src/extended/md5set.c
+
+#sed -i.bak 's/\(^struct GtR {\)/int luaopen_md5_core (lua_State *L);\n\1/' src/gtr.c
+
+
+
+
+
+
 make
 export prefix=$PREFIX
 make install 

--- a/recipes/genometools-genometools/meta.yaml
+++ b/recipes/genometools-genometools/meta.yaml
@@ -8,16 +8,20 @@ source:
   sha1: 733530dfe875cd058da0c3e1b6530b9e085517f4
 
 build:
-  number: 0
+  number: 1
   skip: True  # [osx]
 
 requirements:
   build:
     - gcc
     - pango
+    - python
+
   run:
     - gettext
     - pango
+    - xorg-libxrender
+    - xorg-libsm
 
 test:
   commands:

--- a/recipes/genometools-genometools/meta.yaml
+++ b/recipes/genometools-genometools/meta.yaml
@@ -14,9 +14,15 @@ requirements:
   build:
     - gcc
     - python
+    - pango
 
   run:
     - gettext
+    - pango
+    - xorg-libxrender
+    - xorg-libsm
+    - xorg-libxext
+    - libgcc
 
 test:
   commands:

--- a/recipes/genometools-genometools/meta.yaml
+++ b/recipes/genometools-genometools/meta.yaml
@@ -23,17 +23,16 @@ requirements:
     - zlib
     - expat
     - openssl
+    - cairo   
   run:
     - gettext
     - pango
-
-  test:
-    - python
-
+    - xorg-libxrender
+    - xorg-libsm
+    - xorg-libxext 
 test:
   commands:
     - gt -version > /dev/null
-    - python -c "import gt"
   imports:
     - gt
     

--- a/recipes/genometools-genometools/meta.yaml
+++ b/recipes/genometools-genometools/meta.yaml
@@ -16,6 +16,12 @@ requirements:
     - gcc
     - pango
     - python
+    - samtools
+    - sqlite
+    - bzip2
+    - lua-luafilesystem
+    - zlib
+    - expat
   run:
     - gettext
     - pango

--- a/recipes/genometools-genometools/meta.yaml
+++ b/recipes/genometools-genometools/meta.yaml
@@ -16,13 +16,10 @@ requirements:
     - gcc
     - pango
     - python
-
   run:
     - gettext
     - pango
-    - xorg-libxrender
-    - xorg-libsm
-    - xorg-libxext
+    
 
 test:
   commands:

--- a/recipes/genometools-genometools/meta.yaml
+++ b/recipes/genometools-genometools/meta.yaml
@@ -9,7 +9,6 @@ source:
 
 build:
   number: 1
-  skip: True  # [osx]
 
 requirements:
   build:

--- a/recipes/genometools-genometools/meta.yaml
+++ b/recipes/genometools-genometools/meta.yaml
@@ -22,6 +22,7 @@ requirements:
     - pango
     - xorg-libxrender
     - xorg-libsm
+    - xorg-libxext
 
 test:
   commands:

--- a/recipes/genometools-genometools/meta.yaml
+++ b/recipes/genometools-genometools/meta.yaml
@@ -13,22 +13,11 @@ build:
 requirements:
   build:
     - gcc
-    - pango
     - python
-    - samtools
-    - sqlite
-    - bzip2
-    - lua-luafilesystem
-    - zlib
-    - expat
-    - openssl
-    - cairo   
+
   run:
     - gettext
-    - pango
-    - xorg-libxrender
-    - xorg-libsm
-    - xorg-libxext 
+
 test:
   commands:
     - gt -version > /dev/null

--- a/recipes/genometools-genometools/meta.yaml
+++ b/recipes/genometools-genometools/meta.yaml
@@ -22,15 +22,21 @@ requirements:
     - lua-luafilesystem
     - zlib
     - expat
+    - openssl
   run:
     - gettext
     - pango
-    
+
+  test:
+    - python
 
 test:
   commands:
     - gt -version > /dev/null
-
+    - python -c "import gt"
+  imports:
+    - gt
+    
 about:
   home: http://genometools.org/
   summary: GenomeTools genome analysis system.


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

This is an update to add the genometools python bindings in order to add gff3toembl afterwards. (ref https://github.com/bioconda/bioconda-recipes/issues/5383 )
However, independently of my update the build now wouldn't pass the mulled-test with cairo activated so I had to remove it. I tried without removing the cairo dependencies but the test never passed.  