### PR TITLE
Update to latest release for manta/strelka

### DIFF
--- a/recipes/manta/meta.yaml
+++ b/recipes/manta/meta.yaml
@@ -1,12 +1,12 @@
-{% set version = "1.1.0" %}
+{% set version = "1.2.1" %}
 
 package:
   name: manta
   version: '{{ version }}'
 source:
   fn: manta-{{ version }}.tar.bz2
-  url: https://github.com/Illumina/manta/releases/download/v{{ version }}/manta-{{ version }}.centos5_x86_64.tar.bz2
-  md5: 30d0a28d83ed513e5e785f41291e64d8
+  url: https://github.com/Illumina/manta/releases/download/v{{ version }}/manta-{{ version }}.centos6_x86_64.tar.bz2
+  md5: 06c40ac62ee6c9574f89b01941a873d6
 build:
   number: 0
   skip: True # [not py27 or osx]

--- a/recipes/strelka/meta.yaml
+++ b/recipes/strelka/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.8.2" %}
+{% set version = "2.8.4" %}
 
 package:
   name: strelka
@@ -6,8 +6,8 @@ package:
 
 source:
   fn: strelka-{{ version }}.tar.bz2
-  url: https://github.com/Illumina/strelka/releases/download/v{{ version }}/strelka-{{ version }}.centos5_x86_64.tar.bz2
-  md5: 72c57c3c90dd33a0d91c32298bb6320d
+  url: https://github.com/Illumina/strelka/releases/download/v{{ version }}/strelka-{{ version }}.centos6_x86_64.tar.bz2
+  md5: a38dc1315e1b09d84e71c519f4dd1b2d
 
 build:
   number: 0


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Update manta to v1.2.1 and strelka to v2.8.4. The binary releases for both packages now require Centos 6+.