### PR TITLE
Add matplotlib-nogui

### DIFF
--- a/recipes/matplotlib-nogui/build.sh
+++ b/recipes/matplotlib-nogui/build.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+cat <<EOF > setup.cfg
+[directories]
+basedirlist = $PREFIX
+
+[packages]
+tests = False
+sample_data = False
+toolkits = False
+
+[gui_support]
+agg = True
+cairo = False
+gtk = False
+gtk3agg = False
+gtk3cairo = False
+gtkagg = False
+macosx = False
+pyside = True
+qt4agg = False
+tkagg = False
+windowing = False
+wxagg = auto
+
+[rc_options]
+backend = Agg
+
+EOF
+
+export CPLUS_INCLUDE_PATH="$PREFIX/include"
+
+$PYTHON setup.py install --single-version-externally-managed

--- a/recipes/matplotlib-nogui/meta.yaml
+++ b/recipes/matplotlib-nogui/meta.yaml
@@ -1,0 +1,86 @@
+{% set package = "matplotlib-nogui" %}
+{% set name = "matplotlib" %}
+{% set version = "2.0.2" %}
+
+
+package:
+  name: {{ package }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/{{ name }}/{{ name }}/archive/v{{ version }}.tar.gz
+  sha256: aebed23921562792b68b8ca355de5abc176af4424f1987e2fa95f65e5c5e7e89
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - pkg-config
+    - python
+    - numpy >=1.7.1
+    - setuptools
+    - python-dateutil >=1.1
+    - pyparsing
+    - libpng >=1.6.28,<1.7
+    - pytz
+    - freetype 2.7
+    - cycler >=0.10
+    - six
+    - functools32  # [py27]
+  run:
+    - python
+    - numpy >=1.7.1
+    - setuptools
+    - python-dateutil >=1.1
+    - pyparsing
+    - libpng >=1.6.28,<1.7
+    - pytz
+    - freetype 2.7
+    - cycler >=0.10
+    - six
+    - functools32  # [py27]
+
+test:
+  requires:
+    - pytest
+  imports:
+    # some modules
+    - matplotlib
+    - matplotlib.patches
+    - matplotlib.lines
+    - matplotlib.pyplot
+    - matplotlib.backends.backend_pdf
+    # binary libs
+    - matplotlib._path
+    - matplotlib._png
+    - matplotlib.ft2font
+    - matplotlib._qhull
+    - matplotlib._cntr
+    - matplotlib._tri
+    - matplotlib._image
+    - matplotlib._delaunay
+    - matplotlib.ttconv
+    - matplotlib.backends._tkagg
+    - matplotlib._contour
+    - matplotlib.backends._backend_agg
+  commands:
+    - python -c "import matplotlib.pyplot as p;p.plot([1,2]);p.savefig('t.pdf')"
+    - python -c "import matplotlib.pyplot as p;p.plot([1,2]);p.savefig('t.png')"
+    - python -c "import matplotlib.pyplot as p;p.plot([1,2]);p.savefig('t.svg')"
+
+about:
+  home: http://matplotlib.org/
+  dev_url: https://github.com/matplotlib/matplotlib/
+  license: PSF-based
+  license_family: PSF
+  license_file: LICENSE/LICENSE
+  summary: Matplotlib without GUI dependencies
+  description: |
+    Matplotlib is a Python 2D plotting library which produces publication
+    quality figures in a variety of hardcopy formats and interactive
+    environments across platforms. Matplotlib can be used in Python scripts,
+    the Python and IPython shell, the jupyter notebook, web application
+    servers, and four graphical user interface toolkits.
+    
+    This package omits all GUI backends.

--- a/recipes/quast/meta.yaml
+++ b/recipes/quast/meta.yaml
@@ -7,7 +7,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 1
+  number: 2
   string: boost{{CONDA_BOOST}}_{{PKG_BUILDNUM}}
 
 source:
@@ -21,7 +21,7 @@ requirements:
   - boost {{CONDA_BOOST}}*
   - perl
   - python
-  - matplotlib
+  - matplotlib-nogui
   - openjdk
   - joblib
   - simplejson
@@ -31,7 +31,7 @@ requirements:
   - perl
   - python
   - libgcc
-  - matplotlib
+  - matplotlib-nogui
   - openjdk
   - joblib
   - simplejson


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [x] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

This adds `matplotlib-nogui` as a version of `matplotlib` with reduced dependency tree and modifies `quast` to rely on that package. The plain `matplotlib` package builds and depends on all GUI backends supported by `matplotlib` which lead to a large amount of packages installed needlessly for non-interactive tools. (Which is an issue when running CI tests of depending tools/pipelines as the conda installation frequently times out).

I'm drawn between wanting this package in bioconda or conda-forge. Conda-forge has the `matplotlib` package, however, the issue has been discussed at conda and conda-forge before and re-starting it would likely go into the "doing it right" direction, splitting the package into multiple sub- and meta-packages, and ultimately get deferred past conda 3.0.

In any case, I'd like to see the more rigorous mulled tests to come through here first.

Opionions re bioconda vs conda-forge? @bgruening what do you think?
