### PR TITLE
add GATK jar file

### DIFF
--- a/recipes/gatk/3.6/build.sh
+++ b/recipes/gatk/3.6/build.sh
@@ -6,20 +6,20 @@ PACKAGE_HOME=$PREFIX/opt/$PKG_NAME-$PKG_VERSION
 mkdir -p $PREFIX/bin
 mkdir -p $PACKAGE_HOME
 
-cp $RECIPE_DIR/gatk.py $PACKAGE_HOME/gatk3.py
+cp $RECIPE_DIR/gatk.py $PACKAGE_HOME/gatk.py
 
-SOURCE_FILE=$RECIPE_DIR/gatk-register.sh
-DEST_FILE=$PACKAGE_HOME/gatk3-register.sh
+# jar locations: Handle both nested (GATK3.8) and non-ested (<=GATK 3.7)
+NESTED_GLOB="GenomeAnalysisTK-*/GenomeAnalysisTK.jar"
+if compgen -G "$NESTED_GLOB"; then
+  JARS=( "$NESTED_GLOB" )
+  JAR=( "${JARS[0]}" )
+else
+  JAR=./GenomeAnalysisTK.jar
+fi
 
+mv $JAR $PACKAGE_HOME/
 
-echo "#!/bin/bash" > $DEST_FILE
-echo "PKG_NAME=$PKG_NAME" >> $DEST_FILE
-echo "PKG_VERSION=$PKG_VERSION" >> $DEST_FILE
+chmod +x $PACKAGE_HOME/*.{py,jar}
 
-cat $SOURCE_FILE >> $DEST_FILE
-
-chmod +x $PACKAGE_HOME/*.{sh,py}
-
-ln -s $PACKAGE_HOME/gatk3.py $PREFIX/bin/gatk3
-ln -s $PACKAGE_HOME/gatk3.py $PREFIX/bin/GenomeAnalysisTK
-ln -s $PACKAGE_HOME/gatk3-register.sh $PREFIX/bin/gatk3-register
+ln -s $PACKAGE_HOME/gatk.py $PREFIX/bin/gatk
+ln -s $PACKAGE_HOME/gatk.py $PREFIX/bin/GenomeAnalysisTK

--- a/recipes/gatk/3.6/meta.yaml
+++ b/recipes/gatk/3.6/meta.yaml
@@ -1,17 +1,26 @@
-{% set version = "3.6" %}
+{% set version="3.6" %}
+
+about:
+  home: https://www.broadinstitute.org/gatk/
+  license: BSD
+  summary: The full Genome Analysis Toolkit (GATK) framework, v3
 
 package:
   name: gatk
-  version: '{{ version }}'
+  version: {{ version }}
 
 build:
   noarch: generic
-  number: 7
+  number: 8
+  skip: False
+
+source:
+    url: https://storage.googleapis.com/gatk-software/package-archive/gatk/GenomeAnalysisTK-3.6-0-g89b7209.tar.bz2
+    sha256: 5e7b96717509c61f8048443f1257ccfbc130fb43f30140b288a4210c0e257453
 
 requirements:
   run:
     - openjdk >=8,<9
-    - bzip2 # needed by gatk3-register to extract GATK archive
     - python
     - r-gplots
     - r-ggplot2
@@ -20,14 +29,8 @@ requirements:
 
 test:
   commands:
-    - "gatk3-register --help 2>&1 | grep gatk3-register"
+    - "GenomeAnalysisTK --version"
 
 extra:
-  notes: Due to license restrictions, this recipe cannot distribute and install GATK v3 directly. To fully install GATK, you must download a licensed copy of GATK from the Broad Institute (https://software.broadinstitute.org/gatk/download/archive), install this package, and call "gatk3-register /path/to/GenomeAnalysisTK[-$PKG_VERSION.tar.bz2|.jar]", which will copy GATK into your conda environment. The main run script has been renamed to "gatk3" to allow compatibility with the new GATK 4 launch script (which is now "gatk").
   identifiers:
     - biotools:gatk
-
-about:
-  home: https://software.broadinstitute.org/gatk/download/archive
-  license: https://software.broadinstitute.org/gatk/download/licensing
-  summary: The Genome Analysis Toolkit (GATK) v3, license restricted.

--- a/recipes/gatk/3.6/meta.yaml
+++ b/recipes/gatk/3.6/meta.yaml
@@ -12,7 +12,6 @@ package:
 build:
   noarch: generic
   number: 8
-  skip: False
 
 source:
     url: https://storage.googleapis.com/gatk-software/package-archive/gatk/GenomeAnalysisTK-3.6-0-g89b7209.tar.bz2

--- a/recipes/gatk/build.sh
+++ b/recipes/gatk/build.sh
@@ -6,20 +6,20 @@ PACKAGE_HOME=$PREFIX/opt/$PKG_NAME-$PKG_VERSION
 mkdir -p $PREFIX/bin
 mkdir -p $PACKAGE_HOME
 
-cp $RECIPE_DIR/gatk.py $PACKAGE_HOME/gatk3.py
+cp $RECIPE_DIR/gatk.py $PACKAGE_HOME/gatk.py
 
-SOURCE_FILE=$RECIPE_DIR/gatk-register.sh
-DEST_FILE=$PACKAGE_HOME/gatk3-register.sh
+# jar locations: Handle both nested (GATK3.8) and non-ested (<=GATK 3.7)
+NESTED_GLOB="GenomeAnalysisTK-*/GenomeAnalysisTK.jar"
+if compgen -G "$NESTED_GLOB"; then
+  JARS=( "$NESTED_GLOB" )
+  JAR=( "${JARS[0]}" )
+else
+  JAR=./GenomeAnalysisTK.jar
+fi
 
+mv $JAR $PACKAGE_HOME/
 
-echo "#!/bin/bash" > $DEST_FILE
-echo "PKG_NAME=$PKG_NAME" >> $DEST_FILE
-echo "PKG_VERSION=$PKG_VERSION" >> $DEST_FILE
+chmod +x $PACKAGE_HOME/*.{py,jar}
 
-cat $SOURCE_FILE >> $DEST_FILE
-
-chmod +x $PACKAGE_HOME/*.{sh,py}
-
-ln -s $PACKAGE_HOME/gatk3.py $PREFIX/bin/gatk3
-ln -s $PACKAGE_HOME/gatk3.py $PREFIX/bin/GenomeAnalysisTK
-ln -s $PACKAGE_HOME/gatk3-register.sh $PREFIX/bin/gatk3-register
+ln -s $PACKAGE_HOME/gatk.py $PREFIX/bin/gatk
+ln -s $PACKAGE_HOME/gatk.py $PREFIX/bin/GenomeAnalysisTK

--- a/recipes/gatk/meta.yaml
+++ b/recipes/gatk/meta.yaml
@@ -1,17 +1,26 @@
-{% set version = "3.8" %}
+{% set version="3.8" %}
+
+about:
+  home: https://www.broadinstitute.org/gatk/
+  license: BSD
+  summary: The full Genome Analysis Toolkit (GATK) framework, v3
 
 package:
   name: gatk
-  version: '{{ version }}'
+  version: {{ version }}
 
 build:
   noarch: generic
-  number: 7
+  number: 8
+  skip: False
+
+source:
+    url: https://storage.googleapis.com/gatk-software/package-archive/gatk/GenomeAnalysisTK-3.8-1-0-gf15c1c3ef.tar.bz2
+    sha256: a0829534d2d0ca3ebfbd3b524a9b50427ff238e0db400d6e9e479242d98cbe5c
 
 requirements:
   run:
     - openjdk >=8,<9
-    - bzip2 # needed by gatk3-register to extract GATK archive
     - python
     - r-gplots
     - r-ggplot2
@@ -20,14 +29,8 @@ requirements:
 
 test:
   commands:
-    - "gatk3-register --help 2>&1 | grep gatk3-register"
+    - "GenomeAnalysisTK --version"
 
 extra:
-  notes: Due to license restrictions, this recipe cannot distribute and install GATK v3 directly. To fully install GATK, you must download a licensed copy of GATK from the Broad Institute (https://software.broadinstitute.org/gatk/download/archive), install this package, and call "gatk3-register /path/to/GenomeAnalysisTK[-$PKG_VERSION.tar.bz2|.jar]", which will copy GATK into your conda environment. The main run script has been renamed to "gatk3" to allow compatibility with the new GATK 4 launch script (which is now "gatk").
   identifiers:
     - biotools:gatk
-
-about:
-  home: https://software.broadinstitute.org/gatk/download/archive
-  license: https://software.broadinstitute.org/gatk/download/licensing
-  summary: The Genome Analysis Toolkit (GATK) v3, license restricted.

--- a/recipes/gatk/meta.yaml
+++ b/recipes/gatk/meta.yaml
@@ -12,7 +12,6 @@ package:
 build:
   noarch: generic
   number: 8
-  skip: False
 
 source:
     url: https://storage.googleapis.com/gatk-software/package-archive/gatk/GenomeAnalysisTK-3.8-1-0-gf15c1c3ef.tar.bz2


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).


**Note:** (Exciting news following some conversation internally) The Broad Institute Office of Strategic Alliances and Partnering has given the green light for public (re)distribution of GATK3, in line with how GATK4 will be licensed and distributed. This commit causes the `GenomeAnalysisTK.jar` file to be included in the conda package, sourced from the now-unauthenticated URL for GATK. Minor annoyance: While older GATK versions can be accessed via URLs that include the version number, it seems the latest version can only be pulled from a URL that omits the version.