### PR TITLE
FastQC - Add fonts to fix biocontainer on quay.io 

### DIFF
--- a/recipes/fastqc/meta.yaml
+++ b/recipes/fastqc/meta.yaml
@@ -15,7 +15,7 @@ source:
 
 build:
   detect_binary_files_with_prefix: true
-  number: 0
+  number: 1
 
 requirements:
   run:

--- a/recipes/fastqc/meta.yaml
+++ b/recipes/fastqc/meta.yaml
@@ -21,6 +21,7 @@ requirements:
   run:
     - openjdk
     - perl
+    - font-ttf-dejavu-sans-mono
 
 test:
   commands:


### PR DESCRIPTION
* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [X] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [X] This PR updates an existing recipe.
* [X] This PR does something else (explain below).\

I tried to run the biocontainer created with this recipe and got the following error: 
```
$ docker run -it -v $PWD:/data quay.io/biocontainers/fastqc:0.11.6--pl5.22.0_0
# cd /data
# fastqc example.fq.gz -o /tmp
Started analysis of example.fq.gz
Analysis complete for example.fq.gz
Exception in thread "Thread-1" java.lang.Error: Probable fatal error:No fonts found.
	at sun.font.SunFontManager.getDefaultPhysicalFont(SunFontManager.java:1236)
```

I tried to figure out how the container was built but it seems that the biocontainer on Dockerhub works but is different than the one on quay.io (this is the one missing the font). 

cc @bgruening @luizirber 