### PR TITLE
Update Bowtie2 to 2.3.4

### DIFF
--- a/recipes/bowtie2/build.sh
+++ b/recipes/bowtie2/build.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
-set -eu -o pipefail
+CPPFLAGS="$CPPFLAGS -I${PREFIX}/include"
+export CPPFLAGS
+LDFLAGS="$LDFLAGS -L${PREFIX}/lib"
+export LDFLAGS
 
-make EXTRA_FLAGS="-I${PREFIX}/include -L${PREFIX}/lib"
+make
 
 binaries="\
 bowtie2 \
@@ -19,10 +22,16 @@ pythonfiles="bowtie2-build bowtie2-inspect"
 
 PY3_BUILD="${PY_VER%.*}"
 
-if [ $PY3_BUILD -eq 3 ]
-then
-    for i in $pythonfiles; do 2to3 --write $i; done
+if [ $PY3_BUILD -eq 3 ]; then
+    for i in $pythonfiles; do
+	2to3 --write $i
+    done
 fi
 
-for i in $binaries; do cp $i $PREFIX/bin && chmod +x $PREFIX/bin/$i; done
-for d in $directories; do cp -r $d $PREFIX/bin; done
+for i in $binaries; do
+    cp $i $PREFIX/bin && chmod +x $PREFIX/bin/$i
+done
+
+for d in $directories; do
+    cp -r $d $PREFIX/bin
+done

--- a/recipes/bowtie2/meta.yaml
+++ b/recipes/bowtie2/meta.yaml
@@ -8,7 +8,7 @@ package:
 source:
   fn: bowtie2-{{ version }}-source.zip
   url: http://downloads.sourceforge.net/project/bowtie-bio/bowtie2/{{ version }}/bowtie2-{{ version }}-source.zip
-  sha256: bfde1ca68eec70c2c3cacc2886a0f9d33f44c3c4690a58ed67acdf62615b0009
+  sha256: 51101a0bc180393c48e94e7fd2f5afcaece9eb50d4b2514abdbdbb7509417db2
   patches:
     - bowtie2.patch
 

--- a/recipes/bowtie2/meta.yaml
+++ b/recipes/bowtie2/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.3.3.1" %}
+{% set version = "2.3.4" %}
 
 
 package:
@@ -8,7 +8,7 @@ package:
 source:
   fn: bowtie2-{{ version }}-source.zip
   url: http://downloads.sourceforge.net/project/bowtie-bio/bowtie2/{{ version }}/bowtie2-{{ version }}-source.zip
-  sha256: a60ade7fa5200ae1389f22e5cad3eca017027d3bc6af02c94f2dff85e88a6838
+  sha256: bfde1ca68eec70c2c3cacc2886a0f9d33f44c3c4690a58ed67acdf62615b0009
   patches:
     - bowtie2.patch
 


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).


```
    Fixed major issue causing corrupt SAM output when using many threads (-p/--threads) on certain systems.
    Fixed an issue whereby bowtie2 processes could overwrite each others' named pipes on HPC systems.
    Fixed an issue causing bowtie2-build and bowtie2-inspect to return prematurely on Windows.
    Fixed issues raised by compiler "sanitizers" that could potentially have caused memory corruption or undefined behavior.
    Added the "continuous FASTA" input format (-F) for aligning all the k-mers in the sequences of a FASTA file. Useful for determining mapability of regions of the genome, and similar tasks.
```
