### PR TITLE
Add ARB 6.1.rev16233

### DIFF
--- a/recipes/arb-bio/6.1.rev16223/abs_path_fix.patch
+++ b/recipes/arb-bio/6.1.rev16223/abs_path_fix.patch
@@ -741,9 +741,10 @@ Index: util/usecores.pl
 ===================================================================
 --- Makefile	(revision 16228)
 +++ Makefile	(working copy)
-@@ -711,7 +711,7 @@
+@@ -711,5 +711,5 @@
  ifeq ($(DARWIN),1)
-  TIME:=gtime
+- TIME:=gtime
++ TIME:=command time
  else
 - TIME:=/usr/bin/time
 + TIME:=command time

--- a/recipes/arb-bio/6.1.rev16223/abs_path_fix.patch
+++ b/recipes/arb-bio/6.1.rev16223/abs_path_fix.patch
@@ -738,3 +738,15 @@ Index: util/usecores.pl
  
  # determines cores used by jenkins builds
  my $cores = `cat /proc/cpuinfo | grep processor | wc -l`; # no /proc/cpuinfo (e.g. on OSX) -> falls back to minimum
+===================================================================
+--- Makefile	(revision 16228)
++++ Makefile	(working copy)
+@@ -711,7 +711,7 @@
+ ifeq ($(DARWIN),1)
+  TIME:=gtime
+ else
+- TIME:=/usr/bin/time
++ TIME:=command time
+ endif
+
+ #---------------------- SSE vectorizer

--- a/recipes/arb-bio/6.1.rev16223/abs_path_fix.patch
+++ b/recipes/arb-bio/6.1.rev16223/abs_path_fix.patch
@@ -1,0 +1,740 @@
+Index: BINDINGS/PERL/Makefile
+===================================================================
+--- BINDINGS/PERL/Makefile	(revision 16223)
++++ BINDINGS/PERL/Makefile	(working copy)
+@@ -123,8 +123,8 @@
+ MAKE_APERL_FILE = Makefile.aperl
+ PERLMAINCC = $(CC)
+ PERL_INC = /usr/lib/perl/5.10/CORE
+-PERL = /usr/bin/perl
+-FULLPERL = /usr/bin/perl
++PERL = /usr/bin/env perl
++FULLPERL = /usr/bin/env perl
+ ABSPERL = $(PERL)
+ PERLRUN = $(PERL)
+ FULLPERLRUN = $(FULLPERL)
+@@ -854,7 +854,7 @@
+ 
+ # --- MakeMaker makeaperl section ---
+ MAP_TARGET    = perl
+-FULLPERL      = /usr/bin/perl
++FULLPERL      = /usr/bin/env perl
+ 
+ $(MAP_TARGET) :: static $(MAKE_APERL_FILE)
+ 	$(MAKE) $(USEMAKEFILE) $(MAKE_APERL_FILE) $@
+Index: CONVERTALN/show_error_list.pl
+===================================================================
+--- CONVERTALN/show_error_list.pl	(revision 16223)
++++ CONVERTALN/show_error_list.pl	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ 
+ use strict;
+ use warnings;
+Index: CORE/arb_diff.cxx
+===================================================================
+--- CORE/arb_diff.cxx	(revision 16223)
++++ CORE/arb_diff.cxx	(working copy)
+@@ -262,7 +262,7 @@
+     if      (!GB_is_regularfile(file1)) error = GBS_global_string("No such file '%s'", file1);
+     else if (!GB_is_regularfile(file2)) error = GBS_global_string("No such file '%s'", file2);
+     else {
+-        char *cmd     = GBS_global_string_copy("/usr/bin/diff --unified %s %s", file1, file2);
++        char *cmd     = GBS_global_string_copy("/usr/bin/env diff --unified %s %s", file1, file2);
+         FILE *diffout = popen(cmd, "r");
+ 
+         if (diffout) {
+Index: GDE/SATIVA/arb_sativa.pl
+===================================================================
+--- GDE/SATIVA/arb_sativa.pl	(revision 16223)
++++ GDE/SATIVA/arb_sativa.pl	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ 
+ #############################################################################
+ #                                                                           #
+Index: GDEHELP/cleanmenu.pl
+===================================================================
+--- GDEHELP/cleanmenu.pl	(revision 16223)
++++ GDEHELP/cleanmenu.pl	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ 
+ use strict;
+ use warnings;
+Index: GDEHELP/pp.pl
+===================================================================
+--- GDEHELP/pp.pl	(revision 16223)
++++ GDEHELP/pp.pl	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ # ============================================================ #
+ #                                                              #
+ #   File      : pp.pl                                          #
+Index: HELP_SOURCE/generate_index.pl
+===================================================================
+--- HELP_SOURCE/generate_index.pl	(revision 16223)
++++ HELP_SOURCE/generate_index.pl	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ 
+ use strict;
+ use warnings;
+Index: HELP_SOURCE/genhelp/postprocess_genhelp.pl
+===================================================================
+--- HELP_SOURCE/genhelp/postprocess_genhelp.pl	(revision 16223)
++++ HELP_SOURCE/genhelp/postprocess_genhelp.pl	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ #
+ # The main intention of this script is to make unchangable help files
+ # delivered with some of the integrated software compatible with
+Index: HELP_SOURCE/quietly.pl
+===================================================================
+--- HELP_SOURCE/quietly.pl	(revision 16223)
++++ HELP_SOURCE/quietly.pl	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ 
+ use strict;
+ use warnings;
+Index: HELP_SOURCE/xml_2_depends.pl
+===================================================================
+--- HELP_SOURCE/xml_2_depends.pl	(revision 16223)
++++ HELP_SOURCE/xml_2_depends.pl	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ 
+ use strict;
+ use warnings;
+Index: PERL2ARB/test.pl
+===================================================================
+--- PERL2ARB/test.pl	(revision 16223)
++++ PERL2ARB/test.pl	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ 
+ # Before `make install' is performed this script should be runnable with
+ # `make test'. After `make install' it should work as `perl test.pl'
+Index: PERL_SCRIPTS/ARBTOOLS/IFTHELP/embl_gen_long_features.pl
+===================================================================
+--- PERL_SCRIPTS/ARBTOOLS/IFTHELP/embl_gen_long_features.pl	(revision 16223)
++++ PERL_SCRIPTS/ARBTOOLS/IFTHELP/embl_gen_long_features.pl	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ #  =============================================================== #
+ #                                                                  #
+ #    File      : embl_gen_long_features.pl                         #
+Index: PERL_SCRIPTS/ARBTOOLS/IFTHELP/format_dssp.pl
+===================================================================
+--- PERL_SCRIPTS/ARBTOOLS/IFTHELP/format_dssp.pl	(revision 16223)
++++ PERL_SCRIPTS/ARBTOOLS/IFTHELP/format_dssp.pl	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ 
+ use warnings;
+ use strict;
+Index: PERL_SCRIPTS/ARBTOOLS/IFTHELP/genbank_gen_long_features.pl
+===================================================================
+--- PERL_SCRIPTS/ARBTOOLS/IFTHELP/genbank_gen_long_features.pl	(revision 16223)
++++ PERL_SCRIPTS/ARBTOOLS/IFTHELP/genbank_gen_long_features.pl	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ # ================================================================ #
+ #                                                                  #
+ #   File      : genbank_gen_long_features.pl                       #
+Index: PERL_SCRIPTS/ARBTOOLS/TESTS/manual.pl
+===================================================================
+--- PERL_SCRIPTS/ARBTOOLS/TESTS/manual.pl	(revision 16223)
++++ PERL_SCRIPTS/ARBTOOLS/TESTS/manual.pl	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ #
+ # script that tests features documented in ../../../PERL2ARB/DOC.html
+ # (to make this test working you need to have LintSubs installed)
+Index: PERL_SCRIPTS/ARBTOOLS/import_from_table.pl
+===================================================================
+--- PERL_SCRIPTS/ARBTOOLS/import_from_table.pl	(revision 16223)
++++ PERL_SCRIPTS/ARBTOOLS/import_from_table.pl	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ # =============================================================== #
+ #                                                                 #
+ #   File      : import_from_table.pl                              #
+Index: PERL_SCRIPTS/ARBTOOLS/raxml2arb.pl
+===================================================================
+--- PERL_SCRIPTS/ARBTOOLS/raxml2arb.pl	(revision 16223)
++++ PERL_SCRIPTS/ARBTOOLS/raxml2arb.pl	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ # =============================================================== #
+ #                                                                 #
+ #   File      : raxml2arb.pl                                      #
+Index: PERL_SCRIPTS/BIOPERL/beautifyNewick.pl
+===================================================================
+--- PERL_SCRIPTS/BIOPERL/beautifyNewick.pl	(revision 16223)
++++ PERL_SCRIPTS/BIOPERL/beautifyNewick.pl	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ # ============================================================ #
+ #                                                              #
+ #   File      : beautifyNewick.pl                              #
+Index: PERL_SCRIPTS/GENERAL/listDiff.pl
+===================================================================
+--- PERL_SCRIPTS/GENERAL/listDiff.pl	(revision 16223)
++++ PERL_SCRIPTS/GENERAL/listDiff.pl	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ 
+ use strict;
+ use warnings;
+Index: PERL_SCRIPTS/GENOME/collect_gene_info.pl
+===================================================================
+--- PERL_SCRIPTS/GENOME/collect_gene_info.pl	(revision 16223)
++++ PERL_SCRIPTS/GENOME/collect_gene_info.pl	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ 
+ use strict;
+ use warnings;
+Index: PERL_SCRIPTS/GENOME/import_proteomdata.pl
+===================================================================
+--- PERL_SCRIPTS/GENOME/import_proteomdata.pl	(revision 16223)
++++ PERL_SCRIPTS/GENOME/import_proteomdata.pl	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ 
+ use strict;
+ use warnings;
+Index: PERL_SCRIPTS/MACROS/with_all_marked.pl
+===================================================================
+--- PERL_SCRIPTS/MACROS/with_all_marked.pl	(revision 16223)
++++ PERL_SCRIPTS/MACROS/with_all_marked.pl	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ use strict;
+ use warnings;
+ 
+Index: PERL_SCRIPTS/SAI/SAI_demo.pl
+===================================================================
+--- PERL_SCRIPTS/SAI/SAI_demo.pl	(revision 16223)
++++ PERL_SCRIPTS/SAI/SAI_demo.pl	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ 
+ use strict;
+ use warnings;
+Index: PERL_SCRIPTS/SPECIES/listMarkedSpecies.pl
+===================================================================
+--- PERL_SCRIPTS/SPECIES/listMarkedSpecies.pl	(revision 16223)
++++ PERL_SCRIPTS/SPECIES/listMarkedSpecies.pl	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ # =============================================================== #
+ #                                                                 #
+ #   File      : markedSpecies.pl                                  #
+Index: PERL_SCRIPTS/SPECIES/markSpecies.pl
+===================================================================
+--- PERL_SCRIPTS/SPECIES/markSpecies.pl	(revision 16223)
++++ PERL_SCRIPTS/SPECIES/markSpecies.pl	(working copy)
+@@ -1,4 +1,4 @@
+-#! /usr/bin/perl
++#! /usr/bin/env perl
+ 
+ #############################################################################
+ # Harald Meier (meierh@in.tum.de); 2006 LRR, Technische Universität München #
+Index: SH/dszmconnect.pl
+===================================================================
+--- SH/dszmconnect.pl	(revision 16223)
++++ SH/dszmconnect.pl	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl -w
++#!/usr/bin/env perl
+ # switches for stringent coding and debugging
+ 
+ # This program is an adapter between the ARB program package and the DSZM website.
+Index: SOURCE_TOOLS/arb_cleanup_patches.pl
+===================================================================
+--- SOURCE_TOOLS/arb_cleanup_patches.pl	(revision 16223)
++++ SOURCE_TOOLS/arb_cleanup_patches.pl	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ 
+ use strict;
+ 
+Index: SOURCE_TOOLS/arb_compiler_version.pl
+===================================================================
+--- SOURCE_TOOLS/arb_compiler_version.pl	(revision 16223)
++++ SOURCE_TOOLS/arb_compiler_version.pl	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ 
+ use strict;
+ use warnings;
+Index: SOURCE_TOOLS/asan2msg.pl
+===================================================================
+--- SOURCE_TOOLS/asan2msg.pl	(revision 16223)
++++ SOURCE_TOOLS/asan2msg.pl	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ 
+ use strict;
+ use warnings;
+Index: SOURCE_TOOLS/binuptodate.pl
+===================================================================
+--- SOURCE_TOOLS/binuptodate.pl	(revision 16223)
++++ SOURCE_TOOLS/binuptodate.pl	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ 
+ use strict;
+ use warnings;
+Index: SOURCE_TOOLS/build_info.pl
+===================================================================
+--- SOURCE_TOOLS/build_info.pl	(revision 16223)
++++ SOURCE_TOOLS/build_info.pl	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ 
+ use strict;
+ use warnings;
+Index: SOURCE_TOOLS/check_bin_dependencies.pl
+===================================================================
+--- SOURCE_TOOLS/check_bin_dependencies.pl	(revision 16223)
++++ SOURCE_TOOLS/check_bin_dependencies.pl	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ #
+ # Check whether dependency files in ../BINDEP
+ # match arb-binaries in ../bin
+Index: SOURCE_TOOLS/check_resources.pl
+===================================================================
+--- SOURCE_TOOLS/check_resources.pl	(revision 16223)
++++ SOURCE_TOOLS/check_resources.pl	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ 
+ use strict;
+ use warnings;
+Index: SOURCE_TOOLS/check_same_compiler_version.pl
+===================================================================
+--- SOURCE_TOOLS/check_same_compiler_version.pl	(revision 16223)
++++ SOURCE_TOOLS/check_same_compiler_version.pl	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ 
+ use strict;
+ use warnings;
+Index: SOURCE_TOOLS/deadcode.pl
+===================================================================
+--- SOURCE_TOOLS/deadcode.pl	(revision 16223)
++++ SOURCE_TOOLS/deadcode.pl	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ 
+ use strict;
+ use warnings;
+Index: SOURCE_TOOLS/dependency_graphs.pl
+===================================================================
+--- SOURCE_TOOLS/dependency_graphs.pl	(revision 16223)
++++ SOURCE_TOOLS/dependency_graphs.pl	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ 
+ my $ARBHOME = $ENV{ARBHOME};
+ if (not -d $ARBHOME) {
+Index: SOURCE_TOOLS/diff2grep.pl
+===================================================================
+--- SOURCE_TOOLS/diff2grep.pl	(revision 16223)
++++ SOURCE_TOOLS/diff2grep.pl	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ 
+ use strict;
+ use warnings;
+Index: SOURCE_TOOLS/find_newest_source.pl
+===================================================================
+--- SOURCE_TOOLS/find_newest_source.pl	(revision 16223)
++++ SOURCE_TOOLS/find_newest_source.pl	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ 
+ use strict;
+ use warnings;
+Index: SOURCE_TOOLS/fix_depends.pl
+===================================================================
+--- SOURCE_TOOLS/fix_depends.pl	(revision 16223)
++++ SOURCE_TOOLS/fix_depends.pl	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl -w
++#!/usr/bin/env perl
+ # 
+ # This script parses and fixes dependency lines in Makefiles:
+ # 1. Searches for a line containing '# DO NOT DELETE'
+Index: SOURCE_TOOLS/gen_dep.pl
+===================================================================
+--- SOURCE_TOOLS/gen_dep.pl	(revision 16223)
++++ SOURCE_TOOLS/gen_dep.pl	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ 
+ use strict;
+ use warnings;
+Index: SOURCE_TOOLS/grepx.pl
+===================================================================
+--- SOURCE_TOOLS/grepx.pl	(revision 16223)
++++ SOURCE_TOOLS/grepx.pl	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ # ======================================================================== #
+ #                                                                          #
+ #   File      : grepx.pl                                                   #
+Index: SOURCE_TOOLS/needed_libs.pl
+===================================================================
+--- SOURCE_TOOLS/needed_libs.pl	(revision 16223)
++++ SOURCE_TOOLS/needed_libs.pl	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ 
+ use strict;
+ use warnings;
+Index: SOURCE_TOOLS/postcompile.pl
+===================================================================
+--- SOURCE_TOOLS/postcompile.pl	(revision 16223)
++++ SOURCE_TOOLS/postcompile.pl	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ # ================================================================= #
+ #                                                                   #
+ #   File      : postcompile.pl                                      #
+Index: SOURCE_TOOLS/profile_annotate.pl
+===================================================================
+--- SOURCE_TOOLS/profile_annotate.pl	(revision 16223)
++++ SOURCE_TOOLS/profile_annotate.pl	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ 
+ use strict;
+ use warnings;
+Index: SOURCE_TOOLS/release/release_tool.pl
+===================================================================
+--- SOURCE_TOOLS/release/release_tool.pl	(revision 16223)
++++ SOURCE_TOOLS/release/release_tool.pl	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ 
+ use strict;
+ use warnings;
+Index: SOURCE_TOOLS/remake_after_change.pl
+===================================================================
+--- SOURCE_TOOLS/remake_after_change.pl	(revision 16223)
++++ SOURCE_TOOLS/remake_after_change.pl	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ 
+ use strict;
+ use warnings;
+Index: SOURCE_TOOLS/svn_apply_ignores.pl
+===================================================================
+--- SOURCE_TOOLS/svn_apply_ignores.pl	(revision 16223)
++++ SOURCE_TOOLS/svn_apply_ignores.pl	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ # ============================================================ #
+ #                                                              #
+ #   File      : svn_apply_ignores.pl                           #
+Index: SOURCE_TOOLS/svn_undo_depends.pl
+===================================================================
+--- SOURCE_TOOLS/svn_undo_depends.pl	(revision 16223)
++++ SOURCE_TOOLS/svn_undo_depends.pl	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ # ============================================================ #
+ #                                                              #
+ #   File      : svn_undo_depends.pl                            #
+Index: SOURCE_TOOLS/tabBrake.pl
+===================================================================
+--- SOURCE_TOOLS/tabBrake.pl	(revision 16223)
++++ SOURCE_TOOLS/tabBrake.pl	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ #
+ # checks files for TABs and raises error if TABs found
+ # (TABs are evil, cause they have no default width)
+Index: SOURCE_TOOLS/touch_modified.pl
+===================================================================
+--- SOURCE_TOOLS/touch_modified.pl	(revision 16223)
++++ SOURCE_TOOLS/touch_modified.pl	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ 
+ use strict;
+ use warnings;
+Index: SOURCE_TOOLS/update_config_makefile.pl
+===================================================================
+--- SOURCE_TOOLS/update_config_makefile.pl	(revision 16223)
++++ SOURCE_TOOLS/update_config_makefile.pl	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ 
+ use strict;
+ use warnings;
+Index: SOURCE_TOOLS/valgrind2grep
+===================================================================
+--- SOURCE_TOOLS/valgrind2grep	(revision 16223)
++++ SOURCE_TOOLS/valgrind2grep	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ 
+ use warnings;
+ use strict;
+Index: TEMPLATES/arb_backtrace.h
+===================================================================
+--- TEMPLATES/arb_backtrace.h	(revision 16223)
++++ TEMPLATES/arb_backtrace.h	(working copy)
+@@ -97,7 +97,7 @@
+         static bool filtfailed = false;
+         if (!filtfailed) {
+             // @@@ Warning: this branch ignores parameter 'out'
+-            FILE *filt = popen("/usr/bin/c++filt", "w");
++            FILE *filt = popen("/usr/bin/env c++filt", "w");
+             if (filt) {
+                 filtfailed   = !trace.dump(filt, message);
+                 int exitcode = pclose(filt);
+Index: UNIT_TESTER/gcov2msg.pl
+===================================================================
+--- UNIT_TESTER/gcov2msg.pl	(revision 16223)
++++ UNIT_TESTER/gcov2msg.pl	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ 
+ use strict;
+ use warnings;
+Index: UNIT_TESTER/log_result.pl
+===================================================================
+--- UNIT_TESTER/log_result.pl	(revision 16223)
++++ UNIT_TESTER/log_result.pl	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ use strict;
+ use warnings;
+ 
+Index: UNIT_TESTER/reporter.pl
+===================================================================
+--- UNIT_TESTER/reporter.pl	(revision 16223)
++++ UNIT_TESTER/reporter.pl	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ 
+ use strict;
+ use warnings;
+Index: UNIT_TESTER/run/general/pp.amc
+===================================================================
+--- UNIT_TESTER/run/general/pp.amc	(revision 16223)
++++ UNIT_TESTER/run/general/pp.amc	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ use strict;
+ use warnings;
+ 
+Index: UNIT_TESTER/run/general/pp_exp.amc
+===================================================================
+--- UNIT_TESTER/run/general/pp_exp.amc	(revision 16223)
++++ UNIT_TESTER/run/general/pp_exp.amc	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ use strict;
+ use warnings;
+ 
+Index: UNIT_TESTER/sym2testcode.pl
+===================================================================
+--- UNIT_TESTER/sym2testcode.pl	(revision 16223)
++++ UNIT_TESTER/sym2testcode.pl	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ 
+ use strict;
+ use warnings;
+Index: lib/macro.head
+===================================================================
+--- lib/macro.head	(revision 16223)
++++ lib/macro.head	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ use strict;
+ use warnings;
+ 
+Index: lib/macros/ARB/SEQ_DATA/dashes2dots_at_sequenceends_of_marked.amc
+===================================================================
+--- lib/macros/ARB/SEQ_DATA/dashes2dots_at_sequenceends_of_marked.amc	(revision 16223)
++++ lib/macros/ARB/SEQ_DATA/dashes2dots_at_sequenceends_of_marked.amc	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl -w
++#!/usr/bin/env perl
+ use lib "$ENV{'ARBHOME'}/lib/";
+ use ARB;
+ 
+Index: lib/macros/_dolog.amc
+===================================================================
+--- lib/macros/_dolog.amc	(revision 16223)
++++ lib/macros/_dolog.amc	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ #
+ # auto-record ARB-session
+ # (for debugging purposes; user could as well record ARB crashes)
+Index: lib/macros/replamb.amc
+===================================================================
+--- lib/macros/replamb.amc	(revision 16223)
++++ lib/macros/replamb.amc	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl -w
++#!/usr/bin/env perl
+ use lib "$ENV{'ARBHOME'}/lib/";
+ use ARB;
+ 
+Index: lib/macros/test.amc
+===================================================================
+--- lib/macros/test.amc	(revision 16223)
++++ lib/macros/test.amc	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl -w
++#!/usr/bin/env perl
+ use lib "$ENV{'ARBHOME'}/lib/";
+ use ARB;
+ 
+Index: lib/macros/testwl.amc
+===================================================================
+--- lib/macros/testwl.amc	(revision 16223)
++++ lib/macros/testwl.amc	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl -w
++#!/usr/bin/env perl
+ use lib "$ENV{'ARBHOME'}/lib/";
+ use ARB;
+ 
+Index: lib/macros/toggle_color.amc
+===================================================================
+--- lib/macros/toggle_color.amc	(revision 16223)
++++ lib/macros/toggle_color.amc	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl -w
++#!/usr/bin/env perl
+ use lib "$ENV{'ARBHOME'}/lib/";
+ use ARB;
+ 
+Index: lib/macros/xopen.amc
+===================================================================
+--- lib/macros/xopen.amc	(revision 16223)
++++ lib/macros/xopen.amc	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl -w
++#!/usr/bin/env perl
+ use lib "$ENV{'ARBHOME'}/lib/";
+ use ARB;
+ 
+Index: lib/motifHack/convert_xpm.pl
+===================================================================
+--- lib/motifHack/convert_xpm.pl	(revision 16223)
++++ lib/motifHack/convert_xpm.pl	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ # ============================================================= #
+ #                                                               #
+ #   File      : convert_xpm.pl                                  #
+Index: util/arb_check_build_env.pl
+===================================================================
+--- util/arb_check_build_env.pl	(revision 16223)
++++ util/arb_check_build_env.pl	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ #
+ # This script checks whether all tools needed for ARB compilation are found in path.
+ 
+Index: util/arb_srclst.pl
+===================================================================
+--- util/arb_srclst.pl	(revision 16223)
++++ util/arb_srclst.pl	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ 
+ use strict;
+ use warnings;
+Index: util/arb_tgz2version.pl
+===================================================================
+--- util/arb_tgz2version.pl	(revision 16223)
++++ util/arb_tgz2version.pl	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ 
+ use strict;
+ use warnings;
+Index: util/usecores.pl
+===================================================================
+--- util/usecores.pl	(revision 16223)
++++ util/usecores.pl	(working copy)
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/usr/bin/env perl
+ 
+ # determines cores used by jenkins builds
+ my $cores = `cat /proc/cpuinfo | grep processor | wc -l`; # no /proc/cpuinfo (e.g. on OSX) -> falls back to minimum

--- a/recipes/arb-bio/6.1.rev16223/build.sh
+++ b/recipes/arb-bio/6.1.rev16223/build.sh
@@ -37,7 +37,7 @@ case `uname` in
 	SHARED_LIB_SUFFIX=dylib
 	export CFLAGS="$CFLAGS -w"
 	# needed for ARB Perl Binding compilation using MakeMaker
-	export LDFLAGS="$LDFLAGS -Wl,-rpath,$PREFIX/lib -headerpad_max_install_names"
+	export LDFLAGS="$LDFLAGS -Wl,-rpath,$PREFIX/lib"
 	;;
 esac >> config.makefile
 

--- a/recipes/arb-bio/6.1.rev16223/build.sh
+++ b/recipes/arb-bio/6.1.rev16223/build.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+set -x
+
+#### "./configure" ####
+
+export ARBHOME=`pwd`
+export PATH="$ARBHOME/bin:$PATH"
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$ARBHOME/lib"
+
+export PKG_CONFIG_LIBDIR="$PREFIX/lib/pkgconfig:$PREFIX/share/pkgconfig"
+export XLIBS=$(pkg-config --libs xpm xerces-c)
+export XAW_LIBS=$(pkg-config --libs xaw7)
+export XML_INCLUDES=$(pkg-config --cflags xerces-c)
+export XINCLUDES=$(pkg-config --cflags x11)
+
+## Suppress building tools bundled with ARB for which we have
+# conda packages:
+export ARB_BUILD_SKIP_PKGS="MAFFT MUSCLE RAxML PHYLIP FASTTREE MrBAYES"
+
+# ARB stores build settings in config.makefile. Create one from template:
+cp config.makefile.template config.makefile
+
+# Now add some target specific settings to config.makefile
+case `uname` in
+    Linux)
+	echo DARWIN := 0
+	echo LINUX := 1
+	echo MACH := LINUX
+	echo LINK_STATIC := 0
+	SHARED_LIB_SUFFIX=so
+	;;
+    Darwin)
+	echo DARWIN := 1
+	echo LINUX := 0
+	echo MACH := DARWIN
+	echo LINK_STATIC := 0
+	SHARED_LIB_SUFFIX=dylib
+	export CFLAGS="$CFLAGS -w"
+	# needed for ARB Perl Binding compilation using MakeMaker
+	export LDFLAGS="$LDFLAGS -Wl,-rpath,$PREFIX/lib -headerpad_max_install_names"
+	;;
+esac >> config.makefile
+
+#### "make" ####
+
+make SHARED_LIB_SUFFIX=$SHARED_LIB_SUFFIX -j$CPU_COUNT build | sed 's|'$PREFIX'|$PREFIX|g'
+
+#### "make install" ####
+
+# create tarballs (picks the necessary files out of build tree)
+make SHARED_LIB_SUFFIX=$SHARED_LIB_SUFFIX tarfile_quick | sed 's|'$PREFIX'|$PREFIX|g'
+
+# unpack tarballs at $PREFIX
+ARB_INST=$PREFIX/lib/arb
+mkdir $ARB_INST
+tar -C $ARB_INST -xzf arb.tgz
+tar -C $ARB_INST -xzf arb-dev.tgz
+
+# symlink arb_* executables into PATH
+(
+ cd $PREFIX/bin;
+ for exe in $ARB_INST/bin/arb*; do
+     ln -s "$exe"
+ done
+)
+
+# fix the library paths
+case `uname` in
+    Darwin)
+	# fix library IDs
+	# ARB builds libraries as "-o ../lib/libXYZ.suf". That value becomes the
+	# "ID" of the lib and the path searched for by binaries. We need to
+	# change all these...
+
+	declare -a CHANGE_IDS
+	ARB_LIBS="$ARB_INST"/lib/*.$SHARED_LIB_SUFFIX
+	for lib in $ARB_LIBS; do
+	    old_id=`otool -D "$lib" | tail -n 1`
+	    new_id="@rpath/${lib##$PREFIX/lib/}"
+	    CHANGE_IDS+=("-change" "$old_id" "$new_id")
+	    install_name_tool -id "$new_id" "$lib"
+	    echo "Fixing ID of $lib ($old_id => $new_id)"
+	done
+	echo "Collected changes to me made:"
+	echo "${CHANGE_IDS[@]}"
+
+	ARB_BINS=`find $ARB_INST -type f -perm -a=x | \
+	    xargs file | grep Mach-O | cut -d : -f 1 | grep -v ' '`
+
+	echo "Applying changes to binaries:"
+	for bin in $ARB_BINS; do
+	    if test -e "$bin"; then
+		echo -n "$bin ... "
+		install_name_tool "${CHANGE_IDS[@]}" "$bin"
+		echo "done"
+	    fi
+	done
+	;;
+    Linux)
+	ARB_BINS=`find $ARB_INST -type f -perm -a=x | \
+	    xargs file | grep ELF | cut -d : -f 1 | grep -v ' '`
+	echo "Patching rpath into binaries:"
+	for bin in $ARB_BINS; do
+	    if test -e "$bin"; then
+		echo -n "$bin ..."
+		patchelf --set-rpath \$ORIGIN/../lib "$bin"
+	    fi
+	done
+	;;
+esac
+
+# Create [de]activate scripts
+# (ARB components expect ARBHOME set to the installation directory)
+
+mkdir -p "${PREFIX}/etc/conda/activate.d"
+cat >"${PREFIX}/etc/conda/activate.d/arbhome-activate.sh" <<EOF
+export ARBHOME_BACKUP="\$ARBHOME"
+export ARBHOME="\$CONDA_PREFIX/lib/arb"
+EOF
+mkdir -p "${PREFIX}/etc/conda/deactivate.d"
+cat >"${PREFIX}/etc/conda/deactivate.d/arbhome-deactivate.sh" <<EOF
+export ARBHOME="\$ARB_HOMEBACKUP"
+EOF
+

--- a/recipes/arb-bio/6.1.rev16223/gsed.patch
+++ b/recipes/arb-bio/6.1.rev16223/gsed.patch
@@ -1,0 +1,14 @@
+diff -ru arbsrc_15220.orig/SH/arb_sed arbsrc_15220/SH/arb_sed
+--- SH/arb_sed	2016-05-02 05:19:20.000000000 -0600
++++ SH/arb_sed	2017-06-18 19:11:31.000000000 -0600
+@@ -1,9 +1,3 @@
+ #!/bin/bash
+-
+-if [[ `uname` == Darwin* ]]
+-then
+-    gsed "$@"
+-else
+-    sed "$@"
+-fi
++exec sed "$@"
+ 

--- a/recipes/arb-bio/6.1.rev16223/link_dyn.patch
+++ b/recipes/arb-bio/6.1.rev16223/link_dyn.patch
@@ -10,10 +10,11 @@
   SHARED_LIB_SUFFIX = so# shared lib suffix
   LINK_SHARED_LIB := $(A_CXX) $(llflags) -shared -o# link shared lib
  endif
-@@ -833,7 +836,7 @@
+@@ -833,4 +836,4 @@
 
  # delete variables unused below
- blflags:=
+-blflags:=
++#blflags:=
 -llflags:=
 +#llflags:=
 

--- a/recipes/arb-bio/6.1.rev16223/link_dyn.patch
+++ b/recipes/arb-bio/6.1.rev16223/link_dyn.patch
@@ -1,0 +1,21 @@
+--- Makefile.orig	2017-03-23 13:58:59.000000000 -0600
++++ Makefile	2017-03-23 14:01:56.000000000 -0600
+@@ -821,6 +821,9 @@
+  SHARED_LIB_SUFFIX = a# static lib suffix
+  LINK_SHARED_LIB := $(LINK_STATIC_LIB)
+ else
++ ifeq ($(USE_CLANG),1)
++   llflags += -undefined dynamic_lookup
++ endif
+  SHARED_LIB_SUFFIX = so# shared lib suffix
+  LINK_SHARED_LIB := $(A_CXX) $(llflags) -shared -o# link shared lib
+ endif
+@@ -833,7 +836,7 @@
+
+ # delete variables unused below
+ blflags:=
+-llflags:=
++#llflags:=
+
+ # other used tools
+ MAKEDEPEND_PLAIN = makedepend

--- a/recipes/arb-bio/6.1.rev16223/make.patch
+++ b/recipes/arb-bio/6.1.rev16223/make.patch
@@ -12,15 +12,14 @@
  #  LINK_STATIC=1# link static (testing only)
  endif
 
-@@ -797,6 +797,10 @@
-  cxxflags += $(CPPFLAGS)
- endif
+@@ -770,6 +770,10 @@
+
+ #---------------------- differences between linking executables and shared libs:
 
 +cflags += $(CFLAGS)
 +clflags += $(LDFLAGS)
 +cxxflags += $(CXXFLAGS)
 +
- ifeq ('$(USE_CLANG)','1')
- # none of the following standards works with clang3.3 (under linux) => dont use standard (as done before r15516)
- #  cxxflags += -std=gnu++11
-
+ # executables:
+ ifeq ($(DARWIN),1)
+  blflags:=$(clflags)

--- a/recipes/arb-bio/6.1.rev16223/make.patch
+++ b/recipes/arb-bio/6.1.rev16223/make.patch
@@ -1,0 +1,26 @@
+--- Makefile.orig	2017-03-23 18:26:58.000000000 -0600
++++ Makefile	2017-03-23 19:01:36.000000000 -0600
+@@ -213,9 +213,9 @@
+ #----------------------
+
+ ifeq ($(DARWIN),1)
+- LINK_STATIC=1# link static
++ LINK_STATIC?=1# link static
+ else
+- LINK_STATIC=0# link dynamically
++ LINK_STATIC?=0# link dynamically
+ #  LINK_STATIC=1# link static (testing only)
+ endif
+
+@@ -797,6 +797,10 @@
+  cxxflags += $(CPPFLAGS)
+ endif
+
++cflags += $(CFLAGS)
++clflags += $(LDFLAGS)
++cxxflags += $(CXXFLAGS)
++
+ ifeq ('$(USE_CLANG)','1')
+ # none of the following standards works with clang3.3 (under linux) => dont use standard (as done before r15516)
+ #  cxxflags += -std=gnu++11
+

--- a/recipes/arb-bio/6.1.rev16223/meta.yaml
+++ b/recipes/arb-bio/6.1.rev16223/meta.yaml
@@ -25,6 +25,7 @@ build:
 
 requirements:
   build:
+    - ccache-toolchain
     - gcc   # [linux]
     - llvm  # [osx]
     - pkg-config
@@ -37,6 +38,7 @@ requirements:
     - xorg-libxi
     - xorg-libxaw
     - xorg-libxpm
+    - xorg-libxft
     - xorg-makedepend
     - xerces-c
     - libtiff

--- a/recipes/arb-bio/6.1.rev16223/meta.yaml
+++ b/recipes/arb-bio/6.1.rev16223/meta.yaml
@@ -1,14 +1,15 @@
 {% set name = "ARB" %}
 {% set version = "6.1.rev16223" %}
+{% set sha256 = "680a56cdfe8c867e1c1438f622f6f51329c5e4789496e1eb9ae0acfdf57a719e" %}
 
 package:
   name: {{ name|lower }}-bio
   version: {{ version }}
 
 source:
-  svn_url: http://vc.arb-home.de/readonly/trunk
-  svn_rev: 16223
-  sha256: none
+  fn: {{ name }}_{{ version }}_src_all.zip
+  url: https://depot.galaxyproject.org/software/{{ name }}/{{ name }}_{{ version }}_src_all.zip
+  sha256: {{ sha256 }}
   patches:
     # do not create links for mafft
    - no_mafftlinks.patch
@@ -41,7 +42,7 @@ requirements:
     - xorg-libxft
     - xorg-makedepend
     - xerces-c
-    - libtiff
+    - libtiff >=4.0.3,<4.0.8
     - libxslt
     # perl 5.22.0.1-0 and 5.22.2.1-0 want to use
     # -fstack-protector-strong, which doesn't exist in conda gcc 4.8 and

--- a/recipes/arb-bio/6.1.rev16223/meta.yaml
+++ b/recipes/arb-bio/6.1.rev16223/meta.yaml
@@ -50,7 +50,7 @@ requirements:
     - lynx
     - time
     - sed >=4.4 # 4.2 links to broken gettext
-    - boost-cpp
+    - boost-cpp 1.64.*
     - svn
 
   run:

--- a/recipes/arb-bio/6.1.rev16223/meta.yaml
+++ b/recipes/arb-bio/6.1.rev16223/meta.yaml
@@ -1,14 +1,18 @@
 {% set name = "ARB" %}
-{% set version = "6.1.rev16223" %}
+{% set cargo_version = "6.1.16228" %}
 {% set sha256 = "680a56cdfe8c867e1c1438f622f6f51329c5e4789496e1eb9ae0acfdf57a719e" %}
+
+# The commits 166224 to 16228 where made to branches. In spite of the version in the
+# file name, the real version is this one:
+{% set version = "6.1.rev16223" %}
 
 package:
   name: {{ name|lower }}-bio
   version: {{ version }}
 
 source:
-  fn: {{ name }}_{{ version }}_src_all.zip
-  url: https://depot.galaxyproject.org/software/{{ name }}/{{ name }}_{{ version }}_src_all.zip
+  fn: {{ name }}_{{ cargo_version }}_src_all.zip
+  url: https://depot.galaxyproject.org/software/{{ name }}/{{ name }}_{{ cargo_version }}_src_all.zip
   sha256: {{ sha256 }}
   patches:
     # do not create links for mafft

--- a/recipes/arb-bio/6.1.rev16223/meta.yaml
+++ b/recipes/arb-bio/6.1.rev16223/meta.yaml
@@ -1,0 +1,91 @@
+{% set name = "ARB" %}
+{% set version = "6.1.rev16223" %}
+
+package:
+  name: {{ name|lower }}-bio
+  version: {{ version }}
+
+source:
+  svn_url: http://vc.arb-home.de/readonly/trunk
+  svn_rev: 16223
+  sha256: none
+  patches:
+    # do not create links for mafft
+   - no_mafftlinks.patch
+   # allow linking with missing symbols on macos
+   - link_dyn.patch
+   - make.patch
+   # change all /usr/bin/xyz paths to /usr/bin/env xyz
+   - abs_path_fix.patch
+   # use sed, not gsed
+   - gsed.patch
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - gcc   # [linux]
+    - llvm  # [osx]
+    - pkg-config
+    - openmotif-dev
+    - glib 2.51.* # 2.50.2 links to broken gettext
+    - gettext !=0.19.8  # gettext 0.19.8 is broken
+    - pthread-stubs
+    - xorg-libxp
+    - xorg-libxmu
+    - xorg-libxi
+    - xorg-libxaw
+    - xorg-libxpm
+    - xorg-makedepend
+    - xerces-c
+    - libtiff
+    - libxslt
+    # perl 5.22.0.1-0 and 5.22.2.1-0 want to use
+    # -fstack-protector-strong, which doesn't exist in conda gcc 4.8 and
+    # leads to compile failure
+    - perl 5.22.2.*
+    - lynx
+    - time
+    - sed >=4.4 # 4.2 links to broken gettext
+    - boost-cpp
+    - svn
+
+  run:
+    - libgcc   # [linux]
+    - gettext !=0.19.8  # gettext 0.19.8 is broken
+    - xorg-libxi
+    - xorg-libxmu
+    - xorg-libxp
+    - xorg-libxaw
+    - xorg-libxpm
+    - xorg-libxft
+    - glib 2.51.*
+    - openmotif
+    - gnuplot
+    - muscle
+    - mafft
+    - raxml
+    - mrbayes
+    - phylip
+    - phyml 3.2.0
+    - fasttree
+    - sed >=4.4
+    - xfig
+    - fig2dev
+    - perl 5.22.2.*
+
+test:
+  requires:
+    - conda
+  commands:
+    - if command -v conda; then conda inspect linkages -p $PREFIX $PKG_NAME; fi
+    - if command -v conda; then conda inspect objects -p $PREFIX $PKG_NAME; fi   # [osx]
+    - which arb
+    - which arb_pt_server
+
+about:
+  home: http://www.arb-home.de
+  license: ARB
+  licence_file: arb_LICENSE.txt
+  summary: ARB 6 Sequence Analysis Suite

--- a/recipes/arb-bio/6.1.rev16223/no_mafftlinks.patch
+++ b/recipes/arb-bio/6.1.rev16223/no_mafftlinks.patch
@@ -1,0 +1,11 @@
+--- bin/Makefile	2017-03-23 18:32:13.000000000 -0600
++++ bin/Makefile.new	2017-03-23 18:32:22.000000000 -0600
+@@ -12,7 +12,7 @@
+ # ----------------------------------------
+
+ all:
+-	$(MAKE) scriptlinks mafftlinks
++	$(MAKE) scriptlinks
+
+ develall:
+	$(MAKE) scriptlinks mafftlinks devellinks

--- a/recipes/arb-bio/6.1.rev16223/run_test.sh
+++ b/recipes/arb-bio/6.1.rev16223/run_test.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -x
+set -e
+
+# Just check the main binary
+arb --help
+
+# if we aren't in a conda env, ARBHOME won't be set. Get it.
+
+if [ -z "$CONDA_DEFAULT_ENV" ]; then
+    ARBHOME=$(echo 'echo THE_ARB_HOME $ARBHOME' | \
+		     arb shell | grep THE_ARB_HOME | cut -f2 -d' ')
+    export ARBHOME
+elif [ -z "$ARBHOME" ]; then
+    source activate $CONDA_DEFAULT_ENV
+fi
+
+# Check that ARBHOME exists:
+test -d $ARBHOME
+echo "ARBHOME=$ARBHOME"
+
+# Check that demo.arb exists
+test -r $ARBHOME/demo.arb
+
+# Check arb_2_ascii
+arb_2_ascii $ARBHOME/demo.arb - > ascii.arb
+
+# Check arb_2_bin
+arb_2_bin ascii.arb demo.arb
+


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

The stable release series for ARB (6.0.x) was forked off in 2014 and has since only received bugfix patches. No other releases were made upstream since then, although development is ongoing. However, ARB is in production through a CI system right off of the SVN and SVN trunk is reasonably stable at most times.

This PR creates a package with the "official" version (as set by build system itself) `6.1.rev16233`. It is meant to close the gap until upstream eventually publishes the next release.