### PR TITLE
update: rtg-tools 3.8.4

### DIFF
--- a/recipes/rtg-tools/build.sh
+++ b/recipes/rtg-tools/build.sh
@@ -6,13 +6,15 @@ TGT="$PREFIX/$TGT_BASE"
 [ -d "${PREFIX}/bin" ] || mkdir -p "${PREFIX}/bin"
 
 cd "${SRC_DIR}"
-# Do not install Linux specific x86-acceleration libraries
-cp -rvp third-party $TGT
+
+# Minimum required for operation
 cp RTG.jar $TGT
 cp rtg $TGT
+# Optional utility scripts (e.g. bash completion)
+cp -rvp scripts $TGT
 
-echo "RTG_TALKBACK=     # Attempt to send crash logs to realtime genomics, true to enable
-RTG_USAGE=        # Enable simple usage logging, true to enable
+echo "RTG_TALKBACK=true     # Attempt to send crash logs to realtime genomics, true to enable
+RTG_USAGE=false   # Enable simple usage logging, true to enable
 RTG_JAVA_OPTS=    # Additional arguments passed to the JVM
 RTG_JAVA=/opt/anaconda1anaconda2anaconda3/bin/java   # point to anaconda installed Java
 RTG_JAR=/opt/anaconda1anaconda2anaconda3/${TGT_BASE}/RTG.jar" > $TGT/rtg.cfg

--- a/recipes/rtg-tools/meta.yaml
+++ b/recipes/rtg-tools/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: rtg-tools
-  version: "3.8.2"
+  version: "3.8.4"
 
 source:
-  fn: rtg-tools-3.7.1-nojre.zip
-  url: https://github.com/RealTimeGenomics/rtg-tools/releases/download/3.8.2/rtg-tools-3.8.2-nojre.zip
-  md5: 8d2a41c9a8cc748a7ef6a21c228c3078
+  fn: rtg-tools-3.8.4-nojre.zip
+  url: https://github.com/RealTimeGenomics/rtg-tools/releases/download/3.8.4/rtg-tools-3.8.4-nojre.zip
+  md5: b01349ddff9306da4e0a5b4a15156093
 
 build:
   number: 0


### PR DESCRIPTION
* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [X] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Recipe no longer installs the "third-party" directory, as this is not required at runtime (it is included in the original distribution in order to provide source code to a modified library class).

Recipe now installs the "scripts" directory, which contains a bash-completion helper and some other small resources that may be useful to the end user. (Although this is optional and could be dropped if required.)

Recipe is explicit in settings for usage logging (false) and crash-only reporting (true).
