### PR TITLE
Remove empty lines in build.sh generated with bioconductor_skeleton.py

### DIFF
--- a/scripts/bioconductor/bioconductor_skeleton.py
+++ b/scripts/bioconductor/bioconductor_skeleton.py
@@ -601,12 +601,11 @@ def write_recipe(package, recipe_dir, force=False, bioc_version=None,
 
     with open(os.path.join(recipe_dir, 'build.sh'), 'w') as fout:
         fout.write(dedent(
-            """
+            '''\
             #!/bin/bash
             mv DESCRIPTION DESCRIPTION.old
             grep -v '^Priority: ' DESCRIPTION.old > DESCRIPTION
-            $R CMD INSTALL --build .
-            # """
+            $R CMD INSTALL --build .'''
             )
         )
     logger.info('Wrote recipe in %s', recipe_dir)


### PR DESCRIPTION
* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] This PR updates an existing recipe.
* [X] This PR does something else (explain below).

Remove empty lines in build.sh generated with bioconductor_skeleton.py as discussed in https://github.com/bioconda/bioconda-recipes/pull/5428