### PR TITLE
Updates to the HMMER recipes

### DIFF
--- a/recipes/hmmer/2.3.2/meta.yaml
+++ b/recipes/hmmer/2.3.2/meta.yaml
@@ -5,10 +5,10 @@ package:
 source:
   fn: hmmer-2.3.2.tar.gz
   url: http://eddylab.org/software/hmmer/2.3.2/hmmer-2.3.2.tar.gz
-  md5: 5f073340c0cf761288f961a73821228a
+  sha256: d20e1779fcdff34ab4e986ea74a6c4ac5c5f01da2993b14e92c94d2f076828b4
 
 build:
-  number: 0
+  number: 1
   skip: True # [osx]
 
 requirements:
@@ -18,10 +18,23 @@ requirements:
 
 test:
   commands:
-    - hmmalign -h 2>&1 | grep Usage > /dev/null
+    - hmmsearch -h 2>&1 | grep "HMMER 2\.3\.2" > /dev/null
+    - hmmalign -h 2>&1 | grep "HMMER 2\.3\.2" > /dev/null
+    - hmmbuild -h 2>&1 | grep "HMMER 2\.3\.2" > /dev/null
+    - hmmcalibrate -h 2>&1 | grep "HMMER 2\.3\.2" > /dev/null
+    - hmmconvert -h 2>&1 | grep "HMMER 2\.3\.2" > /dev/null
+    - hmmemit -h 2>&1 | grep "HMMER 2\.3\.2" > /dev/null
+    - hmmfetch -h 2>&1 | grep "HMMER 2\.3\.2" > /dev/null
+    - hmmindex -h 2>&1 | grep "HMMER 2\.3\.2" > /dev/null
+    - hmmpfam -h 2>&1 | grep "HMMER 2\.3\.2" > /dev/null
+    - hmmsearch -h 2>&1 | grep "HMMER 2\.3\.2" > /dev/null
 
 about:
   summary: Biosequence analysis using profile hidden Markov models
   home: http://hmmer.janelia.org/
-  license: GPL3
+  license: GPLv2
   license_file: LICENSE
+  note: |
+    See also the "hmmer2" package which appends "2" to the HMMER
+    binary tool names, allowing it to be installed in parallel with
+    the later versions of this "hmmer" package.

--- a/recipes/hmmer/2.3.2/meta.yaml
+++ b/recipes/hmmer/2.3.2/meta.yaml
@@ -31,7 +31,7 @@ test:
 
 about:
   summary: Biosequence analysis using profile hidden Markov models
-  home: http://hmmer.janelia.org/
+  home: http://hmmer.org/
   license: GPLv2
   license_file: LICENSE
   note: |

--- a/recipes/hmmer/meta.yaml
+++ b/recipes/hmmer/meta.yaml
@@ -5,10 +5,10 @@ package:
 source:
   fn: hmmer-3.1b2.tar.gz
   url: http://eddylab.org/software/hmmer3/3.1b2/hmmer-3.1b2.tar.gz
-  md5: c8c141018bc0ccd7fc37b33f2b945d5f
+  sha256: dd16edf4385c1df072c9e2f58c16ee1872d855a018a2ee6894205277017b5536
 
 build:
-  number: 2
+  number: 3
 
 requirements:
   build:
@@ -17,7 +17,22 @@ requirements:
 
 test:
   commands:
-    - alimask -h 2>&1 | grep Usage > /dev/null
+    - alimask -h 2>&1 | grep "HMMER 3\." > /dev/null
+    - hmmalign -h 2>&1 | grep "HMMER 3\." > /dev/null
+    - hmmbuild -h 2>&1 | grep "HMMER 3\." > /dev/null
+    - hmmconvert -h 2>&1 | grep "HMMER 3\." > /dev/null
+    - hmmemit -h 2>&1 | grep "HMMER 3\." > /dev/null
+    - hmmfetch -h 2>&1 | grep "3\."
+    - hmmpress -h 2>&1 | grep "HMMER 3\." > /dev/null
+    - hmmscan -h 2>&1 | grep "HMMER 3\." > /dev/null
+    - hmmsearch -h 2>&1 | grep "HMMER 3\." > /dev/null
+    - hmmsim -h 2>&1 | grep "HMMER 3\." > /dev/null
+    - hmmstat -h 2>&1 | grep "HMMER 3\." > /dev/null
+    - jackhmmer -h 2>&1 | grep "HMMER 3\." > /dev/null
+    - phmmer -h 2>&1 | grep "HMMER 3\." > /dev/null
+    - nhmmer -h 2>&1 | grep "HMMER 3\." > /dev/null
+    - nhmmscan -h 2>&1 | grep "HMMER 3\." > /dev/null
+    - hmmpgmd -h 2>&1 | grep "HMMER 3\." > /dev/null
 
 about:
   summary: Biosequence analysis using profile hidden Markov models

--- a/recipes/hmmer/meta.yaml
+++ b/recipes/hmmer/meta.yaml
@@ -36,6 +36,6 @@ test:
 
 about:
   summary: Biosequence analysis using profile hidden Markov models
-  home: http://hmmer.janelia.org/
+  home: http://hmmer.org/
   license: GPL3
   license_file: LICENSE

--- a/recipes/hmmer2/meta.yaml
+++ b/recipes/hmmer2/meta.yaml
@@ -5,12 +5,12 @@ package:
 source:
   fn: hmmer-2.3.2.tar.gz
   url: http://eddylab.org/software/hmmer/2.3.2/hmmer-2.3.2.tar.gz
-  md5: 5f073340c0cf761288f961a73821228a
+  sha256: d20e1779fcdff34ab4e986ea74a6c4ac5c5f01da2993b14e92c94d2f076828b4
   patches:
     - Makefile.in.patch
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
@@ -21,10 +21,23 @@ requirements:
 
 test:
   commands:
-    - hmmalign2 -h 2>&1 | grep Usage
+    - hmmsearch2 -h 2>&1 | grep "HMMER 2\." > /dev/null
+    - hmmalign2 -h 2>&1 | grep "HMMER 2\." > /dev/null
+    - hmmbuild2 -h 2>&1 | grep "HMMER 2\." > /dev/null
+    - hmmcalibrate2 -h 2>&1 | grep "HMMER 2\." > /dev/null
+    - hmmconvert2 -h 2>&1 | grep "HMMER 2\." > /dev/null
+    - hmmemit2 -h 2>&1 | grep "HMMER 2\." > /dev/null
+    - hmmfetch2 -h 2>&1 | grep "HMMER 2\." > /dev/null
+    - hmmindex2 -h 2>&1 | grep "HMMER 2\." > /dev/null
+    - hmmpfam2 -h 2>&1 | grep "HMMER 2\." > /dev/null
+    - hmmsearch2 -h 2>&1 | grep "HMMER 2\." > /dev/null
+
 
 about:
   summary: 'Biosequence analysis using profile hidden Markov models'
   home: http://hmmer.janelia.org/
-  license: GPL3
+  license: GPLv2
   license_file: LICENSE
+  notes: |
+    This package appends "2" to the all HMMER tool binary names,
+    allowing use in parallel with HMMER version 3 onwards.

--- a/recipes/hmmer2/meta.yaml
+++ b/recipes/hmmer2/meta.yaml
@@ -35,7 +35,7 @@ test:
 
 about:
   summary: 'Biosequence analysis using profile hidden Markov models'
-  home: http://hmmer.janelia.org/
+  home: http://hmmer.org/
   license: GPLv2
   license_file: LICENSE
   notes: |


### PR DESCRIPTION
Fixes an error in the meta data, the license for HMMER 2.3.2 is GPL v2 not v3 as per the ``LICENCE`` and ``00README`` files. It looks like HMMER3 switched to GPL v3.

Update the checksums from MD5 to SHA256.

Added notes metadata field to talk about having HMMER2 and HMMER3 installed in parallel.

Also expands the tool tests to check *all* the binaries are installed (especially important for the hmmer2 package to confirm the additional 2 is present on the filenames).

* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [X] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
