### PR TITLE
Porechop update

### DIFF
--- a/recipes/porechop/meta.yaml
+++ b/recipes/porechop/meta.yaml
@@ -12,6 +12,7 @@ package:
 
 source:
   fn:  porechop-{{ version }}.tar.gz
+# url: https://github.com/rrwick/Porechop/archive/v{{ version }}.tar.gz
   url: https://github.com/rrwick/Porechop/archive/v0.2.3-C++11.tar.gz
   sha256: 817371dceed77e583e387e9ca7c10214c0faff7c0a89320d60a66efdc6c0d35a
 

--- a/recipes/porechop/meta.yaml
+++ b/recipes/porechop/meta.yaml
@@ -12,12 +12,11 @@ package:
 
 source:
   fn:  porechop-{{ version }}.tar.gz
-  # url: https://github.com/rrwick/Porechop/archive/v{{ version }}.tar.gz
-  url: https://github.com/jvolkening/Porechop/archive/v{{ version }}.tar.gz
-  sha256: 6fd17ff169c4fa20bb6a64978c00cbb8db0893108ee606f02b4b966b86b6ddf0
+  url: https://github.com/rrwick/Porechop/archive/v0.2.3-C++11.tar.gz
+  sha256: 817371dceed77e583e387e9ca7c10214c0faff7c0a89320d60a66efdc6c0d35a
 
 build:
-  number: 1
+  number: 2
   skip: True # [py27]
   entry_points:
     - porechop = porechop.porechop:main


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

This PR points the source metadata to the (now updated) mainstream repo. As the upstream author chose a different version string for the branch/tag, and as this is a temporary workaround for the GCC issue, I have replaced the templated URL string with an explicit string. This seems preferable to modifying the recipe version when there are no actual changes to the package code. This can be replaced for the next upstream release.