### PR TITLE
Update prosolo

### DIFF
--- a/recipes/prosolo/meta.yaml
+++ b/recipes/prosolo/meta.yaml
@@ -14,8 +14,7 @@ build:
 source:
   url: https://github.com/PROSIC/prosolo/archive/v{{ version }}.tar.gz
   fn: prosolo-{{ version }}.tar.gz
-  md5: f70464c825e1b8e20da7d4382dd53f65
-  
+  md5: 485a1578f4464190da0007e644e8182a  
 
 requirements:
   build:

--- a/recipes/prosolo/meta.yaml
+++ b/recipes/prosolo/meta.yaml
@@ -23,11 +23,11 @@ requirements:
     - llvm # [osx]
     - rust >=1.18
     - gsl {{CONDA_GSL}}*
-    - zlib
+    - zlib {{ CONDA_ZLIB }}*
   run:
     - gsl {{CONDA_GSL}}*
     - libgcc # [not osx]
-    - zlib
+    - zlib {{ CONDA_ZLIB }}*
 
 test:
   commands:

--- a/recipes/prosolo/meta.yaml
+++ b/recipes/prosolo/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.2.0" %}
+{% set version = "0.3.0" %}
 
 package:
   name: prosolo

--- a/recipes/prosolo/meta.yaml
+++ b/recipes/prosolo/meta.yaml
@@ -23,10 +23,18 @@ requirements:
     - rust >=1.18
     - gsl {{CONDA_GSL}}*
     - zlib {{ CONDA_ZLIB }}*
+    # new cram dependencies for rust-htslib 0.16.0
+    - bzip2 {{ CONDA_BZIP2 }}*  # [linux]
+    - xz
+    - clangdev
   run:
     - gsl {{CONDA_GSL}}*
     - libgcc # [not osx]
     - zlib {{ CONDA_ZLIB }}*
+    # new cram dependencies for rust-htslib 0.16.0
+    - bzip2 {{ CONDA_BZIP2 }}*  # [linux]
+    - xz
+    - clangdev
 
 test:
   commands:

--- a/recipes/prosolo/meta.yaml
+++ b/recipes/prosolo/meta.yaml
@@ -7,7 +7,7 @@ package:
 build:
   # only on OSX, `cargo install` fails with: `thread 'main' panicked at 'assertion failed: src_path.is_absolute()', src/tools/cargo/src/cargo/core/manifest.rs:311`
   # looks like a `cargo` bug, that may go away with newer `rust` versions; check osx with rust>1.19 when available
-  skip: True # [not linux64]
+  #  skip: True # [not linux64]
   number: 0
   string: "gsl{{CONDA_GSL}}_{{PKG_BUILDNUM}}"
 

--- a/recipes/prosolo/meta.yaml
+++ b/recipes/prosolo/meta.yaml
@@ -5,9 +5,6 @@ package:
   version: {{ version }}
 
 build:
-  # only on OSX, `cargo install` fails with: `thread 'main' panicked at 'assertion failed: src_path.is_absolute()', src/tools/cargo/src/cargo/core/manifest.rs:311`
-  # looks like a `cargo` bug, that may go away with newer `rust` versions; check osx with rust>1.19 when available
-  #  skip: True # [not linux64]
   number: 0
   string: "gsl{{CONDA_GSL}}_{{PKG_BUILDNUM}}"
 

--- a/recipes/prosolo/meta.yaml
+++ b/recipes/prosolo/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.3.0" %}
+{% set version = "0.3.1" %}
 
 package:
   name: prosolo
@@ -11,7 +11,7 @@ build:
 source:
   url: https://github.com/PROSIC/prosolo/archive/v{{ version }}.tar.gz
   fn: prosolo-{{ version }}.tar.gz
-  md5: 485a1578f4464190da0007e644e8182a  
+  md5: 57c767cda5c796fc689928cf21e88cdf
 
 requirements:
   build:

--- a/recipes/prosolo/meta.yaml
+++ b/recipes/prosolo/meta.yaml
@@ -5,6 +5,9 @@ package:
   version: {{ version }}
 
 build:
+  # only on OSX, `cargo install` fails with: `thread 'main' panicked at 'assertion failed: src_path.is_absolute()', src/tools/cargo/src/cargo/core/manifest.rs:311`
+  # looks like a `cargo` bug, that may go away with newer `rust` versions; check osx with rust>1.21 when available
+  skip: True # [not linux64]
   number: 0
   string: "gsl{{CONDA_GSL}}_{{PKG_BUILDNUM}}"
 
@@ -17,7 +20,7 @@ requirements:
   build:
     - gcc # [not osx]
     - llvm # [osx]
-    - rust >=1.18
+    - rust >=1.21
     - gsl {{CONDA_GSL}}*
     - zlib {{ CONDA_ZLIB }}*
     # new cram dependencies for rust-htslib 0.16.0


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Locally (i.e. using `simulate-travis.py`), this new recipe consistently gives me a networking error when doing the mulled-buil test (while I can ping the server `conda.anaconda.org` from my machine's terminal and can access the `repodata.json` from the browser):
```
...17:23:22 BIOCONDA ERROR COMMAND FAILED: mulled-build build-and-test prosolo=0.3.0--gsl1.16_0 -n biocontainers --test prosolo single-cell-bulk --help --extra-channels file:///tmp/miniconda/conda-bld,conda-forge,defaults
17:23:22 BIOCONDA ERROR STDOUT+STDERR:
[Jan 15 17:20:39] DEBU Run file [/tmp/miniconda/lib/python3.5/site-packages/galaxy/tools/deps/mulled/invfile.lua]
[Jan 15 17:20:39] INFO Invoke Task [build]
[Jan 15 17:20:39] STEP Run image [continuumio/miniconda:latest] with command [[rm -rf /data/dist]]
[Jan 15 17:20:39] DEBU Creating container [step-f02494e624]
[Jan 15 17:20:40] DEBU Created container [1d54045e4594 step-f02494e624], starting it
[Jan 15 17:20:40] DEBU Container [1d54045e4594 step-f02494e624] started, waiting for completion
[Jan 15 17:20:40] DEBU Container [1d54045e4594 step-f02494e624] completed with exit code [0] as expected
[Jan 15 17:20:40] DEBU Container [1d54045e4594 step-f02494e624] removed
[Jan 15 17:20:40] STEP Run image [continuumio/miniconda:latest] with command [[/bin/sh -c conda install  -c bioconda -c file:///tmp/miniconda/conda-bld -c conda-forge -c defaults  prosolo=0.3.0=gsl1.16_0 -p /usr/local --copy --yes --quiet]]
[Jan 15 17:20:40] DEBU Creating container [step-8e38f3b897]
[Jan 15 17:20:40] DEBU Created container [304ebfc51ea4 step-8e38f3b897], starting it
[Jan 15 17:20:41] DEBU Container [304ebfc51ea4 step-8e38f3b897] started, waiting for completion
[Jan 15 17:23:21] SERR 
[Jan 15 17:23:21] SERR 
[Jan 15 17:23:21] SERR CondaHTTPError: HTTP None None for url <https://conda.anaconda.org/bioconda/linux-64/repodata.json>
[Jan 15 17:23:21] SERR Elapsed: None
[Jan 15 17:23:21] SERR 
[Jan 15 17:23:21] SERR An HTTP error occurred when trying to retrieve this URL.
[Jan 15 17:23:21] SERR HTTP errors are often intermittent, and a simple retry will get you on your way.
[Jan 15 17:23:21] SERR ConnectionError(MaxRetryError("HTTPSConnectionPool(host='conda.anaconda.org', port=443): Max retries exceeded with url: /bioconda/linux-64/repodata.json (Caused by NewConnectionError('<requests.packages.urllib3.connection.VerifiedHTTPSConnection object at 0x7f652cbdb190>: Failed to establish a new connection: [Errno -3] Temporary failure in name resolution',))",),)
[Jan 15 17:23:21] SERR 
[Jan 15 17:23:21] SERR 
[Jan 15 17:23:21] SERR 
[Jan 15 17:23:22] ERRO Task processing failed: Unexpected exit code [1] of container [304ebfc51ea4 step-8e38f3b897], container preserved
involucro -v=2 -f /tmp/miniconda/lib/python3.5/site-packages/galaxy/tools/deps/mulled/invfile.lua -set CHANNELS='bioconda,file:///tmp/miniconda/conda-bld,conda-forge,defaults' -set TEST='prosolo single-cell-bulk --help' -set TARGETS='prosolo=0.3.0=gsl1.16_0' -set REPO='quay.io/biocontainers/prosolo:0.3.0--gsl1.16_0' -set BINDS='build/dist:/usr/local/,/tmp/miniconda/conda-bld:/tmp/miniconda/conda-bld' build-and-test


17:23:36 BIOCONDA ERROR TEST FAILED: recipes/prosolo, CONDA_ALLOW_SOFTLINKS=false;CONDA_BOOST=1.64;CONDA_BZIP2=1.0;CONDA_GMP=5.1;CONDA_GSL=1.16;CONDA_HDF5=1.8.17;CONDA_HTSLIB=1.6;CONDA_NCURSES=5.9;CONDA_NPY=112;CONDA_PERL=5.22.0;CONDA_PY=27;CONDA_R=3.4.1;CONDA_ROOT=/tmp/miniconda;CONDA_XZ=5.2;CONDA_ZLIB=1.2.8;LANG=en_US.UTF-8;LC_ADDRESS=de_DE.UTF-8;LC_IDENTIFICATION=de_DE.UTF-8;LC_MEASUREMENT=de_DE.UTF-8;LC_MONETARY=de_DE.UTF-8;LC_NAME=de_DE.UTF-8;LC_NUMERIC=de_DE.UTF-8;LC_PAPER=de_DE.UTF-8;LC_TELEPHONE=de_DE.UTF-8;LC_TIME=de_DE.UTF-8;MACOSX_DEPLOYMENT_TARGET=10.9
17:23:37 BIOCONDA ERROR BUILD SUMMARY: of 1 recipes, 1 failed and 0 were skipped. Details of recipes and environments follow.
17:23:37 BIOCONDA ERROR BUILD SUMMARY: FAILED recipe prosolo-0.3.0-gsl1.16_0.tar.bz2, environment CONDA_ZLIB=1.2.8;CONDA_R=3.4.1;CONDA_GSL=1.16;CONDA_GMP=5.1;MACOSX_DEPLOYMENT_TARGET=10.9;CONDA_XZ=5.2;CONDA_NCURSES=5.9;CONDA_NPY=112;CONDA_PERL=5.22.0;CONDA_HTSLIB=1.6;CONDA_BZIP2=1.0;CONDA_BOOST=1.64;CONDA_HDF5=1.8.17;CONDA_PY=27
```

This is an attempt to try my luck with the Travis CI tests.