### PR TITLE
update blasr 5.2p1 to use current hdf5. allows comaptability with nan…

### DIFF
--- a/recipes/blasr/5.2p1/blasr.patch
+++ b/recipes/blasr/5.2p1/blasr.patch
@@ -1,0 +1,41 @@
+--- configure.py    2016-08-04 20:35:56.000000000 +0300
++++ configure.py        2016-08-04 20:40:38.000000000 +0300
+@@ -3,7 +3,7 @@
+
+ - Create defines.mk
+ """
+-import commands
++import subprocess
+ import contextlib
+ import optparse
+ import os
+@@ -23,7 +23,7 @@
+
+ def shell(cmd):
+     log('`%s`'%cmd)
+-    status, output = commands.getstatusoutput(cmd)
++    status, output = subprocess.getstatusoutput(cmd)
+     if status:
+         raise Exception('%d <- %r' %(status, cmd))
+     log(output)
+
+--- libcpp/configure.py     2016-08-04 20:46:18.000000000 +0300
++++ libcpp/configure.py 2016-08-04 20:42:45.000000000 +0300
+@@ -9,7 +9,7 @@
+
+ This is not used by './unittest/'.
+ """
+-import commands
++import subprocess
+ import contextlib
+ import os
+ import sys
+@@ -22,7 +22,7 @@
+
+ def shell(cmd):
+     log(cmd)
+-    status, output = commands.getstatusoutput(cmd)
++    status, output = subprocess.getstatusoutput(cmd)
+     if status:
+         raise Exception('%d <- %r' %(status, cmd))
+     return output

--- a/recipes/blasr/5.2p1/build.sh
+++ b/recipes/blasr/5.2p1/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+mkdir -p $PREFIX/bin
+
+#wget -O libcpp.tar.gz https://github.com/PacificBiosciences/blasr_libcpp/archive/0ae16915b48d1ee77cb7cd4c95764181467c7175.tar.gz
+#tar -xvf libcpp.tar.gz
+#mv blasr_libcpp-0ae16915b48d1ee77cb7cd4c95764181467c7175 libcpp
+
+./configure.py --shared --sub --no-pbbam HDF5_INCLUDE=$PREFIX/include HDF5_LIB=$PREFIX/lib
+
+make configure-submodule
+
+make build-submodule
+
+make blasr
+cp blasr $PREFIX/bin
+cp libcpp/alignment/libblasr.* $PREFIX/lib
+cp libcpp/hdf/libpbihdf.* $PREFIX/lib
+cp libcpp/pbdata/libpbdata.* $PREFIX/lib
+LD_LIBRARY_PATH=$PREFIX/lib

--- a/recipes/blasr/5.2p1/meta.yaml
+++ b/recipes/blasr/5.2p1/meta.yaml
@@ -1,0 +1,45 @@
+{% set version = "5.2p1" %}
+
+package:
+  name: blasr
+  version: {{ version }}
+
+build:
+  number: 1
+  skip: True # [not py27 or osx]
+
+source:
+#  fn: blasr_{{ version }}.tar.gz
+#  url: https://github.com/PacificBiosciences/blasr/archive/061bd35783637f511bdec6c237a2f8d1c0514e6e.tar.gz
+#  md5: 257828868b17903608b010c7b2966d51
+
+  git_url: https://github.com/PacificBiosciences/blasr.git
+  git_rev: 061bd35783637f511bdec6c237a2f8d1c0514e6e
+
+  patches:
+      - blasr.patch
+requirements:
+  build:
+  - gcc # [not osx]
+  - llvm # [osx]
+  - hdf5 1.8.18|1.8.18.*
+  - git 
+
+  run:
+  - libgcc # [not osx]
+  - hdf5 1.8.18|1.8.18.*
+
+test:
+  commands:
+    - blasr --version
+
+about:
+  home: https://github.com/PacificBiosciences/blasr
+  license: BSD-3-Clause-Clear
+  license_file: LICENSE
+  summary: BLASR - The PacBio long read aligner
+
+    © 2017 GitHub, Inc.
+    Terms
+    Privacy
+    Security


### PR DESCRIPTION
…opolish, poretools, etc

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

This updates an older version of blasr to use a newer hdf5 library. This will allow users to use blasr 5.2p1 (currently the only working version) in the same environment at other long-read tools