### PR TITLE
(cwltest) Pinned typing to v3.5.*

### DIFF
--- a/recipes/cwltest/meta.yaml
+++ b/recipes/cwltest/meta.yaml
@@ -17,14 +17,14 @@ requirements:
     - python
     - setuptools
     - schema-salad
-    - typing 3.5.*
+    - typing >=3.5.3
     - junit-xml
     - futures
 
   run:
     - python
     - schema-salad
-    - typing 3.5.*
+    - typing >=3.5.3
     - junit-xml
     - futures
 

--- a/recipes/cwltest/meta.yaml
+++ b/recipes/cwltest/meta.yaml
@@ -17,14 +17,14 @@ requirements:
     - python
     - setuptools
     - schema-salad
-    - typing >=3.5.3
+    - typing >=3.5.3,<3.6
     - junit-xml
     - futures
 
   run:
     - python
     - schema-salad
-    - typing >=3.5.3
+    - typing >=3.5.3,<3.6
     - junit-xml
     - futures
 

--- a/recipes/cwltest/meta.yaml
+++ b/recipes/cwltest/meta.yaml
@@ -17,14 +17,14 @@ requirements:
     - python
     - setuptools
     - schema-salad
-    - typing
+    - typing 3.5.*
     - junit-xml
     - futures
 
   run:
     - python
     - schema-salad
-    - typing
+    - typing 3.5.*
     - junit-xml
     - futures
 

--- a/recipes/cwltest/meta.yaml
+++ b/recipes/cwltest/meta.yaml
@@ -9,7 +9,7 @@ source:
 
 
 build:
-  number: 0
+  number: 1
   skip: True # [not py27]
 
 requirements:


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

conda-forge provides `typing 3.6` as the latest version, which conflicts with schema-salad. 