### PR TITLE
Get MultiQC working properly under python3

### DIFF
--- a/recipes/multiqc/meta.yaml
+++ b/recipes/multiqc/meta.yaml
@@ -6,9 +6,11 @@ source:
   fn: v1.3.tar.gz
   url: https://github.com/ewels/MultiQC/archive/v1.3.tar.gz
   md5: 67c4aae8b85ae40fcb2e98319fb629ac
+  patches:
+    - setup.patch # [py3k]
 
 build:
-  number: 1
+  number: 2
   preserve_egg_dir: True
 
 requirements:
@@ -119,6 +121,7 @@ test:
 
   commands:
     - multiqc --version
+    - multiqc .
 
 about:
   home: http://multiqc.info

--- a/recipes/multiqc/setup.patch
+++ b/recipes/multiqc/setup.patch
@@ -1,0 +1,12 @@
+--- setup.py	2017-11-03 14:33:21.000000000 +0100
++++ setup.py	2017-11-03 14:33:21.000000000 +0100
+@@ -59,8 +59,7 @@
+         'pyyaml',
+         'requests',
+         'simplejson',
+-        'spectra',
+-        'enum34'
++        'spectra'
+     ],
+     entry_points = {
+         'multiqc.modules.v1': [


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

I had hoped that enum34 was only actually needed in python2.7, since `enum` was added in python 3.4. However, since it's listed in `setup.py` you get errors like the following if you actually try to run the current recipe:

```
$ multiqc ./
[INFO   ]         multiqc : This is MultiQC v1.3
[INFO   ]         multiqc : Template    : default
[INFO   ]         multiqc : Searching './'
Traceback (most recent call last):
  File "/package/anaconda3/envs/MultiQC-1.3/bin/multiqc", line 724, in <module>
    multiqc()
  File "/package/anaconda3/envs/MultiQC-1.3/lib/python3.5/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/package/anaconda3/envs/MultiQC-1.3/lib/python3.5/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/package/anaconda3/envs/MultiQC-1.3/lib/python3.5/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/package/anaconda3/envs/MultiQC-1.3/lib/python3.5/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/package/anaconda3/envs/MultiQC-1.3/bin/multiqc", line 390, in multiqc
    template_mod = config.avail_templates[config.template].load()
  File "/package/anaconda3/envs/MultiQC-1.3/lib/python3.5/site-packages/pkg_resources/__init__.py", line 2408, in load
    self.require(*args, **kwargs)
  File "/package/anaconda3/envs/MultiQC-1.3/lib/python3.5/site-packages/pkg_resources/__init__.py", line 2431, in require
    items = working_set.resolve(reqs, env, installer, extras=self.extras)
  File "/package/anaconda3/envs/MultiQC-1.3/lib/python3.5/site-packages/pkg_resources/__init__.py", line 867, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'enum34' distribution was not found and is required by the application
```

This patches to get around this and then tests that it's actually working.