### PR TITLE
Add Bioconductor data package SNPlocs.Hsapiens.dbSNP144.GRCh38.

### DIFF
--- a/recipes/bioconductor-snplocs.hsapiens.dbsnp144.grch38/meta.yaml
+++ b/recipes/bioconductor-snplocs.hsapiens.dbsnp144.grch38/meta.yaml
@@ -1,0 +1,43 @@
+{% set version = "0.99.20" %}
+{% set name = "SNPlocs.Hsapiens.dbSNP144.GRCh38" %}
+{% set bioc = "3.6" %}
+
+package:
+  name: 'bioconductor-{{ name|lower }}'
+  version: '{{ version }}'
+source:
+  fn: '{{ name }}_{{ version }}.tar.gz'
+  url:
+    - 'http://bioconductor.org/packages/{{ bioc }}/data/annotation/src/contrib/{{ name }}_{{ version }}.tar.gz'
+    - 'https://depot.galaxyproject.org/software/{{ name }}/{{ name }}_{{ version }}_src_all.tar.gz'
+  sha256: b6c6ae8d3a866501146e325d40dc1695b26b522c6f9d063218fc6466bbd5b57b
+build:
+  number: 0
+  rpaths:
+    - lib/R/lib/
+    - lib/
+requirements:
+  build:
+    - bioconductor-biocgenerics
+    - 'bioconductor-bsgenome >=1.43.4'
+    - bioconductor-genomeinfodb
+    - bioconductor-genomicranges
+    - bioconductor-iranges
+    - bioconductor-s4vectors
+    - r-base
+  run:
+    - bioconductor-biocgenerics
+    - 'bioconductor-bsgenome >=1.43.4'
+    - bioconductor-genomeinfodb
+    - bioconductor-genomicranges
+    - bioconductor-iranges
+    - bioconductor-s4vectors
+    - r-base
+    - wget
+test:
+  commands:
+    - '$R -e "library(''{{ name }}'')"'
+about:
+  home: 'http://bioconductor.org/packages/{{ bioc }}/data/annotation/html/{{ name }}.html'
+  license: Artistic-2.0
+  summary: 'SNP locations and alleles for Homo sapiens extracted from NCBI dbSNP Build 144. The source data files used for this package were created by NCBI on May 30, 2015, and contain SNPs mapped to reference genome GRCh38.p2 (a patched version of GRCh38 that doesn''t alter chromosomes 1-22, X, Y, MT). Note that these SNPs can be "injected" in BSgenome.Hsapiens.NCBI.GRCh38 or in BSgenome.Hsapiens.UCSC.hg38.'

--- a/recipes/bioconductor-snplocs.hsapiens.dbsnp144.grch38/post-link.sh
+++ b/recipes/bioconductor-snplocs.hsapiens.dbsnp144.grch38/post-link.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+FN="SNPlocs.Hsapiens.dbSNP144.GRCh38_0.99.20.tar.gz"
+URLS=(
+  "http://bioconductor.org/packages/3.6/data/annotation/src/contrib/SNPlocs.Hsapiens.dbSNP144.GRCh38_0.99.20.tar.gz"
+  "https://depot.galaxyproject.org/software/SNPlocs.Hsapiens.dbSNP144.GRCh38/SNPlocs.Hsapiens.dbSNP144.GRCh38_0.99.20_src_all.tar.gz"
+)
+    MD5="128c95e327adf72ae137fb5ae58270fc"
+
+# Use a staging area in the conda dir rather than temp dirs, both to avoid
+# permission issues as well as to have things downloaded in a predictable
+# manner.
+STAGING=$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM
+mkdir -p $STAGING
+TARBALL=$STAGING/$FN
+
+SUCCESS=0
+for URL in ${URLS[@]}; do
+  wget -O- -q $URL > $TARBALL
+  [[ $? == 0 ]] || continue
+
+  # Platform-specific md5sum checks.
+  if [[ $(uname -s) == "Linux" ]]; then
+    if [[ $(md5sum -c <<<"$MD5  $TARBALL") ]]; then
+      SUCCESS=1
+      break
+    fi
+  else if [[ $(uname -s) == "Darwin" ]]; then
+    if [[ $(md5 $TARBALL | cut -f4 -d " ") == "$MD5" ]]; then
+      SUCCESS=1
+      break
+    fi
+  fi
+fi
+done
+
+if [[ $SUCCESS != 1 ]]; then
+  echo "ERROR: post-link.sh was unable to download any of the following URLs with the md5sum $MD5:"
+  printf '%s\n' "${URLS[@]}"
+  exit 1
+fi
+
+# Install and clean up
+R CMD INSTALL --build $TARBALL
+rm $TARBALL


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [x] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

https://bioconductor.org/packages/3.2/data/annotation/html/SNPlocs.Hsapiens.dbSNP144.GRCh38.html

Notes:
* I created the recipe using bioconductor-skeleton
* I tested it locally on a linux-64 machine, but if failed. This is my first recipe for a Bioconductor data package, so I'm not sure how to debug this. Output below:

```
$ ./simulate-travis.py --disable-docker --packages bioconductor-snplocs.hsapiens.dbsnp144.grch38
# Skipping lots of output...
INFO:fetch.update:898581361
INFO:fetch.stop:None
INFO:conda_build.build:Packaging bioconductor-snplocs.hsapiens.dbsnp144.grch38-0.99.20-r3.4.1_0
BUILD START: bioconductor-snplocs.hsapiens.dbsnp144.grch38-0.99.20-r3.4.1_0
    (actual version deferred until further download or env creation)

The following NEW packages will be INSTALLED:

    bioconductor-biobase:              2.38.0-r3.4.1_0   bioconda   
    bioconductor-biocgenerics:         0.24.0-r3.4.1_0   bioconda   
    bioconductor-biocparallel:         1.12.0-r3.4.1_0   bioconda   
    bioconductor-biostrings:           2.46.0-r3.4.1_0   bioconda   
    bioconductor-bsgenome:             1.46.0-r3.4.1_0   bioconda   
    bioconductor-delayedarray:         0.4.1-r3.4.1_0    bioconda   
    bioconductor-genomeinfodb:         1.14.0-r3.4.1_0   bioconda   
    bioconductor-genomeinfodbdata:     0.99.1-r3.4.1_0   bioconda   
    bioconductor-genomicalignments:    1.14.0-r3.4.1_0   bioconda   
    bioconductor-genomicranges:        1.30.0-r3.4.1_0   bioconda   
    bioconductor-iranges:              2.12.0-r3.4.1_0   bioconda   
    bioconductor-rsamtools:            1.30.0-r3.4.1_0   bioconda   
    bioconductor-rtracklayer:          1.38.0-r3.4.1_0   bioconda   
    bioconductor-s4vectors:            0.16.0-r3.4.1_0   bioconda   
    bioconductor-summarizedexperiment: 1.8.0-r3.4.1_0    bioconda   
    bioconductor-xvector:              0.18.0-r3.4.1_0   bioconda   
    bioconductor-zlibbioc:             1.24.0-r3.4.1_0   bioconda   
    bzip2:                             1.0.6-1           conda-forge
    ca-certificates:                   2017.11.5-0       conda-forge
    cairo:                             1.14.6-5          conda-forge
    curl:                              7.55.1-0          conda-forge
    fontconfig:                        2.12.1-6          conda-forge
    freetype:                          2.7-2             conda-forge
    gettext:                           0.19.7-1          conda-forge
    glib:                              2.51.4-0          conda-forge
    graphite2:                         1.3.10-0          conda-forge
    gsl:                               2.1-2             conda-forge
    harfbuzz:                          1.4.3-0           conda-forge
    icu:                               58.2-0            conda-forge
    jpeg:                              9b-2              conda-forge
    krb5:                              1.14.2-0          conda-forge
    libffi:                            3.2.1-3           conda-forge
    libgcc:                            5.2.0-0                      
    libiconv:                          1.15-0            conda-forge
    libpng:                            1.6.28-2          conda-forge
    libssh2:                           1.8.0-2           conda-forge
    libtiff:                           4.0.7-1           conda-forge
    libxml2:                           2.9.5-2           conda-forge
    ncurses:                           5.9-10            conda-forge
    openssl:                           1.0.2m-0          conda-forge
    pango:                             1.40.4-0          conda-forge
    pcre:                              8.39-0            conda-forge
    pixman:                            0.34.0-1          conda-forge
    r-base:                            3.4.1-2           conda-forge
    r-bh:                              1.65.0_1-r3.4.1_0 conda-forge
    r-bitops:                          1.0_6-r3.4.1_0    conda-forge
    r-futile.logger:                   1.4.3-r3.4.1_0    conda-forge
    r-futile.options:                  1.0.0-r3.4.1_0    conda-forge
    r-lambda.r:                        1.1.9-r3.4.1_0    conda-forge
    r-lattice:                         0.20_34-r3.4.1_0  conda-forge
    r-matrix:                          1.2_7.1-r3.4.1_0  conda-forge
    r-matrixstats:                     0.52.2-r3.4.1_0   conda-forge
    r-rcurl:                           1.95_4.8-r3.4.1_0 conda-forge
    r-snow:                            0.4_2-r3.4.1_0    conda-forge
    r-xml:                             3.98_1.6-r3.4.1_0 conda-forge
    readline:                          6.2-0             conda-forge
    tk:                                8.5.19-2          conda-forge
    wget:                              1.18-0                       
    xz:                                5.2.3-0           conda-forge
    zlib:                              1.2.11-0          conda-forge

Source cache directory is: /home/jdb-work/miniconda-bioconda/conda-bld/src_cache
Downloading source to cache: SNPlocs.Hsapiens.dbSNP144.GRCh38_0.99.20.tar.gz
Downloading http://bioconductor.org/packages/3.6/data/annotation/src/contrib/SNPlocs.Hsapiens.dbSNP144.GRCh38_0.99.20.tar.gz
Success
Extracting download
BUILD START (revised): bioconductor-snplocs.hsapiens.dbsnp144.grch38-0.99.20-r3.4.1_0
Package: bioconductor-snplocs.hsapiens.dbsnp144.grch38-0.99.20-r3.4.1_0
source tree in: /home/jdb-work/miniconda-bioconda/conda-bld/bioconductor-snplocs.hsapiens.dbsnp144.grch38_1511994522469/work/SNPlocs.Hsapiens.dbSNP144.GRCh38
number of files: 1
Fixing permissions
Fixing permissions
/home/jdb-work/miniconda-bioconda/conda-bld/linux-64/bioconductor-snplocs.hsapiens.dbsnp144.grch38-0.99.20-r3.4.1_0.tar.bz2
updating index in: /home/jdb-work/miniconda-bioconda/conda-bld
updating index in: /home/jdb-work/miniconda-bioconda/conda-bld/noarch
updating index in: /home/jdb-work/miniconda-bioconda/conda-bld/linux-64
updating: bioconductor-snplocs.hsapiens.dbsnp144.grch38-0.99.20-r3.4.1_0.tar.bz2
updating index in: /home/jdb-work/miniconda-bioconda/conda-bld
TEST START: /home/jdb-work/miniconda-bioconda/conda-bld/linux-64/bioconductor-snplocs.hsapiens.dbsnp144.grch38-0.99.20-r3.4.1_0.tar.bz2
Deleting work directory, /home/jdb-work/miniconda-bioconda/conda-bld/bioconductor-snplocs.hsapiens.dbsnp144.grch38_1511994522469/work/SNPlocs.Hsapiens.dbSNP144.GRCh38

The following NEW packages will be INSTALLED:

    bioconductor-biobase:                          2.38.0-r3.4.1_0   bioconda   
    bioconductor-biocgenerics:                     0.24.0-r3.4.1_0   bioconda   
    bioconductor-biocparallel:                     1.12.0-r3.4.1_0   bioconda   
    bioconductor-biostrings:                       2.46.0-r3.4.1_0   bioconda   
    bioconductor-bsgenome:                         1.46.0-r3.4.1_0   bioconda   
    bioconductor-delayedarray:                     0.4.1-r3.4.1_0    bioconda   
    bioconductor-genomeinfodb:                     1.14.0-r3.4.1_0   bioconda   
    bioconductor-genomeinfodbdata:                 0.99.1-r3.4.1_0   bioconda   
    bioconductor-genomicalignments:                1.14.0-r3.4.1_0   bioconda   
    bioconductor-genomicranges:                    1.30.0-r3.4.1_0   bioconda   
    bioconductor-iranges:                          2.12.0-r3.4.1_0   bioconda   
    bioconductor-rsamtools:                        1.30.0-r3.4.1_0   bioconda   
    bioconductor-rtracklayer:                      1.38.0-r3.4.1_0   bioconda   
    bioconductor-s4vectors:                        0.16.0-r3.4.1_0   bioconda   
    bioconductor-snplocs.hsapiens.dbsnp144.grch38: 0.99.20-r3.4.1_0  local      
    bioconductor-summarizedexperiment:             1.8.0-r3.4.1_0    bioconda   
    bioconductor-xvector:                          0.18.0-r3.4.1_0   bioconda   
    bioconductor-zlibbioc:                         1.24.0-r3.4.1_0   bioconda   
    bzip2:                                         1.0.6-1           conda-forge
    ca-certificates:                               2017.11.5-0       conda-forge
    cairo:                                         1.14.6-5          conda-forge
    curl:                                          7.55.1-0          conda-forge
    fontconfig:                                    2.12.1-6          conda-forge
    freetype:                                      2.7-2             conda-forge
    gettext:                                       0.19.7-1          conda-forge
    glib:                                          2.51.4-0          conda-forge
    graphite2:                                     1.3.10-0          conda-forge
    gsl:                                           2.1-2             conda-forge
    harfbuzz:                                      1.4.3-0           conda-forge
    icu:                                           58.2-0            conda-forge+ source /home/jdb-work/miniconda-bioconda/bin/activate /home/jdb-work/miniconda-bioconda/conda-bld/bioconductor-snplocs.hsapiens.dbsnp144.grch38_1511994522469/_t_env
+ /bin/bash -x -e /home/jdb-work/miniconda-bioconda/conda-bld/bioconductor-snplocs.hsapiens.dbsnp144.grch38_1511994522469/test_tmp/run_test.sh
+ /home/jdb-work/miniconda-bioconda/conda-bld/bioconductor-snplocs.hsapiens.dbsnp144.grch38_1511994522469/_t_env/bin/R -e 'library('\''SNPlocs.Hsapiens.dbSNP144.GRCh38'\'')'

R version 3.4.1 (2017-06-30) -- "Single Candle"
Copyright (C) 2017 The R Foundation for Statistical Computing
Platform: x86_64-pc-linux-gnu (64-bit)

R is free software and comes with ABSOLUTELY NO WARRANTY.
You are welcome to redistribute it under certain conditions.
Type 'license()' or 'licence()' for distribution details.

  Natural language support but running in an English locale

R is a collaborative project with many contributors.
Type 'contributors()' for more information and
'citation()' on how to cite R or R packages in publications.

Type 'demo()' for some demos, 'help()' for on-line help, or
'help.start()' for an HTML browser interface to help.
Type 'q()' to quit R.

> library('SNPlocs.Hsapiens.dbSNP144.GRCh38')
Error in library("SNPlocs.Hsapiens.dbSNP144.GRCh38") : 
  there is no package called ‘SNPlocs.Hsapiens.dbSNP144.GRCh38’
Execution halted

WARNING: conda-build appears to be out of date. You have version 2.1.16 but the
latest version is 3.0.19. Run

conda update -n root conda-build

to get the latest version.


    jpeg:                                          9b-2              conda-forge
    krb5:                                          1.14.2-0          conda-forge
    libffi:                                        3.2.1-3           conda-forge
    libgcc:                                        5.2.0-0                      
    libiconv:                                      1.15-0            conda-forge
    libpng:                                        1.6.28-2          conda-forge
    libssh2:                                       1.8.0-2           conda-forge
    libtiff:                                       4.0.7-1           conda-forge
    libxml2:                                       2.9.5-2           conda-forge
    ncurses:                                       5.9-10            conda-forge
    openssl:                                       1.0.2m-0          conda-forge
    pango:                                         1.40.4-0          conda-forge
    pcre:                                          8.39-0            conda-forge
    pixman:                                        0.34.0-1          conda-forge
    r-base:                                        3.4.1-2           conda-forge
    r-bh:                                          1.65.0_1-r3.4.1_0 conda-forge
    r-bitops:                                      1.0_6-r3.4.1_0    conda-forge
    r-futile.logger:                               1.4.3-r3.4.1_0    conda-forge
    r-futile.options:                              1.0.0-r3.4.1_0    conda-forge
    r-lambda.r:                                    1.1.9-r3.4.1_0    conda-forge
    r-lattice:                                     0.20_34-r3.4.1_0  conda-forge
    r-matrix:                                      1.2_7.1-r3.4.1_0  conda-forge
    r-matrixstats:                                 0.52.2-r3.4.1_0   conda-forge
    r-rcurl:                                       1.95_4.8-r3.4.1_0 conda-forge
    r-snow:                                        0.4_2-r3.4.1_0    conda-forge
    r-xml:                                         3.98_1.6-r3.4.1_0 conda-forge
    readline:                                      6.2-0             conda-forge
    tk:                                            8.5.19-2          conda-forge
    wget:                                          1.18-0                       
    xz:                                            5.2.3-0           conda-forge
    zlib:                                          1.2.11-0          conda-forge

TESTS FAILED: bioconductor-snplocs.hsapiens.dbsnp144.grch38-0.99.20-r3.4.1_0.tar.bz2


16:42:41 BIOCONDA ERROR BUILD FAILED recipes/bioconductor-snplocs.hsapiens.dbsnp144.grch38, CONDA_BOOST=1.64;CONDA_BZIP2=1.0;CONDA_GMP=5.1;CONDA_GSL=1.16;CONDA_HDF5=1.8.17;CONDA_HTSLIB=1.6;CONDA_NCURSES=5.9;CONDA_NPY=112;CONDA_PERL=5.22.0;CONDA_PY=27;CONDA_R=3.4.1;CONDA_XZ=5.2;CONDA_ZLIB=1.2.8;MACOSX_DEPLOYMENT_TARGET=10.9
16:43:22 BIOCONDA ERROR BUILD SUMMARY: of 1 recipes, 1 failed and 0 were skipped. Details of recipes and environments follow.
16:43:22 BIOCONDA ERROR BUILD SUMMARY: FAILED recipe bioconductor-snplocs.hsapiens.dbsnp144.grch38-0.99.20-r3.4.1_0.tar.bz2, environment CONDA_NCURSES=5.9;CONDA_HTSLIB=1.6;CONDA_BZIP2=1.0;CONDA_GMP=5.1;CONDA_R=3.4.1;CONDA_XZ=5.2;CONDA_BOOST=1.64;CONDA_PY=27;CONDA_GSL=1.16;CONDA_ZLIB=1.2.8;MACOSX_DEPLOYMENT_TARGET=10.9;CONDA_PERL=5.22.0;CONDA_NPY=112;CONDA_HDF5=1.8.17

16:42:41 BIOCONDA ERROR BUILD FAILED recipes/bioconductor-snplocs.hsapiens.dbsnp144.grch38, CONDA_BOOST=1.64;CONDA_BZIP2=1.0;CONDA_GMP=5.1;CONDA_GSL=1.16;CONDA_HDF5=1.8.17;CONDA_HTSLIB=1.6;CONDA_NCURSES=5.9;CONDA_NPY=112;CONDA_PERL=5.22.0;CONDA_PY=27;CONDA_R=3.4.1;CONDA_XZ=5.2;CONDA_ZLIB=1.2.8;MACOSX_DEPLOYMENT_TARGET=10.9
16:43:22 BIOCONDA ERROR BUILD SUMMARY: of 1 recipes, 1 failed and 0 were skipped. Details of recipes and environments follow.
16:43:22 BIOCONDA ERROR BUILD SUMMARY: FAILED recipe bioconductor-snplocs.hsapiens.dbsnp144.grch38-0.99.20-r3.4.1_0.tar.bz2, environment CONDA_NCURSES=5.9;CONDA_HTSLIB=1.6;CONDA_BZIP2=1.0;CONDA_GMP=5.1;CONDA_R=3.4.1;CONDA_XZ=5.2;CONDA_BOOST=1.64;CONDA_PY=27;CONDA_GSL=1.16;CONDA_ZLIB=1.2.8;MACOSX_DEPLOYMENT_TARGET=10.9;CONDA_PERL=5.22.0;CONDA_NPY=112;CONDA_HDF5=1.8.17

```