### PR TITLE
abyss: add abyss-pe wrappers, fixes installs on long prefixes

### DIFF
--- a/recipes/abyss/1.5.2/build.sh
+++ b/recipes/abyss/1.5.2/build.sh
@@ -13,12 +13,5 @@ fi
 make AM_CXXFLAGS=-Wall
 make install
 
-WRAPPER_PATH="$PREFIX/bin/abyss-pe"
-WRAPPED_PATH="$PREFIX/bin/abyss-pe.Makefile"
-mv "$WRAPPER_PATH" "$WRAPPED_PATH"
-chmod a-x "$WRAPPED_PATH"
-cat >"${WRAPPER_PATH}" <<EOF
-#!/bin/bash
-$(sed 's|^#!/usr/bin/||;q' "$WRAPPED_PATH") '$WRAPPED_PATH' \$@
-EOF
-chmod u+x "$WRAPPER_PATH"
+$RECIPE_DIR/create-wrapper.sh "$PREFIX/bin/abyss-pe" "$PREFIX/bin/abyss-pe.Makefile"
+$RECIPE_DIR/create-wrapper.sh "$PREFIX/bin/abyss-bloom-dist.mk" "$PREFIX/bin/abyss-bloom-dist.mk.Makefile"

--- a/recipes/abyss/1.5.2/build.sh
+++ b/recipes/abyss/1.5.2/build.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-mkdir -p $PREFIX/bin
-sed -i.bak "1 s|/usr/bin/make|$PREFIX/bin/make|"  bin/abyss-pe
-rm bin/abyss-pe.bak
-
 if [[ $(uname) == "Darwin" ]]; then
 	echo "Configuring for OSX..."
   	export CPPFLAGS="${CPPFLAGS} -I$PREFIX/include -I$PREFIX/include/boost --stdlib=libstdc++"
@@ -17,3 +13,12 @@ fi
 make AM_CXXFLAGS=-Wall
 make install
 
+WRAPPER_PATH="$PREFIX/bin/abyss-pe"
+WRAPPED_PATH="$PREFIX/bin/abyss-pe.Makefile"
+mv "$WRAPPER_PATH" "$WRAPPED_PATH"
+chmod a-x "$WRAPPED_PATH"
+cat >"${WRAPPER_PATH}" <<EOF
+#!/bin/bash
+$(sed 's|^#!/usr/bin/||;q' "$WRAPPED_PATH") '$WRAPPED_PATH' \$@
+EOF
+chmod u+x "$WRAPPER_PATH"

--- a/recipes/abyss/1.5.2/create-wrapper.sh
+++ b/recipes/abyss/1.5.2/create-wrapper.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Usage: create-wrapper.sh <SCRIPT_PATH> <NEW_PATH>
+#
+#  - moves <SCRIPT_PATH> to <NEW_PATH>
+#  - creates wrapper <SCRIPT_PATH>
+#    - takes original shebang line
+#    - removes prefix #!/bin or #!/usr/bin
+#    - uses resulting command CMD for a call to `exec CMD <NEW_PATH> "$@"`
+
+test ! -e "$2"
+mv "$1" "$2"
+chmod a-x "$2"
+
+cat >"$1" <<EOF
+#!/bin/bash
+exec $(sed 's|^#!/\(usr/\)\?bin/||;q' "$2") '$2' "\$@"
+EOF
+chmod u+x "$1"

--- a/recipes/abyss/1.5.2/meta.yaml
+++ b/recipes/abyss/1.5.2/meta.yaml
@@ -4,7 +4,7 @@ package:
   version: "1.5.2"
 
 build:
-  number: 1
+  number: 2
   string: boost1.61_{{PKG_BUILDNUM}}
 
 source:

--- a/recipes/abyss/1.9.0/build.sh
+++ b/recipes/abyss/1.9.0/build.sh
@@ -13,12 +13,5 @@ fi
 make AM_CXXFLAGS=-Wall
 make install
 
-WRAPPER_PATH="$PREFIX/bin/abyss-pe"
-WRAPPED_PATH="$PREFIX/bin/abyss-pe.Makefile"
-mv "$WRAPPER_PATH" "$WRAPPED_PATH"
-chmod a-x "$WRAPPED_PATH"
-cat >"${WRAPPER_PATH}" <<EOF
-#!/bin/bash
-$(sed 's|^#!/usr/bin/||;q' "$WRAPPED_PATH") '$WRAPPED_PATH' \$@
-EOF
-chmod u+x "$WRAPPER_PATH"
+$RECIPE_DIR/create-wrapper.sh "$PREFIX/bin/abyss-pe" "$PREFIX/bin/abyss-pe.Makefile"
+$RECIPE_DIR/create-wrapper.sh "$PREFIX/bin/abyss-bloom-dist.mk" "$PREFIX/bin/abyss-bloom-dist.mk.Makefile"

--- a/recipes/abyss/1.9.0/build.sh
+++ b/recipes/abyss/1.9.0/build.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-mkdir -p $PREFIX/bin
-sed -i.bak "1 s|/usr/bin/make|$PREFIX/bin/make|"  bin/abyss-pe
-rm bin/abyss-pe.bak
-
 if [[ $(uname) == "Darwin" ]]; then
 	echo "Configuring for OSX..."
 	export CPPFLAGS="${CPPFLAGS} -I$PREFIX/include -I$PREFIX/include/boost --stdlib=libstdc++"
@@ -17,3 +13,12 @@ fi
 make AM_CXXFLAGS=-Wall
 make install
 
+WRAPPER_PATH="$PREFIX/bin/abyss-pe"
+WRAPPED_PATH="$PREFIX/bin/abyss-pe.Makefile"
+mv "$WRAPPER_PATH" "$WRAPPED_PATH"
+chmod a-x "$WRAPPED_PATH"
+cat >"${WRAPPER_PATH}" <<EOF
+#!/bin/bash
+$(sed 's|^#!/usr/bin/||;q' "$WRAPPED_PATH") '$WRAPPED_PATH' \$@
+EOF
+chmod u+x "$WRAPPER_PATH"

--- a/recipes/abyss/1.9.0/create-wrapper.sh
+++ b/recipes/abyss/1.9.0/create-wrapper.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Usage: create-wrapper.sh <SCRIPT_PATH> <NEW_PATH>
+#
+#  - moves <SCRIPT_PATH> to <NEW_PATH>
+#  - creates wrapper <SCRIPT_PATH>
+#    - takes original shebang line
+#    - removes prefix #!/bin or #!/usr/bin
+#    - uses resulting command CMD for a call to `exec CMD <NEW_PATH> "$@"`
+
+test ! -e "$2"
+mv "$1" "$2"
+chmod a-x "$2"
+
+cat >"$1" <<EOF
+#!/bin/bash
+exec $(sed 's|^#!/\(usr/\)\?bin/||;q' "$2") '$2' "\$@"
+EOF
+chmod u+x "$1"

--- a/recipes/abyss/1.9.0/meta.yaml
+++ b/recipes/abyss/1.9.0/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: "1.9.0"
 
 build:
-  number: 3
+  number: 4
   string: boost1.61_{{PKG_BUILDNUM}}
 
 source:

--- a/recipes/abyss/2.0.2-k128/build.sh
+++ b/recipes/abyss/2.0.2-k128/build.sh
@@ -13,12 +13,5 @@ fi
 make AM_CXXFLAGS=-Wall
 make install 
 
-WRAPPER_PATH="$PREFIX/bin/abyss-pe"
-WRAPPED_PATH="$PREFIX/bin/abyss-pe.Makefile"
-mv "$WRAPPER_PATH" "$WRAPPED_PATH"
-chmod a-x "$WRAPPED_PATH"
-cat >"${WRAPPER_PATH}" <<EOF
-#!/bin/bash
-$(sed 's|^#!/usr/bin/||;q' "$WRAPPED_PATH") '$WRAPPED_PATH' \$@
-EOF
-chmod u+x "$WRAPPER_PATH"
+$RECIPE_DIR/create-wrapper.sh "$PREFIX/bin/abyss-pe" "$PREFIX/bin/abyss-pe.Makefile"
+$RECIPE_DIR/create-wrapper.sh "$PREFIX/bin/abyss-bloom-dist.mk" "$PREFIX/bin/abyss-bloom-dist.mk.Makefile"

--- a/recipes/abyss/2.0.2-k128/build.sh
+++ b/recipes/abyss/2.0.2-k128/build.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-mkdir -p $PREFIX/bin
-sed -i.bak "1 s|/usr/bin/make|$PREFIX/bin/make|"  bin/abyss-pe
-rm bin/abyss-pe.bak
-
 if [[ $(uname) == "Darwin" ]]; then
 	echo "Configuring for OSX..."
 	export CPPFLAGS="${CPPFLAGS} -I$PREFIX/include -I$PREFIX/include/boost --stdlib=libstdc++"
@@ -16,3 +12,13 @@ fi
 ./configure --prefix=$PREFIX --with-boost=$PREFIX/include --with-mpi=$PREFIX/include --enable-maxk=128
 make AM_CXXFLAGS=-Wall
 make install 
+
+WRAPPER_PATH="$PREFIX/bin/abyss-pe"
+WRAPPED_PATH="$PREFIX/bin/abyss-pe.Makefile"
+mv "$WRAPPER_PATH" "$WRAPPED_PATH"
+chmod a-x "$WRAPPED_PATH"
+cat >"${WRAPPER_PATH}" <<EOF
+#!/bin/bash
+$(sed 's|^#!/usr/bin/||;q' "$WRAPPED_PATH") '$WRAPPED_PATH' \$@
+EOF
+chmod u+x "$WRAPPER_PATH"

--- a/recipes/abyss/2.0.2-k128/create-wrapper.sh
+++ b/recipes/abyss/2.0.2-k128/create-wrapper.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Usage: create-wrapper.sh <SCRIPT_PATH> <NEW_PATH>
+#
+#  - moves <SCRIPT_PATH> to <NEW_PATH>
+#  - creates wrapper <SCRIPT_PATH>
+#    - takes original shebang line
+#    - removes prefix #!/bin or #!/usr/bin
+#    - uses resulting command CMD for a call to `exec CMD <NEW_PATH> "$@"`
+
+test ! -e "$2"
+mv "$1" "$2"
+chmod a-x "$2"
+
+cat >"$1" <<EOF
+#!/bin/bash
+exec $(sed 's|^#!/\(usr/\)\?bin/||;q' "$2") '$2' "\$@"
+EOF
+chmod u+x "$1"

--- a/recipes/abyss/2.0.2-k128/meta.yaml
+++ b/recipes/abyss/2.0.2-k128/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 build:
   skip: True # [osx]
-  number: 0
+  number: 1
   string: boost{{CONDA_BOOST}}_{{PKG_BUILDNUM}}
 
 source:

--- a/recipes/abyss/build.sh
+++ b/recipes/abyss/build.sh
@@ -13,12 +13,5 @@ fi
 make AM_CXXFLAGS=-Wall
 make install
 
-WRAPPER_PATH="$PREFIX/bin/abyss-pe"
-WRAPPED_PATH="$PREFIX/bin/abyss-pe.Makefile"
-mv "$WRAPPER_PATH" "$WRAPPED_PATH"
-chmod a-x "$WRAPPED_PATH"
-cat >"${WRAPPER_PATH}" <<EOF
-#!/bin/bash
-$(sed 's|^#!/usr/bin/||;q' "$WRAPPED_PATH") '$WRAPPED_PATH' \$@
-EOF
-chmod u+x "$WRAPPER_PATH"
+$RECIPE_DIR/create-wrapper.sh "$PREFIX/bin/abyss-pe" "$PREFIX/bin/abyss-pe.Makefile"
+$RECIPE_DIR/create-wrapper.sh "$PREFIX/bin/abyss-bloom-dist.mk" "$PREFIX/bin/abyss-bloom-dist.mk.Makefile"

--- a/recipes/abyss/build.sh
+++ b/recipes/abyss/build.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-mkdir -p $PREFIX/bin
-sed -i.bak "1 s|/usr/bin/make|$PREFIX/bin/make|"  bin/abyss-pe
-rm bin/abyss-pe.bak
-
 if [[ $(uname) == "Darwin" ]]; then
 	echo "Configuring for OSX..."
 	export CPPFLAGS="${CPPFLAGS} -I$PREFIX/include -I$PREFIX/include/boost --stdlib=libstdc++"
@@ -16,3 +12,13 @@ fi
 ./configure --prefix=$PREFIX --with-boost=$PREFIX/include --with-mpi=$PREFIX/include --enable-maxk=96
 make AM_CXXFLAGS=-Wall
 make install
+
+WRAPPER_PATH="$PREFIX/bin/abyss-pe"
+WRAPPED_PATH="$PREFIX/bin/abyss-pe.Makefile"
+mv "$WRAPPER_PATH" "$WRAPPED_PATH"
+chmod a-x "$WRAPPED_PATH"
+cat >"${WRAPPER_PATH}" <<EOF
+#!/bin/bash
+$(sed 's|^#!/usr/bin/||;q' "$WRAPPED_PATH") '$WRAPPED_PATH' \$@
+EOF
+chmod u+x "$WRAPPER_PATH"

--- a/recipes/abyss/create-wrapper.sh
+++ b/recipes/abyss/create-wrapper.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Usage: create-wrapper.sh <SCRIPT_PATH> <NEW_PATH>
+#
+#  - moves <SCRIPT_PATH> to <NEW_PATH>
+#  - creates wrapper <SCRIPT_PATH>
+#    - takes original shebang line
+#    - removes prefix #!/bin or #!/usr/bin
+#    - uses resulting command CMD for a call to `exec CMD <NEW_PATH> "$@"`
+
+test ! -e "$2"
+mv "$1" "$2"
+chmod a-x "$2"
+
+cat >"$1" <<EOF
+#!/bin/bash
+exec $(sed 's|^#!/\(usr/\)\?bin/||;q' "$2") '$2' "\$@"
+EOF
+chmod u+x "$1"

--- a/recipes/abyss/meta.yaml
+++ b/recipes/abyss/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 build:
   skip: True # [osx]
-  number: 0
+  number: 1
   string: boost{{CONDA_BOOST}}_{{PKG_BUILDNUM}}
 
 source:


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

@jamesabbott: I didn't consider overly long shebang lines when I recommended to replace `/usr` with `$PREFIX` in `abyss-pe`, my bad.
This creates a wrapper for `abyss-pe` and moves the original `abyss-pe` to `abyss-pe.Makefile`. Although it would be nicer to move it to `$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM/abyss-pe.Makefile` or the like, I didn't do that since the makefile has a line
```
path?=$(shell dirname `which $(MAKEFILE_LIST)`)
```
which depends on the directory the makefile is in. If we want to move it out of `$PREFIX/bin`, we'd have to patch that too.

@pvanheus: sorry for the troubles!