### PR TITLE
Only build on macos if linux succeeded outside of the master branch.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,6 +188,7 @@ workflows:
       - test-macos:
           requires:
             - lint
+            - test-linux
           filters:
             branches:
               ignore:


### PR DESCRIPTION
This way, we save build time that would otherwise be wasted.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

Otherwise, we would waste macos build time for every failed attempt to get a recipe working.