### PR TITLE
Update: DESeq2, Bubbletree, MultiQC_bcbio

### DIFF
--- a/recipes/bioconductor-bubbletree/meta.yaml
+++ b/recipes/bioconductor-bubbletree/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 'https://depot.galaxyproject.org/software/{{ name }}/{{ name }}_{{ version }}_src_all.tar.gz'
   sha256: 218d2c332c8b861af538cf4e5a2b470b7fdb76602cc2f8766b72aad8ac3e0eda
 build:
-  number: 0
+  number: 1
   rpaths:
     - lib/R/lib/
     - lib/
@@ -22,6 +22,8 @@ requirements:
     - 'bioconductor-biocgenerics >=0.7.5'
     - bioconductor-biocstyle
     - bioconductor-biovizbase
+    - 'bioconductor-genomeinfodb >=1.14.0'
+    - 'bioconductor-genomeinfodbdata >=1.0.0'
     - bioconductor-genomicranges
     - bioconductor-iranges
     - bioconductor-limma
@@ -41,6 +43,8 @@ requirements:
     - 'bioconductor-biocgenerics >=0.7.5'
     - bioconductor-biocstyle
     - bioconductor-biovizbase
+    - 'bioconductor-genomeinfodb >=1.14.0'
+    - 'bioconductor-genomeinfodbdata >=1.0.0'
     - bioconductor-genomicranges
     - bioconductor-iranges
     - bioconductor-limma

--- a/recipes/bioconductor-deseq2/meta.yaml
+++ b/recipes/bioconductor-deseq2/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 'https://depot.galaxyproject.org/software/{{ name }}/{{ name }}_{{ version }}_src_all.tar.gz'
   sha256: bb6a175217f3aea72003457f092df029800d20d2087444776db774a0c3abd1c7
 build:
-  number: 0
+  number: 1
   rpaths:
     - lib/R/lib/
     - lib/
@@ -20,16 +20,17 @@ requirements:
   build:
     - bioconductor-biobase
     - 'bioconductor-biocgenerics >=0.7.5'
-    - bioconductor-biocparallel
+    - 'bioconductor-biocparallel >=1.12.0'
     - bioconductor-genefilter
     - bioconductor-geneplotter
     - bioconductor-genomicranges
     - bioconductor-iranges
     - 'bioconductor-s4vectors >=0.9.25'
-    - 'bioconductor-summarizedexperiment >=1.1.6'
+    - 'bioconductor-summarizedexperiment >=1.8.0'
     - r-base
     - r-ggplot2
     - r-hmisc
+    - 'r-lazyeval >=0.2.0'
     - r-locfit
     - 'r-rcpp >=0.11.0'
     - r-rcpparmadillo
@@ -38,16 +39,17 @@ requirements:
   run:
     - bioconductor-biobase
     - 'bioconductor-biocgenerics >=0.7.5'
-    - bioconductor-biocparallel
+    - 'bioconductor-biocparallel >=1.12.0'
     - bioconductor-genefilter
     - bioconductor-geneplotter
     - bioconductor-genomicranges
     - bioconductor-iranges
     - 'bioconductor-s4vectors >=0.9.25'
-    - 'bioconductor-summarizedexperiment >=1.1.6'
+    - 'bioconductor-summarizedexperiment >=1.8.0'
     - r-base
     - r-ggplot2
     - r-hmisc
+    - 'r-lazyeval >=0.2.0'
     - r-locfit
     - 'r-rcpp >=0.11.0'
     - r-rcpparmadillo

--- a/recipes/multiqc-bcbio/meta.yaml
+++ b/recipes/multiqc-bcbio/meta.yaml
@@ -1,13 +1,13 @@
-{% set tag="fc4786f" %}
+{% set tag="f68e0dd" %}
 
 package:
   name: multiqc-bcbio
-  version: "0.2.3"
+  version: "0.2.4"
 
 source:
   fn: multiqc-bcbio-{{ tag }}.tar.gz
   url: https://github.com/MultiQC/MultiQC_bcbio/archive/{{ tag }}.tar.gz
-  md5: 6b0e9e473b78f11e6dd2aa958cb97aa5
+  md5: d012950d4246130d7810ae506d176ee7
 
 build:
   number: 0


### PR DESCRIPTION
- deseq2: pin required dependency versions for latest release
  https://groups.google.com/d/msgid/biovalidation/e5fe0b7d-3a07-4f79-b78e-373724b31e55%40googlegroups.com
- bubbletree: include required genomeinfodb package
  (chapmanb/bcbio-nextgen#2180)
- multiqc-bcbio: Fix support for read_count_multiplier in display

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
