### PR TITLE
Update entrez direct

### DIFF
--- a/recipes/entrez-direct/build.sh
+++ b/recipes/entrez-direct/build.sh
@@ -3,5 +3,5 @@
 mv * "$PREFIX/bin/"
 mkdir -p "$PREFIX/home"
 export HOME="$PREFIX/home"
-cd ${PREFIX}/bin/
-sh "setup.sh"
+sh ${PREFIX}/bin/setup.sh
+

--- a/recipes/entrez-direct/build.sh
+++ b/recipes/entrez-direct/build.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-mv * "$PREFIX/bin/"
+sh "setup.sh"
+mv edirect.pl efetch epost efilter eproxy einfo econtact elink espell enotify esummary entrez-phrase-search xtract "$PREFIX/bin/"
 mkdir -p "$PREFIX/home"
 export HOME="$PREFIX/home"
-sh "$PREFIX/bin/setup.sh"
+

--- a/recipes/entrez-direct/build.sh
+++ b/recipes/entrez-direct/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-sh "setup.sh"
-mv edirect.pl efetch epost efilter eproxy einfo econtact elink espell enotify esummary entrez-phrase-search xtract "$PREFIX/bin/"
+mv * "$PREFIX/bin/"
 mkdir -p "$PREFIX/home"
 export HOME="$PREFIX/home"
-
+cd ${PREFIX}/bin/
+sh "setup.sh"

--- a/recipes/entrez-direct/ftp-cp.patch
+++ b/recipes/entrez-direct/ftp-cp.patch
@@ -1,0 +1,8 @@
+--- ftp-cp	2017-06-06 20:00:25.000000000 +0200
++++ ftp-cp	2017-08-10 09:57:27.271794263 +0200
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl -w
++#!/usr/bin/env perl
+ # Usage: ftp-cp SERVER PATH FILE...
+ 
+ use strict;

--- a/recipes/entrez-direct/meta.yaml
+++ b/recipes/entrez-direct/meta.yaml
@@ -1,14 +1,21 @@
+{% set version = "7.00" %}
+{% set sha256 = "6e655d05f1e2c23dc26fb78176307be045ef5db3ca30d518bdb969fc77fb3e3b"  %}
+
+
+
 package:
   name: entrez-direct
-  version: "7.00"
+  version: {{ version }}
 
 build:
-  number: 0
+  number: 1
 
 source:
   fn: edirect.tar.gz
-  url: ftp://ftp.ncbi.nlm.nih.gov/entrez/entrezdirect/versions/7.00.20170710/edirect.tar.gz
-  sha256: 3db51402fadfad15714ab7f4a8ecff82fd13ab70b046584d32b29c281cc9ca68
+  url: ftp://ftp.ncbi.nlm.nih.gov/entrez/entrezdirect/versions/{{ version }}.20170714/edirect.tar.gz
+  sha256: {{ sha256 }}
+  patches:
+  - xtract.patch
 
 requirements:
   build:
@@ -32,6 +39,7 @@ test:
     - enotify --help
     - esummary --help
     - entrez-phrase-search --help
+    - xtract -version
 
 about:
   home: ftp://ftp.ncbi.nlm.nih.gov/entrez/entrezdirect/versions/7.00.20170710/README

--- a/recipes/entrez-direct/meta.yaml
+++ b/recipes/entrez-direct/meta.yaml
@@ -14,8 +14,6 @@ source:
   fn: edirect.tar.gz
   url: ftp://ftp.ncbi.nlm.nih.gov/entrez/entrezdirect/versions/{{ version }}.20170714/edirect.tar.gz
   sha256: {{ sha256 }}
-  patches:
-  - xtract.patch
 
 requirements:
   build:

--- a/recipes/entrez-direct/meta.yaml
+++ b/recipes/entrez-direct/meta.yaml
@@ -14,6 +14,8 @@ source:
   fn: edirect.tar.gz
   url: ftp://ftp.ncbi.nlm.nih.gov/entrez/entrezdirect/versions/{{ version }}.20170714/edirect.tar.gz
   sha256: {{ sha256 }}
+  patches:
+  - ftp-cp.patch
 
 requirements:
   build:

--- a/recipes/entrez-direct/meta.yaml
+++ b/recipes/entrez-direct/meta.yaml
@@ -16,6 +16,7 @@ source:
   sha256: {{ sha256 }}
   patches:
   - ftp-cp.patch
+  - xtract.patch
 
 requirements:
   build:

--- a/recipes/entrez-direct/xtract.patch
+++ b/recipes/entrez-direct/xtract.patch
@@ -1,6 +1,42 @@
 --- setup.sh	2017-04-26 23:25:19.000000000 +0200
-+++ setup.sh	2017-08-09 16:46:03.179495988 +0200
-@@ -41,7 +41,8 @@
++++ setup.sh	2017-08-09 18:30:48.319400055 +0200
+@@ -2,35 +2,7 @@
+ 
+ DIR="$( cd "$( dirname "$0" )" && pwd )"
+ 
+-cat <<EOF
+-
+-Trying to establish local installations of any missing Perl modules
+-(as logged in $DIR/setup-deps.log).
+-Please be patient, as this step may take a little while.
+-EOF
+-
+ cd "$DIR"
+-
+-mkdir -p _cpan/CPAN
+-echo '1;' >> _cpan/CPAN/MyConfig.pm
+-if ! perl -I_cpan setup-deps.pl </dev/null >setup-deps.log 2>&1
+-then
+-  if grep '^read timeout.*HTTP' setup-deps.log >/dev/null
+-  then
+-    cat <<EOF
+-Unable to access the Comprehensive Perl Archive Network.  You might
+-need to set http_proxy and/or ftp_proxy in your user environment.
+-Please consult your network administrator for suitable values.
+-EOF
+-  fi
+-fi
+-rm -rf _cpan
+-
+-if ! perl -Iaux/lib/perl5 -MMozilla::CA -e '1;' 2>/dev/null
+-then
+-  gzip -cd Mozilla-CA.tar.gz | tar xvf -
+-fi
+-
+ osname=`uname -s | sed -e 's/[0-9.-]*$//'`
+ cputype=`uname -m`
+ case "$osname-$cputype" in
+@@ -41,7 +13,8 @@
  esac
  if [ -f xtract."$osname" ]
  then

--- a/recipes/entrez-direct/xtract.patch
+++ b/recipes/entrez-direct/xtract.patch
@@ -1,0 +1,47 @@
+--- setup.sh	2017-04-26 23:25:19.000000000 +0200
++++ setup.sh	2017-08-09 17:08:51.703475100 +0200
+@@ -2,34 +2,6 @@
+ 
+ DIR="$( cd "$( dirname "$0" )" && pwd )"
+ 
+-cat <<EOF
+-
+-Trying to establish local installations of any missing Perl modules
+-(as logged in $DIR/setup-deps.log).
+-Please be patient, as this step may take a little while.
+-EOF
+-
+-cd "$DIR"
+-
+-mkdir -p _cpan/CPAN
+-echo '1;' >> _cpan/CPAN/MyConfig.pm
+-if ! perl -I_cpan setup-deps.pl </dev/null >setup-deps.log 2>&1
+-then
+-  if grep '^read timeout.*HTTP' setup-deps.log >/dev/null
+-  then
+-    cat <<EOF
+-Unable to access the Comprehensive Perl Archive Network.  You might
+-need to set http_proxy and/or ftp_proxy in your user environment.
+-Please consult your network administrator for suitable values.
+-EOF
+-  fi
+-fi
+-rm -rf _cpan
+-
+-if ! perl -Iaux/lib/perl5 -MMozilla::CA -e '1;' 2>/dev/null
+-then
+-  gzip -cd Mozilla-CA.tar.gz | tar xvf -
+-fi
+ 
+ osname=`uname -s | sed -e 's/[0-9.-]*$//'`
+ cputype=`uname -m`
+@@ -41,7 +13,8 @@
+ esac
+ if [ -f xtract."$osname" ]
+ then
+-  chmod +x xtract."$osname"
++  mv xtract."$osname" xtract
++  chmod +x xtract
+ else
+   echo "Unable to download a prebuilt xtract executable; attempting to"
+   echo "build one from xtract.go.  A Perl fallback is also available, and"

--- a/recipes/entrez-direct/xtract.patch
+++ b/recipes/entrez-direct/xtract.patch
@@ -1,41 +1,5 @@
 --- setup.sh	2017-04-26 23:25:19.000000000 +0200
 +++ setup.sh	2017-08-09 18:30:48.319400055 +0200
-@@ -2,35 +2,7 @@
- 
- DIR="$( cd "$( dirname "$0" )" && pwd )"
- 
--cat <<EOF
--
--Trying to establish local installations of any missing Perl modules
--(as logged in $DIR/setup-deps.log).
--Please be patient, as this step may take a little while.
--EOF
--
- cd "$DIR"
--
--mkdir -p _cpan/CPAN
--echo '1;' >> _cpan/CPAN/MyConfig.pm
--if ! perl -I_cpan setup-deps.pl </dev/null >setup-deps.log 2>&1
--then
--  if grep '^read timeout.*HTTP' setup-deps.log >/dev/null
--  then
--    cat <<EOF
--Unable to access the Comprehensive Perl Archive Network.  You might
--need to set http_proxy and/or ftp_proxy in your user environment.
--Please consult your network administrator for suitable values.
--EOF
--  fi
--fi
--rm -rf _cpan
--
--if ! perl -Iaux/lib/perl5 -MMozilla::CA -e '1;' 2>/dev/null
--then
--  gzip -cd Mozilla-CA.tar.gz | tar xvf -
--fi
--
- osname=`uname -s | sed -e 's/[0-9.-]*$//'`
- cputype=`uname -m`
- case "$osname-$cputype" in
 @@ -41,7 +13,8 @@
  esac
  if [ -f xtract."$osname" ]

--- a/recipes/entrez-direct/xtract.patch
+++ b/recipes/entrez-direct/xtract.patch
@@ -1,41 +1,6 @@
 --- setup.sh	2017-04-26 23:25:19.000000000 +0200
-+++ setup.sh	2017-08-09 17:08:51.703475100 +0200
-@@ -2,34 +2,6 @@
- 
- DIR="$( cd "$( dirname "$0" )" && pwd )"
- 
--cat <<EOF
--
--Trying to establish local installations of any missing Perl modules
--(as logged in $DIR/setup-deps.log).
--Please be patient, as this step may take a little while.
--EOF
--
--cd "$DIR"
--
--mkdir -p _cpan/CPAN
--echo '1;' >> _cpan/CPAN/MyConfig.pm
--if ! perl -I_cpan setup-deps.pl </dev/null >setup-deps.log 2>&1
--then
--  if grep '^read timeout.*HTTP' setup-deps.log >/dev/null
--  then
--    cat <<EOF
--Unable to access the Comprehensive Perl Archive Network.  You might
--need to set http_proxy and/or ftp_proxy in your user environment.
--Please consult your network administrator for suitable values.
--EOF
--  fi
--fi
--rm -rf _cpan
--
--if ! perl -Iaux/lib/perl5 -MMozilla::CA -e '1;' 2>/dev/null
--then
--  gzip -cd Mozilla-CA.tar.gz | tar xvf -
--fi
- 
- osname=`uname -s | sed -e 's/[0-9.-]*$//'`
- cputype=`uname -m`
-@@ -41,7 +13,8 @@
++++ setup.sh	2017-08-09 16:46:03.179495988 +0200
+@@ -41,7 +41,8 @@
  esac
  if [ -f xtract."$osname" ]
  then


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

This is a patch for fixing the xtract binary name. Without this patch the latest xtract version must be accessed by xtract.Linux our xtract.Darwin. Otherwise xtract alone is of version 2.9999 instead of 7.00. Plus there was a problem in one of the perl file to download the binary, fixed it in ftp-cp.patch.

Otherwise I have noted that the install scripts copies a bunch of files in the ${PREFIX}/bin folder, some that are not binarie, and that the setup.sh contacts CPAN to install dependencies, I have tried removing this steps to rely only on the bioconda dependencies but I'm not sure this is the proper way to proceed so they are not included in this PR. Tell me if you'd rather I put them back.