### PR TITLE
rebuild with newer conda-build

### DIFF
--- a/recipes/ribotaper/meta.yaml
+++ b/recipes/ribotaper/meta.yaml
@@ -9,7 +9,7 @@ source:
 
 build:
   skip: True  # [not linux]
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
To overcome the error ``An error occurred while installing package 'defaults::r-base-3.2.2-0'. PaddingError: Placeholder of length '80' too short in package. (..) The package must be rebuilt with conda-build > 2.0.``

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
