### PR TITLE
Pin Perl verison in Meraculous to the current defualt in conda-forge

### DIFF
--- a/recipes/meraculous/meta.yaml
+++ b/recipes/meraculous/meta.yaml
@@ -9,7 +9,7 @@ source:
 
 build:
     skip: True  # [osx]
-    string: pl_5_22_{{PKG_BUILDNUM}}
+    string: pl5.22_{{PKG_BUILDNUM}}
     number: 1
 
 requirements:

--- a/recipes/meraculous/meta.yaml
+++ b/recipes/meraculous/meta.yaml
@@ -9,7 +9,7 @@ source:
 
 build:
     skip: True  # [osx]
-    string: pl_5_22
+    string: pl_5_22_{{PKG_BUILDNUM}}
     number: 1
 
 requirements:
@@ -17,14 +17,14 @@ requirements:
     - cmake >=2.8
     - gcc # [linux]
     - libgd >=2.0
-    - boost-cpp ==1.65.0
+    - boost-cpp {{CONDA_BOOST}}*
     - perl ==5.22.2.1
     - perl-log-log4perl >=1.31
     - gnuplot >=3.7
     run:
     - libgcc # [linux]
     - libgd >=2.0
-    - boost-cpp ==1.65.0
+    - boost-cpp {{CONDA_BOOST}}*
     - perl ==5.22.2.1
     - perl-log-log4perl >=1.31
     - gnuplot >=3.7

--- a/recipes/meraculous/meta.yaml
+++ b/recipes/meraculous/meta.yaml
@@ -9,7 +9,8 @@ source:
 
 build:
     skip: True  # [osx]
-    number: 0
+    string: pl_5_22
+    number: 1
 
 requirements:
     build:
@@ -17,14 +18,14 @@ requirements:
     - gcc # [linux]
     - libgd >=2.0
     - boost-cpp ==1.65.0
-    - perl >=5.10
+    - perl ==5.22.2.1
     - perl-log-log4perl >=1.31
     - gnuplot >=3.7
     run:
     - libgcc # [linux]
     - libgd >=2.0
     - boost-cpp ==1.65.0
-    - perl >=5.10
+    - perl ==5.22.2.1
     - perl-log-log4perl >=1.31
     - gnuplot >=3.7
 


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Meraculous use Perl functions that are depreciated in the newer version of Perl, which is the case in the default channel.  This may is probably not necessary to pin the Perl version right now if we can assume that users will always set conda's the channel preference based on bioconda's recommendation.  However it has not been the case in my experience.  Additionally, this change will mitigate the risk of conda-forge upgrading its default Perl to a version that is not compatible with Meraculous in the future. 
