### PR TITLE
Abyss osx other versions

### DIFF
--- a/recipes/abyss/1.5.2/build.sh
+++ b/recipes/abyss/1.5.2/build.sh
@@ -1,15 +1,24 @@
 #!/bin/bash
 
-if [[ $(uname) == "Darwin" ]]; then
-	echo "Configuring for OSX..."
-  	export CPPFLAGS="${CPPFLAGS} -I$PREFIX/include -I$PREFIX/include/boost --stdlib=libstdc++"
-  	export CXXFLAGS="${CXXFLAGS} --stdlib=libstdc++"
-else
-	echo "Configuring for Linux..."
-  	export CPPFLAGS="-I$PREFIX/include" 
+if [[ "$(uname)" == Darwin ]]; then
+    # Fix for install_name_tool error:
+    #   error: install_name_tool: changing install names or rpaths can't be
+    #   redone for: $PREFIX/bin/abyss-overlap (for architecture x86_64) because
+    #   larger updated load commands do not fit (the program must be relinked,
+    #   and you may need to use -headerpad or -headerpad_max_install_names)
+    export LDFLAGS="$LDFLAGS -headerpad_max_install_names"
 fi
 
-./configure --prefix=$PREFIX --with-boost=$PREFIX/include --with-mpi=$PREFIX/include --enable-maxk=96
+SPARSE_HASH_INCLUDE="-I$PREFIX/include"
+CPPFLAGS="$CPPFLAGS $SPARSE_HASH_INCLUDE"
+
+BOOST_INCLUDE="$PREFIX/include"
+./configure \
+    --prefix="$PREFIX" \
+    --with-boost="$BOOST_INCLUDE" \
+    --with-mpi="$PREFIX" \
+    --with-sparsehash="$PREFIX" \
+    --enable-maxk=96
 make AM_CXXFLAGS=-Wall
 make install
 

--- a/recipes/abyss/1.5.2/build.sh
+++ b/recipes/abyss/1.5.2/build.sh
@@ -17,8 +17,7 @@ BOOST_INCLUDE="$PREFIX/include"
     --prefix="$PREFIX" \
     --with-boost="$BOOST_INCLUDE" \
     --with-mpi="$PREFIX" \
-    --with-sparsehash="$PREFIX" \
-    --enable-maxk=96
+    --with-sparsehash="$PREFIX"
 make AM_CXXFLAGS=-Wall
 make install
 

--- a/recipes/abyss/1.5.2/meta.yaml
+++ b/recipes/abyss/1.5.2/meta.yaml
@@ -1,17 +1,19 @@
----
+{% set version = "1.5.2" %}
+
 package:
   name: abyss
-  version: "1.5.2"
+  version: {{ version }}
 
 build:
-  skip: True # [osx]
-  number: 3
+  number: 4
   string: boost1.61_{{PKG_BUILDNUM}}
 
 source:
-  fn: abyss-1.5.2.tar.gz
-  url: https://github.com/bcgsc/abyss/releases/download/1.5.2/abyss-1.5.2.tar.gz
+  fn: abyss-{{ version }}.tar.gz
+  url: https://github.com/bcgsc/abyss/releases/download/{{ version }}/abyss-{{ version }}.tar.gz
   md5: 10d6d72d1a915e618d41a5cbbcf2364c
+  patches:
+    - osx-std_string_length-no-export.patch  # can be removed for "abyss >2.0.2"
 
 requirements:
   build:

--- a/recipes/abyss/1.5.2/meta.yaml
+++ b/recipes/abyss/1.5.2/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - gcc # [not osx]
     - llvm # [osx]
     - boost 1.61.0
-    - google-sparsehash
+    - sparsehash
     - sqlite
     - openmpi
 

--- a/recipes/abyss/1.5.2/osx-std_string_length-no-export.patch
+++ b/recipes/abyss/1.5.2/osx-std_string_length-no-export.patch
@@ -1,0 +1,25 @@
+--- MergePaths/PathConsensus.cpp.orig	2017-11-22 21:12:27.777282838 +0100
++++ MergePaths/PathConsensus.cpp	2017-11-22 21:13:44.742889962 +0100
+@@ -507,6 +507,13 @@
+ 	return path;
+ }
+ 
++template <typename Seq>
++struct GetLength {
++    size_t operator()(const Seq& sequence) {
++        return sequence.length();
++    }
++};
++
+ /* Resolve ambiguous region using multiple alignment of all paths in
+  * `solutions'.
+  */
+@@ -589,7 +596,7 @@
+ 
+ 	vector<unsigned> lengths(amb_seqs.size());
+ 	transform(amb_seqs.begin(), amb_seqs.end(), lengths.begin(),
+-			mem_fun_ref(&string::length));
++			GetLength<Sequence>());
+ 	unsigned minLength = *min_element(lengths.begin(), lengths.end());
+ 	unsigned maxLength = *max_element(lengths.begin(), lengths.end());
+ 	float lengthRatio = (float)minLength / maxLength;

--- a/recipes/abyss/1.9.0/build.sh
+++ b/recipes/abyss/1.9.0/build.sh
@@ -13,8 +13,7 @@ fi
     --prefix="$PREFIX" \
     --with-boost="$PREFIX" \
     --with-mpi="$PREFIX" \
-    --with-sparsehash="$PREFIX" \
-    --enable-maxk=96
+    --with-sparsehash="$PREFIX"
 make AM_CXXFLAGS=-Wall
 make install
 

--- a/recipes/abyss/1.9.0/build.sh
+++ b/recipes/abyss/1.9.0/build.sh
@@ -1,15 +1,20 @@
 #!/bin/bash
 
-if [[ $(uname) == "Darwin" ]]; then
-	echo "Configuring for OSX..."
-	export CPPFLAGS="${CPPFLAGS} -I$PREFIX/include -I$PREFIX/include/boost --stdlib=libstdc++"
-	export CXXFLAGS="${CXXFLAGS} --stdlib=libstdc++"
-	else
-	echo "Configuring for Linux..."
-	export CPPFLAGS="-I$PREFIX/include"
+if [[ "$(uname)" == Darwin ]]; then
+    # Fix for install_name_tool error:
+    #   error: install_name_tool: changing install names or rpaths can't be
+    #   redone for: $PREFIX/bin/abyss-overlap (for architecture x86_64) because
+    #   larger updated load commands do not fit (the program must be relinked,
+    #   and you may need to use -headerpad or -headerpad_max_install_names)
+    export LDFLAGS="$LDFLAGS -headerpad_max_install_names"
 fi
 
-./configure --prefix=$PREFIX --with-boost=$PREFIX/include --with-mpi=$PREFIX/include --enable-maxk=96
+./configure \
+    --prefix="$PREFIX" \
+    --with-boost="$PREFIX" \
+    --with-mpi="$PREFIX" \
+    --with-sparsehash="$PREFIX" \
+    --enable-maxk=96
 make AM_CXXFLAGS=-Wall
 make install
 

--- a/recipes/abyss/1.9.0/meta.yaml
+++ b/recipes/abyss/1.9.0/meta.yaml
@@ -21,7 +21,7 @@ requirements:
   - gcc # [not osx]
   - llvm # [osx]
   - boost 1.61.0
-  - google-sparsehash
+  - sparsehash
   - sqlite
   - openmpi
 

--- a/recipes/abyss/1.9.0/meta.yaml
+++ b/recipes/abyss/1.9.0/meta.yaml
@@ -1,16 +1,20 @@
+{% set name = "abyss" %}
+{% set version = "1.9.0" %}
+
 package:
   name: abyss
-  version: "1.9.0"
+  version: {{ version }}
 
 build:
-  skip: True # [osx]
-  number: 5
+  number: 6
   string: boost1.61_{{PKG_BUILDNUM}}
 
 source:
-  fn: abyss-1.9.0.tar.gz
-  url: https://github.com/bcgsc/abyss/releases/download/1.9.0/abyss-1.9.0.tar.gz
+  fn: abyss-{{ version }}.tar.gz
+  url: https://github.com/bcgsc/abyss/releases/download/{{ version }}/abyss-{{ version }}.tar.gz
   md5: 7b1b9f060dbae6c7fe815b1e50487c83
+  patches:
+    - osx-std_string_length-no-export.patch  # can be removed for "abyss >2.0.2"
 
 requirements:
   build:

--- a/recipes/abyss/1.9.0/osx-std_string_length-no-export.patch
+++ b/recipes/abyss/1.9.0/osx-std_string_length-no-export.patch
@@ -1,9 +1,10 @@
 --- MergePaths/PathConsensus.cpp.orig	2017-11-22 21:14:18.752421900 +0100
-+++ MergePaths/PathConsensus.cpp	2017-11-22 21:15:03.061812202 +0100
-@@ -533,6 +533,12 @@
++++ MergePaths/PathConsensus.cpp	2017-11-22 22:06:07.003253446 +0100
+@@ -533,6 +533,13 @@
  	return path;
  }
  
++template <typename Seq>
 +struct GetLength {
 +    size_t operator()(const Seq& sequence) {
 +        return sequence.length();
@@ -13,7 +14,7 @@
  /* Resolve ambiguous region using multiple alignment of all paths in
   * `solutions'.
   */
-@@ -615,7 +621,7 @@
+@@ -615,7 +622,7 @@
  
  	vector<unsigned> lengths(amb_seqs.size());
  	transform(amb_seqs.begin(), amb_seqs.end(), lengths.begin(),

--- a/recipes/abyss/1.9.0/osx-std_string_length-no-export.patch
+++ b/recipes/abyss/1.9.0/osx-std_string_length-no-export.patch
@@ -1,0 +1,24 @@
+--- MergePaths/PathConsensus.cpp.orig	2017-11-22 21:14:18.752421900 +0100
++++ MergePaths/PathConsensus.cpp	2017-11-22 21:15:03.061812202 +0100
+@@ -533,6 +533,12 @@
+ 	return path;
+ }
+ 
++struct GetLength {
++    size_t operator()(const Seq& sequence) {
++        return sequence.length();
++    }
++};
++
+ /* Resolve ambiguous region using multiple alignment of all paths in
+  * `solutions'.
+  */
+@@ -615,7 +621,7 @@
+ 
+ 	vector<unsigned> lengths(amb_seqs.size());
+ 	transform(amb_seqs.begin(), amb_seqs.end(), lengths.begin(),
+-			mem_fun_ref(&string::length));
++			GetLength<Sequence>());
+ 	unsigned minLength = *min_element(lengths.begin(), lengths.end());
+ 	unsigned maxLength = *max_element(lengths.begin(), lengths.end());
+ 	float lengthRatio = (float)minLength / maxLength;


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ x AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

This updates `abyss 1.5.2` and `abyss 1.9.0` to enable builds on OSX (like it's done for the current version in https://github.com/bioconda/bioconda-recipes/pull/6867).
It also removes the explicit `--enable-maxk=96` parameter. This is no change for `1.9.0` (default already 96) but for `1.5.2` this now uses the default 64.