### PR TITLE
Removing quast from the build-fail blacklist

### DIFF
--- a/build-fail-blacklist
+++ b/build-fail-blacklist
@@ -14,7 +14,6 @@ recipes/abyss/1.9.0
 recipes/abyss/2.0.1-k128
 
 recipes/clever-toolkit
-recipes/quast
 recipes/transcomb
 recipes/rsem
 recipes/metaprob


### PR DESCRIPTION
Needed for updating quast to 4.6.0

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

Quast was included in the build-fail blacklist, so update to v4.6.0 (https://github.com/bioconda/bioconda-recipes/pull/6420) has no desired effect.