### PR TITLE
Update: dx-cwl, bcbio, bcbio-vm

### DIFF
--- a/recipes/bcbio-nextgen-vm/meta.yaml
+++ b/recipes/bcbio-nextgen-vm/meta.yaml
@@ -3,13 +3,13 @@ package:
   version: '0.1.0a'
 
 build:
-  number: 113
+  number: 114
   skip: True # [not py27]
 
 source:
-  fn: bcbio-nextgen-vm-4bad653.tar.gz
-  url: https://github.com/chapmanb/bcbio-nextgen-vm/archive/4bad653.tar.gz
-  md5: 73e7e2e5c8204906b1877c8826905b55
+  fn: bcbio-nextgen-vm-a890e16.tar.gz
+  url: https://github.com/chapmanb/bcbio-nextgen-vm/archive/a890e16.tar.gz
+  md5: 79febfa4066af9cae500f28a2ca54940
 
 requirements:
   build:

--- a/recipes/bcbio-nextgen/meta.yaml
+++ b/recipes/bcbio-nextgen/meta.yaml
@@ -3,15 +3,15 @@ package:
   version: '1.0.7a0'
 
 build:
-  number: 6
+  number: 7
   skip: True # [not py27]
 
 source:
   #fn: bcbio-nextgen-1.0.6.tar.gz
   #url: https://pypi.io/packages/source/b/bcbio-nextgen/bcbio-nextgen-1.0.6.tar.gz
-  fn: bcbio-nextgen-c276b41.tar.gz
-  url: https://github.com/chapmanb/bcbio-nextgen/archive/c276b41.tar.gz
-  md5: d55dbe159ced56805e3e390f8fece46d
+  fn: bcbio-nextgen-bd0072d.tar.gz
+  url: https://github.com/chapmanb/bcbio-nextgen/archive/bd0072d.tar.gz
+  md5: 87302c84a8113454efe578c9fa358fb1
 
 requirements:
   build:

--- a/recipes/dx-cwl/meta.yaml
+++ b/recipes/dx-cwl/meta.yaml
@@ -1,13 +1,14 @@
-{% set version="0.1.0a20171222" %}
-{% set revision="2687fe8" %}
+{% set version="0.1.0a20171231" %}
+{% set revision="12a8005" %}
 package:
   name: dx-cwl
   version: {{ version }}
 
 source:
   fn: dx-cwl-{{ version }}.tar.gz
-  url: https://github.com/dnanexus/dx-cwl/archive/{{ revision }}.tar.gz
-  md5: ad78ea964f78d7b352ef84b5f384fc84
+  #url: https://github.com/dnanexus/dx-cwl/archive/{{ revision }}.tar.gz
+  url: https://github.com/chapmanb/dx-cwl/archive/{{ revision }}.tar.gz
+  md5: 35910cf52b992aa8e160354e49a86dce
 
 build:
   number: 0


### PR DESCRIPTION
Adds support for generating RNA-seq CWL in bcbio and allows
referencing external reference genomes in DNAnexus.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
