### PR TITLE
build abyss 2.0.2

### DIFF
--- a/build-fail-blacklist
+++ b/build-fail-blacklist
@@ -6,9 +6,14 @@ recipes/mothur/1.36.1
 # recipes/metaprob
 
 # more temporary blacklisting to get other packages to run
-recipes/abyss
+
+# Older versions of abyss need older versions of boost
+# https://github.com/bcgsc/abyss/issues/130
+# recipes/abyss
+recipes/abyss/1.5.2
 recipes/abyss/1.9.0
 recipes/abyss/2.0.1-k128
+
 recipes/augustus
 recipes/clever-toolkit
 recipes/blast
@@ -33,20 +38,10 @@ recipes/bioconductor-pcaexplorer
 #blocked by https://github.com/conda-forge/staged-recipes/pull/4038
 recipes/bioconductor-monocle
 
-# Error : object ‘%<=%’ is not exported by 'namespace:future'
-#recipes/r-aroma.core
-# depends on r-arome.core https://github.com/conda-forge/staged-recipes/pull/4039
-# recipes/r-aroma.affymetrix
-
-# r-aroma.affymetrix 3.4.1 version is missing
-# recipes/bioconductor-repitools
-
-# r-aroma.core is missing
-recipes/bioconductor-peca
-
 #OSX failures - library loading
 recipes/r-spp
 recipes/r-pscbs/0.61.0
 # takes to long on bulk, needs a separate PR
 recipes/cgat-scripts-devel
 
+recipes/bioconductor-peca

--- a/build-fail-blacklist
+++ b/build-fail-blacklist
@@ -36,5 +36,3 @@ recipes/r-spp
 recipes/r-pscbs/0.61.0
 # takes to long on bulk, needs a separate PR
 recipes/cgat-scripts-devel
-
-recipes/bioconductor-peca

--- a/recipes/abyss/meta.yaml
+++ b/recipes/abyss/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "abyss" %}
-{% set version = "2.0.1" %}
+{% set version = "2.0.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,13 +7,13 @@ package:
 
 build:
   skip: True # [osx]
-  number: 2
+  number: 0
   string: boost{{CONDA_BOOST}}_{{PKG_BUILDNUM}}
 
 source:
   fn: {{ name|lower }}-{{ version }}.tar.gz
-  url: http://www.bcgsc.ca/platform/bioinfo/software/{{ name|lower }}/releases/{{ version }}/{{ name|lower }}-{{ version }}.tar.gz
-  md5: 596c56a476b26a294b46e6e36890c136
+  url: https://github.com/bcgsc/abyss/releases/download/{{ version}}/abyss-{{ version }}.tar.gz
+  sha256: d87b76edeac3a6fb48f24a1d63f243d8278a324c9a5eb29027b640f7089422df
 
 requirements:
   build:


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

xref #6122 

@bioconda/core I have some questions here:

**Earlier versions of ABYSS:** ABYSS versions <2.0.2 do not work with later version of boost (https://github.com/bcgsc/abyss/issues/130). It looks like the preprocessing selectors are processed before even jinja templating, so we can't do things like `skip: True # [ float({{ CONDA_BOOST }}) < 1.62]`. One solution would be to pin boost (ignoring CONDA_BOOST) in these older recipes; another would be to keep them in the blacklist. Another would be to remove the recipes. I don't know what the demand is for earlier versions of ABYSS to know whether they're worth rebuilding on earlier boost. Here I'm taking the path of least disruption and leaving them in the blacklist.

**Wrapping a makefile:** I updated the main recipe to ABYSS 2.0.2 but this is failing in the mulled-build test. The reason for failure is that `abyss-pe` is a Makefile which has a shebang line of `#!/usr/bin/make -rRf`, but in the container `make` lives at `/usr/local/bin/make`. We can't change the shebang line to `#!/usr/bin/env make -rRf` because of the extra arguments. Would a wrapper script work to solve this? The `abyss-pe` Makefile is over my head; I don't know about the implications of a wrapper script.

