### PR TITLE
Remove unnecessary gcc build/run dependencies

### DIFF
--- a/recipes/perl-text-balanced/build.sh
+++ b/recipes/perl-text-balanced/build.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-cpanm -n -f -i .
+HOME=/tmp cpanm -i .

--- a/recipes/perl-text-balanced/meta.yaml
+++ b/recipes/perl-text-balanced/meta.yaml
@@ -8,7 +8,7 @@ about:
   summary: Text::Balanced - Extract delimited text sequences from strings
 
 build:
-  number: 0
+  number: 1
 
 source:
   fn: Text-Balanced-2.03.tar.gz
@@ -19,17 +19,11 @@ source:
 
 requirements:
   build:
-    - perl-threaded #>=5.22.1
+    - perl
     - perl-app-cpanminus
-    - libgcc # [linux]
-    - llvm # [osx]
-    - gcc # [linux]
 
   run: 
-    - perl-threaded #>=5.22.1
-    - libgcc # [linux]
-    - llvm # [osx]
-    - gcc # [linux]
+    - perl
 
 test:
   imports:


### PR DESCRIPTION
* [ X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

When attempting to update a perl recipe that depends on this one (https://github.com/bioconda/bioconda-recipes/pull/7261), the mulled-build failed when installing gcc as previously required to build/run this recipe, apparently related to issue https://github.com/bioconda/bioconda-recipes/issues/3496. However, as no compiler is actually needed to build/run this perl module, I propose removing such dependencies from the recipe.