### PR TITLE
Set hstlib version to use as recipe clone master branch

### DIFF
--- a/recipes/ococo/build.sh
+++ b/recipes/ococo/build.sh
@@ -26,5 +26,7 @@ export LIBRARY_PATH=$LIBRARY_PATH:${PREFIX}/lib
 make VERBOSE=1
 mkdir -p ${PREFIX}/bin
 cp ococo ${PREFIX}/bin
-cp ococo.1 ${PREFIX}/share/man/man1
+if [ -e ${PREFIX}/share/man/man1 ]; then
+    cp ococo.1 ${PREFIX}/share/man/man1
+fi
 

--- a/recipes/ococo/build.sh
+++ b/recipes/ococo/build.sh
@@ -13,6 +13,7 @@ export LIBRARY_PATH=$LIBRARY_PATH:${PREFIX}/lib
 	cd ext
 	rm -fr htslib
 	git clone git://github.com/samtools/htslib
+        cd htslib && git checkout tags/1.3.2
 )
 
 #echo "g++"

--- a/recipes/ococo/meta.yaml
+++ b/recipes/ococo/meta.yaml
@@ -3,11 +3,12 @@ package:
   version: "0.1.2.4"
 
 build:
-  number: 0
+  number: 1
 
 source:
   fn: 0.1.2.4.tar.gz
   url: https://github.com/karel-brinda/ococo/archive/0.1.2.4.tar.gz
+  md5: e0e5bd2daf71c89820bad2e745b6def6
 
 requirements:
   build:


### PR DESCRIPTION
Using master branch, software does not compile anymore. Furthermore it removes reproducibility.

Recipe may be improved to use htslib conda package but this fix at least the rebuild of the package.

Add hash to source.

* [ X ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ X ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
