### PR TITLE
porechop: fixes: python pinning

### DIFF
--- a/recipes/porechop/build.sh
+++ b/recipes/porechop/build.sh
@@ -1,2 +1,4 @@
-$PYTHON setup.py install
+#!/bin/bash
+
+$PYTHON setup.py install --single-version-externally-managed --record=record.txt
 $PYTHON -m unittest

--- a/recipes/porechop/meta.yaml
+++ b/recipes/porechop/meta.yaml
@@ -36,5 +36,5 @@ test:
 
 about:
   home: https://github.com/rrwick/Porechop
-  license: GPL3
+  license: GPL-3.0-only AND BSD-3-Clause
   summary: Adapter removal and demultiplexing of Oxford Nanopore reads

--- a/recipes/porechop/meta.yaml
+++ b/recipes/porechop/meta.yaml
@@ -16,6 +16,8 @@ source:
 build:
   number: 0
   skip: True # [py27]
+  entry_points:
+    - porechop = porechop.porechop:main
 
 requirements:
   build:

--- a/recipes/porechop/meta.yaml
+++ b/recipes/porechop/meta.yaml
@@ -14,7 +14,7 @@ source:
   md5: 648fbf44b8fe70aa771786b5180b4e22
 
 build:
-  number: 0
+  number: 1
   skip: True # [py27]
   entry_points:
     - porechop = porechop.porechop:main

--- a/recipes/porechop/meta.yaml
+++ b/recipes/porechop/meta.yaml
@@ -19,12 +19,12 @@ build:
 
 requirements:
   build:
-    - python >=3.4
+    - python
     - gcc  # [not osx]
     - llvm # [osx]
 
   run:
-    - python >=3.4
+    - python
     - libgcc # [not osx]
 
 test:

--- a/recipes/porechop/meta.yaml
+++ b/recipes/porechop/meta.yaml
@@ -4,14 +4,17 @@
 # When GCC 4.9 or later is available on conda, the source metadata should be
 # updated to point to the latest mainstream Porechop release.
 
+{% set version = "0.2.3_seqan2.1.1" %}
+
 package:
   name: porechop
-  version: '0.2.3_seqan2.1.1'
+  version: {{ version }}
 
 source:
-  fn:  Porechop-0.2.3_seqan2.1.1.tar.gz
-  url: https://github.com/jvolkening/Porechop/archive/v0.2.3_seqan2.1.1.tar.gz
-  md5: 648fbf44b8fe70aa771786b5180b4e22
+  fn:  porechop-{{ version }}.tar.gz
+  # url: https://github.com/rrwick/Porechop/archive/v{{ version }}.tar.gz
+  url: https://github.com/jvolkening/Porechop/archive/v{{ version }}.tar.gz
+  sha256: 6fd17ff169c4fa20bb6a64978c00cbb8db0893108ee606f02b4b966b86b6ddf0
 
 build:
   number: 1

--- a/recipes/porechop/meta.yaml
+++ b/recipes/porechop/meta.yaml
@@ -20,6 +20,7 @@ build:
 requirements:
   build:
     - python
+    - setuptools
     - gcc  # [not osx]
     - llvm # [osx]
 


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Followup to #7382. Adds some minor fixes and one crucial one: Due to a bug in `conda-build 2.1.x` Python won't get properly pinned if its version is constrained (and `python` is `build`+`run` requirement and not `noarch: python`), i.e., we get a Python version-specific package with a non version-specific build string.