### PR TITLE
add perl-indirect

### DIFF
--- a/recipes/perl-indirect/build.sh
+++ b/recipes/perl-indirect/build.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# If it has Build.PL use that, otherwise use Makefile.PL
+if [ -f Build.PL ]; then
+    perl Build.PL
+    perl ./Build
+    perl ./Build test
+    # Make sure this goes in site
+    perl ./Build install --installdirs site
+elif [ -f Makefile.PL ]; then
+    # Make sure this goes in site
+    perl Makefile.PL INSTALLDIRS=site
+    make
+    make test
+    make install
+else
+    echo 'Unable to find Build.PL or Makefile.PL. You need to modify build.sh.'
+    exit 1
+fi
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/recipes/perl-indirect/meta.yaml
+++ b/recipes/perl-indirect/meta.yaml
@@ -1,0 +1,48 @@
+{% set name = "perl-indirect" %}
+{% set version = "0.38" %}
+{% set sha256 = "bef9c253d4cf864987dd6d6466067ef7a165f79f18a7cdeee8a80e902e52658e" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: indirect-0.38.tar.gz
+  url: https://cpan.metacpan.org/authors/id/V/VP/VPIT/indirect-0.38.tar.gz
+  sha256: {{ sha256 }}
+
+# If this is a new build for the same version, increment the build
+# number. If you do not include this key, it defaults to 0.
+build:
+  number: 0
+
+requirements:
+  build:
+    - perl {{CONDA_PERL}}*
+    - perl-extutils-makemaker
+    - perl-carp
+    - perl-lib
+    - perl-xsloader
+    - perl-socket6
+
+  run:
+    - perl {{CONDA_PERL}}*
+    - perl-xsloader
+    - perl-carp
+
+test:
+  # Perl 'use' tests
+  imports:
+    - indirect
+
+  # You can also put a file called run_test.pl (or run_test.py) in the recipe
+  # that will be run at test time.
+
+about:
+  home: http://search.cpan.org/dist/indirect/
+  license: perl_5
+  summary: 'Lexically warn about using the indirect method call syntax.'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/recipes/perl-indirect/meta.yaml
+++ b/recipes/perl-indirect/meta.yaml
@@ -11,8 +11,6 @@ source:
   url: https://cpan.metacpan.org/authors/id/V/VP/VPIT/indirect-0.38.tar.gz
   sha256: {{ sha256 }}
 
-# If this is a new build for the same version, increment the build
-# number. If you do not include this key, it defaults to 0.
 build:
   number: 0
 
@@ -31,18 +29,11 @@ requirements:
     - perl-carp
 
 test:
-  # Perl 'use' tests
   imports:
     - indirect
-
-  # You can also put a file called run_test.pl (or run_test.py) in the recipe
-  # that will be run at test time.
 
 about:
   home: http://search.cpan.org/dist/indirect/
   license: perl_5
   summary: 'Lexically warn about using the indirect method call syntax.'
 
-# See
-# http://docs.continuum.io/conda/build.html for
-# more information about meta.yaml


### PR DESCRIPTION
* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [X] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

@bioconda/perl So should I add this? This is not a bio related perl package, but as far as I can see anything perl currently lives in bioconda. Need this as a dependency of a proper bioinformatics tool.
