### PR TITLE
nanopore_simulation, haploclique: trigger osx builds

### DIFF
--- a/recipes/haploclique/1.3.1/meta.yaml
+++ b/recipes/haploclique/1.3.1/meta.yaml
@@ -2,13 +2,6 @@
 {% set version = "1.3.1" %}
 {% set sha256 = "7418392a72f5420db56a9170aaf0fe4bc055b6221e61cb6012681c51cd314a45" %}
 
-about:
-    summary: Viral quasispecies assembly via maximal clique finding. A method to reconstruct viral haplotypes and detect large insertions and deletions from NGS data.
-    home: https://github.com/cbg-ethz/{{ name }}
-    license: GPLv3+
-    license_family: GPL3
-    license_file: LICENSE.md
-
 package:
     name: {{ name|lower }}
     version: {{ version }}
@@ -42,3 +35,10 @@ requirements:
 test:
   commands:
     - {{ name }} -h
+
+about:
+    home: https://github.com/cbg-ethz/{{ name }}
+    license: GPLv3+
+    license_family: GPL3
+    license_file: LICENSE.md
+    summary: Viral quasispecies assembly via maximal clique finding. A method to reconstruct viral haplotypes and detect large insertions and deletions from NGS data.

--- a/recipes/nanopore_simulation/meta.yaml
+++ b/recipes/nanopore_simulation/meta.yaml
@@ -5,8 +5,8 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/crohrandt/nanopore_simulation/archive/a748cd1ddbaf2856b183ed873c40415ad069d943.tar.gz
   fn: nanopore_simulation_{{ version }}.tar.gz
+  url: https://github.com/crohrandt/nanopore_simulation/archive/a748cd1ddbaf2856b183ed873c40415ad069d943.tar.gz
   sha256: 4e42d56a9e3d5a1209eba264379831f064a9c705920963516859f8b68af81fce
 
 build:


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

While #6950 happened, two commits to `master` (https://github.com/bioconda/bioconda-recipes/commit/b273e3be8e868162f1bcd44173fb2220617c5863, https://github.com/bioconda/bioconda-recipes/commit/0d0b215a5c3099b8d058c02b97959622bd1a1ff5) didn't build for OSX.