### PR TITLE
Update Build to include executables from lib

### DIFF
--- a/recipes/ragout/build.sh
+++ b/recipes/ragout/build.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
+# creates executables in ./lib/ : ragout-maf2synteny ragout-overlap
 make
 
 cp ragout.py $PREFIX/bin/
 cp -r ragout $PREFIX/bin/
+# copy executables created in ./lib/ to $PREFIX/bin so ragout can find them
+cp -r ./lib/ragout-* $PREFIX/bin/


### PR DESCRIPTION
See comments;  the make step creates executables that need to end up in the PATH so ragout can find them later.

* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [X] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
