### PR TITLE
Add singlecell-barcodes.

### DIFF
--- a/recipes/singlecell-barcodes/build.sh
+++ b/recipes/singlecell-barcodes/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+mkdir -p $PREFIX/share/singlecell-barcodes 
+mv * $PREFIX/share/singlecell-barcodes/.

--- a/recipes/singlecell-barcodes/meta.yaml
+++ b/recipes/singlecell-barcodes/meta.yaml
@@ -1,0 +1,22 @@
+package:
+  name: singlecell-barcodes
+  version: '0.1'
+
+build:
+  number: 1
+
+source:
+  fn: fb08911.tar.gz
+  url: https://github.com/roryk/singlecell-barcodes/archive/fb08911.tar.gz
+  md5: 8a84f43cdc078e7bec9fdabb29762cc7
+
+requirements:
+  build: []
+  run: []
+test:
+  commands: []
+
+about:
+  home: https://github.com/roryk/singlecell-barcodes
+  license: MIT
+  summary: whitelisted singlecell barcodes and information regarding where molecular/sample/cellular barcodes are in each read, for various singlecell protocols


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [x] This PR adds a new recipe.
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

This recipe adds a repository of cellular barcodes used in single-cell sequencing along with descriptions of the read structure for each protocol. These can be tough to track down and understand, so this has them all in one place, organized in a way that makes it easy to parse programmatically.