### PR TITLE
Update CNVkit to version 0.9.1

### DIFF
--- a/recipes/cnvkit/meta.yaml
+++ b/recipes/cnvkit/meta.yaml
@@ -1,14 +1,12 @@
-{% set version="0.9.1a0" %}
+{% set version="0.9.1" %}
 package:
   name: cnvkit
   version: {{ version }}
 
 source:
-  fn: cnvkit-dc3a6b6.tar.gz
-  url: https://github.com/etal/cnvkit/archive/dc3a6b6.tar.gz
-  #fn: cnvkit-{{ version }}.tar.gz
-  #url: https://pypi.io/packages/source/c/cnvkit/CNVkit-{{ version }}.tar.gz
-  md5: c5bccc7f09426a5dcd2cfb3113d3690c
+  fn: cnvkit-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/c/cnvkit/CNVkit-{{ version }}.tar.gz
+  md5: c216738f950093f86d2cd4176c1478b8
 
 build:
   number: 0
@@ -21,6 +19,7 @@ requirements:
   run:
     - python
     - atlas # [not osx]
+    - bioconductor-dnacopy
     - numpy >=1.9
     - scipy >=0.15.0
     - pandas >=0.18.1
@@ -28,7 +27,6 @@ requirements:
     - biopython >=1.62
     - reportlab >=3.0
     - pysam >=0.10.0
-    - r-pscbs
     - r-cghflasso
     - pyfaidx >=0.4.7
     - future >=0.15.2

--- a/recipes/cnvkit/meta.yaml
+++ b/recipes/cnvkit/meta.yaml
@@ -10,6 +10,7 @@ source:
 
 build:
   number: 0
+  noarch: python
 
 requirements:
   build:


### PR DESCRIPTION
The switch from r-pscbs to bioconductor-dnacopy should reduce the number of R dependencies and shorten the installation time.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
