### PR TITLE
Changing kraken version naming

### DIFF
--- a/recipes/kraken/meta.yaml
+++ b/recipes/kraken/meta.yaml
@@ -1,13 +1,15 @@
+{% set version = "0.10.6_beta.a0" %}
+
 package:
   name: kraken
-  version: "0.10.6_eaf8fb68"
+  version: {{ version }}
 source:
   fn: kraken-eaf8fb68.tar.gz
   url: https://github.com/DerrickWood/kraken/archive/eaf8fb68.tar.gz
   sha256: 0425fb88ce1d66ca5187cf348970d1dd2cec61d69bd53c466ca43f957de71ffd
 
 build:
-  number: 4
+  number: 0
   has_prefix_files:
     - libexec/kraken
     - libexec/kraken-build


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [x] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

@bioconda/core  I was planning to update kraken to a version that handle the new ncbi stucture better. However the the current bioconda version naming contains the commit id which would not work in the long run. I would therefor like to start by changing the version naming. Either somethin like I suggested here or to include date in ISO format instead of git commit id. Do you have any preferences? 