### PR TITLE
Add bwa 0.7.3a recipe

### DIFF
--- a/recipes/bwa/0.7.3a/build.sh
+++ b/recipes/bwa/0.7.3a/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+export C_INCLUDE_PATH=${PREFIX}/include
+export LIBRARY_PATH=${PREFIX}/lib
+
+make
+mkdir -p $PREFIX/bin
+cp bwa $PREFIX/bin

--- a/recipes/bwa/0.7.3a/meta.yaml
+++ b/recipes/bwa/0.7.3a/meta.yaml
@@ -18,6 +18,10 @@ requirements:
     - libgcc
     - zlib
 
+test:
+  commands:
+    - bwa 2>&1 | grep 'index sequences'
+
 about:
   home: http://bio-bwa.sourceforge.net
   license: MIT

--- a/recipes/bwa/0.7.3a/meta.yaml
+++ b/recipes/bwa/0.7.3a/meta.yaml
@@ -1,0 +1,24 @@
+package:
+  name: bwa
+  version: "0.7.3a"
+
+build:
+  number: 0
+
+source:
+  fn: bwa-0.7.3a.tar.bz2
+  url: http://downloads.sourceforge.net/project/bio-bwa/bwa-0.7.3a.tar.bz2
+  md5: 7ed9f5d750d26f5bf91cee1fa6f65df2
+
+requirements:
+  build:
+    - gcc
+    - zlib
+  run:
+    - libgcc
+    - zlib
+
+about:
+  home: http://bio-bwa.sourceforge.net
+  license: MIT
+  summary: The BWA read mapper.

--- a/recipes/bwa/0.7.3a/meta.yaml
+++ b/recipes/bwa/0.7.3a/meta.yaml
@@ -20,7 +20,7 @@ requirements:
 
 test:
   commands:
-    - bwa 2>&1 | grep 'index sequences'
+    - bwa 2>&1 | grep "index sequences"
 
 about:
   home: http://bio-bwa.sourceforge.net


### PR DESCRIPTION
Based off of the bwa 0.7.8 recipe.

Based on md5sum pulled from sourceforge on 2017-09-07.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [x] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).

To get it to pass the `simulate-travis` tests, I added this to meta.yaml (taken from an earlier PR to add bwa 0.6):

```
test:
  commands:
    - bwa 2>&1 | grep 'index sequences'
```

but there do not appear to be tests for other bwa commands, so I'm not sure whether this is required.

At a minimum, it seems to build just fine.
