### PR TITLE
quotes options passed to picard, updates picard to latest version

### DIFF
--- a/recipes/picard/meta.yaml
+++ b/recipes/picard/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.17.3" %}
+{% set version = "2.17.4" %}
 
 package:
   name: picard
@@ -7,7 +7,7 @@ package:
 source:
   fn: picard.jar
   url: https://github.com/broadinstitute/picard/releases/download/{{ version }}/picard.jar
-  sha256: 97aad11a339012044cbfbbc8874e1e800609e85892be1177ad46df28ad0515dc
+  sha256: c27d4c7abc0832a8d814287632db84290fed3f8aefca29e51607d23c278ace01
 
 build:
   number: 0

--- a/recipes/picard/picard.sh
+++ b/recipes/picard/picard.sh
@@ -2,7 +2,6 @@
 # Picard executable shell script
 set -eu -o pipefail
 
-set -o pipefail
 export LC_ALL=en_US.UTF-8
 
 # Find original directory of bash script, resolving symlinks
@@ -45,7 +44,12 @@ for arg in "$@"; do
             jvm_mem_opts="$jvm_mem_opts $arg"
             ;;
          *)
-            pass_args="$pass_args $arg"
+	    if [[ ${pass_args} == '' ]] #needed to avoid preceeding space on first arg e.g. ' MarkDuplicates'
+            then 
+                pass_args="$arg" 
+	    else
+                pass_args="$pass_args \"$arg\"" #quotes later arguments to avoid problem with ()s in MarkDuplicates regex arg
+            fi
             ;;
     esac
 done


### PR DESCRIPTION
Turns out that quoting the arguments is an easy fix.
also removes a duplicated -o pipefail
fixes #7322

* [x ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
