### PR TITLE
ipython-cluster-helper to 6.0.1.

### DIFF
--- a/recipes/ipython-cluster-helper/meta.yaml
+++ b/recipes/ipython-cluster-helper/meta.yaml
@@ -1,4 +1,4 @@
-{% set version="0.6.0" %}
+{% set version="0.6.1" %}
 package:
   name: ipython-cluster-helper
   version: {{ version }}
@@ -6,9 +6,8 @@ package:
 source:
   fn: ipython-cluster-helper-{{ version }}.tar.gz
   # work around issue with no profile directory in 0.6.0 release with fix
-  url: https://github.com/roryk/ipython-cluster-helper/archive/f0a86ff.tar.gz
-  #url: https://pypi.io/packages/source/i/ipython-cluster-helper/ipython-cluster-helper-{{ version }}.tar.gz
-  md5: 14cfcb714922db29894591073d1c6002
+  url: https://pypi.io/packages/source/i/ipython-cluster-helper/ipython-cluster-helper-{{ version }}.tar.gz
+  md5: 5144fae6fa4f990f26f570452e210df9
 
 build:
   number: 0
@@ -22,7 +21,7 @@ requirements:
 
   run:
     - python
-    - ipyparallel >=4.0,<5.0
+    - ipyparallel >=6.0.2
     - zeromq
     - pyzmq
     - netifaces
@@ -30,11 +29,7 @@ requirements:
 
 test:
   imports:
-    # Failing on OSX for some reason, even though ZeroMQ present
-    # ImportError: dlopen(/anaconda/conda-bld/ipython-cluster-helper_1502206283587/_t_env/lib/python2.7/site-packages/zmq/backend/cython/constants.so, 2): Library not loaded: @rpath/libzmq.5.dylib
-    # Referenced from: /anaconda/conda-bld/ipython-cluster-helper_1502206283587/_t_env/lib/python2.7/site-packages/zmq/backend/cython/constants.so
-    # Reason: image not found
-    #- cluster_helper.cluster
+    - cluster_helper.cluster
 
 about:
   home: https://github.com/roryk/ipython-cluster-helper


### PR DESCRIPTION
This relaxes some of the dependency pinning. Tested to work
on SGE and SLURM.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Pushing without local testing, I couldn't figure out how to get CircleCI working locally.
