### PR TITLE
Staged and conditional testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,3 @@
-os:
-  - osx
-  - linux
 language: generic
 sudo: required
 
@@ -18,7 +15,14 @@ before_install:
 
 install: scripts/travis-setup.sh
 
-script: scripts/travis-run.sh
+jobs:
+  include:
+    - stage: Linux
+      os: linux
+      script: scripts/travis-run.sh
+    - stage: macOS
+      os: osx
+      script: scripts/travis-run.sh
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,19 @@ install: scripts/travis-setup.sh
 
 jobs:
   include:
+    # in forks, master and bulk, we run osx and linux in parallel on each push
+    - stage: Linux+macOS
+      if: (type = push) AND ((branch IN (master, bulk)) OR (fork = true))
+      os:
+        - linux
+        - osx
+    # in pull requests, we first run linux and only if that succeeds, we run osx
     - stage: Linux
-      if: (branch IN (master, bulk)) OR (type = pull_request) OR (fork = true)
+      if: type = pull_request
       os: linux
       script: scripts/travis-run.sh
     - stage: macOS
-      if: (branch IN (master, bulk)) OR (type = pull_request) OR (fork = true)
+      if: type = pull_request
       os: osx
       script: scripts/travis-run.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,11 @@ install: scripts/travis-setup.sh
 jobs:
   include:
     - stage: Linux
-      if: (branch IN (master, bulk)) OR (type = pull_request) OR (repo != bioconda/bioconda-recipes)
+      if: (branch IN (master, bulk)) OR (type = pull_request) OR (fork = true)
       os: linux
       script: scripts/travis-run.sh
     - stage: macOS
-      if: (branch IN (master, bulk)) OR (type = pull_request) OR (repo != bioconda/bioconda-recipes)
+      if: (branch IN (master, bulk)) OR (type = pull_request) OR (fork = true)
       os: osx
       script: scripts/travis-run.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,11 @@ install: scripts/travis-setup.sh
 jobs:
   include:
     - stage: Linux
+      if: (branch IN (master, bulk)) OR (type = pull_request) OR (repo != bioconda/bioconda-recipes)
       os: linux
       script: scripts/travis-run.sh
     - stage: macOS
+      if: (branch IN (master, bulk)) OR (type = pull_request) OR (repo != bioconda/bioconda-recipes)
       os: osx
       script: scripts/travis-run.sh
 


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

This PR modifies builds in two ways.
1. Linux and macOS builds happen in two stages. If the first stage (linux) fails, the second is not tried. While this could in theory make builds slower, the osx queue is in practice so slow that the difference should not be noticeable. Moreover the benefit is that we only fill the osx queue for builds that pass the linux tests. This should significantly improve the backlog situation within Bioconda.
2. The skipping of pushes in pull requests is now handled via conditions in the travis configuration. This means that, instead starting a job and exiting immediately, we do not even need to start the job. Again, this should help a lot with our queue. Further, it also makes the PR experience cleaner, because we have no pseudo-succeeded jobs.

ping @bioconda/core.