### PR TITLE
IgDiscover: Depend on seaborn 0.7

### DIFF
--- a/recipes/igdiscover/meta.yaml
+++ b/recipes/igdiscover/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - snakemake >=3.9.0
     - cutadapt
     - xopen >=0.1.1
-    - seaborn >=0.6.0
+    - seaborn >=0.6,<0.8
     - scipy >=0.16.1
     - ruamel.yaml
     - muscle
@@ -42,12 +42,12 @@ requirements:
     - snakemake >=3.9.0
     - cutadapt
     - xopen >=0.1.1
-    - seaborn >=0.6.0
+    - seaborn >=0.6,<0.8
     - scipy >=0.16.1
     - ruamel.yaml
 
 build:
-  number: 0
+  number: 1
   skip: True  # [py27]
   script: python3 setup.py install
 


### PR DESCRIPTION
Seaborn 0.8, which has been released recently, contains a regression that
makes IgDiscover fail when creating some plots.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
