### PR TITLE
BLAST+ 2.7.0

### DIFF
--- a/recipes/blast/meta.yaml
+++ b/recipes/blast/meta.yaml
@@ -15,7 +15,7 @@ source:
     sha256: c295aa858638a8194d6b4abbefedaa2759e67ee2932e3553ffbc4afa138b20ee # [osx]
 
 build:
-  number: 2
+  number: 0
   string: boost{{CONDA_BOOST}}_{{PKG_BUILDNUM}}
 
 requirements:

--- a/recipes/blast/meta.yaml
+++ b/recipes/blast/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.6.0" %}
+{% set version = "2.7.0" %}
 
 package:
     name: blast
@@ -6,13 +6,13 @@ package:
 
 source:
     fn: ncbi-blast-{{ version }}+-src.tar.gz # [linux]
-    url: http://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/{{ version }}/ncbi-blast-{{ version }}+-src.tar.gz # [linux]
-    md5: c8ce8055b10c4d774d995f88c7cc6225 # [linux]
+    url: https://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/{{ version }}/ncbi-blast-{{ version }}+-src.tar.gz # [linux]
+    sha256: fc338ccbf466bb3e2e042c973d17ec600fba9adf3b1292a496ad5023ed1c759a # [linux]
     patches:
       - boost_106400.patch # [linux]
     fn: ncbi-blast-{{ version }}+-x64-macosx.tar.gz # [osx]
-    url: http://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/{{ version }}/ncbi-blast-{{ version }}+-x64-macosx.tar.gz # [osx]
-    md5: 7dc2ebc86b3a064bae6a3e378495d414 # [osx]
+    url: https://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/{{ version }}/ncbi-blast-{{ version }}+-x64-macosx.tar.gz # [osx]
+    sha256: c295aa858638a8194d6b4abbefedaa2759e67ee2932e3553ffbc4afa138b20ee # [osx]
 
 build:
   number: 2


### PR DESCRIPTION
Updates the recipe from BLAST+ 2.6.0 to 2.7.0

Also switched from HTTP to HTTPS in line with NCBI site changes.

Also switched from MD5 to SHA256 checksum.

* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [X] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [X] This PR does something else (explain below).
