### PR TITLE
Du Novo: Update to 2.0.12, reduce redundancy in build.sh.

### DIFF
--- a/recipes/dunovo/build.sh
+++ b/recipes/dunovo/build.sh
@@ -1,31 +1,26 @@
 #!/bin/bash
 
 # Download submodules and move them to lib.
-## kalign
-kalignver=0.2.0
-wget --no-check-certificate "https://github.com/makrutenko/kalign-dunovo/archive/v$kalignver.tar.gz"
-hash=`sha256sum v$kalignver.tar.gz | tr -s ' ' | cut -d ' ' -f 1`
-[ $hash = 473dd562f520a218df2dd147c89940422344adad6d8824141bffe6466c6d40e7 ]
-tar -zxvpf v$kalignver.tar.gz
-rm -rf kalign
-mv kalign-dunovo-$kalignver kalign
-rm v$kalignver.tar.gz
-## utillib
-utilver=0.1.0
-wget --no-check-certificate "https://github.com/NickSto/utillib/archive/v$utilver.tar.gz"
-hash=`sha256sum v$utilver.tar.gz | tr -s ' ' | cut -d ' ' -f 1`
-[ $hash = bffe515f7bd98661657c26003c41c1224f405c3a36ddabf5bf961fab86f9651a ]
-tar -zxvpf v$utilver.tar.gz
-mv utillib-$utilver $PREFIX/lib/utillib
-rm v$utilver.tar.gz
-## ET
-ETver=0.2.2
-wget --no-check-certificate "https://github.com/NickSto/ET/archive/v$ETver.tar.gz"
-hash=`sha256sum v$ETver.tar.gz | tr -s ' ' | cut -d ' ' -f 1`
-[ $hash = 11dc5cb02521a2260e6c88a83d489c72f819bd759aeff31d66aa40ca2f1358a6 ]
-tar -zxvpf v$ETver.tar.gz
-mv ET-$ETver $PREFIX/lib/ET
-rm v$ETver.tar.gz
+get_submodule () {
+  read name version owner repo hash <<< "$@"
+  wget --no-check-certificate "https://github.com/$owner/$repo/archive/v$version.tar.gz"
+  downloaded_hash=`sha256sum v$version.tar.gz | tr -s ' ' | cut -d ' ' -f 1`
+  if ! [ "$hash" = "$downloaded_hash" ]; then
+    echo "Error: Hash does not match!" >&2
+    return 1
+  fi
+  tar -zxvpf v$version.tar.gz
+  rm -rf $name
+  if [ "$name" == kalign ]; then
+    mv $repo-$version $name
+  else
+    mv $repo-$version $PREFIX/lib/$name
+  fi
+  rm v$version.tar.gz
+}
+get_submodule kalign  0.2.0 makrutenko kalign-dunovo 473dd562f520a218df2dd147c89940422344adad6d8824141bffe6466c6d40e7
+get_submodule utillib 0.1.0 NickSto    utillib       bffe515f7bd98661657c26003c41c1224f405c3a36ddabf5bf961fab86f9651a
+get_submodule ET      0.2.2 NickSto    ET            11dc5cb02521a2260e6c88a83d489c72f819bd759aeff31d66aa40ca2f1358a6
 
 # Compile binaries and move them to lib.
 make

--- a/recipes/dunovo/meta.yaml
+++ b/recipes/dunovo/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.0.9" %}
+{% set version = "2.0.12" %}
 
 package:
   name: dunovo
@@ -7,7 +7,7 @@ package:
 source:
   fn: v{{ version }}.tar.gz
   url: https://github.com/galaxyproject/dunovo/archive/v{{ version }}.tar.gz
-  sha256: 6f5295b8eae0e161ee3bd28829ca140657743c695624ffc7f467f13eab2c547c
+  sha256: 6973f163dabf82d236982534d88b5d11573a5aa0982bf9d6236be635fb9b4e11
 
 build:
   number: 0
@@ -24,8 +24,7 @@ requirements:
     - libgcc
     - python
     - mafft 7.221
-    - samtools 0.1.18
-    - bowtie2 2.2.5
+    - bowtie >=1.1.2
     - networkx <2.0
     - paste
     - gawk


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

This updates the recipe to install Du Novo 2.0.12 instead of 2.0.9.

The new version has different dependencies, namely a switch from bowtie2 to bowtie, and dropping the samtools requirement.

I also rewrote `build.sh` to put the code for installing a submodule in a function, instead of repeating it for each of the 3 submodules.