### PR TITLE
.circleci: set LC_ALL+LANG to en_US.UTF-8 on macos

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,9 @@ variables:
   macos: &macos
     macos:
       xcode: "8.3.3"
+    environment:
+      LC_ALL: en_US.UTF-8
+      LANG: en_US.UTF-8
   linux: &linux
     machine: true
 


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

In CircleCI's macOS image the locale isn't set with `LC_ALL` and `LANG`. Hence `click` will complain if run with Python 3, see https://github.com/bioconda/bioconda-recipes/pull/7417.
The variables are set to `en_US.UTF-8` which mirrors the `extended-base` image.
Tested on https://github.com/bioconda/bioconda-recipes/pull/7417 and works as intended.