### PR TITLE
Bump vsearch version and add .gz support

### DIFF
--- a/recipes/vsearch/meta.yaml
+++ b/recipes/vsearch/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "vsearch" %}
-{% set version = "2.4.4" %}
-{% set hash = "13909f188d0e0ddb24a845e3d8d60afe965751e800659ae729bb61c5e5230ab5" %}
+{% set version = "2.5.0" %}
+{% set hash = "7f26b7f905699c86c753bae7462a00804bac15c37371ffa3ceb8126df1701ccd" %}
 
 package:
   name: {{ name|lower }}
@@ -21,9 +21,11 @@ requirements:
     - m4
     - gcc  # [linux]
     - llvm  # [osx]
-    - perl 
+    - perl
+    - zlib
   run:
     - libgcc  # [linux]
+    - zlib
 
 test:
   commands:

--- a/recipes/vsearch/meta.yaml
+++ b/recipes/vsearch/meta.yaml
@@ -22,10 +22,10 @@ requirements:
     - gcc  # [linux]
     - llvm  # [osx]
     - perl
-    - zlib
+    - zlib {{CONDA_ZLIB}}*
   run:
     - libgcc  # [linux]
-    - zlib
+    - zlib {{CONDA_ZLIB}}*
 
 test:
   commands:


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

This updates to the newest release of vsearch, also also supports reading `.gz` files directly.