### PR TITLE
Du Novo: Update to 0.7.6 (bugfix).

### DIFF
--- a/recipes/dunovo/meta.yaml
+++ b/recipes/dunovo/meta.yaml
@@ -1,12 +1,12 @@
 
 package:
   name: dunovo
-  version: '0.7.5'
+  version: '0.7.6'
 
 source:
-  fn: v0.7.5.tar.gz
-  url: https://github.com/galaxyproject/dunovo/archive/v0.7.5.tar.gz
-  sha256: 76f6c54d4a79d9c0d2abe3efd4c23d9ba496debb3087cafecaec53fe8879474b
+  fn: v0.7.6.tar.gz
+  url: https://github.com/galaxyproject/dunovo/archive/v0.7.6.tar.gz
+  sha256: d184d192f7b7577826c240ee8f0488046b0b38e032325dcf9aa3f6c730f8ea0d
 
 build:
   number: 0


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

This is a very minor update that just bumps the version of Du Novo installed from 0.7.5 to 0.7.6.

Du Novo 0.7.6 itself is a two-line bugfix.