### PR TITLE
Du Novo: Update to 2.0.4.

### DIFF
--- a/recipes/dunovo/build.sh
+++ b/recipes/dunovo/build.sh
@@ -1,10 +1,15 @@
 #!/bin/bash
 
-# Compile binaries and move them to lib.
-make
-mv *.so $PREFIX/lib
-
 # Download submodules and move them to lib.
+## kalign
+kalignver=0.1.2
+wget --no-check-certificate "https://github.com/makrutenko/kalign-dunovo/archive/v$kalignver.tar.gz"
+hash=`sha256sum v$kalignver.tar.gz | tr -s ' ' | cut -d ' ' -f 1`
+[ $hash = 398f699491b2aa607c32062007228a1de853e2f665340e82dc1fc967b0ee8d85 ]
+tar -zxvpf v$kalignver.tar.gz
+rm -rf kalign
+mv kalign-dunovo-$kalignver kalign
+rm v$kalignver.tar.gz
 ## utillib
 utilver=0.1.0
 wget --no-check-certificate "https://github.com/NickSto/utillib/archive/v$utilver.tar.gz"
@@ -14,13 +19,18 @@ tar -zxvpf v$utilver.tar.gz
 mv utillib-$utilver $PREFIX/lib/utillib
 rm v$utilver.tar.gz
 ## ET
-ETver=0.1.1
+ETver=0.2.2
 wget --no-check-certificate "https://github.com/NickSto/ET/archive/v$ETver.tar.gz"
 hash=`sha256sum v$ETver.tar.gz | tr -s ' ' | cut -d ' ' -f 1`
-[ $hash = 552c371f0fe0000b6037038ad1aeae09111d066c362d45655e40381cb0c325e4 ]
+[ $hash = 11dc5cb02521a2260e6c88a83d489c72f819bd759aeff31d66aa40ca2f1358a6 ]
 tar -zxvpf v$ETver.tar.gz
 mv ET-$ETver $PREFIX/lib/ET
 rm v$ETver.tar.gz
+
+# Compile binaries and move them to lib.
+make
+mv *.so $PREFIX/lib
+mv kalign $PREFIX/lib
 
 # Move scripts to lib and link to them from bin.
 for script in *.awk *.sh *.py; do

--- a/recipes/dunovo/meta.yaml
+++ b/recipes/dunovo/meta.yaml
@@ -1,12 +1,13 @@
+{% set version = "2.0.4" %}
 
 package:
   name: dunovo
-  version: '0.8.1'
+  version: {{ version }}
 
 source:
-  fn: v0.8.1.tar.gz
-  url: https://github.com/galaxyproject/dunovo/archive/v0.8.1.tar.gz
-  sha256: f85fd35ef67c8f76af0d556a4babe9acf7b8abdd8a77232d4f4763cc7de60eed
+  fn: v{{ version }}.tar.gz
+  url: https://github.com/galaxyproject/dunovo/archive/v{{ version }}.tar.gz
+  sha256: c84e9d837de06439b5e59b9e64c85b9ca6253e5e1212a8473a36d14906b4cc70
 
 build:
   number: 0
@@ -25,20 +26,20 @@ requirements:
     - mafft 7.221
     - samtools 0.1.18
     - bowtie2 2.2.5
-    - networkx
+    - networkx 1.11
     - paste
     - gawk
 
 test:
   commands:
-    - 'correct.py -h > /dev/null'
-    - 'align_families.py -h > /dev/null'
+    - 'correct.py --version > /dev/null'
+    - 'align_families.py --version > /dev/null'
     - 'dunovo.py --version > /dev/null'
   imports:
     - networkx
 
 about:
   home: https://github.com/galaxyproject/dunovo
-  license: BSD
+  license: GPLv2
   license_file: LICENSE.txt
   summary: "Du Novo: A pipeline for processing duplex sequencing data."


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

This update installs the 2.0.4 release of Du Novo, along with a few tweaks to the `meta.yaml`.

The main new thing is installing a new submodule, `kalign`, and placing its `.so` files correctly after compilation.

Passes `simulate-travis.py` locally.