### PR TITLE
Testing whether bx-python builds on py3

### DIFF
--- a/recipes/bx-python/meta.yaml
+++ b/recipes/bx-python/meta.yaml
@@ -10,8 +10,8 @@ source:
 
 build:
   number: 0
-  skip: True # [not py27]
-
+  # skip: True # [not py27]
+    
 requirements:
   build:
     - python


### PR DESCRIPTION
Testing whether bx-python builds on py3 too. It works for me on py3 through pypi.

I have started watching the bx-labs/bx-python repo and will try to fix any py3 issues :)

* [*] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [*] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [*] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
