### PR TITLE
Illumina interop: Prefix command names with interop

### DIFF
--- a/recipes/illumina-interop/build.sh
+++ b/recipes/illumina-interop/build.sh
@@ -1,9 +1,13 @@
 #!/bin/bash
 
+mkdir -p $PREFIX/interop/bin
 mkdir -p $PREFIX/bin
 
 mkdir -p build
 cd build
-cmake -DCMAKE_INSTALL_PREFIX:PATH=$PREFIX ..
+cmake -DCMAKE_INSTALL_PREFIX:PATH=$PREFIX/interop ..
 make
 make install
+for FPATH in $(find $PREFIX/interop/bin -maxdepth 1 -mindepth 1 -type f -or -type l); do
+    ln -sfvn $FPATH $PREFIX/bin/interop_$(basename $FPATH)
+done

--- a/recipes/illumina-interop/meta.yaml
+++ b/recipes/illumina-interop/meta.yaml
@@ -4,7 +4,7 @@ package:
   name: illumina-interop
   version: {{ version }}
 build:
-  number: 0
+  number: 1
   skip: True # [osx]
 source:
   fn: "Interop_v{{ version }}.tar.gz"
@@ -18,18 +18,18 @@ requirements:
     - libgcc
 test:
   commands:
-    - dumptext | grep Version > /dev/null
-    - imaging_table | grep Version > /dev/null
-    - summary | grep Version > /dev/null
-    - plot_by_cycle | grep Version > /dev/null
-    - plot_by_lane | grep Version > /dev/null
-    - plot_flowcell | grep Version > /dev/null
-    - plot_qscore_histogram | grep Version > /dev/null
-    - plot_qscore_heatmap | grep Version > /dev/null
-    - plot_sample_qc | grep Version > /dev/null
-    - index-summary | grep Version > /dev/null
-    - dumpbin | grep Version > /dev/null
-    - aggregate | grep Version > /dev/null
+    - interop_dumptext | grep Version > /dev/null
+    - interop_imaging_table | grep Version > /dev/null
+    - interop_summary | grep Version > /dev/null
+    - interop_plot_by_cycle | grep Version > /dev/null
+    - interop_plot_by_lane | grep Version > /dev/null
+    - interop_plot_flowcell | grep Version > /dev/null
+    - interop_plot_qscore_histogram | grep Version > /dev/null
+    - interop_plot_qscore_heatmap | grep Version > /dev/null
+    - interop_plot_sample_qc | grep Version > /dev/null
+    - interop_index-summary | grep Version > /dev/null
+    - interop_dumpbin | grep Version > /dev/null
+    - interop_aggregate | grep Version > /dev/null
 
 about:
   home: "http://illumina.github.io/interop/index.html"


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

@matthdsm put up an interop recipe for Illumina's interop library in  #6015, but commented that the command names were very generic and looked for a solution. I agree - the names should be prefixed, otherwise I think they're likely to unintentionally shadow other tool names (plus harder to tell where they are from in scripts).

This recipe updates the illumina-interop recipe to prefix all commands with `interop_`.

Not sure what the policy is regarding these sorts of changes / respecting tool names.

cc @kyleabeauchamp 