### PR TITLE
Du Novo: Include VERSION file in build, to allow --version and --phone-home to work.

### DIFF
--- a/recipes/dunovo/build.sh
+++ b/recipes/dunovo/build.sh
@@ -27,5 +27,7 @@ for script in *.awk *.sh *.py; do
   mv $script $PREFIX/lib
   ln -s ../lib/$script $PREFIX/bin
 done
+# Handle special cases.
 mv utils/outconv.py $PREFIX/lib
 ln -s ../lib/outconv.py $PREFIX/bin
+mv VERSION $PREFIX/lib

--- a/recipes/dunovo/meta.yaml
+++ b/recipes/dunovo/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: d184d192f7b7577826c240ee8f0488046b0b38e032325dcf9aa3f6c730f8ea0d
 
 build:
-  number: 0
+  number: 1
   skip: True  # [py3k or osx]
 
 requirements:


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

This update simply adds a line to `build.sh` to move the `VERSION` file to `$PREFIX/lib`. This allows the various scripts to find the current Du Novo version number, allowing the `--version` option to work. This also allows `--phone-home` to work, since that requires the version number.