### PR TITLE
Yara 0.9.9 64x

### DIFF
--- a/recipes/yara/build.sh
+++ b/recipes/yara/build.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eu -o pipefail
 
 BINARY_HOME=$PREFIX/bin
 PKG_HOME=$PREFIX/opt/$PKG_NAME-$PKG_VERSION

--- a/recipes/yara/meta.yaml
+++ b/recipes/yara/meta.yaml
@@ -1,22 +1,24 @@
+{% set version="0.9.9" %}
+
 build:
   number: 0
+
+about:
+  home: https://github.com/seqan/seqan/blob/develop/apps/yara/README.rst
+  license: https://raw.githubusercontent.com/seqan/seqan/develop/apps/yara/LICENSE
+  summary: Yara is an exact tool for aligning DNA sequencing reads to reference genomes.
 
 package:
   name: yara
   version: "0.9.6"
+
 source:
-  fn: yara-0.9.6-Mac-x86_64.zip # [osx]
-  url:  http://packages.seqan.de/yara/yara-0.9.6-Mac-x86_64.zip # [osx]
-  md5: 7998612718b0edf955bde507d3ac66fe # [osx]
-  fn: yara-0.9.6-Linux-x86_64.zip # [linux64]
-  url:  http://packages.seqan.de/yara/yara-0.9.6-Linux-x86_64.zip # [linux64]
-  md5: fca52e83f786b71ce622f108a9e18a24 # [linux64]
+  url:  http://packages.seqan.de/yara/yara-{{ version }}-Mac-x86_64.zip # [osx]
+  sha256: 716230b2f2b147e1d6db7aba017adcf668484436aa7541228776c23b0c5f52a2 # [osx]
+  url: http://packages.seqan.de/yara/yara-{{ version }}-Linux-x86_64.tar.xz # [linux64]
+  sha256: b8c6fac0481a3438eeb34a5d1330dd73af8fcc1febdf84adba6058a820323da0 # [linux64]
 
 test:
   commands:
     - yara_indexer --help 2>&1 > /dev/null
     - yara_mapper --help 2>&1 > /dev/null
-about:
-  home: https://github.com/seqan/seqan/blob/develop/apps/yara/README.rst
-  license: https://raw.githubusercontent.com/seqan/seqan/develop/apps/yara/LICENSE
-  summary: Yara is an exact tool for aligning DNA sequencing reads to reference genomes.

--- a/recipes/yara/meta.yaml
+++ b/recipes/yara/meta.yaml
@@ -10,7 +10,7 @@ about:
 
 package:
   name: yara
-  version: "0.9.6"
+  version: {{ version }}
 
 source:
   url:  http://packages.seqan.de/yara/yara-{{ version }}-Mac-x86_64.zip # [osx]


### PR DESCRIPTION
* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [X] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Hey @bioconda/core ,

there are also binaries that are compiled with SSE4 support and are therefore more efficient.
For the sake of maximizing compatibility, there are only the 64x packages in this recipe.

I have found three different ways so far to include the SSE4 packages which each have different requirements:

- Check for SSE4 support in meta.yaml:
    This could be done by `{% set sse4_support = os.system("grep flags /proc/cpuinfo | grep sse4  > /dev/null") %} # [linux64]` for linux and a similar command for osx, but it would require os to be available in the jinja environment
- Download all sources and check for SSE4 support in build.sh:
    This would require at least cond-build 3.0, so you can download different sources and put them in different folders by using the 'folder: <folder>' directive in the source part.
- Build from source and check for SSE4 support in build.sh:
    This would require gcc >=4.9.* in any channel used by conda-build. There is one in the `https://repo.continuum.io/pkgs/main/linux-64/` channel, but it isn't included.

I guess the best solution would be to wait for gcc >= 4.9 to be available and until then to just distribute the packages without SSE4 support?

Best,
Enrico
