### PR TITLE
Orthofinder update 1.1.8

### DIFF
--- a/recipes/orthofinder/build.sh
+++ b/recipes/orthofinder/build.sh
@@ -7,6 +7,5 @@ cd orthofinder/
 cp orthofinder.py $PREFIX/bin/orthofinder
 
 cp -r scripts $PREFIX/bin/
-ln -s ./scripts/trees_from_MSA.py $PREFIX/bin/trees_from_MSA
 
-chmod a+x $PREFIX/bin/orthofinder $PREFIX/bin/scripts/trees_from_MSA.py
+chmod a+x $PREFIX/bin/orthofinder 

--- a/recipes/orthofinder/meta.yaml
+++ b/recipes/orthofinder/meta.yaml
@@ -1,4 +1,5 @@
-{% set version = "1.1.4" %}
+{% set version = "1.1.8" %}
+{% set sha256 = "7b3d016cf1795ba4603ff2825abc1eb3b54e1e950910c93b4353d6508a4bd52e" %}
 
 package:
   name: orthofinder
@@ -11,7 +12,7 @@ build:
 source:
   fn: OrthoFinder-{{ version }}_source.tar.gz
   url: https://github.com/davidemms/OrthoFinder/releases/download/{{ version }}/OrthoFinder-{{ version }}_source.tar.gz
-  sha256: b05eb76f4f7029b5735bd0aaf60b50ffea9384dc3f727f49e5e339be36ec259f
+  sha256: {{ sha256 }} 
 
 requirements:
   run:
@@ -25,8 +26,7 @@ requirements:
 test:
   commands:
     - orthofinder > /dev/null
-    - trees_from_MSA > /dev/null
-
+    
 about:
   home: https://github.com/davidemms/OrthoFinder
   summary: Accurate inference of orthogroups, orthologues, gene trees and rooted species tree made easy!


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

This adds the new version of orthofinder. I have removed the links to  tree_from_MSA because now everything should be run from the orthofinder script. One can add more software (mafft, fasttree) depending on the type of analysis needed but it is not compulsory. 

Cheers,