### PR TITLE
Fix BLAST 2.6.0 when LD_LIBRARY_PATH is defined

### DIFF
--- a/recipes/blast/boost_106400.patch
+++ b/recipes/blast/boost_106400.patch
@@ -1,0 +1,116 @@
+diff -Naur ncbi-blast-2.6.0+-src.old/c++/src/corelib/teamcity_boost.cpp ncbi-blast-2.6.0+-src/c++/src/corelib/teamcity_boost.cpp
+--- ncbi-blast-2.6.0+-src.old/c++/src/corelib/teamcity_boost.cpp	2017-09-12 19:57:11.390617575 +0100
++++ ncbi-blast-2.6.0+-src/c++/src/corelib/teamcity_boost.cpp	2017-09-12 19:57:55.787781855 +0100
+@@ -91,7 +91,7 @@
+         if (underTeamcity()) {
+             boost::unit_test::unit_test_log.set_formatter(new TeamcityBoostLogFormatter());
+             boost::unit_test::unit_test_log.set_threshold_level
+-                (RTCFG(but::log_level, LOG_LEVEL, log_level));
++                (RTCFG(but::log_level, LOG_LEVEL));
+         }
+     }
+ };
+diff -Naur ncbi-blast-2.6.0+-src.old/c++/src/corelib/test_boost.cpp ncbi-blast-2.6.0+-src/c++/src/corelib/test_boost.cpp
+--- ncbi-blast-2.6.0+-src.old/c++/src/corelib/test_boost.cpp	2017-09-12 19:57:11.390617575 +0100
++++ ncbi-blast-2.6.0+-src/c++/src/corelib/test_boost.cpp	2017-09-12 19:57:55.787781855 +0100
+@@ -93,12 +93,31 @@
+ #  define IGNORE_STATUS
+ #endif
+ 
++#if BOOST_VERSION >= 106400
++#  define LIST_CONTENT      btrt_list_content
++#  define LIST_LABELS       btrt_list_labels
++#  define LOG_FORMAT        btrt_log_format
++#  define LOG_LEVEL         btrt_log_level
++#  define REPORT_FORMAT     btrt_report_format
++#  define RESULT_CODE       btrt_result_code
++#  define RUN_FILTERS       btrt_run_filters
++#  define WAIT_FOR_DEBUGGER btrt_wait_for_debugger
++#elif BOOST_VERSION < 106000
++#  define LIST_CONTENT      list_content
++#  define LIST_LABELS       list_labels
++#  define LOG_FORMAT        log_format
++#  define LOG_LEVEL         log_level
++#  define REPORT_FORMAT     report_format
++#  define RUN_FILTERS       test_to_run
++#  define WAIT_FOR_DEBUGGER wait_for_debugger
++#endif
++
+ #if BOOST_VERSION >= 106000
+ #  define attr_value utils::attr_value
+-#  define RTCFG(type, new_name, old_name) \
+-    but::runtime_config::get<type >(but::runtime_config::new_name)
++#  define RTCFG(type, name) \
++    but::runtime_config::get<type >(but::runtime_config::name)
+ #else
+-#  define RTCFG(type, new_name, old_name) but::runtime_config::old_name()
++#  define RTCFG(type, name) but::runtime_config::name()
+ #  if BOOST_VERSION >= 105900
+ #    define BOOST_TEST_I_TRY      BOOST_TEST_IMPL_TRY
+ #    define BOOST_TEST_I_CATCH    BOOST_TEST_IMPL_CATCH
+@@ -113,7 +132,7 @@
+ #endif
+ 
+ #define CONFIGURED_FILTERS \
+-    RTCFG(std::vector<std::string>, RUN_FILTERS, test_to_run)
++    RTCFG(std::vector<std::string>, RUN_FILTERS)
+ 
+ #ifdef NCBI_COMPILER_MSVC
+ #  pragma warning(pop)
+@@ -1657,8 +1676,7 @@
+ inline void
+ CNcbiTestApplication::x_SetupBoostReporters(void)
+ {
+-    but::output_format format = RTCFG(but::output_format, REPORT_FORMAT,
+-                                      report_format);
++    but::output_format format = RTCFG(but::output_format, REPORT_FORMAT);
+ 
+     CNcbiEnvironment env;
+     string is_autobuild = env.Get("NCBI_AUTOMATED_BUILD");
+@@ -1685,8 +1703,7 @@
+     m_Reporter->SetOutputFormat(format);
+     but::results_reporter::set_format(m_Reporter);
+ 
+-    m_Logger->SetOutputFormat(RTCFG(but::output_format, LOG_FORMAT,
+-                                    log_format));
++    m_Logger->SetOutputFormat(RTCFG(but::output_format, LOG_FORMAT));
+     but::unit_test_log.set_formatter(m_Logger);
+ }
+ 
+@@ -2241,7 +2258,7 @@
+         ncbi::s_GetTestApp().InitTestsBeforeRun();
+ 
+ #if BOOST_VERSION >= 105900
+-        if( RTCFG(bool, WAIT_FOR_DEBUGGER, wait_for_debugger) ) {
++        if( RTCFG(bool, WAIT_FOR_DEBUGGER) ) {
+             results_reporter::get_stream() << "Press any key to continue..." << std::endl;
+ 
+             std::getchar();
+@@ -2250,8 +2267,7 @@
+ 
+         framework::finalize_setup_phase();
+ 
+-        output_format list_cont = RTCFG(output_format, LIST_CONTENT,
+-                                        list_content);
++        output_format list_cont = RTCFG(output_format, LIST_CONTENT);
+         if( list_cont != but::OF_INVALID ) {
+             if( list_cont == but::OF_DOT ) {
+                 ut_detail::dot_content_reporter reporter( results_reporter::get_stream() );
+@@ -2267,7 +2283,7 @@
+             return boost::exit_success;
+         }
+ 
+-        if( RTCFG(bool, LIST_LABELS, list_labels) ) {
++        if( RTCFG(bool, LIST_LABELS) ) {
+             ut_detail::labels_collector collector;
+ 
+             traverse_test_tree( framework::master_test_suite().p_id, collector, true );
+@@ -2294,7 +2310,7 @@
+ 
+         if (
+ #if BOOST_VERSION >= 106000
+-            runtime_config::get<bool>( runtime_config::RESULT_CODE )
++            RTCFG(bool, RESULT_CODE)
+ #else
+             !runtime_config::no_result_code()
+ #endif

--- a/recipes/blast/build.sh
+++ b/recipes/blast/build.sh
@@ -2,7 +2,7 @@
 
 set -e -x -o pipefail
 
-mkdir -p $PREFIX/bin/
+mkdir -p $PREFIX/bin
 
 if [ "$(uname)" == "Darwin" ]; then
     echo "Platform: Mac"
@@ -13,7 +13,10 @@ elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
     echo "Platform: Linux"
 
     cd $SRC_DIR/c++/
-    ./configure --prefix=$PREFIX
+    # --with-hard-runpath is needed otherwise BLAST programs would search
+    # libraries first in the directories defined by the LD_LIBRARY_PATH
+    # environment variable, instead of using the rpath specified by conda
+    ./configure --prefix=$PREFIX --with-hard-runpath
 
     make -j${CPU_COUNT}
 

--- a/recipes/blast/meta.yaml
+++ b/recipes/blast/meta.yaml
@@ -8,12 +8,14 @@ source:
     fn: ncbi-blast-{{ version }}+-src.tar.gz # [linux]
     url: http://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/{{ version }}/ncbi-blast-{{ version }}+-src.tar.gz # [linux]
     md5: c8ce8055b10c4d774d995f88c7cc6225 # [linux]
+    patches:
+      - boost_106400.patch # [linux]
     fn: ncbi-blast-{{ version }}+-x64-macosx.tar.gz # [osx]
     url: http://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/{{ version }}/ncbi-blast-{{ version }}+-x64-macosx.tar.gz # [osx]
     md5: 7dc2ebc86b3a064bae6a3e378495d414 # [osx]
 
 build:
-  number: 1
+  number: 2
   string: boost{{CONDA_BOOST}}_{{PKG_BUILDNUM}}
 
 requirements:


### PR DESCRIPTION
If `--with-hard-runpath` configure option is not used, BLAST programs search libraries first in the directories defined by the `LD_LIBRARY_PATH` environment variable, instead of using the rpath specified by conda.

Also add patch to support Boost 1.64.0 and later.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
