### PR TITLE
Pin trnascan-se version to 1.3.1

### DIFF
--- a/recipes/maker/meta.yaml
+++ b/recipes/maker/meta.yaml
@@ -8,7 +8,7 @@ source:
   md5: 63d79e37d25c60d236658f847b74ea18
 
 build:
-  number: 2
+  number: 3
   skip: True # [osx]
 
 requirements:
@@ -58,7 +58,7 @@ requirements:
     - perl-forks
     - perl-perl-unsafe-signals
     - openmpi
-    - trnascan-se
+    - trnascan-se ==1.3.1
     - postgresql
     # GeneMarkS, GeneMark-ES and FGENESH are optional requirements but are not free
 


### PR DESCRIPTION
* [X ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [X ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Trigger **maker** biocontainers image rebuild to use functional trnascan-se bioconda recipe, and allow trnascan-se to (eventually) be upgraded to version 2.0 (which unfortunately introduces some minor CLI option incompatibilities vs. trnascan-se 1.3.1, one of which affects maker 2.31.9).