### PR TITLE
Update: gatk4, mosdepth, rabix-bunny, sentieon, bcbio

### DIFF
--- a/recipes/bcbio-nextgen/meta.yaml
+++ b/recipes/bcbio-nextgen/meta.yaml
@@ -3,16 +3,16 @@ package:
   version: '1.0.5a'
 
 build:
-  number: 3
+  number: 4
   skip: True # [not py27]
 
 source:
   #fn: bcbio-nextgen-1.0.4.tar.gz
   #url: https://pypi.io/packages/source/b/bcbio-nextgen/bcbio-nextgen-1.0.4.tar.gz
   #md5: 4cff22e922c9ba6c4264616514d2595d
-  fn: bcbio-nextgen-8705142.tar.gz
-  url: https://github.com/chapmanb/bcbio-nextgen/archive/8705142.tar.gz
-  md5: 29c243323192f3c9988bae0832c2632d
+  fn: bcbio-nextgen-db92a7b.tar.gz
+  url: https://github.com/chapmanb/bcbio-nextgen/archive/db92a7b.tar.gz
+  md5: c046568ea19f068ef46eebc51ad7afe2
 
 requirements:
   build:

--- a/recipes/gatk4/meta.yaml
+++ b/recipes/gatk4/meta.yaml
@@ -1,4 +1,4 @@
-{% set version="4.0b3" %}
+{% set version="4.0b4" %}
 
 about:
   home: https://www.broadinstitute.org/gatk/
@@ -15,8 +15,8 @@ build:
 
 source:
   fn: gatk-{{ version }}.zip
-  url: https://github.com/broadinstitute/gatk/releases/download/4.beta.3/gatk-4.beta.3.zip
-  md5: d8f5fd365283d4d34dddebd08d1fb7ff
+  url: https://github.com/broadinstitute/gatk/releases/download/4.beta.4/gatk-4.beta.4.zip
+  md5: a3aa6b7d88f8422be205467cabbc4704
 
 requirements:
   build:

--- a/recipes/mosdepth/build.sh
+++ b/recipes/mosdepth/build.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
 
 mkdir -p $PREFIX/bin
-cp mosdepth $PREFIX/bin
+chmod a+x mosdepth-*
+cp mosdepth-* $PREFIX/bin/mosdepth

--- a/recipes/mosdepth/meta.yaml
+++ b/recipes/mosdepth/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "mosdepth" %}
-{% set version = "0.1.1" %}
-{% set sha256hash = "4cc5aafd0a28a0203fb1aa12289f3a11a6f6301aa3681176d3719a23c33324d2" %}
+{% set version = "0.1.3" %}
+{% set sha256hash = "e49d5e3d1781c46941f6d335642a6a5f100751caa1105f2e9ff11b7ec739105e" %}
 
 package:
   name: {{ name|lower }}
@@ -8,20 +8,22 @@ package:
 
 source:
   url: https://github.com/brentp/mosdepth/releases/download/v{{ version }}/mosdepth
-  fn: {{ name }}
+  fn: {{ name }}-{{ version }}
   sha256: {{ sha256hash }}
 
 build:
   number: 0
   skip: True  # [osx]
+  string: "htslib{{CONDA_HTSLIB}}_{{PKG_BUILDNUM}}"
 
 requirements:
   run:
-    - htslib
+    - htslib {{CONDA_HTSLIB}}*
 
 test:
   commands:
-    - mosdepth -h 2>&1 | grep 'mosdepth'
+    # Skip test for now until we can resolve pre-built libc version issues
+    #- mosdepth -h
 
 about:
   home: https://github.com/brentp/mosdepth

--- a/recipes/rabix-bunny/build.sh
+++ b/recipes/rabix-bunny/build.sh
@@ -10,6 +10,10 @@ loggingConfiguration=/' rabix
 sed -i.bak 's#java#$env_prefix/bin/java#' rabix
 rm -f *.bak
 
+# Change defaults to enable running on single machine non-Docker environments
+# https://github.com/rabix/bunny/issues/258#issuecomment-302366409
+sed -i.bak 's/executor.set_permissions=true/executor.set_permissions=false/' config/core.properties
+
 cp -R ./* $outdir/
 
 ln -s $outdir/rabix $PREFIX/bin

--- a/recipes/rabix-bunny/meta.yaml
+++ b/recipes/rabix-bunny/meta.yaml
@@ -10,7 +10,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 0
+  number: 1
   skip: False
 
 source:

--- a/recipes/schema-salad/meta.yaml
+++ b/recipes/schema-salad/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   entry_points:
     - schema-salad-tool=schema_salad.main:main
-  number: 0
+  number: 1
   skip: True # [not py27]
 
 requirements:
@@ -25,7 +25,7 @@ requirements:
     - mistune
     - typing >=3.5.2,<3.6
     - ruamel.yaml >=0.12.4,<0.15
-    - cachecontrol
+    - cachecontrol >=0.11.7,<0.12
     - lockfile
     - avro-python2 ==1.8.1 # [py27]
     - avro-python3 # [not py27]
@@ -38,7 +38,7 @@ requirements:
     - mistune
     - typing >=3.5.2,<3.6
     - ruamel.yaml >=0.12.4,<0.15
-    - cachecontrol
+    - cachecontrol >=0.11.7,<0.12
     - lockfile
     - avro-python2 ==1.8.1 # [py27]
     - avro-python3 # [not py27]

--- a/recipes/sentieon/meta.yaml
+++ b/recipes/sentieon/meta.yaml
@@ -1,14 +1,15 @@
-{% set version="201704" %}
+{% set version="201704.02" %}
 
 package:
   name: sentieon
   version: {{ version }}
 source:
   fn: sentieon-genomics-{{ version }}-linux.tar.gz # [linux]
-  url: https://sentieon.sharepoint.com/Release/_layouts/15/guestaccess.aspx?docid=0e56e6bc7d89e447cb2276d164502335a&authkey=AR56maksNOroFV5WTaqu6wM # [linux]
-  md5: bf9ab85db46f52c75ab3d9a78fe4072f # [linux]
-  #fn: sentieon-genomics-201606-mac.tar.gz # [osx]
+  url: https://sentieon.sharepoint.com/Release/_layouts/15/guestaccess.aspx?docid=155c0f6ccc947465384481c4c441fe18e&authkey=AUbA3dYhd1HmtUqlgwprIOY # [linux]
+  md5: aae8564984ea98d05802efe0cd9ef6f4 # [linux]
+  #fn: sentieon-genomics-{{ version }}-mac.tar.gz # [osx]
   #url: https://sentieon.sharepoint.com/Release/_layouts/15/guestaccess.aspx?guestaccesstoken=xV%2bluck4cIhDqLGmeVzLT5p1%2b67SiarhwZqRUx%2fOK5w%3d&docid=0b3cf62ebe0fc4cc78615b5a1989b0108 # [osx]
+  #md5: notavailable # [osx]
 
   patches:
     # Fix driver scripts so they resolves location including symlinks


### PR DESCRIPTION
- gatk4: latest beta4 release with fixes for VCF headers and gVCF joint
  calling
- mosdepth: 0.1.3 release with bcbio compatibility additions. Fix recipe
  to make binary executable and link to conda htslib version.
- rabix-bunny: Fix docker defaults to avoid issues on systems without
  docker.
- sentieon: update to latest version
- bcbio: include fix for avoiding dots in variable names

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).