### PR TITLE
Ensure 2 perl wrapper scripts do not mask failures

### DIFF
--- a/recipes/pfam_scan/build.sh
+++ b/recipes/pfam_scan/build.sh
@@ -9,8 +9,7 @@ cp -r * $outdir
 # Short wrapper script which sets PERL5LIB while running
 cat > $PREFIX/bin/pfam_scan.pl <<EOF
 #!/bin/bash
-export PERL5LIB=$outdir:$outdir/
-$outdir/pfam_scan.pl \$@
-unset PERL5LIB
+# Last line of script to ensure any failure return code is passed on:
+PERL5LIB=$outdir:$PERL5LIB $outdir/pfam_scan.pl \$@
 EOF
 chmod +x $PREFIX/bin/pfam_scan.pl

--- a/recipes/pfam_scan/build.sh
+++ b/recipes/pfam_scan/build.sh
@@ -10,6 +10,6 @@ cp -r * $outdir
 cat > $PREFIX/bin/pfam_scan.pl <<EOF
 #!/bin/bash
 # Last line of script to ensure any failure return code is passed on:
-PERL5LIB=$outdir:$PERL5LIB $outdir/pfam_scan.pl \$@
+PERL5LIB=$outdir:$outdir/treg_comparator exec $outdir/pfam_scan.pl "\$@"
 EOF
 chmod +x $PREFIX/bin/pfam_scan.pl

--- a/recipes/pfam_scan/build.sh
+++ b/recipes/pfam_scan/build.sh
@@ -9,7 +9,6 @@ cp -r * $outdir
 # Short wrapper script which sets PERL5LIB while running
 cat > $PREFIX/bin/pfam_scan.pl <<EOF
 #!/bin/bash
-# Last line of script to ensure any failure return code is passed on:
-PERL5LIB=$outdir:$outdir/treg_comparator exec $outdir/pfam_scan.pl "\$@"
+PERL5LIB=$outdir exec $outdir/pfam_scan.pl "\$@"
 EOF
 chmod +x $PREFIX/bin/pfam_scan.pl

--- a/recipes/pfam_scan/meta.yaml
+++ b/recipes/pfam_scan/meta.yaml
@@ -7,7 +7,7 @@ source:
   sha256: 365c96bc150d5057349c3016d62667c58cb33afcfb6329457ae16ab5aae4f401
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipes/pfam_scan/meta.yaml
+++ b/recipes/pfam_scan/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - perl-moose
     # Authors tested on 1.4, believe works on 1.6
     - perl-bioperl >=1.4
+    - perl-ipc-run
 
 test:
   commands:

--- a/recipes/trawler/build.sh
+++ b/recipes/trawler/build.sh
@@ -9,8 +9,7 @@ cp -r * $outdir
 # Short wrapper script
 cat > $PREFIX/bin/trawler <<EOF
 #!/bin/bash
-export PERL5LIB=$outdir:$outdir/treg_comparator
-$outdir/bin/trawler.pl \$@
-unset PERL5LIB
+# Last line of script to ensure any failure return code is passed on:
+PERL5LIB=$outdir:$outdir/treg_comparator $outdir/bin/trawler.pl \$@
 EOF
 chmod +x $PREFIX/bin/trawler

--- a/recipes/trawler/build.sh
+++ b/recipes/trawler/build.sh
@@ -16,7 +16,6 @@ cp -r * $outdir
 # Short wrapper script
 cat > $PREFIX/bin/trawler <<EOF
 #!/bin/bash
-# Last line of script to ensure any failure return code is passed on:
 PERL5LIB=$outdir:$outdir/treg_comparator exec $outdir/bin/trawler.pl "\$@"
 EOF
 chmod +x $PREFIX/bin/trawler

--- a/recipes/trawler/build.sh
+++ b/recipes/trawler/build.sh
@@ -2,6 +2,13 @@
 
 outdir=$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM
 
+# See https://github.com/Ramialison-Lab-ARMI/Trawler-2.0/issues/1
+# Fix space in some hash-bang lines,
+sed -i.bak 's|#! usr/bin/perl|#!/usr/bin/env perl|' bin/*.pl
+# Fix hash-bang lines not to use system Perl,
+sed -i.bak 's|#!/usr/bin/perl|#!/usr/bin/env perl|' bin/*.pl
+rm -rf bin/*.bak
+
 rm -rf test_data examples
 mkdir -p $outdir
 cp -r * $outdir

--- a/recipes/trawler/build.sh
+++ b/recipes/trawler/build.sh
@@ -17,6 +17,6 @@ cp -r * $outdir
 cat > $PREFIX/bin/trawler <<EOF
 #!/bin/bash
 # Last line of script to ensure any failure return code is passed on:
-PERL5LIB=$outdir:$outdir/treg_comparator $outdir/bin/trawler.pl \$@
+PERL5LIB=$outdir:$outdir/treg_comparator exec $outdir/bin/trawler.pl "\$@"
 EOF
 chmod +x $PREFIX/bin/trawler

--- a/recipes/trawler/meta.yaml
+++ b/recipes/trawler/meta.yaml
@@ -29,7 +29,7 @@ test:
   requires:
     - perl
   commands:
-    - trawler 
+    - trawler -version | grep trawler
 
 about:
   home: https://trawler.erc.monash.edu.au/help.html

--- a/recipes/trawler/meta.yaml
+++ b/recipes/trawler/meta.yaml
@@ -8,7 +8,7 @@ source:
   sha1: c02ce9aaf6bf743b2dcf056bf697a79d10b37be7 
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipes/trawler/meta.yaml
+++ b/recipes/trawler/meta.yaml
@@ -5,7 +5,7 @@ package:
 source:
   url: https://api.github.com/repos/Ramialison-Lab-ARMI/Trawler-2.0/tarball/5f391e0
   fn: trawler-2.0.tar.gz
-  sha1: c02ce9aaf6bf743b2dcf056bf697a79d10b37be7 
+  sha256: c04157db18dc165df52d754ca875a198cbc63d0256b1870c5508a42dfe9c3594
 
 build:
   number: 1


### PR DESCRIPTION
* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [X] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

e.g. Using -pfamB with pfam_scan.pl should return error code 1, but as written the wrapper script returned 0.

I've opted to use the simple one-line approach to setting the variable, which ensures the call is the last line of the script - and thus its return value gets passed back.