### PR TITLE
Fgbio should be supported in any python version

### DIFF
--- a/recipes/fgbio/meta.yaml
+++ b/recipes/fgbio/meta.yaml
@@ -9,7 +9,7 @@ package:
     version: {{ version }}
 build:
   number: 0
-  skip: False
+  skip: false
 source:
   fn: fgbio-{{ tag }}.tar.gz
   url: https://github.com/fulcrumgenomics/fgbio/archive/{{ tag }}.tar.gz

--- a/recipes/fgbio/meta.yaml
+++ b/recipes/fgbio/meta.yaml
@@ -9,7 +9,7 @@ package:
     version: {{ version }}
 build:
   number: 0
-  skip: true # [not py27]
+  skip: False
 source:
   fn: fgbio-{{ tag }}.tar.gz
   url: https://github.com/fulcrumgenomics/fgbio/archive/{{ tag }}.tar.gz


### PR DESCRIPTION
@chapmanb I think you added fgbio originally (thank-you!).  I am not sure why it requires python 2.7 only (I want python 3 support); perhaps the included script to run `fgbio`?  It feels odd to me to depend on a specific version of python when `fgbio` itself does not.  An alternate solution would be to (picard/meta.yaml)[https://github.com/bioconda/bioconda-recipes/blob/master/recipes/picard/meta.yaml]

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
