### PR TITLE
bump gnu-getopt build

### DIFF
--- a/recipes/gnu-getopt/meta.yaml
+++ b/recipes/gnu-getopt/meta.yaml
@@ -3,7 +3,7 @@ about:
     license: "GPLv2"
     summary: "Command-line option parsing library"
 build:
-  number: 3
+  number: 4
   skip: True # [not osx]
 package: 
   name: gnu-getopt


### PR DESCRIPTION
gnu-getopt depends on gettext, which had a linking issue with 0.19.8 (fixed in 0.19.8.1). This bumps gnu-getopt to hopefully trigger a rebuild with gettext 0.19.8.1 from conda-forge

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

I'll also try to add gnu-getopt to conda-forge, but I submit this to bioconda now since conda-forge is slow to add new recipes. Edit: [PR to add to conda-forge is open](https://github.com/conda-forge/staged-recipes/pull/4063).