### PR TITLE
update busco; add config generation script

### DIFF
--- a/recipes/busco/build.sh
+++ b/recipes/busco/build.sh
@@ -5,9 +5,14 @@ mkdir -p $PREFIX/bin/
 cp scripts/run_BUSCO.py $PREFIX/bin
 cp scripts/generate_plot.py $PREFIX/bin
 
+# To minimize $PREFIX/bin clutter, copy over the config.ini.default to the
+# share directory, and put the config-generator script there as well. Then
+# symlink only the script over to $PREFIX/bin. The script will resolve its own
+# symlink to the share directory to find the config file, and replace paths in
+# the config file with the (unresolved) symlink's directory, which is
+# $PREFIX/bin.
 SHARE=$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM
 mkdir -p $SHARE
-
 cp config/config.ini.default $SHARE/config.ini.default
 cp $RECIPE_DIR/generate-busco-config.py $SHARE/generate-busco-config.py
 chmod +x $SHARE/generate-busco-config.py

--- a/recipes/busco/build.sh
+++ b/recipes/busco/build.sh
@@ -5,6 +5,14 @@ mkdir -p $PREFIX/bin/
 cp scripts/run_BUSCO.py $PREFIX/bin
 cp scripts/generate_plot.py $PREFIX/bin
 
+SHARE=$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM
+mkdir -p $SHARE
+
+cp config/config.ini.default $SHARE/config.ini.default
+cp $RECIPE_DIR/generate-busco-config.py $SHARE/generate-busco-config.py
+chmod +x $SHARE/generate-busco-config.py
+ln -s $SHARE/generate-busco-config.py $PREFIX/bin/generate-busco-config.py
+
 ln -s $PREFIX/bin/run_BUSCO.py $PREFIX/bin/run_busco
 ln -s $PREFIX/bin/generate_plot.py $PREFIX/bin/generate_plot
 

--- a/recipes/busco/generate-busco-config.py
+++ b/recipes/busco/generate-busco-config.py
@@ -4,8 +4,18 @@ import os
 import sys
 import argparse
 
-if sys.argv[1].lower() in ['-h', '--help', 'help']:
-    print('usage: %s > path-to-new-config-file.ini' % sys.argv[0])
+if (len(sys.argv) > 1) and sys.argv[1].lower() in ['-h', '--help', 'help']:
+    print(
+        '''
+        usage: %s > path-to-new-config-file.ini
+
+        BUSCO requires a config file with absolute paths to external
+        dependencies. When using this conda package, those dependencies are
+        installed in the same environment as BUSCO itself. This script replaces
+        the paths in the default BUSCO config file with the correct paths to
+        this conda environment's bin dir.
+        ''' % sys.argv[0]
+    )
 
 # directory where symlink lives
 bindir = os.path.dirname(os.path.abspath(__file__))

--- a/recipes/busco/generate-busco-config.py
+++ b/recipes/busco/generate-busco-config.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+import glob
+import os
+import sys
+import argparse
+
+if sys.argv[1].lower() in ['-h', '--help', 'help']:
+    print('usage: %s > path-to-new-config-file.ini' % sys.argv[0])
+
+# directory where symlink lives
+bindir = os.path.dirname(os.path.abspath(__file__))
+
+# directory after resolving symlink (which is where the example config file is
+# found)
+share = os.path.dirname(os.path.realpath(__file__))
+config = os.path.join(share, 'config.ini.default')
+
+# One option for editing paths would be to use configparser, but this would
+# remove all the helpful comments in the config file. Instead, we match on "^path = "
+lines = []
+for line in open(config):
+    if line.startswith('path = '):
+        lines.append('path = ' + bindir + '\n')
+    else:
+        lines.append(line)
+sys.stdout.write(''.join(lines))

--- a/recipes/busco/meta.yaml
+++ b/recipes/busco/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "busco" %}
-{% set version = "3.0.1" %}
-{% set md5 = "0f7a05aa307b3061430f551780ad7102" %}
+{% set version = "3.0.2" %}
+{% set sha256 = "cd0699545a126c7cc94604eef7c8dc50379b5d11becbad3a0f55d995a4c5e1c0" %}
 
 package:
   name: {{ name|lower }}
@@ -13,8 +13,8 @@ build:
 
 source:
   fn: {{ name|lower }}_{{ version }}.tar.gz
-  url: https://gitlab.com/ezlab/busco/repository/archive.tar.gz?ref=078252e0
-  md5: {{ md5 }}
+  url: https://gitlab.com/ezlab/busco/repository/archive.tar.bz2?ref={{ version }}
+  sha256: {{ sha256 }}
 
 requirements:
   build:

--- a/recipes/busco/meta.yaml
+++ b/recipes/busco/meta.yaml
@@ -40,3 +40,8 @@ about:
            assembly, gene set, and transcriptome completeness based on
            evolutionarily informed expectations of gene content from
            near-universal single-copy orthologs selected from OrthoDB.
+
+extra:
+  notes: An additional script, generate-busco-config.py, is installed with the package
+         to generate a config file that has the correct paths to the dependencies
+         used by busco that are also installed via conda.

--- a/recipes/busco/run_test.sh
+++ b/recipes/busco/run_test.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
+set -euo pipefail
+
+(generate-busco-config.py -h | grep "usage:") || exit 1
+
 # The directory in which generate-busco-config.py is stored should itself be
 # found in the "path = " lines of its output
 d=$(dirname $(which generate-busco-config.py))
-generate-busco-config.py | grep "path = " | grep $d
+(generate-busco-config.py | grep "path = " | grep $d) || exit 1

--- a/recipes/busco/run_test.sh
+++ b/recipes/busco/run_test.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# The directory in which generate-busco-config.py is stored should itself be
+# found in the "path = " lines of its output
+d=$(dirname $(which generate-busco-config.py))
+generate-busco-config.py | grep "path = " | grep $d


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

Updates busco to v3.0.2, and adds a config generation script to set the paths appropriately for the conda-installed external dependencies of busco (hmmsearch, tblastn, etc). Also tests for correct paths in generated config.

cc @mschatz, xref #5429