### PR TITLE
Bumped up the default memory for fgbio's JVM to 4g.

### DIFF
--- a/recipes/fgbio/fgbio.py
+++ b/recipes/fgbio/fgbio.py
@@ -16,7 +16,7 @@ from os import access, getenv, path, X_OK
 JAR_NAME = 'fgbio.jar'
 
 # Default options passed to the `java` executable.
-DEFAULT_JVM_MEM_OPTS = ['-Xms512m', '-Xmx1g']
+DEFAULT_JVM_MEM_OPTS = ['-Xms512m', '-Xmx4g']
 
 
 def real_dirname(in_path):

--- a/recipes/fgbio/meta.yaml
+++ b/recipes/fgbio/meta.yaml
@@ -7,7 +7,7 @@ package:
     name: fgbio
     version: {{ version }}
 build:
-  number: 0
+  number: 1
   skip: false
 source:
   fn: fgbio-{{ version }}.jar


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

I'm bumping up the memory allocated in the default invocation of fgbio via the wrapper script to 4GB from 1GB.  Most of the programs are fairly memory intensive and will struggle in 1GB.  4GB should be enough for most to succeed.