### PR TITLE
Du Novo: Bump to 0.7.5: Make failures in --phone-home not fatal.

### DIFF
--- a/recipes/dunovo/build.sh
+++ b/recipes/dunovo/build.sh
@@ -1,22 +1,26 @@
 #!/bin/bash
-set -x
+
 # Compile binaries and move them to lib.
 make
 mv *.so $PREFIX/lib
 
 # Download submodules and move them to lib.
-wget --no-check-certificate 'https://github.com/NickSto/utillib/archive/v0.1.0.tar.gz'
-hash=`sha256sum v0.1.0.tar.gz | tr -s ' ' | cut -d ' ' -f 1`
-[ $hash == bffe515f7bd98661657c26003c41c1224f405c3a36ddabf5bf961fab86f9651a ]
-tar -zxvpf v0.1.0.tar.gz
-mv utillib-0.1.0 $PREFIX/lib/utillib
-rm v0.1.0.tar.gz
-wget --no-check-certificate 'https://github.com/NickSto/ET/archive/v0.1.0.tar.gz'
-hash=`sha256sum v0.1.0.tar.gz | tr -s ' ' | cut -d ' ' -f 1`
-[ $hash == 57c2050715bd7383dc35ed4e1ad7f9078749a6b2459fd1730b8928fd0cbb2c5c ]
-tar -zxvpf v0.1.0.tar.gz
-mv ET-0.1.0 $PREFIX/lib/ET
-rm v0.1.0.tar.gz
+## utillib
+utilver=0.1.0
+wget --no-check-certificate "https://github.com/NickSto/utillib/archive/v$utilver.tar.gz"
+hash=`sha256sum v$utilver.tar.gz | tr -s ' ' | cut -d ' ' -f 1`
+[ $hash = bffe515f7bd98661657c26003c41c1224f405c3a36ddabf5bf961fab86f9651a ]
+tar -zxvpf v$utilver.tar.gz
+mv utillib-$utilver $PREFIX/lib/utillib
+rm v$utilver.tar.gz
+## ET
+ETver=0.1.1
+wget --no-check-certificate "https://github.com/NickSto/ET/archive/v$ETver.tar.gz"
+hash=`sha256sum v$ETver.tar.gz | tr -s ' ' | cut -d ' ' -f 1`
+[ $hash = 552c371f0fe0000b6037038ad1aeae09111d066c362d45655e40381cb0c325e4 ]
+tar -zxvpf v$ETver.tar.gz
+mv ET-$ETver $PREFIX/lib/ET
+rm v$ETver.tar.gz
 
 # Move scripts to lib and link to them from bin.
 for script in *.awk *.sh *.py; do

--- a/recipes/dunovo/meta.yaml
+++ b/recipes/dunovo/meta.yaml
@@ -1,12 +1,12 @@
 
 package:
   name: dunovo
-  version: '0.7.4'
+  version: '0.7.5'
 
 source:
-  fn: v0.7.4.tar.gz
-  url: https://github.com/galaxyproject/dunovo/archive/v0.7.4.tar.gz
-  sha256: eb361939b1321c289bb8a4a8db676d24bdee95debcf8100c8ad9425dee90cb8e
+  fn: v0.7.5.tar.gz
+  url: https://github.com/galaxyproject/dunovo/archive/v0.7.5.tar.gz
+  sha256: 76f6c54d4a79d9c0d2abe3efd4c23d9ba496debb3087cafecaec53fe8879474b
 
 build:
   number: 0


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Making an optional feature not crash the tool if it fails (e.g. b/c of network error).

Passes `simulate-travis.py`.