### PR TITLE
mira 4.9.5 and 4.9.6 (developement series)

### DIFF
--- a/recipes/mira/4.9.5/build.sh
+++ b/recipes/mira/4.9.5/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+mkdir -p ${PREFIX}/bin
+cp bin/* ${PREFIX}/bin
+cp scripts/* ${PREFIX}/bin

--- a/recipes/mira/4.9.5/meta.yaml
+++ b/recipes/mira/4.9.5/meta.yaml
@@ -1,0 +1,32 @@
+about:
+  home: https://sourceforge.net/p/mira-assembler/wiki/Home/
+  license: 'GNU General Public License v2 or later (GPLv2+)'
+  license_file: LICENCE
+  summary: 'MIRA is a whole genome shotgun and EST sequence assembler for Sanger, 454, Solexa (Illumina), IonTorrent data and PacBio (the later at the moment only CCS and error-corrected CLR reads)'
+
+build:
+  number: 0
+  skip: True # [not linux64]
+
+package:
+  name: mira
+  # Note Bastien labeled MIRA 4.9.x as a development release,
+  # while 4.0.2 is the current latest stable release, but he
+  # has started to recommend using this on the mailing list
+  # anyway:
+  version: '4.9.5'
+
+# No build requirements as using the author's binaries.
+requirements:
+  build:
+  run:
+
+source:
+  fn: mira_4.9.5.tar.bz2
+  # http://downloads.sourceforge.net/project/mira-assembler/MIRA/development/mira_4.9.5_2_linux-gnu_x86_64_static.tar.bz2
+  url: https://depot.galaxyproject.org/software/mira/mira_4.9.5_linux_x64.tar.bz2
+  sha256: 3848885cb041cd9bf7aa8f220dd3f084443f5060fa433b669f7d28880ba4c61f
+
+test:
+  commands:
+  - mira --help

--- a/recipes/mira/4.9.5/meta.yaml
+++ b/recipes/mira/4.9.5/meta.yaml
@@ -16,11 +16,6 @@ package:
   # anyway:
   version: '4.9.5'
 
-# No build requirements as using the author's binaries.
-requirements:
-  build:
-  run:
-
 source:
   fn: mira_4.9.5.tar.bz2
   # http://downloads.sourceforge.net/project/mira-assembler/MIRA/development/mira_4.9.5_2_linux-gnu_x86_64_static.tar.bz2
@@ -29,4 +24,4 @@ source:
 
 test:
   commands:
-  - mira --help
+    - mira --help

--- a/recipes/mira/4.9.5/meta.yaml
+++ b/recipes/mira/4.9.5/meta.yaml
@@ -18,7 +18,6 @@ package:
 
 source:
   fn: mira_4.9.5.tar.bz2
-  # http://downloads.sourceforge.net/project/mira-assembler/MIRA/development/mira_4.9.5_2_linux-gnu_x86_64_static.tar.bz2
   url: https://depot.galaxyproject.org/software/mira/mira_4.9.5_linux_x64.tar.bz2
   sha256: 3848885cb041cd9bf7aa8f220dd3f084443f5060fa433b669f7d28880ba4c61f
 

--- a/recipes/mira/4.9.6/build.sh
+++ b/recipes/mira/4.9.6/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+mkdir -p ${PREFIX}/bin
+cp bin/* ${PREFIX}/bin
+cp scripts/* ${PREFIX}/bin

--- a/recipes/mira/4.9.6/build.sh
+++ b/recipes/mira/4.9.6/build.sh
@@ -1,5 +1,5 @@
+
 #!/bin/bash
 
 mkdir -p ${PREFIX}/bin
 cp bin/* ${PREFIX}/bin
-cp scripts/* ${PREFIX}/bin

--- a/recipes/mira/4.9.6/meta.yaml
+++ b/recipes/mira/4.9.6/meta.yaml
@@ -20,11 +20,11 @@ requirements:
 source:
   fn: mira_4.9.6.tar.bz2
   # http://downloads.sourceforge.net/project/mira-assembler/MIRA/development/mira_4.9.6_linux-gnu_x86_64_static.tar.bz2
-  url: https://depot.galaxyproject.org/software/mira/mira_4.9.6_linux_x64.tar.bz2 [linux64]
-  sha256: 3c2c343a75045c2c69cb4aba283821d6e82202c37792af886aab0002a8194dee # [linux64]
+  url: https://depot.galaxyproject.org/software/mira/mira_4.9.6_linux_x64.tar.bz2  # [linux64]
+  sha256: 3c2c343a75045c2c69cb4aba283821d6e82202c37792af886aab0002a8194dee  # [linux64]
   # http://downloads.sourceforge.net/project/mira-assembler/MIRA/development/mira_4.9.6_darwin15.4.0_x86_64_static.tar.bz2
-  url: https://depot.galaxyproject.org/software/mira/mira_4.9.6_darwin_x64.tar.bz2 # [osx]
-  sha256: 3d0bb15adad0e1e27899d21223cb552968d34d35ad9b1184e85832fc0b3d22ce # [osx]
+  url: https://depot.galaxyproject.org/software/mira/mira_4.9.6_darwin_x64.tar.bz2  # [osx]
+  sha256: 3d0bb15adad0e1e27899d21223cb552968d34d35ad9b1184e85832fc0b3d22ce  # [osx]
 
 test:
   commands:

--- a/recipes/mira/4.9.6/meta.yaml
+++ b/recipes/mira/4.9.6/meta.yaml
@@ -14,10 +14,8 @@ package:
 
 source:
   fn: mira_4.9.6.tar.bz2
-  # http://downloads.sourceforge.net/project/mira-assembler/MIRA/development/mira_4.9.6_linux-gnu_x86_64_static.tar.bz2
   url: https://depot.galaxyproject.org/software/mira/mira_4.9.6_linux_x64.tar.bz2  # [linux64]
   sha256: 3c2c343a75045c2c69cb4aba283821d6e82202c37792af886aab0002a8194dee  # [linux64]
-  # http://downloads.sourceforge.net/project/mira-assembler/MIRA/development/mira_4.9.6_darwin15.4.0_x86_64_static.tar.bz2
   url: https://depot.galaxyproject.org/software/mira/mira_4.9.6_darwin_x64.tar.bz2  # [osx]
   sha256: 3d0bb15adad0e1e27899d21223cb552968d34d35ad9b1184e85832fc0b3d22ce  # [osx]
 

--- a/recipes/mira/4.9.6/meta.yaml
+++ b/recipes/mira/4.9.6/meta.yaml
@@ -6,16 +6,11 @@ about:
 
 build:
   number: 0
-  skip: True # [not linux64 and not osx]
+  skip: True  # [not linux64 and not osx]
 
 package:
   name: mira
   version: '4.9.6'
-
-# No build requirements as using the author's binaries.
-requirements:
-  build:
-  run:
 
 source:
   fn: mira_4.9.6.tar.bz2
@@ -28,4 +23,4 @@ source:
 
 test:
   commands:
-  - mira --help
+    - mira --help

--- a/recipes/mira/4.9.6/meta.yaml
+++ b/recipes/mira/4.9.6/meta.yaml
@@ -6,7 +6,8 @@ about:
 
 build:
   number: 0
-  skip: True  # [not linux64 and not osx]
+  # TODO - this ought to work on osx as well
+  skip: True # [not linux64]
 
 package:
   name: mira

--- a/recipes/mira/4.9.6/meta.yaml
+++ b/recipes/mira/4.9.6/meta.yaml
@@ -1,0 +1,31 @@
+about:
+  home: https://sourceforge.net/p/mira-assembler/wiki/Home/
+  license: 'GNU General Public License v2 or later (GPLv2+)'
+  license_file: LICENCE
+  summary: 'MIRA is a whole genome shotgun and EST sequence assembler for Sanger, 454, Solexa (Illumina), IonTorrent data and PacBio (the later at the moment only CCS and error-corrected CLR reads)'
+
+build:
+  number: 0
+  skip: True # [not linux64 and not osx]
+
+package:
+  name: mira
+  version: '4.9.6'
+
+# No build requirements as using the author's binaries.
+requirements:
+  build:
+  run:
+
+source:
+  fn: mira_4.9.6.tar.bz2
+  # http://downloads.sourceforge.net/project/mira-assembler/MIRA/development/mira_4.9.6_linux-gnu_x86_64_static.tar.bz2
+  url: https://depot.galaxyproject.org/software/mira/mira_4.9.6_linux_x64.tar.bz2 [linux64]
+  sha256: 3c2c343a75045c2c69cb4aba283821d6e82202c37792af886aab0002a8194dee # [linux64]
+  # http://downloads.sourceforge.net/project/mira-assembler/MIRA/development/mira_4.9.6_darwin15.4.0_x86_64_static.tar.bz2
+  url: https://depot.galaxyproject.org/software/mira/mira_4.9.6_darwin_x64.tar.bz2 # [osx]
+  sha256: 3d0bb15adad0e1e27899d21223cb552968d34d35ad9b1184e85832fc0b3d22ce # [osx]
+
+test:
+  commands:
+  - mira --help


### PR DESCRIPTION
* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [X] This PR adds a new recipe.
* [X] This PR updates an existing recipe.
* [X] This PR does something else (explain below).

MIRA's stable series is currently version 4.0.x, latest is version 4.0.2 - and I have therefore left ``recipes/mira/meta.yaml`` for the stable release.

MIRA's development series is currently version  4.9.x, most recently 4.9.5 and 4.9.6 - which I have defined with explicit sub-folders.

I am including 4.9.5 (for which only Linux binaries were provided) as this is/was used by one of my Galaxy wrappers https://github.com/peterjc/galaxy_mira/tree/master/tools/mira4_9

I am including 4.9.6 (Linux and Mac) as the current latest release.

Question: Should these development releases be tagged differently in conda? In practice the author has started recommending them now anyway, so I don't think it really matter.