### PR TITLE
bioconductor-limma - add statmod as dependency

### DIFF
--- a/recipes/bioconductor-limma/meta.yaml
+++ b/recipes/bioconductor-limma/meta.yaml
@@ -15,7 +15,6 @@ build:
 requirements:
   build:
     - r-base
-    - r-statmod
   run:
     - r-base
     - r-statmod

--- a/recipes/bioconductor-limma/meta.yaml
+++ b/recipes/bioconductor-limma/meta.yaml
@@ -7,7 +7,7 @@ source:
   sha256: a092cf82fe93d5a089dfe8df1a662d67da4cf19f22c65f4011985b95c29a28ca
 
 build:
-  number: 0
+  number: 1
   rpaths:
     - lib/R/lib/
     - lib/

--- a/recipes/bioconductor-limma/meta.yaml
+++ b/recipes/bioconductor-limma/meta.yaml
@@ -15,8 +15,10 @@ build:
 requirements:
   build:
     - r-base
+    - r-statmod
   run:
     - r-base
+    - r-statmod
 
 test:
   commands:


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

In this PR I've added statmod as a dependency to limma, as discussed in the Galaxy IUC PR here https://github.com/galaxyproject/tools-iuc/pull/1471 (cc @bgruening ) and also because in the limma user guide pg 9 (here: https://www.bioconductor.org/packages/devel/bioc/vignettes/limma/inst/doc/usersguide.pdf) it states "you’ll probably want biocLite("statmod)" as well".