### PR TITLE
antismash: Pin meme version to 4.11.2

### DIFF
--- a/recipes/antismash/meta.yaml
+++ b/recipes/antismash/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 build:
   skip: True # [not py27]
-  number: 1
+  number: 2
 
 source:
   fn: {{ name|lower }}-{{ version }}.tar.gz
@@ -39,7 +39,7 @@ requirements:
     - libxml2 ==2.9.4
     - mafft
     - matplotlib  
-    - meme
+    - meme ==4.11.2
     - muscle
     - networkx
     - numpy


### PR DESCRIPTION
MEME's FIMO tool changes output formatting in version 4.11.4+, so pin meme to the supported version of 4.11.2

Signed-off-by: Kai Blin <kblin@biosustain.dtu.dk>

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
