### PR TITLE
Du Novo: Update to 2.0.8.

### DIFF
--- a/recipes/dunovo/build.sh
+++ b/recipes/dunovo/build.sh
@@ -2,10 +2,10 @@
 
 # Download submodules and move them to lib.
 ## kalign
-kalignver=0.1.2
+kalignver=0.1.3
 wget --no-check-certificate "https://github.com/makrutenko/kalign-dunovo/archive/v$kalignver.tar.gz"
 hash=`sha256sum v$kalignver.tar.gz | tr -s ' ' | cut -d ' ' -f 1`
-[ $hash = 398f699491b2aa607c32062007228a1de853e2f665340e82dc1fc967b0ee8d85 ]
+[ $hash = 712b149038a818d296d0bcc53e997487c768a151e46e500f1753ba6c3dd9852d ]
 tar -zxvpf v$kalignver.tar.gz
 rm -rf kalign
 mv kalign-dunovo-$kalignver kalign

--- a/recipes/dunovo/meta.yaml
+++ b/recipes/dunovo/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - mafft 7.221
     - samtools 0.1.18
     - bowtie2 2.2.5
-    - networkx 1.10
+    - networkx <2.0
     - paste
     - gawk
 

--- a/recipes/dunovo/meta.yaml
+++ b/recipes/dunovo/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.0.6" %}
+{% set version = "2.0.8" %}
 
 package:
   name: dunovo
@@ -7,7 +7,7 @@ package:
 source:
   fn: v{{ version }}.tar.gz
   url: https://github.com/galaxyproject/dunovo/archive/v{{ version }}.tar.gz
-  sha256: 3d628d297767f9836ab57ef738b2b29f588c36df8c43ec6814ea97e29da1d5ec
+  sha256: 4c105e29eff271b9e32f12c5d2862b717ba960981f4820dae26e159e2a0ed33d
 
 build:
   number: 0
@@ -26,7 +26,7 @@ requirements:
     - mafft 7.221
     - samtools 0.1.18
     - bowtie2 2.2.5
-    - networkx 1.11
+    - networkx 1.10
     - paste
     - gawk
 


### PR DESCRIPTION
Update to install Du Novo 2.0.8 (a bugfix release).
Also, change networkx dependency to version 1.10 to allow compatibility with Galaxy Toolshed (which lacks a 1.11).


* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).