### PR TITLE
Add backspinpy from PyPI.

### DIFF
--- a/recipes/backspinpy/meta.yaml
+++ b/recipes/backspinpy/meta.yaml
@@ -1,0 +1,49 @@
+{% set name = "backspinpy" %}
+{% set version = "0.2.1" %}
+{% set hash_type = "sha256" %}
+{% set hash_value = "91f8b6b3d5acb318844d8ecdd4b67bf8c37a19fa129466cebf2083dc0fc5476c" %}
+
+package:
+  name: '{{ name|lower }}'
+  version: '{{ version }}'
+
+source:
+  fn: '{{ name }}-{{ version }}.tar.gz'
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  '{{ hash_type }}': '{{ hash_value }}'
+
+build:
+  number: 0
+  script: python setup.py install  --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - future
+    - numpy
+    - scipy
+    - scikit-learn
+  run:
+    - python
+    - future
+    - numpy
+    - scipy
+    - scikit-learn
+
+test:
+  imports:
+    - backspinpy
+
+  commands:
+    - backspin -h
+
+about:
+  home: https://github.com/linnarsson-lab/BackSPIN
+  license: MIT
+  license_family: MIT
+  summary: backSPIN clustering algorythm
+
+extra:
+  recipe-maintainers:
+    - jdblischak


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [x] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Some notes for reviewers:

* [backspinpy](https://pypi.python.org/pypi/backspinpy) implements the [BackSPIN](https://github.com/linnarsson-lab/BackSPIN) algorithm for clustering single cells based on their gene expression levels.
* I created the recipe using conda-build 3.0.19.
* The package exports a command-line tool, `backspin`, so I added a test for this.
* The license situation is confusing. In the `setup.py` it says the license is MIT ([link](https://github.com/linnarsson-lab/BackSPIN/blob/406c150e0e29979b06bdd418b9680186333e128d/setup.py#L21)); however, the file [LICENSE](https://github.com/linnarsson-lab/BackSPIN/blob/406c150e0e29979b06bdd418b9680186333e128d/LICENSE) in the repo is BSD-2. I tried to manually add the license file using the [conda-forge trick](https://conda-forge.org/docs/meta.html#packaging-the-license-manually) of `'{{ environ["RECIPE_DIR"] }}/LICENSE'`, but I received an error stating that the variable `environ` was not defined.
* The recipe was [built successfully](https://travis-ci.org/jdblischak/bioconda-recipes/builds/293645416) on my fork.
* I tried adding `noarch: python` to the recipe since it only contains Python files, but this [build failed](https://travis-ci.org/jdblischak/bioconda-recipes/builds/293666125) on linux but passed on macOS. It's unclear to me what a "pure python package" is anyways. The recipe depends on numpy/scipy, so I assume that means a pure python package cannot have dependencies which require compilation.


Unrelated to this specific recipe: I get strange errors on the Travis build when I modify my commit history and force push to the feature branch on my fork. For example, I removed the commit that tried `noarch` and pushed the change back to GitHub, and the second time around my build failed (even though it was the exact same commit that had just passed). Is there anyway to avoid/fix this? I like to overwrite my history to keep the commit history clean when I submit a PR.

https://travis-ci.org/jdblischak/bioconda-recipes/jobs/293666127#L821