### PR TITLE
save miniconda temp file with .sh ext to avoid "bash" or "sh" warnings

### DIFF
--- a/simulate-travis.py
+++ b/simulate-travis.py
@@ -11,14 +11,15 @@ except ImportError:
 import subprocess as sp
 import shlex
 import argparse
+import tempfile
 
 if sys.version_info.major == 3:
     PY3 = True
-    from urllib.request import urlretrieve, urlcleanup
+    from urllib.request import urlretrieve
 
 else:
     PY3 = True
-    from urllib import urlretrieve, urlcleanup
+    from urllib import urlretrieve
 
 usage = """
 This is the script used on travis-ci to set up the environment for testing. It
@@ -116,11 +117,12 @@ class TmpDownload(object):
         self.url = url
 
     def __enter__(self):
-        filename, headers = urlretrieve(self.url)
+        self.filename = tempfile.NamedTemporaryFile(prefix='Miniconda_', suffix='.sh').name
+        filename, headers = urlretrieve(self.url, filename=self.filename)
         return filename
 
     def __exit__(self, exc_type, exc_value, traceback):
-        urlcleanup()
+        os.unlink(self.filename)
 
 
 def bin_for(name='conda'):


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

Avoids causing the warning `Please run using "bash" or "sh", but not "." or "source"` when using `simulate-travis.py --bootstrap` (xref https://github.com/bioconda/bioconda-recipes/issues/5374#issuecomment-320710105)