### PR TITLE
round 1 of ucsc updates

### DIFF
--- a/recipes/ucsc-bedgraphtobigwig/build.sh
+++ b/recipes/ucsc-bedgraphtobigwig/build.sh
@@ -1,12 +1,16 @@
 #!/bin/bash
-
-export MACHTYPE=x86_64
-export BINDIR=$(pwd)/bin
-mkdir -p $BINDIR
-(cd kent/src/lib && make)
-(cd kent/src/jkOwnLib && make)
-(cd kent/src/hg/lib && make)
-(cd kent/src/utils/bedGraphToBigWig && make)
-mkdir -p $PREFIX/bin
-cp bin/bedGraphToBigWig $PREFIX/bin
-chmod +x $PREFIX/bin/bedGraphToBigWig
+mkdir -p "$PREFIX/bin"
+if [ "$(uname)" == "Darwin" ]; then
+    cp bedGraphToBigWig "$PREFIX/bin"
+else
+    export MACHTYPE=x86_64
+    export BINDIR=$(pwd)/bin
+    mkdir -p "$BINDIR"
+    (cd kent/src/lib && make)
+    (cd kent/src/htslib && make)
+    (cd kent/src/jkOwnLib && make)
+    (cd kent/src/hg/lib && make)
+    (cd kent/src/utils/bedGraphToBigWig && make)
+    cp bin/bedGraphToBigWig "$PREFIX/bin"
+fi
+chmod +x "$PREFIX/bin/bedGraphToBigWig"

--- a/recipes/ucsc-bedgraphtobigwig/include.patch
+++ b/recipes/ucsc-bedgraphtobigwig/include.patch
@@ -1,11 +1,11 @@
---- kent/src/inc/common.mk
-+++ kent/src/inc/common.mk
+--- kent/src/inc/common.mk	2017-11-07 17:46:00.000000000 -0500
++++ kent/src/inc/common.mk.new	2017-11-13 17:44:51.017090255 -0500
 @@ -17,7 +17,7 @@
  endif
-
+ 
  HG_DEFS=-D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_GNU_SOURCE -DMACHTYPE_${MACHTYPE}
--HG_INC+=-I../inc -I../../inc -I../../../inc -I../../../../inc -I../../../../../inc
-+HG_INC+=-I../inc -I../../inc -I../../../inc -I../../../../inc -I../../../../../inc -I ${PREFIX}/include
-
+-HG_INC+=-I../inc -I../../inc -I../../../inc -I../../../../inc -I../../../../../inc -I$(kentSrc)/htslib
++HG_INC+=-I../inc -I../../inc -I../../../inc -I../../../../inc -I../../../../../inc -I$(kentSrc)/htslib -I ${PREFIX}/include
+ 
  # to check for Mac OSX Darwin specifics:
  UNAME_S := $(shell uname -s)

--- a/recipes/ucsc-bedgraphtobigwig/meta.yaml
+++ b/recipes/ucsc-bedgraphtobigwig/meta.yaml
@@ -1,40 +1,48 @@
+{% set package = "ucsc-bedgraphtobigwig" %}
+{% set program = "bedGraphToBigWig" %}
+{% set version = "357" %}
+{% set sha256 = "0cec445f47c319e407d2cf866fb2f6ec0c9b72a2b10a0f75142ebc01ca4aca87" %}
+
 package:
-    name: "ucsc-bedgraphtobigwig"
-    version: "332"
+  name: "{{ package }}"
+  version: "{{ version }}"
+
 source:
-    url: "http://hgdownload.cse.ucsc.edu/admin/exe/userApps.v332.src.tgz"          # [linux]
-    fn: "userApps.src.tgz"                                                                     # [linux]
-    md5: "8c2663c7bd302a77cdf52b2e9e85e2cd"                                                    # [linux]
-    patches:                                                                                   # [linux]
-        - "include.patch"                                                                      # [linux]
+  url: "http://hgdownload.cse.ucsc.edu/admin/exe/userApps.v{{ version }}.src.tgz"                      # [linux]
+  fn: "userApps.src.tgz"                                                                     # [linux]
+  sha256: "{{ sha256 }}"                                                    # [linux]
+  patches:                                                                                   # [linux]
+    - "include.patch"                                                                        # [linux]
 
-    url: "http://hgdownload.cse.ucsc.edu/admin/exe/macOSX.x86_64/bedGraphToBigWig"                    # [osx]
-    fn: "bedGraphToBigWig"                                                                            # [osx]
+  url: "http://hgdownload.cse.ucsc.edu/admin/exe/macOSX.x86_64/{{ program }}"                    # [osx]
+  fn: "{{ program }}"                                                                            # [osx]
 
-build:                                                                                       # [osx]
-    script: "mkdir -p $PREFIX/bin; cp bedGraphToBigWig $PREFIX/bin; chmod +x $PREFIX/bin/bedGraphToBigWig" # [osx]
+build:
+  number: 0
 
 requirements:
-    build:
-        - libpng                                                    # [linux]
-        - mysql                                                     # [linux]
-        - zlib                                                      # [linux]
-        - openssl                                                   # [linux]
-        - gcc
+  build:
+    - gcc                                                       # [linux]
+    - libpng                                                    # [linux]
+    - libuuid                                                   # [linux]
+    - mysql-connector-c                                         # [linux]
+    - openssl                                                   # [linux]
+    - zlib                                                      # [linux]
 
-    run:                                                            # [linux]
-        - libpng                                                    # [linux]
-        - mysql                                                     # [linux]
-        - zlib                                                      # [linux]
-        - openssl                                                   # [linux]
-        - libgcc
+  run:
+    - libgcc                                                    # [linux]
+    - libpng                                                    # [linux]
+    - libuuid                                                   # [linux]
+    - mysql-connector-c                                         # [linux]
+    - openssl                                                   # [linux]
+    - zlib                                                      # [linux]
 
 test:
-    commands:
-        # just check for existence, because the individual programs have no unified behavior
-        - which bedGraphToBigWig
+  commands:
+    # just check for existence, because the individual packages have no unified behavior
+    - which {{ program }}
 
 about:
-    home: "http://hgdownload.cse.ucsc.edu/admin/exe/"
-    license: "varies; see http://genome.ucsc.edu/license"
-    summary: "Convert a bedGraph file to bigWig format."
+  home: "http://hgdownload.cse.ucsc.edu/admin/exe/"
+  license: "varies; see http://genome.ucsc.edu/license"
+  summary: "Convert a bedGraph file to bigWig format."

--- a/recipes/ucsc-bedtobigbed/build.sh
+++ b/recipes/ucsc-bedtobigbed/build.sh
@@ -1,12 +1,16 @@
 #!/bin/bash
-
-export MACHTYPE=x86_64
-export BINDIR=$(pwd)/bin
-mkdir -p $BINDIR
-(cd kent/src/lib && make)
-(cd kent/src/jkOwnLib && make)
-(cd kent/src/hg/lib && make)
-(cd kent/src/utils/bedToBigBed && make)
-mkdir -p $PREFIX/bin
-cp bin/bedToBigBed $PREFIX/bin
-chmod +x $PREFIX/bin/bedToBigBed
+mkdir -p "$PREFIX/bin"
+if [ "$(uname)" == "Darwin" ]; then
+    cp bedToBigBed "$PREFIX/bin"
+else
+    export MACHTYPE=x86_64
+    export BINDIR=$(pwd)/bin
+    mkdir -p "$BINDIR"
+    (cd kent/src/lib && make)
+    (cd kent/src/htslib && make)
+    (cd kent/src/jkOwnLib && make)
+    (cd kent/src/hg/lib && make)
+    (cd kent/src/utils/bedToBigBed && make)
+    cp bin/bedToBigBed "$PREFIX/bin"
+fi
+chmod +x "$PREFIX/bin/bedToBigBed"

--- a/recipes/ucsc-bedtobigbed/include.patch
+++ b/recipes/ucsc-bedtobigbed/include.patch
@@ -1,11 +1,11 @@
---- kent/src/inc/common.mk
-+++ kent/src/inc/common.mk
+--- kent/src/inc/common.mk	2017-11-07 17:46:00.000000000 -0500
++++ kent/src/inc/common.mk.new	2017-11-13 17:44:51.017090255 -0500
 @@ -17,7 +17,7 @@
  endif
-
+ 
  HG_DEFS=-D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_GNU_SOURCE -DMACHTYPE_${MACHTYPE}
--HG_INC+=-I../inc -I../../inc -I../../../inc -I../../../../inc -I../../../../../inc
-+HG_INC+=-I../inc -I../../inc -I../../../inc -I../../../../inc -I../../../../../inc -I ${PREFIX}/include
-
+-HG_INC+=-I../inc -I../../inc -I../../../inc -I../../../../inc -I../../../../../inc -I$(kentSrc)/htslib
++HG_INC+=-I../inc -I../../inc -I../../../inc -I../../../../inc -I../../../../../inc -I$(kentSrc)/htslib -I ${PREFIX}/include
+ 
  # to check for Mac OSX Darwin specifics:
  UNAME_S := $(shell uname -s)

--- a/recipes/ucsc-bedtobigbed/meta.yaml
+++ b/recipes/ucsc-bedtobigbed/meta.yaml
@@ -1,40 +1,48 @@
+{% set package = "ucsc-bedtobigbed" %}
+{% set program = "bedToBigBed" %}
+{% set version = "357" %}
+{% set sha256 = "0cec445f47c319e407d2cf866fb2f6ec0c9b72a2b10a0f75142ebc01ca4aca87" %}
+
 package:
-    name: "ucsc-bedtobigbed"
-    version: "332"
+  name: "{{ package }}"
+  version: "{{ version }}"
+
 source:
-    url: "http://hgdownload.cse.ucsc.edu/admin/exe/userApps.v332.src.tgz"          # [linux]
-    fn: "userApps.src.tgz"                                                                     # [linux]
-    md5: "8c2663c7bd302a77cdf52b2e9e85e2cd"                                                    # [linux]
-    patches:                                                                                   # [linux]
-        - "include.patch"                                                                      # [linux]
+  url: "http://hgdownload.cse.ucsc.edu/admin/exe/userApps.v{{ version }}.src.tgz"                      # [linux]
+  fn: "userApps.src.tgz"                                                                     # [linux]
+  sha256: "{{ sha256 }}"                                                    # [linux]
+  patches:                                                                                   # [linux]
+    - "include.patch"                                                                        # [linux]
 
-    url: "http://hgdownload.cse.ucsc.edu/admin/exe/macOSX.x86_64/bedToBigBed"                    # [osx]
-    fn: "bedToBigBed"                                                                            # [osx]
+  url: "http://hgdownload.cse.ucsc.edu/admin/exe/macOSX.x86_64/{{ program }}"                    # [osx]
+  fn: "{{ program }}"                                                                            # [osx]
 
-build:                                                                                       # [osx]
-    script: "mkdir -p $PREFIX/bin; cp bedToBigBed $PREFIX/bin; chmod +x $PREFIX/bin/bedToBigBed" # [osx]
+build:
+  number: 0
 
 requirements:
-    build:
-        - libpng                                                    # [linux]
-        - mysql                                                     # [linux]
-        - zlib                                                      # [linux]
-        - openssl                                                   # [linux]
-        - gcc
+  build:
+    - gcc                                                       # [linux]
+    - libpng                                                    # [linux]
+    - libuuid                                                   # [linux]
+    - mysql-connector-c                                         # [linux]
+    - openssl                                                   # [linux]
+    - zlib                                                      # [linux]
 
-    run:                                                            # [linux]
-        - libpng                                                    # [linux]
-        - mysql                                                     # [linux]
-        - zlib                                                      # [linux]
-        - openssl                                                   # [linux]
-        - libgcc
+  run:
+    - libgcc                                                    # [linux]
+    - libpng                                                    # [linux]
+    - libuuid                                                   # [linux]
+    - mysql-connector-c                                         # [linux]
+    - openssl                                                   # [linux]
+    - zlib                                                      # [linux]
 
 test:
-    commands:
-        # just check for existence, because the individual programs have no unified behavior
-        - which bedToBigBed
+  commands:
+    # just check for existence, because the individual packages have no unified behavior
+    - which {{ program }}
 
 about:
-    home: "http://hgdownload.cse.ucsc.edu/admin/exe/"
-    license: "varies; see http://genome.ucsc.edu/license"
-    summary: "Convert bed file to bigBed. (BigBed version: 4)"
+  home: "http://hgdownload.cse.ucsc.edu/admin/exe/"
+  license: "varies; see http://genome.ucsc.edu/license"
+  summary: "Convert bed file to bigBed. (BigBed version: 4)"

--- a/recipes/ucsc-bigbedinfo/build.sh
+++ b/recipes/ucsc-bigbedinfo/build.sh
@@ -1,12 +1,16 @@
 #!/bin/bash
-
-export MACHTYPE=x86_64
-export BINDIR=$(pwd)/bin
-mkdir -p $BINDIR
-(cd kent/src/lib && make)
-(cd kent/src/jkOwnLib && make)
-(cd kent/src/hg/lib && make)
-(cd kent/src/utils/bigBedInfo && make)
-mkdir -p $PREFIX/bin
-cp bin/bigBedInfo $PREFIX/bin
-chmod +x $PREFIX/bin/bigBedInfo
+mkdir -p "$PREFIX/bin"
+if [ "$(uname)" == "Darwin" ]; then
+    cp bigBedInfo "$PREFIX/bin"
+else
+    export MACHTYPE=x86_64
+    export BINDIR=$(pwd)/bin
+    mkdir -p "$BINDIR"
+    (cd kent/src/lib && make)
+    (cd kent/src/htslib && make)
+    (cd kent/src/jkOwnLib && make)
+    (cd kent/src/hg/lib && make)
+    (cd kent/src/utils/bigBedInfo && make)
+    cp bin/bigBedInfo "$PREFIX/bin"
+fi
+chmod +x "$PREFIX/bin/bigBedInfo"

--- a/recipes/ucsc-bigbedinfo/include.patch
+++ b/recipes/ucsc-bigbedinfo/include.patch
@@ -1,11 +1,11 @@
---- kent/src/inc/common.mk
-+++ kent/src/inc/common.mk
+--- kent/src/inc/common.mk	2017-11-07 17:46:00.000000000 -0500
++++ kent/src/inc/common.mk.new	2017-11-13 17:44:51.017090255 -0500
 @@ -17,7 +17,7 @@
  endif
-
+ 
  HG_DEFS=-D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_GNU_SOURCE -DMACHTYPE_${MACHTYPE}
--HG_INC+=-I../inc -I../../inc -I../../../inc -I../../../../inc -I../../../../../inc
-+HG_INC+=-I../inc -I../../inc -I../../../inc -I../../../../inc -I../../../../../inc -I ${PREFIX}/include
-
+-HG_INC+=-I../inc -I../../inc -I../../../inc -I../../../../inc -I../../../../../inc -I$(kentSrc)/htslib
++HG_INC+=-I../inc -I../../inc -I../../../inc -I../../../../inc -I../../../../../inc -I$(kentSrc)/htslib -I ${PREFIX}/include
+ 
  # to check for Mac OSX Darwin specifics:
  UNAME_S := $(shell uname -s)

--- a/recipes/ucsc-bigbedinfo/meta.yaml
+++ b/recipes/ucsc-bigbedinfo/meta.yaml
@@ -1,40 +1,48 @@
+{% set package = "ucsc-bigbedinfo" %}
+{% set program = "bigBedInfo" %}
+{% set version = "357" %}
+{% set sha256 = "0cec445f47c319e407d2cf866fb2f6ec0c9b72a2b10a0f75142ebc01ca4aca87" %}
+
 package:
-    name: "ucsc-bigbedinfo"
-    version: "332"
+  name: "{{ package }}"
+  version: "{{ version }}"
+
 source:
-    url: "http://hgdownload.cse.ucsc.edu/admin/exe/userApps.v332.src.tgz"          # [linux]
-    fn: "userApps.src.tgz"                                                                     # [linux]
-    md5: "8c2663c7bd302a77cdf52b2e9e85e2cd"                                                    # [linux]
-    patches:                                                                                   # [linux]
-        - "include.patch"                                                                      # [linux]
+  url: "http://hgdownload.cse.ucsc.edu/admin/exe/userApps.v{{ version }}.src.tgz"                      # [linux]
+  fn: "userApps.src.tgz"                                                                     # [linux]
+  sha256: "{{ sha256 }}"                                                    # [linux]
+  patches:                                                                                   # [linux]
+    - "include.patch"                                                                        # [linux]
 
-    url: "http://hgdownload.cse.ucsc.edu/admin/exe/macOSX.x86_64/bigBedInfo"                    # [osx]
-    fn: "bigBedInfo"                                                                            # [osx]
+  url: "http://hgdownload.cse.ucsc.edu/admin/exe/macOSX.x86_64/{{ program }}"                    # [osx]
+  fn: "{{ program }}"                                                                            # [osx]
 
-build:                                                                                       # [osx]
-    script: "mkdir -p $PREFIX/bin; cp bigBedInfo $PREFIX/bin; chmod +x $PREFIX/bin/bigBedInfo" # [osx]
+build:
+  number: 0
 
 requirements:
-    build:
-        - libpng                                                    # [linux]
-        - mysql                                                     # [linux]
-        - zlib                                                      # [linux]
-        - openssl                                                   # [linux]
-        - gcc
+  build:
+    - gcc                                                       # [linux]
+    - libpng                                                    # [linux]
+    - libuuid                                                   # [linux]
+    - mysql-connector-c                                         # [linux]
+    - openssl                                                   # [linux]
+    - zlib                                                      # [linux]
 
-    run:                                                            # [linux]
-        - libpng                                                    # [linux]
-        - mysql                                                     # [linux]
-        - zlib                                                      # [linux]
-        - openssl                                                   # [linux]
-        - libgcc
+  run:
+    - libgcc                                                    # [linux]
+    - libpng                                                    # [linux]
+    - libuuid                                                   # [linux]
+    - mysql-connector-c                                         # [linux]
+    - openssl                                                   # [linux]
+    - zlib                                                      # [linux]
 
 test:
-    commands:
-        # just check for existence, because the individual programs have no unified behavior
-        - which bigBedInfo
+  commands:
+    # just check for existence, because the individual packages have no unified behavior
+    - which {{ program }}
 
 about:
-    home: "http://hgdownload.cse.ucsc.edu/admin/exe/"
-    license: "varies; see http://genome.ucsc.edu/license"
-    summary: "Show information about a bigBed file."
+  home: "http://hgdownload.cse.ucsc.edu/admin/exe/"
+  license: "varies; see http://genome.ucsc.edu/license"
+  summary: "Show information about a bigBed file."

--- a/recipes/ucsc-bigbedsummary/build.sh
+++ b/recipes/ucsc-bigbedsummary/build.sh
@@ -1,12 +1,16 @@
 #!/bin/bash
-
-export MACHTYPE=x86_64
-export BINDIR=$(pwd)/bin
-mkdir -p $BINDIR
-(cd kent/src/lib && make)
-(cd kent/src/jkOwnLib && make)
-(cd kent/src/hg/lib && make)
-(cd kent/src/utils/bigBedSummary && make)
-mkdir -p $PREFIX/bin
-cp bin/bigBedSummary $PREFIX/bin
-chmod +x $PREFIX/bin/bigBedSummary
+mkdir -p "$PREFIX/bin"
+if [ "$(uname)" == "Darwin" ]; then
+    cp bigBedSummary "$PREFIX/bin"
+else
+    export MACHTYPE=x86_64
+    export BINDIR=$(pwd)/bin
+    mkdir -p "$BINDIR"
+    (cd kent/src/lib && make)
+    (cd kent/src/htslib && make)
+    (cd kent/src/jkOwnLib && make)
+    (cd kent/src/hg/lib && make)
+    (cd kent/src/utils/bigBedSummary && make)
+    cp bin/bigBedSummary "$PREFIX/bin"
+fi
+chmod +x "$PREFIX/bin/bigBedSummary"

--- a/recipes/ucsc-bigbedsummary/include.patch
+++ b/recipes/ucsc-bigbedsummary/include.patch
@@ -1,11 +1,11 @@
---- kent/src/inc/common.mk
-+++ kent/src/inc/common.mk
+--- kent/src/inc/common.mk	2017-11-07 17:46:00.000000000 -0500
++++ kent/src/inc/common.mk.new	2017-11-13 17:44:51.017090255 -0500
 @@ -17,7 +17,7 @@
  endif
-
+ 
  HG_DEFS=-D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_GNU_SOURCE -DMACHTYPE_${MACHTYPE}
--HG_INC+=-I../inc -I../../inc -I../../../inc -I../../../../inc -I../../../../../inc
-+HG_INC+=-I../inc -I../../inc -I../../../inc -I../../../../inc -I../../../../../inc -I ${PREFIX}/include
-
+-HG_INC+=-I../inc -I../../inc -I../../../inc -I../../../../inc -I../../../../../inc -I$(kentSrc)/htslib
++HG_INC+=-I../inc -I../../inc -I../../../inc -I../../../../inc -I../../../../../inc -I$(kentSrc)/htslib -I ${PREFIX}/include
+ 
  # to check for Mac OSX Darwin specifics:
  UNAME_S := $(shell uname -s)

--- a/recipes/ucsc-bigbedsummary/meta.yaml
+++ b/recipes/ucsc-bigbedsummary/meta.yaml
@@ -1,40 +1,48 @@
+{% set package = "ucsc-bigbedsummary" %}
+{% set program = "bigBedSummary" %}
+{% set version = "357" %}
+{% set sha256 = "0cec445f47c319e407d2cf866fb2f6ec0c9b72a2b10a0f75142ebc01ca4aca87" %}
+
 package:
-    name: "ucsc-bigbedsummary"
-    version: "332"
+  name: "{{ package }}"
+  version: "{{ version }}"
+
 source:
-    url: "http://hgdownload.cse.ucsc.edu/admin/exe/userApps.v332.src.tgz"          # [linux]
-    fn: "userApps.src.tgz"                                                                     # [linux]
-    md5: "8c2663c7bd302a77cdf52b2e9e85e2cd"                                                    # [linux]
-    patches:                                                                                   # [linux]
-        - "include.patch"                                                                      # [linux]
+  url: "http://hgdownload.cse.ucsc.edu/admin/exe/userApps.v{{ version }}.src.tgz"                      # [linux]
+  fn: "userApps.src.tgz"                                                                     # [linux]
+  sha256: "{{ sha256 }}"                                                    # [linux]
+  patches:                                                                                   # [linux]
+    - "include.patch"                                                                        # [linux]
 
-    url: "http://hgdownload.cse.ucsc.edu/admin/exe/macOSX.x86_64/bigBedSummary"                    # [osx]
-    fn: "bigBedSummary"                                                                            # [osx]
+  url: "http://hgdownload.cse.ucsc.edu/admin/exe/macOSX.x86_64/{{ program }}"                    # [osx]
+  fn: "{{ program }}"                                                                            # [osx]
 
-build:                                                                                       # [osx]
-    script: "mkdir -p $PREFIX/bin; cp bigBedSummary $PREFIX/bin; chmod +x $PREFIX/bin/bigBedSummary" # [osx]
+build:
+  number: 0
 
 requirements:
-    build:
-        - libpng                                                    # [linux]
-        - mysql                                                     # [linux]
-        - zlib                                                      # [linux]
-        - openssl                                                   # [linux]
-        - gcc
+  build:
+    - gcc                                                       # [linux]
+    - libpng                                                    # [linux]
+    - libuuid                                                   # [linux]
+    - mysql-connector-c                                         # [linux]
+    - openssl                                                   # [linux]
+    - zlib                                                      # [linux]
 
-    run:                                                            # [linux]
-        - libpng                                                    # [linux]
-        - mysql                                                     # [linux]
-        - zlib                                                      # [linux]
-        - openssl                                                   # [linux]
-        - libgcc
+  run:
+    - libgcc                                                    # [linux]
+    - libpng                                                    # [linux]
+    - libuuid                                                   # [linux]
+    - mysql-connector-c                                         # [linux]
+    - openssl                                                   # [linux]
+    - zlib                                                      # [linux]
 
 test:
-    commands:
-        # just check for existence, because the individual programs have no unified behavior
-        - which bigBedSummary
+  commands:
+    # just check for existence, because the individual packages have no unified behavior
+    - which {{ program }}
 
 about:
-    home: "http://hgdownload.cse.ucsc.edu/admin/exe/"
-    license: "varies; see http://genome.ucsc.edu/license"
-    summary: "Extract summary information from a bigBed file."
+  home: "http://hgdownload.cse.ucsc.edu/admin/exe/"
+  license: "varies; see http://genome.ucsc.edu/license"
+  summary: "Extract summary information from a bigBed file."

--- a/recipes/ucsc-bigbedtobed/build.sh
+++ b/recipes/ucsc-bigbedtobed/build.sh
@@ -1,12 +1,16 @@
 #!/bin/bash
-
-export MACHTYPE=x86_64
-export BINDIR=$(pwd)/bin
-mkdir -p $BINDIR
-(cd kent/src/lib && make)
-(cd kent/src/jkOwnLib && make)
-(cd kent/src/hg/lib && make)
-(cd kent/src/utils/bigBedToBed && make)
-mkdir -p $PREFIX/bin
-cp bin/bigBedToBed $PREFIX/bin
-chmod +x $PREFIX/bin/bigBedToBed
+mkdir -p "$PREFIX/bin"
+if [ "$(uname)" == "Darwin" ]; then
+    cp bigBedToBed "$PREFIX/bin"
+else
+    export MACHTYPE=x86_64
+    export BINDIR=$(pwd)/bin
+    mkdir -p "$BINDIR"
+    (cd kent/src/lib && make)
+    (cd kent/src/htslib && make)
+    (cd kent/src/jkOwnLib && make)
+    (cd kent/src/hg/lib && make)
+    (cd kent/src/utils/bigBedToBed && make)
+    cp bin/bigBedToBed "$PREFIX/bin"
+fi
+chmod +x "$PREFIX/bin/bigBedToBed"

--- a/recipes/ucsc-bigbedtobed/include.patch
+++ b/recipes/ucsc-bigbedtobed/include.patch
@@ -1,11 +1,11 @@
---- kent/src/inc/common.mk
-+++ kent/src/inc/common.mk
+--- kent/src/inc/common.mk	2017-11-07 17:46:00.000000000 -0500
++++ kent/src/inc/common.mk.new	2017-11-13 17:44:51.017090255 -0500
 @@ -17,7 +17,7 @@
  endif
-
+ 
  HG_DEFS=-D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_GNU_SOURCE -DMACHTYPE_${MACHTYPE}
--HG_INC+=-I../inc -I../../inc -I../../../inc -I../../../../inc -I../../../../../inc
-+HG_INC+=-I../inc -I../../inc -I../../../inc -I../../../../inc -I../../../../../inc -I ${PREFIX}/include
-
+-HG_INC+=-I../inc -I../../inc -I../../../inc -I../../../../inc -I../../../../../inc -I$(kentSrc)/htslib
++HG_INC+=-I../inc -I../../inc -I../../../inc -I../../../../inc -I../../../../../inc -I$(kentSrc)/htslib -I ${PREFIX}/include
+ 
  # to check for Mac OSX Darwin specifics:
  UNAME_S := $(shell uname -s)

--- a/recipes/ucsc-bigbedtobed/meta.yaml
+++ b/recipes/ucsc-bigbedtobed/meta.yaml
@@ -1,40 +1,48 @@
+{% set package = "ucsc-bigbedtobed" %}
+{% set program = "bigBedToBed" %}
+{% set version = "357" %}
+{% set sha256 = "0cec445f47c319e407d2cf866fb2f6ec0c9b72a2b10a0f75142ebc01ca4aca87" %}
+
 package:
-    name: "ucsc-bigbedtobed"
-    version: "332"
+  name: "{{ package }}"
+  version: "{{ version }}"
+
 source:
-    url: "http://hgdownload.cse.ucsc.edu/admin/exe/userApps.v332.src.tgz"          # [linux]
-    fn: "userApps.src.tgz"                                                                     # [linux]
-    md5: "8c2663c7bd302a77cdf52b2e9e85e2cd"                                                    # [linux]
-    patches:                                                                                   # [linux]
-        - "include.patch"                                                                      # [linux]
+  url: "http://hgdownload.cse.ucsc.edu/admin/exe/userApps.v{{ version }}.src.tgz"                      # [linux]
+  fn: "userApps.src.tgz"                                                                     # [linux]
+  sha256: "{{ sha256 }}"                                                    # [linux]
+  patches:                                                                                   # [linux]
+    - "include.patch"                                                                        # [linux]
 
-    url: "http://hgdownload.cse.ucsc.edu/admin/exe/macOSX.x86_64/bigBedToBed"                    # [osx]
-    fn: "bigBedToBed"                                                                            # [osx]
+  url: "http://hgdownload.cse.ucsc.edu/admin/exe/macOSX.x86_64/{{ program }}"                    # [osx]
+  fn: "{{ program }}"                                                                            # [osx]
 
-build:                                                                                       # [osx]
-    script: "mkdir -p $PREFIX/bin; cp bigBedToBed $PREFIX/bin; chmod +x $PREFIX/bin/bigBedToBed" # [osx]
+build:
+  number: 0
 
 requirements:
-    build:
-        - libpng                                                    # [linux]
-        - mysql                                                     # [linux]
-        - zlib                                                      # [linux]
-        - openssl                                                   # [linux]
-        - gcc
+  build:
+    - gcc                                                       # [linux]
+    - libpng                                                    # [linux]
+    - libuuid                                                   # [linux]
+    - mysql-connector-c                                         # [linux]
+    - openssl                                                   # [linux]
+    - zlib                                                      # [linux]
 
-    run:                                                            # [linux]
-        - libpng                                                    # [linux]
-        - mysql                                                     # [linux]
-        - zlib                                                      # [linux]
-        - openssl                                                   # [linux]
-        - libgcc
+  run:
+    - libgcc                                                    # [linux]
+    - libpng                                                    # [linux]
+    - libuuid                                                   # [linux]
+    - mysql-connector-c                                         # [linux]
+    - openssl                                                   # [linux]
+    - zlib                                                      # [linux]
 
 test:
-    commands:
-        # just check for existence, because the individual programs have no unified behavior
-        - which bigBedToBed
+  commands:
+    # just check for existence, because the individual packages have no unified behavior
+    - which {{ program }}
 
 about:
-    home: "http://hgdownload.cse.ucsc.edu/admin/exe/"
-    license: "varies; see http://genome.ucsc.edu/license"
-    summary: "Convert from bigBed to ascii bed format."
+  home: "http://hgdownload.cse.ucsc.edu/admin/exe/"
+  license: "varies; see http://genome.ucsc.edu/license"
+  summary: "Convert from bigBed to ascii bed format."

--- a/recipes/ucsc-bigwiginfo/build.sh
+++ b/recipes/ucsc-bigwiginfo/build.sh
@@ -1,12 +1,16 @@
 #!/bin/bash
-
-export MACHTYPE=x86_64
-export BINDIR=$(pwd)/bin
-mkdir -p $BINDIR
-(cd kent/src/lib && make)
-(cd kent/src/jkOwnLib && make)
-(cd kent/src/hg/lib && make)
-(cd kent/src/utils/bigWigInfo && make)
-mkdir -p $PREFIX/bin
-cp bin/bigWigInfo $PREFIX/bin
-chmod +x $PREFIX/bin/bigWigInfo
+mkdir -p "$PREFIX/bin"
+if [ "$(uname)" == "Darwin" ]; then
+    cp bigWigInfo "$PREFIX/bin"
+else
+    export MACHTYPE=x86_64
+    export BINDIR=$(pwd)/bin
+    mkdir -p "$BINDIR"
+    (cd kent/src/lib && make)
+    (cd kent/src/htslib && make)
+    (cd kent/src/jkOwnLib && make)
+    (cd kent/src/hg/lib && make)
+    (cd kent/src/utils/bigWigInfo && make)
+    cp bin/bigWigInfo "$PREFIX/bin"
+fi
+chmod +x "$PREFIX/bin/bigWigInfo"

--- a/recipes/ucsc-bigwiginfo/include.patch
+++ b/recipes/ucsc-bigwiginfo/include.patch
@@ -1,11 +1,11 @@
---- kent/src/inc/common.mk
-+++ kent/src/inc/common.mk
+--- kent/src/inc/common.mk	2017-11-07 17:46:00.000000000 -0500
++++ kent/src/inc/common.mk.new	2017-11-13 17:44:51.017090255 -0500
 @@ -17,7 +17,7 @@
  endif
-
+ 
  HG_DEFS=-D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_GNU_SOURCE -DMACHTYPE_${MACHTYPE}
--HG_INC+=-I../inc -I../../inc -I../../../inc -I../../../../inc -I../../../../../inc
-+HG_INC+=-I../inc -I../../inc -I../../../inc -I../../../../inc -I../../../../../inc -I ${PREFIX}/include
-
+-HG_INC+=-I../inc -I../../inc -I../../../inc -I../../../../inc -I../../../../../inc -I$(kentSrc)/htslib
++HG_INC+=-I../inc -I../../inc -I../../../inc -I../../../../inc -I../../../../../inc -I$(kentSrc)/htslib -I ${PREFIX}/include
+ 
  # to check for Mac OSX Darwin specifics:
  UNAME_S := $(shell uname -s)

--- a/recipes/ucsc-bigwiginfo/meta.yaml
+++ b/recipes/ucsc-bigwiginfo/meta.yaml
@@ -1,40 +1,48 @@
+{% set package = "ucsc-bigwiginfo" %}
+{% set program = "bigWigInfo" %}
+{% set version = "357" %}
+{% set sha256 = "0cec445f47c319e407d2cf866fb2f6ec0c9b72a2b10a0f75142ebc01ca4aca87" %}
+
 package:
-    name: "ucsc-bigwiginfo"
-    version: "332"
+  name: "{{ package }}"
+  version: "{{ version }}"
+
 source:
-    url: "http://hgdownload.cse.ucsc.edu/admin/exe/userApps.v332.src.tgz"          # [linux]
-    fn: "userApps.src.tgz"                                                                     # [linux]
-    md5: "8c2663c7bd302a77cdf52b2e9e85e2cd"                                                    # [linux]
-    patches:                                                                                   # [linux]
-        - "include.patch"                                                                      # [linux]
+  url: "http://hgdownload.cse.ucsc.edu/admin/exe/userApps.v{{ version }}.src.tgz"                      # [linux]
+  fn: "userApps.src.tgz"                                                                     # [linux]
+  sha256: "{{ sha256 }}"                                                    # [linux]
+  patches:                                                                                   # [linux]
+    - "include.patch"                                                                        # [linux]
 
-    url: "http://hgdownload.cse.ucsc.edu/admin/exe/macOSX.x86_64/bigWigInfo"                    # [osx]
-    fn: "bigWigInfo"                                                                            # [osx]
+  url: "http://hgdownload.cse.ucsc.edu/admin/exe/macOSX.x86_64/{{ program }}"                    # [osx]
+  fn: "{{ program }}"                                                                            # [osx]
 
-build:                                                                                       # [osx]
-    script: "mkdir -p $PREFIX/bin; cp bigWigInfo $PREFIX/bin; chmod +x $PREFIX/bin/bigWigInfo" # [osx]
+build:
+  number: 0
 
 requirements:
-    build:
-        - libpng                                                    # [linux]
-        - mysql                                                     # [linux]
-        - zlib                                                      # [linux]
-        - openssl                                                   # [linux]
-        - gcc
+  build:
+    - gcc                                                       # [linux]
+    - libpng                                                    # [linux]
+    - libuuid                                                   # [linux]
+    - mysql-connector-c                                         # [linux]
+    - openssl                                                   # [linux]
+    - zlib                                                      # [linux]
 
-    run:                                                            # [linux]
-        - libpng                                                    # [linux]
-        - mysql                                                     # [linux]
-        - zlib                                                      # [linux]
-        - openssl                                                   # [linux]
-        - libgcc
+  run:
+    - libgcc                                                    # [linux]
+    - libpng                                                    # [linux]
+    - libuuid                                                   # [linux]
+    - mysql-connector-c                                         # [linux]
+    - openssl                                                   # [linux]
+    - zlib                                                      # [linux]
 
 test:
-    commands:
-        # just check for existence, because the individual programs have no unified behavior
-        - which bigWigInfo
+  commands:
+    # just check for existence, because the individual packages have no unified behavior
+    - which {{ program }}
 
 about:
-    home: "http://hgdownload.cse.ucsc.edu/admin/exe/"
-    license: "varies; see http://genome.ucsc.edu/license"
-    summary: "Print out information about bigWig file."
+  home: "http://hgdownload.cse.ucsc.edu/admin/exe/"
+  license: "varies; see http://genome.ucsc.edu/license"
+  summary: "Print out information about bigWig file."

--- a/recipes/ucsc-bigwigsummary/build.sh
+++ b/recipes/ucsc-bigwigsummary/build.sh
@@ -1,12 +1,16 @@
 #!/bin/bash
-
-export MACHTYPE=x86_64
-export BINDIR=$(pwd)/bin
-mkdir -p $BINDIR
-(cd kent/src/lib && make)
-(cd kent/src/jkOwnLib && make)
-(cd kent/src/hg/lib && make)
-(cd kent/src/utils/bigWigSummary && make)
-mkdir -p $PREFIX/bin
-cp bin/bigWigSummary $PREFIX/bin
-chmod +x $PREFIX/bin/bigWigSummary
+mkdir -p "$PREFIX/bin"
+if [ "$(uname)" == "Darwin" ]; then
+    cp bigWigSummary "$PREFIX/bin"
+else
+    export MACHTYPE=x86_64
+    export BINDIR=$(pwd)/bin
+    mkdir -p "$BINDIR"
+    (cd kent/src/lib && make)
+    (cd kent/src/htslib && make)
+    (cd kent/src/jkOwnLib && make)
+    (cd kent/src/hg/lib && make)
+    (cd kent/src/utils/bigWigSummary && make)
+    cp bin/bigWigSummary "$PREFIX/bin"
+fi
+chmod +x "$PREFIX/bin/bigWigSummary"

--- a/recipes/ucsc-bigwigsummary/include.patch
+++ b/recipes/ucsc-bigwigsummary/include.patch
@@ -1,11 +1,11 @@
---- kent/src/inc/common.mk
-+++ kent/src/inc/common.mk
+--- kent/src/inc/common.mk	2017-11-07 17:46:00.000000000 -0500
++++ kent/src/inc/common.mk.new	2017-11-13 17:44:51.017090255 -0500
 @@ -17,7 +17,7 @@
  endif
-
+ 
  HG_DEFS=-D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_GNU_SOURCE -DMACHTYPE_${MACHTYPE}
--HG_INC+=-I../inc -I../../inc -I../../../inc -I../../../../inc -I../../../../../inc
-+HG_INC+=-I../inc -I../../inc -I../../../inc -I../../../../inc -I../../../../../inc -I ${PREFIX}/include
-
+-HG_INC+=-I../inc -I../../inc -I../../../inc -I../../../../inc -I../../../../../inc -I$(kentSrc)/htslib
++HG_INC+=-I../inc -I../../inc -I../../../inc -I../../../../inc -I../../../../../inc -I$(kentSrc)/htslib -I ${PREFIX}/include
+ 
  # to check for Mac OSX Darwin specifics:
  UNAME_S := $(shell uname -s)

--- a/recipes/ucsc-bigwigsummary/meta.yaml
+++ b/recipes/ucsc-bigwigsummary/meta.yaml
@@ -1,40 +1,48 @@
+{% set package = "ucsc-bigwigsummary" %}
+{% set program = "bigWigSummary" %}
+{% set version = "357" %}
+{% set sha256 = "0cec445f47c319e407d2cf866fb2f6ec0c9b72a2b10a0f75142ebc01ca4aca87" %}
+
 package:
-    name: "ucsc-bigwigsummary"
-    version: "332"
+  name: "{{ package }}"
+  version: "{{ version }}"
+
 source:
-    url: "http://hgdownload.cse.ucsc.edu/admin/exe/userApps.v332.src.tgz"          # [linux]
-    fn: "userApps.src.tgz"                                                                     # [linux]
-    md5: "8c2663c7bd302a77cdf52b2e9e85e2cd"                                                    # [linux]
-    patches:                                                                                   # [linux]
-        - "include.patch"                                                                      # [linux]
+  url: "http://hgdownload.cse.ucsc.edu/admin/exe/userApps.v{{ version }}.src.tgz"                      # [linux]
+  fn: "userApps.src.tgz"                                                                     # [linux]
+  sha256: "{{ sha256 }}"                                                    # [linux]
+  patches:                                                                                   # [linux]
+    - "include.patch"                                                                        # [linux]
 
-    url: "http://hgdownload.cse.ucsc.edu/admin/exe/macOSX.x86_64/bigWigSummary"                    # [osx]
-    fn: "bigWigSummary"                                                                            # [osx]
+  url: "http://hgdownload.cse.ucsc.edu/admin/exe/macOSX.x86_64/{{ program }}"                    # [osx]
+  fn: "{{ program }}"                                                                            # [osx]
 
-build:                                                                                       # [osx]
-    script: "mkdir -p $PREFIX/bin; cp bigWigSummary $PREFIX/bin; chmod +x $PREFIX/bin/bigWigSummary" # [osx]
+build:
+  number: 0
 
 requirements:
-    build:
-        - libpng                                                    # [linux]
-        - mysql                                                     # [linux]
-        - zlib                                                      # [linux]
-        - openssl                                                   # [linux]
-        - gcc
+  build:
+    - gcc                                                       # [linux]
+    - libpng                                                    # [linux]
+    - libuuid                                                   # [linux]
+    - mysql-connector-c                                         # [linux]
+    - openssl                                                   # [linux]
+    - zlib                                                      # [linux]
 
-    run:                                                            # [linux]
-        - libpng                                                    # [linux]
-        - mysql                                                     # [linux]
-        - zlib                                                      # [linux]
-        - openssl                                                   # [linux]
-        - libgcc
+  run:
+    - libgcc                                                    # [linux]
+    - libpng                                                    # [linux]
+    - libuuid                                                   # [linux]
+    - mysql-connector-c                                         # [linux]
+    - openssl                                                   # [linux]
+    - zlib                                                      # [linux]
 
 test:
-    commands:
-        # just check for existence, because the individual programs have no unified behavior
-        - which bigWigSummary
+  commands:
+    # just check for existence, because the individual packages have no unified behavior
+    - which {{ program }}
 
 about:
-    home: "http://hgdownload.cse.ucsc.edu/admin/exe/"
-    license: "varies; see http://genome.ucsc.edu/license"
-    summary: "Extract summary information from a bigWig file."
+  home: "http://hgdownload.cse.ucsc.edu/admin/exe/"
+  license: "varies; see http://genome.ucsc.edu/license"
+  summary: "Extract summary information from a bigWig file."

--- a/scripts/ucsc/create-ucsc-packages.py
+++ b/scripts/ucsc/create-ucsc-packages.py
@@ -49,14 +49,14 @@ def parse_footer(fn):
 
 
 # Identify version of the last available tarball visible on
-# http://hgdownload.cse.ucsc.edu/admin/exe and compute its md5sum; place them
+# http://hgdownload.cse.ucsc.edu/admin/exe and compute its  sha256; place them
 # in the ucsc_config.yaml file that looks like:
 #
 #   version: 332
-#   md5: 8c2663c7bd302a77cdf52b2e9e85e2cd
+#   sha256: 8c2663c7bd302a77cdf52b2e9e85e2cd
 ucsc_config = yaml.load(open('ucsc_config.yaml'))
 VERSION = ucsc_config['version']
-MD5 = ucsc_config['md5']
+SHA256 = ucsc_config['sha256']
 
 # Download tarball if it doesn't exist. Always download FOOTER.
 tarball = (
@@ -104,11 +104,29 @@ problematic = {
 # the header and values are the dir in the source code.
 resolve_header_and_summary_conflicts = {
     'rmFaDups': 'rmFaDups',
+    'bedJoinTabOffset': 'bedJoinTabOffset',
+    'webSync': 'webSync',
 }
 
 # Some programs' descriptions do not meet the regex in FOOTER and therefore
 # must be manually assigned.
 manual_descriptions = {
+
+    'expMatrixToBarchartBed': dedent(
+        """
+        Generate a barChart bed6+5 file from a matrix, meta data, and
+        coordinates.
+        """),
+
+    'pslRc': 'reverse-complement psl',
+
+    'pslMapPostChain': dedent(
+        """
+        Post genomic pslMap (TransMap) chaining.  This takes transcripts
+        that have been mapped via genomic chains adds back in
+        blocks that didn't get include in genomic chains due
+        to complex rearrangements or other issues.
+        """),
 
     'estOrient': dedent(
         """
@@ -226,7 +244,7 @@ for block in parse_footer('FOOTER'):
                 package=package,
                 summary=description,
                 version=VERSION,
-                md5=MD5,
+                sha256=SHA256,
             )
         )
 

--- a/scripts/ucsc/include.patch
+++ b/scripts/ucsc/include.patch
@@ -1,11 +1,11 @@
---- kent/src/inc/common.mk
-+++ kent/src/inc/common.mk
+--- kent/src/inc/common.mk	2017-11-07 17:46:00.000000000 -0500
++++ kent/src/inc/common.mk.new	2017-11-13 17:44:51.017090255 -0500
 @@ -17,7 +17,7 @@
  endif
-
+ 
  HG_DEFS=-D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_GNU_SOURCE -DMACHTYPE_${MACHTYPE}
--HG_INC+=-I../inc -I../../inc -I../../../inc -I../../../../inc -I../../../../../inc
-+HG_INC+=-I../inc -I../../inc -I../../../inc -I../../../../inc -I../../../../../inc -I ${PREFIX}/include
-
+-HG_INC+=-I../inc -I../../inc -I../../../inc -I../../../../inc -I../../../../../inc -I$(kentSrc)/htslib
++HG_INC+=-I../inc -I../../inc -I../../../inc -I../../../../inc -I../../../../../inc -I$(kentSrc)/htslib -I ${PREFIX}/include
+ 
  # to check for Mac OSX Darwin specifics:
  UNAME_S := $(shell uname -s)

--- a/scripts/ucsc/template-build.sh
+++ b/scripts/ucsc/template-build.sh
@@ -7,6 +7,7 @@ else
     export BINDIR=$(pwd)/bin
     mkdir -p "$BINDIR"
     (cd kent/src/lib && make)
+    (cd kent/src/htslib && make)
     (cd kent/src/jkOwnLib && make)
     (cd kent/src/hg/lib && make)
     (cd {program_source_dir} && make)

--- a/scripts/ucsc/template-meta.yaml
+++ b/scripts/ucsc/template-meta.yaml
@@ -1,16 +1,21 @@
+{{% set package = "{package}" %}}
+{{% set program = "{program}" %}}
+{{% set version = "{version}" %}}
+{{% set sha256 = "{sha256}" %}}
+
 package:
-  name: "{package}"
-  version: "{version}"
+  name: "{{{{ package }}}}"
+  version: "{{{{ version }}}}"
 
 source:
-  url: "http://hgdownload.cse.ucsc.edu/admin/exe/userApps.v{version}.src.tgz"                      # [linux]
+  url: "http://hgdownload.cse.ucsc.edu/admin/exe/userApps.v{{{{ version }}}}.src.tgz"                      # [linux]
   fn: "userApps.src.tgz"                                                                     # [linux]
-  md5: "{md5}"                                                    # [linux]
+  sha256: "{{{{ sha256 }}}}"                                                    # [linux]
   patches:                                                                                   # [linux]
     - "include.patch"                                                                        # [linux]
 
-  url: "http://hgdownload.cse.ucsc.edu/admin/exe/macOSX.x86_64/{program}"                    # [osx]
-  fn: "{program}"                                                                            # [osx]
+  url: "http://hgdownload.cse.ucsc.edu/admin/exe/macOSX.x86_64/{{{{ program }}}}"                    # [osx]
+  fn: "{{{{ program }}}}"                                                                            # [osx]
 
 build:
   number: 0
@@ -19,21 +24,23 @@ requirements:
   build:
     - gcc                                                       # [linux]
     - libpng                                                    # [linux]
-    - mysql                                                     # [linux]
+    - libuuid                                                   # [linux]
+    - mysql-connector-c                                         # [linux]
     - openssl                                                   # [linux]
     - zlib                                                      # [linux]
 
   run:
     - libgcc                                                    # [linux]
     - libpng                                                    # [linux]
-    - mysql                                                     # [linux]
+    - libuuid                                                   # [linux]
+    - mysql-connector-c                                         # [linux]
     - openssl                                                   # [linux]
     - zlib                                                      # [linux]
 
 test:
   commands:
-    # just check for existence, because the individual programs have no unified behavior
-    - which {program}
+    # just check for existence, because the individual packages have no unified behavior
+    - which {{{{ program }}}}
 
 about:
   home: "http://hgdownload.cse.ucsc.edu/admin/exe/"

--- a/scripts/ucsc/ucsc_config.yaml
+++ b/scripts/ucsc/ucsc_config.yaml
@@ -1,2 +1,2 @@
-version: 332
-md5: 8c2663c7bd302a77cdf52b2e9e85e2cd
+version: 357
+sha256: 0cec445f47c319e407d2cf866fb2f6ec0c9b72a2b10a0f75142ebc01ca4aca87


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

Also updates the `scripts/ucsc/*` files which were used to generate these recipes.

As discussed in https://github.com/bioconda/bioconda-recipes/issues/5430, this uses `mysql-connector-c` instead of the full `mysql` to reduce the size of the resulting packages. Other modifications include:

- build the bundled `htslib`
- make the meta.yaml files templated
- use sha256 instead of md5
- move osx-specific copying to build.sh
- fix patch file