### PR TITLE
DeepVariant: 0.4.1 with post-link model download

### DIFF
--- a/recipes/deepvariant/build.sh
+++ b/recipes/deepvariant/build.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -eu -o pipefail
+
+# ## Binary install with wrappers
+
+SHAREDIR="share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM"
+TGT="$PREFIX/$SHAREDIR"
+[ -d "$TGT" ] || mkdir -p "$TGT"
+[ -d "${PREFIX}/bin" ] || mkdir -p "${PREFIX}/bin"
+
+mv binaries $TGT
+mv models $TGT
+
+cd $PREFIX
+BINARY_DIR=`ls -d $SHAREDIR/binaries/DeepVariant/*/DeepVariant*`
+WGS_MODEL_DIR=`ls -d $SHAREDIR/models/DeepVariant/*/DeepVariant*wgs_standard`
+cd $SRC_DIR
+
+# models installed in post-link script
+rm -rf $TGT/models
+
+# Fix hardcoded python inside binary directories
+for ZIPBIN in make_examples call_variants postprocess_variants
+do
+	unzip -d $ZIPBIN $PREFIX/$BINARY_DIR/$ZIPBIN.zip
+	sed -i.bak "s|PYTHON_BINARY = '/usr/bin/python'|PYTHON_BINARY = sys.executable|" $ZIPBIN/__main__.py
+	rm -f $ZIPBIN/*.bak
+	cd $ZIPBIN
+	zip -r ../$ZIPBIN.zip *
+	cd ..
+	mv $ZIPBIN.zip $PREFIX/$BINARY_DIR
+done
+
+# Copy wrapper scripts, pointing to internal binary and model directories
+cp ${RECIPE_DIR}/dv_make_examples.py $PREFIX/bin
+sed -i.bak "s|BINARYSUB|${BINARY_DIR}|" $PREFIX/bin/dv_make_examples.py
+cp ${RECIPE_DIR}/dv_call_variants.py $PREFIX/bin
+sed -i.bak "s|BINARYSUB|${BINARY_DIR}|" $PREFIX/bin/dv_call_variants.py
+sed -i.bak "s|MODELSUB|${WGS_MODEL_DIR}|" $PREFIX/bin/dv_call_variants.py
+cp ${RECIPE_DIR}/dv_postprocess_variants.py $PREFIX/bin
+sed -i.bak "s|BINARYSUB|${BINARY_DIR}|" $PREFIX/bin/dv_postprocess_variants.py
+rm -f $PREFIX/bin/*.bak
+
+# ## Work in progress to build from source
+# Trouble using pre-built clif so use binaries
+# Left here as bread crumbs for future work
+
+# # Need tensorflow bazel GitHub definitions for building
+# git clone https://github.com/tensorflow/tensorflow
+# sed -i.bak 's|%workspace%/../tensorflow|%workspace%/tensorflow|g' ${SRC_DIR}/tools/bazel.rc
+# sed -i.bak "s|\.\./tensorflow|${SRC_DIR}/tensorflow|g" ${SRC_DIR}/WORKSPACE
+# cd tensorflow
+# echo | ./configure
+# 
+# # clif for building
+# gsutil cp gs://deepvariant/packages/oss_clif/oss_clif.ubuntu-14.latest.tgz .
+# tar -xzpf oss_clif*.tgz
+# sed -i.bak "s|#!/usr/local|#!${SRC_DIR}/usr/local|" usr/local/clif/bin/pyclif
+# sed -i.bak "s|#!/usr/local|#!${SRC_DIR}/usr/local|" usr/local/clif/bin/pyclif_proto
+# 
+# export PATH=$PATH:${SRC_DIR}/usr/local/clif/bin
+# 
+# cd ..
+# source settings.sh
+# bazel build -c opt ${DV_COPT_FLAGS} deepvariant:binaries
+# bazel build :licenses_zip

--- a/recipes/deepvariant/dv_call_variants.py
+++ b/recipes/deepvariant/dv_call_variants.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+#
+# Wrapper script for DeepVariant call_variants
+
+BINARY_DIR="/opt/anaconda1anaconda2anaconda3/BINARYSUB"
+MODEL_DIR="/opt/anaconda1anaconda2anaconda3/MODELSUB"
+
+import argparse
+import os
+import subprocess
+import sys
+
+def real_dirname(path):
+    """Return the symlink-resolved, canonicalized directory-portion of path."""
+    return os.path.realpath(path)
+
+class DVHelp(argparse._HelpAction):
+    def __call__(self, parser, namespace, values, option_string=None):
+        print("Baseline DeepVariant arguments")
+        print(subprocess.check_output([sys.executable, "%s/call_variants.zip" % real_dirname(BINARY_DIR), "--help"]))
+        print()
+        print("Wrapper arguments")
+        parser.print_help()
+
+def main():
+    parser = argparse.ArgumentParser(description="DeepVariant call_variants wrapper", add_help=False)
+    parser.add_argument("--cores", default=1)
+    parser.add_argument("--outfile", required=True)
+    parser.add_argument("--examples", required=True, help="Example directory from make_examples")
+    parser.add_argument("--sample", required=True, help="Sample name")
+    parser.add_argument("-h", "--help", action=DVHelp)
+
+    args = parser.parse_args()
+
+    bin_dir = real_dirname(BINARY_DIR)
+    model_dir = real_dirname(MODEL_DIR)
+    py_exe = sys.executable
+    cmd = ("{py_exe} {bin_dir}/call_variants.zip "
+           "--outfile {args.outfile} --examples {args.examples}/{args.sample}.tfrecord@{args.cores}.gz "
+           "--checkpoint {model_dir}/model.ckpt")
+    sys.exit(subprocess.call(cmd.format(**locals()), shell=True))
+
+if __name__ == '__main__':
+    main()

--- a/recipes/deepvariant/dv_make_examples.py
+++ b/recipes/deepvariant/dv_make_examples.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+#
+# Wrapper script for DeepVariant make_examples
+
+BINARY_DIR="/opt/anaconda1anaconda2anaconda3/BINARYSUB"
+
+import argparse
+import os
+import subprocess
+import sys
+
+def real_dirname(path):
+    """Return the symlink-resolved, canonicalized directory-portion of path."""
+    return os.path.realpath(path)
+
+class DVHelp(argparse._HelpAction):
+    def __call__(self, parser, namespace, values, option_string=None):
+        print("Baseline DeepVariant arguments")
+        bin_dir = real_dirname(BINARY_DIR)
+        conda_path = os.path.dirname(os.path.realpath(sys.executable))
+        lib_path = os.path.join(os.path.dirname(conda_path), "lib")
+        py_exe = sys.executable
+        cmd = ("export LD_LIBRARY_PATH={lib_path}:$LD_LIBRARY_PATH && "
+               "{py_exe} {bin_dir}/make_examples.zip --help")
+        print(subprocess.check_output(cmd.format(**locals()), shell=True))
+        print()
+        print("Wrapper arguments")
+        parser.print_help()
+
+def main():
+    parser = argparse.ArgumentParser(description="DeepVariant make_examples wrapper", add_help=False)
+    parser.add_argument("--cores", default=1)
+    parser.add_argument("--sample", required=True, help="Sample name")
+    parser.add_argument("--ref", required=True, help="Reference genome")
+    parser.add_argument("--reads", required=True, help="Input BAM file")
+    parser.add_argument("--regions", required=True, help="Genomic region to process")
+    parser.add_argument("--logdir", required=True)
+    parser.add_argument("--examples", required=True, help="Output directory for examples")
+    parser.add_argument("-h", "--help", action=DVHelp)
+
+    args = parser.parse_args()
+
+    bin_dir = real_dirname(BINARY_DIR)
+    conda_path = os.path.dirname(os.path.realpath(sys.executable))
+    lib_path = os.path.join(os.path.dirname(conda_path), "lib")
+    py_exe = sys.executable
+    split_inputs = " ".join(str(x) for x in range(0, int(args.cores)))
+    cmd = ("export PATH={conda_path}:$PATH && export LD_LIBRARY_PATH={lib_path}:$LD_LIBRARY_PATH && "
+           "parallel --eta --halt 2 --joblog {args.logdir}/log --res {args.logdir} "
+           "{py_exe} {bin_dir}/make_examples.zip "
+           "--mode calling --ref {args.ref} --reads {args.reads} --regions {args.regions} "
+           "--examples {args.examples}/{args.sample}.tfrecord@{args.cores}.gz --task {{}} "
+           "::: {split_inputs}")
+    sys.exit(subprocess.call(cmd.format(**locals()), shell=True))
+
+if __name__ == '__main__':
+    main()

--- a/recipes/deepvariant/dv_postprocess_variants.py
+++ b/recipes/deepvariant/dv_postprocess_variants.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+#
+# Wrapper script for DeepVariant postprocess_variants
+
+BINARY_DIR="/opt/anaconda1anaconda2anaconda3/BINARYSUB"
+
+import argparse
+import os
+import subprocess
+import sys
+
+def real_dirname(path):
+    """Return the symlink-resolved, canonicalized directory-portion of path."""
+    return os.path.realpath(path)
+
+class DVHelp(argparse._HelpAction):
+    def __call__(self, parser, namespace, values, option_string=None):
+        print("Baseline DeepVariant arguments")
+        bin_dir = real_dirname(BINARY_DIR)
+        conda_path = os.path.dirname(os.path.realpath(sys.executable))
+        lib_path = os.path.join(os.path.dirname(conda_path), "lib")
+        py_exe = sys.executable
+        cmd = ("export LD_LIBRARY_PATH={lib_path}:$LD_LIBRARY_PATH && "
+               "{py_exe} {bin_dir}/postprocess_variants.zip --help")
+        print(subprocess.check_output(cmd.format(**locals()), shell=True))
+        print()
+        print("Wrapper arguments")
+        parser.print_help()
+
+def main():
+    parser = argparse.ArgumentParser(description="DeepVariant postprocess_variants wrapper", add_help=False)
+    parser.add_argument("--ref", required=True, help="Reference genome")
+    parser.add_argument("--infile", required=True, help="Input tfrecord file from call_variants")
+    parser.add_argument("--outfile", required=True)
+    parser.add_argument("-h", "--help", action=DVHelp)
+
+    args = parser.parse_args()
+
+    bin_dir = real_dirname(BINARY_DIR)
+    conda_path = os.path.dirname(os.path.realpath(sys.executable))
+    lib_path = os.path.join(os.path.dirname(conda_path), "lib")
+    py_exe = sys.executable
+    cmd = ("export LD_LIBRARY_PATH={lib_path}:$LD_LIBRARY_PATH && "
+           "{py_exe} {bin_dir}/postprocess_variants.zip "
+           "--ref {args.ref} --infile {args.infile} --outfile {args.outfile}")
+    sys.exit(subprocess.call(cmd.format(**locals()), shell=True))
+
+if __name__ == '__main__':
+    main()

--- a/recipes/deepvariant/meta.yaml
+++ b/recipes/deepvariant/meta.yaml
@@ -1,0 +1,66 @@
+{% set version="0.4.1" %}
+# When updating, also need to update model reference in post-link.sh
+
+package:
+  name: deepvariant
+  version: {{ version }}
+
+# Things to work on:
+# - Uses pre-built binaries, building problematic due to clif dependency
+# - Need recent kernel with GLIBC > 2.23 due to pre-built htslib
+# - Build patches __main__.py in zip files to generalize python dependency
+# - Requires numpy 1.13, want to sync with CONDA_NPY
+# - Uses python wrappers that don't expose all underlying options
+# - Ships with pre-built model. Longer term will need way to fetch models on demand.
+
+source:
+  fn: deepvariant-{{ version }}.zip
+  url: https://github.com/google/deepvariant/releases/download/v0.4.1/deepvariant.zip
+  md5: 0e3e34e4f5cbfb6d0f3007656a6a2632
+
+build:
+  number: 0
+  skip: true  # [osx or not py27]
+
+requirements:
+  build:
+    - python
+    - unzip
+    - zip
+    - curl
+    # Needed for non-binary build
+    # - google-cloud-sdk
+    # - bazel
+  run:
+    - openjdk >=8,<9
+    - python
+    - google-cloud-sdk
+    - zlib {{ CONDA_ZLIB }}*
+    - boost {{ CONDA_BOOST }}*
+    - htslib {{ CONDA_HTSLIB }}*
+    - numpy 1.13.*
+    - curl
+    - tensorflow
+    - contextlib2
+    - enum34
+    - intervaltree
+    - mock
+    - numpy
+    - requests
+    - scipy
+    - oauth2client
+    - six
+    - crcmod
+    - parallel
+    
+test:
+  commands:
+    # Pre-built binaries need GLIBC 2.16 and 2.23 (htslib) so fail
+    # - dv_make_examples.py -h
+    # - dv_call_variants.py -h
+    # - dv_postprocess_variants.py -h
+
+about:
+  home: https://github.com/google/deepvariant
+  license: MIT
+  summary: DeepVariant is an analysis pipeline that uses a deep neural network to call genetic variants from next-generation DNA sequencing data

--- a/recipes/deepvariant/post-link.sh
+++ b/recipes/deepvariant/post-link.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -eu -o pipefail
+
+MODEL_VERSION="0.4.0"
+MODEL_NAME="DeepVariant-inception_v3-0.4.0+cl-174375304.data-wgs_standard"
+GSREF="gs://deepvariant/models/DeepVariant/$MODEL_VERSION/$MODEL_NAME"
+GSUTIL=$PREFIX/bin/gsutil
+OUTDIR=$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM/models/DeepVariant/$MODEL_VERSION/$MODEL_NAME
+
+mkdir -p $OUTDIR
+$GSUTIL cp $GSREF/* $OUTDIR/

--- a/recipes/deepvariant/pre-unlink.sh
+++ b/recipes/deepvariant/pre-unlink.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -eu -o pipefail
+OUTDIR=$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM/models
+rm -rf OUTDIR


### PR DESCRIPTION
DeepVariant with post-link based download of models, following up on
review and discussion in #7134. The whole genome model will be
downloaded on the users machine during installation.

This works on recent Ubuntu 16.04+, Centos 7+ with pre-built binaries.

Additional work to do:

    - Uses pre-built binaries, building problematic due to clif dependency
    - Need recent kernel with GLIBC > 2.23 due to pre-built htslib
    - Build patches main.py in zip files to generalize python dependency
    - Requires numpy 1.13, want to sync with CONDA_NPY
    - Uses python wrappers that don't expose all underlying options

Fixes google/deepvariant#9

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [x] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
