### PR TITLE
Downgrade networkx dependency

### DIFF
--- a/recipes/multiqc/meta.yaml
+++ b/recipes/multiqc/meta.yaml
@@ -25,6 +25,7 @@ requirements:
     - requests
     - simplejson
     - spectra
+    - networkx <2
 
   run:
     - python
@@ -39,6 +40,7 @@ requirements:
     - requests
     - simplejson
     - spectra
+    - networkx <2
     - libgcc  # [linux]
 
 test:


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Networkx has recently been updated to 2.0, which is incompatible with `colormath` `spectra` dependency (see https://github.com/ewels/MultiQC/pull/561 and 
https://github.com/ewels/MultiQC/issues/592). Until a new `colormath` version is released, we have to downgrade `networkx` dependency for MultiQC.

cc @ewels 