### PR TITLE
travis: easy_install pip (trying xcode8.3 image)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ sudo: required
 services:
   - docker
 
+osx_image: xcode8.3
+
 before_install:
     - set -e
     - |

--- a/scripts/travis-setup.sh
+++ b/scripts/travis-setup.sh
@@ -22,7 +22,7 @@ done
 
 SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
-easy_install --user pip
+which python python2 python3 pip pip2 pip3
 pip install pyyaml
 sudo mkdir /anaconda
 sudo chown -R $USER /anaconda

--- a/scripts/travis-setup.sh
+++ b/scripts/travis-setup.sh
@@ -22,6 +22,7 @@ done
 
 SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
+easy_install --user pip
 pip install pyyaml
 sudo mkdir /anaconda
 sudo chown -R $USER /anaconda

--- a/scripts/travis-setup.sh
+++ b/scripts/travis-setup.sh
@@ -22,7 +22,7 @@ done
 
 SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
-which python python2 python3 pip pip2 pip3
+compgen -c | grep '^\(py\|pip\|easy_\)' | sort
 pip install pyyaml
 sudo mkdir /anaconda
 sudo chown -R $USER /anaconda


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

@bioconda/osx: should we try to use [Travis' new default image](https://blog.travis-ci.com/2017-11-21-xcode8-3-default-image-announce) or should we just add `osx_image: xcode7.3` to `.travis.yml` for now?