### PR TITLE
bugfix in conda jannovar command (jannovar.sh)

### DIFF
--- a/recipes/jannovar-cli/jannovar.sh
+++ b/recipes/jannovar-cli/jannovar.sh
@@ -53,7 +53,7 @@ if [ "$jvm_mem_opts" == "" ]; then
 fi
 
 pass_arr=($pass_args)
-if [[ ${pass_arr[0]:=} == org* ]]
+if [[ ${pass_arr[0]:=} == de* ]]
 then
     eval "$java" $jvm_mem_opts $jvm_prop_opts -cp "$JAR_DIR/jannovar-cli-$PKG_VERSION.jar" $pass_args
 else

--- a/recipes/jannovar-cli/meta.yaml
+++ b/recipes/jannovar-cli/meta.yaml
@@ -11,7 +11,7 @@ source:
   md5: "{{ md5sum }}"
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   run:


### PR DESCRIPTION
…fied in jannovar sources must start withe de (de.charite.compbio....) not with org

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).


bugfix in conda jannovar command (`jannovar.sh`). If main file is specified in jannovar sources must start withe `de` (`de.charite.compbio...`) not with `org`
