### PR TITLE
Added a recipe for UROPA

### DIFF
--- a/recipes/uropa/build.sh
+++ b/recipes/uropa/build.sh
@@ -9,3 +9,4 @@ mv uropa/* $PREFIX/bin/uropa
 # Auxillary scripts
 mv summary.R $PREFIX/bin
 mv reformat_output.R $PREFIX/bin
+mv utils/uropa2gtf.R $PREFIX/bin

--- a/recipes/uropa/build.sh
+++ b/recipes/uropa/build.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+mkdir -p $PREFIX/bin/uropa
+mv uropa.py $PREFIX/bin
+mv uropa/* $PREFIX/bin/uropa

--- a/recipes/uropa/build.sh
+++ b/recipes/uropa/build.sh
@@ -1,12 +1,3 @@
 #!/usr/bin/env bash
 
-# Main program
-mv uropa.py $PREFIX/bin
-
-mkdir -p $PREFIX/bin/uropa
-mv uropa/* $PREFIX/bin/uropa
-
-# Auxillary scripts
-mv summary.R $PREFIX/bin
-mv reformat_output.R $PREFIX/bin
-mv utils/uropa2gtf.R $PREFIX/bin
+$PYTHON setup.py install --single-version-externally-managed --record=record.txt

--- a/recipes/uropa/build.sh
+++ b/recipes/uropa/build.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
-mkdir -p $PREFIX/bin/uropa
+# Main program
 mv uropa.py $PREFIX/bin
+
+mkdir -p $PREFIX/bin/uropa
 mv uropa/* $PREFIX/bin/uropa
+
+# Auxillary scripts
+mv summary.R $PREFIX/bin
+mv reformat_output.R $PREFIX/bin

--- a/recipes/uropa/meta.yaml
+++ b/recipes/uropa/meta.yaml
@@ -6,13 +6,18 @@ source:
   url: https://github.molgen.mpg.de/loosolab/UROPA/archive/1.1.1.tar.gz
   md5: b07fd3d15664c9aea0a2ffc3ef202768
 
+build:
+  skip: True # [not py27]
+
 requirements:
   build:
     - python
     - numpy
+    - pysam
   run:
     - python
     - numpy
+    - pysam
 
 test:
   commands:

--- a/recipes/uropa/meta.yaml
+++ b/recipes/uropa/meta.yaml
@@ -1,10 +1,12 @@
+{% set version = "1.1.2" %}
+
 package:
   name: uropa
-  version: "1.1.1"
+  version: {{ version }}
 
 source:
-  url: https://github.molgen.mpg.de/loosolab/UROPA/archive/1.1.1.tar.gz
-  md5: b07fd3d15664c9aea0a2ffc3ef202768
+  url: https://github.molgen.mpg.de/loosolab/UROPA/archive/{{ version }}.tar.gz
+  md5: fbf6a808a1bd0b047a0f08c22fcfafd8
 
 build:
   skip: True # [not py27]
@@ -18,10 +20,21 @@ requirements:
     - python
     - numpy
     - pysam
+    - r-base
+    - r-ggplot2
+    - r-gplots
+    - r-gridextra
+    - r-jsonlite
+    - r-venndiagram
+    - r-getopt
+    - bioconductor-graph
+    - bioconductor-rbgl
 
 test:
   commands:
     - "uropa.py -h > /dev/null"
+    - "summary.R -h > /dev/null"
+    - "reformat_output.R -h > /dev/null"
 
 about:
   home: https://github.molgen.mpg.de/loosolab/UROPA

--- a/recipes/uropa/meta.yaml
+++ b/recipes/uropa/meta.yaml
@@ -1,0 +1,20 @@
+package:
+  name: uropa
+  version: "1.1.1"
+
+source:
+  git_rev: 1.1.1
+  git_url: https://github.molgen.mpg.de/loosolab/UROPA.git
+
+requirements:
+  build:
+    - python
+    - numpy
+  run:
+    - python
+    - numpy
+
+about:
+  home: https://github.molgen.mpg.de/loosolab/UROPA
+  license: MIT
+  license_file: LICENSE

--- a/recipes/uropa/meta.yaml
+++ b/recipes/uropa/meta.yaml
@@ -3,8 +3,8 @@ package:
   version: "1.1.1"
 
 source:
-  git_rev: 1.1.1
-  git_url: https://github.molgen.mpg.de/loosolab/UROPA.git
+  url: https://github.molgen.mpg.de/loosolab/UROPA/archive/1.1.1.tar.gz
+  md5: b07fd3d15664c9aea0a2ffc3ef202768
 
 requirements:
   build:
@@ -14,7 +14,11 @@ requirements:
     - python
     - numpy
 
+test:
+  commands:
+    - "uropa.py -h > /dev/null"
+
 about:
   home: https://github.molgen.mpg.de/loosolab/UROPA
   license: MIT
-  license_file: LICENSE
+  summary: "UROPA (Universal RObust Peak Annotator) is a command line based tool, intended for genomic region annotation."

--- a/recipes/uropa/meta.yaml
+++ b/recipes/uropa/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.1.2" %}
+{% set version = "1.2.0" %}
 
 package:
   name: uropa
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.molgen.mpg.de/loosolab/UROPA/archive/{{ version }}.tar.gz
-  md5: fbf6a808a1bd0b047a0f08c22fcfafd8
+  md5: b6894ffb1c4616788a6a89d0541e5d19
 
 build:
   skip: True # [not py27]
@@ -14,8 +14,6 @@ build:
 requirements:
   build:
     - python
-    - numpy
-    - pysam
   run:
     - python
     - numpy
@@ -27,6 +25,8 @@ requirements:
     - r-jsonlite
     - r-venndiagram
     - r-getopt
+    - r-tidyr
+    - r-upsetr
     - bioconductor-graph
     - bioconductor-rbgl
 

--- a/recipes/uropa/meta.yaml
+++ b/recipes/uropa/meta.yaml
@@ -1,12 +1,14 @@
-{% set version = "1.2.0" %}
+{% set name = "uropa" %}
+{% set version = "1.2.1" %}
 
 package:
-  name: uropa
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://github.molgen.mpg.de/loosolab/UROPA/archive/{{ version }}.tar.gz
-  md5: b6894ffb1c4616788a6a89d0541e5d19
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  fn: {{ name }}-{{ version }}.tar.gz
+  md5: 10e53bad46946c6c5f29a577de1220a7
 
 build:
   skip: True # [not py27]
@@ -14,6 +16,7 @@ build:
 requirements:
   build:
     - python
+    - setuptools
   run:
     - python
     - numpy
@@ -32,11 +35,20 @@ requirements:
 
 test:
   commands:
-    - "uropa.py -h > /dev/null"
-    - "summary.R -h > /dev/null"
-    - "reformat_output.R -h > /dev/null"
+    - "uropa -h"
+    - "uropa_summary.R -h"
+    - "uropa_reformat_output.R -h"
+    - "uropa2gtf.R -h"
 
 about:
   home: https://github.molgen.mpg.de/loosolab/UROPA
+  doc_url: http://uropa-manual.readthedocs.io
   license: MIT
-  summary: "UROPA (Universal RObust Peak Annotator) is a command line based tool, intended for genomic region annotation."
+  summary: |
+    UROPA (Universal RObust Peak Annotator) is a command line based tool, intended for genomic region annotation from e.g. peak calling.
+    It detects the most appropriate annotation by taking parameters such as feature type, anchor, direction and strand into account.
+    Furthermore, it allows filtering for GTF attribute values, e.g. protein_coding.
+
+extra:
+  recipe-maintainers:
+    - jenzopr


### PR DESCRIPTION
* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [X] This PR adds a new recipe.
* [X] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Hi all,
UROPA (‘Universal RObust Peak Annotator’) is a python-based tool, intended for genomic region annotation. Based on a configuration file, different target features can be prioritized with multiple integrated queries. These can be sensitive for feature type, distance, strand specificity, feature attributes (eg. protein_coding) or the anchor position relative to the feature. UROPA can incorporate reference annotation files (GTF) from different sources, like Gencode, Ensembl, or RefSeq, as well as custom reference files produced by the user. UROPA is published under the doi: [10.1038/s41598-017-02464-y](https://www.nature.com/articles/s41598-017-02464-y).

Because of the requirement installation burden, we would like to include UROPA in bioconda to enable the usage for a wider target audience.
I would be very happy to address any reviews or remarks.

Thanks a lot,
Jens