### PR TITLE
Revert blacklisting of BLAST+ package.

### DIFF
--- a/build-fail-blacklist
+++ b/build-fail-blacklist
@@ -14,7 +14,6 @@ recipes/abyss/1.9.0
 recipes/abyss/2.0.1-k128
 
 recipes/clever-toolkit
-recipes/blast
 recipes/quast
 recipes/transcomb
 recipes/rsem


### PR DESCRIPTION
See today's discussion on #6073, starting at https://github.com/bioconda/bioconda-recipes/pull/6073#issuecomment-335876343

This appears to have been done as part of #6119 out of expediency to get a large set of builds done.

Cross reference #6282 for updating to BLAST+ 2.7.0 which was merged recently.

* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [X] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [X] This PR updates an existing recipe.
* [X] This PR does something else (explain below).
