### PR TITLE
Fix JAVA_HOME ignored

### DIFF
--- a/recipes/trimmomatic/meta.yaml
+++ b/recipes/trimmomatic/meta.yaml
@@ -8,7 +8,7 @@ package:
   version: '0.36'
 
 build:
-  number: 4
+  number: 5
   skip: False
 
 source:

--- a/recipes/trimmomatic/trimmomatic.sh
+++ b/recipes/trimmomatic/trimmomatic.sh
@@ -19,7 +19,7 @@ JAR_DIR=$DIR
 
 java=java
 
-if [ -z "${JAVA_HOME:=}" ]; then
+if [ -n "${JAVA_HOME:=}" ]; then
   if [ -e "$JAVA_HOME/bin/java" ]; then
       java="$JAVA_HOME/bin/java"
   fi


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

The custom wrapper script in the recipe checks for `$JAVA_HOME/bin/java` if `JAVA_HOME` is empty (`-z`) rather than if its non-empty (`-n`). 