### PR TITLE
spades 3.9.0 with python 3.6

### DIFF
--- a/recipes/spades/3.9.0/meta.yaml
+++ b/recipes/spades/3.9.0/meta.yaml
@@ -5,8 +5,10 @@ package:
 source:
   fn: SPAdes-3.9.0-Linux.tar.gz                                              # [linux]
   url: http://spades.bioinf.spbau.ru/release3.9.0/SPAdes-3.9.0-Linux.tar.gz  # [linux]
+  md5: 7d4729764a6e21d9289ff438830b4ae5                                      # [linux]
   fn: SPAdes-3.9.0-Darwin.tar.gz                                             # [osx]
   url: http://spades.bioinf.spbau.ru/release3.9.0/SPAdes-3.9.0-Darwin.tar.gz # [osx]
+  md5: 9e4d280fefe67589c028170fcb6749b3                                      # [osx]
 
 build:
   number: 2

--- a/recipes/spades/3.9.0/meta.yaml
+++ b/recipes/spades/3.9.0/meta.yaml
@@ -15,7 +15,6 @@ build:
   skip: True  # [py36]
 
 requirements:
-  build:
   run:
     - python
 

--- a/recipes/spades/3.9.0/meta.yaml
+++ b/recipes/spades/3.9.0/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   number: 1
-  skip: True  # [not py2k and not py35]
+  skip: True  # [py36]
 
 requirements:
   build:

--- a/recipes/spades/3.9.0/meta.yaml
+++ b/recipes/spades/3.9.0/meta.yaml
@@ -9,7 +9,7 @@ source:
   url: http://spades.bioinf.spbau.ru/release3.9.0/SPAdes-3.9.0-Darwin.tar.gz # [osx]
 
 build:
-  number: 1
+  number: 2
   skip: True  # [py36]
 
 requirements:

--- a/recipes/spades/3.9.0/meta.yaml
+++ b/recipes/spades/3.9.0/meta.yaml
@@ -20,7 +20,7 @@ requirements:
 
 test:
   commands:
-    - spades.py --test
+    - spades.py --test && rm -rf spades_test
 
 about:
   home: http://bioinf.spbau.ru/en/spades


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

I noticed that spades version 3.9.0 is not running on python 3.6 but conda does install it without dependency errors. I changed the recipe but I am not sure if that is the correct way of doing it.

```
$ spades.py --test; echo $?


== Error ==  python version 3.6 is not supported!
Supported versions are 2.4, 2.5, 2.6, 2.7, 3.2, 3.3, 3.4, 3.5


In case you have troubles running SPAdes, you can write to spades.support@bioinf.spbau.ru
Please provide us with params.txt and spades.log files from the output directory.
1
```