### PR TITLE
enum34 was missing as a dependency for MultiQC

### DIFF
--- a/recipes/multiqc/meta.yaml
+++ b/recipes/multiqc/meta.yaml
@@ -8,7 +8,7 @@ source:
   md5: 67c4aae8b85ae40fcb2e98319fb629ac
 
 build:
-  number: 0
+  number: 1
   preserve_egg_dir: True
 
 requirements:
@@ -44,6 +44,7 @@ requirements:
     - requests
     - simplejson
     - spectra
+    - enum34
 
 test:
   # Python imports

--- a/recipes/multiqc/meta.yaml
+++ b/recipes/multiqc/meta.yaml
@@ -44,7 +44,7 @@ requirements:
     - requests
     - simplejson
     - spectra
-    - enum34
+    - enum34 # [py27]
 
 test:
   # Python imports


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
