### PR TITLE
Add Mummer4 recipe

### DIFF
--- a/recipes/mummer4/build.sh
+++ b/recipes/mummer4/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+./configure --prefix=$HOME
+make
+make install

--- a/recipes/mummer4/build.sh
+++ b/recipes/mummer4/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-./configure --prefix=$HOME
+./configure --prefix=$PREFIX
 make
 make install

--- a/recipes/mummer4/meta.yaml
+++ b/recipes/mummer4/meta.yaml
@@ -1,0 +1,29 @@
+{% set name = "mummer4" %}
+{% set version = "4.0.0beta2" %}
+
+about:
+    home: 'http://mummer.sourceforge.net/'
+    license: "The Artistic License 2"
+    summary: "MUMmer is a system for rapidly aligning entire genomes"
+build:
+  number: 0
+  skip: False
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+source:
+  fn: {{ name|lower }}-{{ version }}.tar.gz
+  sha256: cece76e418bf9c294f348972e5b23a0230beeba7fd7d042d5584ce075ccd1b93
+  url: https://github.com/mummer4/mummer/releases/download/v{{ version }}/mummer-{{ version }}.tar.gz
+requirements:
+  build:
+    - perl
+  run:
+    - perl
+test:
+    commands:
+        - "mummer -h &> /dev/null"
+        - "mummerplot -h &> /dev/null"
+        - "nucmer -h &> /dev/null"
+        - "promer -h &> /dev/null"
+        - "show-aligns -h &> /dev/null"

--- a/recipes/mummer4/meta.yaml
+++ b/recipes/mummer4/meta.yaml
@@ -7,6 +7,7 @@ about:
     summary: "MUMmer is a system for rapidly aligning entire genomes"
 build:
   number: 0
+  skip: True #[osx]
 package:
   name: {{ name|lower }}
   version: {{ version }}
@@ -22,9 +23,9 @@ requirements:
     - perl
     - libgcc
 test:
-    commands:
-        - "mummer -h &> /dev/null"
-        - "mummerplot -h &> /dev/null"
-        - "nucmer -h &> /dev/null"
-        - "promer -h &> /dev/null"
-        - "show-aligns -h &> /dev/null"
+  commands:
+    - "mummer 2>&1 | grep mummer &> /dev/null"
+    - "mummerplot  2>&1 | grep mummer &> /dev/null"
+    - "nucmer  2>&1 | grep nucmer &> /dev/null"
+    - "promer  2>&1 | grep promer &> /dev/null"
+    - "show-aligns -h &> /dev/null"

--- a/recipes/mummer4/meta.yaml
+++ b/recipes/mummer4/meta.yaml
@@ -17,7 +17,6 @@ source:
   url: https://github.com/mummer4/mummer/releases/download/v{{ version }}/mummer-{{ version }}.tar.gz
 requirements:
   build:
-    - pytz
     - perl
   run:
     - perl

--- a/recipes/mummer4/meta.yaml
+++ b/recipes/mummer4/meta.yaml
@@ -2,12 +2,11 @@
 {% set version = "4.0.0beta2" %}
 
 about:
-    home: 'http://mummer.sourceforge.net/'
-    license: "The Artistic License 2"
+    home: 'https://mummer4.github.io/'
+    license: "The Artistic License 2.0"
     summary: "MUMmer is a system for rapidly aligning entire genomes"
 build:
   number: 0
-  skip: False
 package:
   name: {{ name|lower }}
   version: {{ version }}
@@ -18,8 +17,10 @@ source:
 requirements:
   build:
     - perl
+    - gcc
   run:
     - perl
+    - libgcc
 test:
     commands:
         - "mummer -h &> /dev/null"

--- a/recipes/mummer4/meta.yaml
+++ b/recipes/mummer4/meta.yaml
@@ -17,6 +17,7 @@ source:
   url: https://github.com/mummer4/mummer/releases/download/v{{ version }}/mummer-{{ version }}.tar.gz
 requirements:
   build:
+    - pytz
     - perl
   run:
     - perl


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [x] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

This PR adds [mummer4](https://mummer4.github.io), which is partially backwards compatible with mummer3 syntax but includes niceties like multithreaded nucmer, out of the box 64bit support (any sized genome), read-based analysis and SAM output.

This does conflict with the `mummer` recipe that exists, in that the binaries have the same name.  I'm adding a new, `mummer4` recipe instead of updating the existing mummer recipe since the build process has changed and requires newer libgcc, which may not be compatible with existing environments.  

