### PR TITLE
Busco config

### DIFF
--- a/recipes/busco/build.sh
+++ b/recipes/busco/build.sh
@@ -8,6 +8,10 @@ SHARE=$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM
 mkdir -p $SHARE
 cp config/config.ini.default $SHARE/config.ini.default
 
+cp $RECIPE_DIR/generate-busco-config.py $SHARE/generate-busco-config.py
+chmod +x $SHARE/generate-busco-config.py
+ln -s $SHARE/generate-busco-config.py $PREFIX/bin/generate-busco-config.py
+
 ln -s $PREFIX/bin/run_BUSCO.py $PREFIX/bin/run_busco
 ln -s $PREFIX/bin/generate_plot.py $PREFIX/bin/generate_plot
 

--- a/recipes/busco/generate-busco-config.py
+++ b/recipes/busco/generate-busco-config.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+import glob
+import os
+import sys
+import argparse
+
+if (len(sys.argv) > 1) and sys.argv[1].lower() in ['-h', '--help', 'help']:
+    print(
+        '''
+        usage: %s > path-to-new-config-file.ini
+
+        BUSCO requires a config file with absolute paths to external
+        dependencies. When using this conda package, those dependencies are
+        installed in the same environment as BUSCO itself. This script replaces
+        the paths in the default BUSCO config file with the correct paths to
+        this conda environment's bin dir.
+        ''' % sys.argv[0]
+    )
+
+# directory where symlink lives
+bindir = os.path.dirname(os.path.abspath(__file__))
+
+# directory after resolving symlink (which is where the example config file is
+# found)
+share = os.path.dirname(os.path.realpath(__file__))
+config = os.path.join(share, 'config.ini.default')
+
+# One option for editing paths would be to use configparser, but this would
+# remove all the helpful comments in the config file. Instead, we match on "^path = "
+lines = []
+for line in open(config):
+    if line.startswith('path = '):
+        lines.append('path = ' + bindir + '\n')
+    else:
+        lines.append(line)
+sys.stdout.write(''.join(lines))

--- a/recipes/busco/meta.yaml
+++ b/recipes/busco/meta.yaml
@@ -9,7 +9,7 @@ package:
 build:
   # Not available for osx because requires augustus
   skip: True # [py27 or osx]
-  number: 1
+  number: 2
 
 source:
   fn: {{ name|lower }}_{{ version }}.tar.gz
@@ -21,6 +21,7 @@ requirements:
     - python
   run:
     - python
+    - wget
     - blast
     - hmmer
     - augustus

--- a/recipes/busco/post-link.sh
+++ b/recipes/busco/post-link.sh
@@ -7,4 +7,4 @@
 # stored in the share dir, replacing paths as necessary.
 SHARE=$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM
 mkdir -p $PREFIX/config
-sed "s|^path = .*$|path = $PREFIX/bin|g" $SHARE/config.ini.default > $PREFIX/config/config.ini
+generate-busco-config.py > $PREFIX/config/config.ini

--- a/recipes/busco/run_test.sh
+++ b/recipes/busco/run_test.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -euo pipefail
+
+cat > ex.fasta <<EOF
+>1
+AATTCC
+EOF
+wget http://busco.ezlab.org/datasets/proteobacteria_odb9.tar.gz
+tar -xf proteobacteria_odb9.tar.gz
+
+run_busco -i ex.fasta -o out -l proteobacteria_odb9 -m geno


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Another attempt at #5429.

Since there's a lot going on with dependencies and paths, this recipe now includes a minimal functional test. Data (10MB) are temporarily downloaded within `run_test.sh`. The test includes a command similar to https://github.com/bioconda/bioconda-recipes/issues/5429#issuecomment-322312966.

@mschatz your comment shows that the config needs to be adjusted depending on the tool, so I had added back in the more flexible python config generator that is run in the post-link step. However the test seems to be running without special-casing the augustus paths or the env var, so we might be OK as-is. Is there something in the eukaryota_odb9 example you show that triggers a call to gff2gbSmallDNA.pl that is not being triggered in this test with proteobacteria_odb9?
