### PR TITLE
Add chipseq-greylist.

### DIFF
--- a/recipes/chipseq-greylist/build.sh
+++ b/recipes/chipseq-greylist/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+if [ `uname` == Darwin ]; then
+	export MACOSX_DEPLOYMENT_TARGET=10.9
+fi
+$PYTHON setup.py install --single-version-externally-managed --record=record.txt

--- a/recipes/chipseq-greylist/build.sh
+++ b/recipes/chipseq-greylist/build.sh
@@ -1,5 +1,2 @@
 #!/bin/bash
-if [ `uname` == Darwin ]; then
-	export MACOSX_DEPLOYMENT_TARGET=10.9
-fi
 $PYTHON setup.py install --single-version-externally-managed --record=record.txt

--- a/recipes/chipseq-greylist/meta.yaml
+++ b/recipes/chipseq-greylist/meta.yaml
@@ -1,0 +1,35 @@
+package:
+  name: chipseq-greylist
+  version: '1.0.1'
+
+build:
+  number: 0
+
+source:
+  fn: chipseq-greylist-2a58267.tar.gz
+  url: https://github.com/roryk/chipseq-greylist/archive/2a58267.tar.gz
+  md5: 2e212b8a77f0e0a507b2de494d495df4
+
+requirements:
+  build:
+    - python
+    - pandas
+    - numpy
+    - scipy
+    - statsmodels
+    - sambamba
+  run:
+    - python
+    - pandas
+    - numpy
+    - scipy
+    - statsmodels
+    - sambamba
+test:
+  commands:
+    - chipseq-greylist --help
+
+about:
+  home: https://github.com/roryk/chipseq-greylist
+  license: MIT
+  summary: Python implementation of GreyListChIP Bioconductor package.


### PR DESCRIPTION
This is a command line re-implementation of the ChIP-seq greylisting Bioconductor package written in python with some fixes to make it easier to use when building ChIP-seq pipelines.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [x] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
