### PR TITLE
Add missing pizzly scripts.

### DIFF
--- a/recipes/pizzly/build.sh
+++ b/recipes/pizzly/build.sh
@@ -1,3 +1,6 @@
 #!/bin/sh
-
 cp pizzly $PREFIX/bin
+wget https://raw.githubusercontent.com/pmelsted/pizzly/master/scripts/flatten_json.py -O $PREFIX/bin/pizzly_flatten_json.py
+chmod +x $PREFIX/bin/pizzly_flatten_json.py
+wget https://github.com/pmelsted/pizzly/blob/master/scripts/get_fragment_length.py -O $PREFIX/bin/pizzly_get_fragment_length.py
+chmod +x $PREFIX/bin/pizzly_flatten_json.py

--- a/recipes/pizzly/meta.yaml
+++ b/recipes/pizzly/meta.yaml
@@ -11,7 +11,15 @@ source:
   sha256: bdd07e0aaaded045fee03e5eb0cae9a9b5c509c28cca501617ded3e0e1307138  # [osx]
 
 build:
-  number: 0
+  number: 1
+
+requirements:
+  build:
+    - wget
+  run:
+    - python
+    - numpy
+    - h5py
 
 test:
   commands:


### PR DESCRIPTION
This prepends a `pizzly_` prefix onto the scripts to make them more unique,
since they are generically named.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

There are two python scripts that go along with pizzly that are missing from the installation, for now we grab them and prefix them with `pizzly_` to make them more unique.
