### PR TITLE
Racon: Remove python and mummer run deps

### DIFF
--- a/recipes/racon/meta.yaml
+++ b/recipes/racon/meta.yaml
@@ -7,7 +7,6 @@ package:
 
 build:
   number: 0
-  skip: False
 
 source:
   fn: {{ name|lower }}_{{ version }}.tar.gz

--- a/recipes/racon/meta.yaml
+++ b/recipes/racon/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 build:
   number: 0
-  skip: True # [not py27]
+  skip: False
 
 source:
   fn: {{ name|lower }}_{{ version }}.tar.gz
@@ -22,10 +22,6 @@ requirements:
   run:
     - libgcc
     - zlib
-    - python
-    - numpy
-    - matplotlib
-    - mummer
 
 test:
   commands:

--- a/recipes/racon/meta.yaml
+++ b/recipes/racon/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 0
+  number: 1
 
 source:
   fn: {{ name|lower }}_{{ version }}.tar.gz
@@ -16,11 +16,11 @@ source:
 requirements:
   build:
     - gcc
-    - zlib
+    - zlib {{ CONDA_ZLIB }}*
 
   run:
     - libgcc
-    - zlib
+    - zlib {{ CONDA_ZLIB }}*
 
 test:
   commands:


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

This is an update to the run dependencies for racon.  The current recipe prevents installs on py3 environments because of a conflicting numpy/matplotlib requirement in the example script.  I don't think these should be enforced as strict run dependencies since the example script is discarded during install.  Also, the Unicycler recipe needs racon and is only py3 compatible 