### PR TITLE
Pinned prestor's pandoc dependency to 1.19.2 since 2.x removes an opt…

### DIFF
--- a/recipes/r-prestor/meta.yaml
+++ b/recipes/r-prestor/meta.yaml
@@ -47,7 +47,7 @@ requirements:
     - r-bibtex
     - r-captioner
     - r-alakazam
-    - pandoc 1.19.2
+    - pandoc <2.0
     - texlive-core
 
 test:

--- a/recipes/r-prestor/meta.yaml
+++ b/recipes/r-prestor/meta.yaml
@@ -11,7 +11,7 @@ source:
   md5: 085f7c2e289f73ad9dbf779fac187211
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -47,7 +47,7 @@ requirements:
     - r-bibtex
     - r-captioner
     - r-alakazam
-    - pandoc
+    - pandoc 1.19.2
     - texlive-core
 
 test:


### PR DESCRIPTION
…ion that is used.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Just a small update to a recipe to pin the version of pandoc that is used.  Without the pin pandoc resolves to pandoc 2.x which removed an option that prestor uses.