### PR TITLE
canopy: target march=x86-64 instead of march=native

### DIFF
--- a/recipes/mgs-canopy/build.sh
+++ b/recipes/mgs-canopy/build.sh
@@ -4,7 +4,7 @@ cd src/
 echo "> Compiling sources"
 for F in $(find . -name "*.cpp") ; do
 	FF=${F%.*}
-	g++ -o $FF.o -fopenmp -c -Wall -Wextra -O3 -march=native -I./ -I${PREFIX}/include -L${PREFIX}/lib $FF.cpp
+	g++ -o $FF.o -fopenmp -c -Wall -Wextra -O3 -march=x86-64 -I./ -I${PREFIX}/include -L${PREFIX}/lib $FF.cpp
 done;
 
 echo "> Building target: cc.bin"

--- a/recipes/mgs-canopy/meta.yaml
+++ b/recipes/mgs-canopy/meta.yaml
@@ -28,8 +28,8 @@ requirements:
 
 test:
   commands:
-    - command -v cc.bin
-    - command -v canopy
+    - cc.bin --help | grep "Allowed options"
+    - canopy --help | grep "Allowed options"
 
 about:
   home: "https://github.com/fplaza/mgs-canopy-algorithm"

--- a/recipes/mgs-canopy/meta.yaml
+++ b/recipes/mgs-canopy/meta.yaml
@@ -13,7 +13,7 @@ source:
   md5: {{ md5 }}
 
 build:
-  number: 0
+  number: 1
   skip: True  # [osx]
 
 requirements:


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Likely resolves: https://github.com/bioconda/bioconda-recipes/pull/2499#issuecomment-347174900