### PR TITLE
Update: bcbio, bcbio-vm; no ipyparallel pinning

### DIFF
--- a/recipes/bcbio-nextgen-vm/meta.yaml
+++ b/recipes/bcbio-nextgen-vm/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: '0.1.0a'
 
 build:
-  number: 118
+  number: 119
   skip: True # [not py27]
 
 source:
@@ -19,7 +19,7 @@ requirements:
   run:
     - python
     - bcbio-nextgen >=1.0.7
-    - ipyparallel >=4.0,<5.0
+    - ipyparallel >=6.0.2
     - pysam >=0.13.0
     - arvados-cwl-runner >=1.0.20171211211613
     - cwl2wdl

--- a/recipes/bcbio-nextgen/meta.yaml
+++ b/recipes/bcbio-nextgen/meta.yaml
@@ -3,15 +3,15 @@ package:
   version: '1.0.8a'
 
 build:
-  number: 4
+  number: 5
   skip: True # [not py27]
 
 source:
   #fn: bcbio-nextgen-1.0.7.tar.gz
   #url: https://pypi.io/packages/source/b/bcbio-nextgen/bcbio-nextgen-1.0.7.tar.gz
-  fn: bcbio-nextgen-a6cbc9f.tar.gz
-  url: https://github.com/chapmanb/bcbio-nextgen/archive/a6cbc9f.tar.gz
-  md5: e2cf9b36322b3042827dd97e4aa33230
+  fn: bcbio-nextgen-a8e669c.tar.gz
+  url: https://github.com/chapmanb/bcbio-nextgen/archive/a8e669c.tar.gz
+  md5: a355130f0d1ddfb425a0ef390fedf45e
 
 requirements:
   build:
@@ -36,17 +36,13 @@ requirements:
     - gffutils
     - h5py
     - htslib {{ CONDA_HTSLIB }}*
-    - ipyparallel >=4.0,<5.0
-    - ipython-cluster-helper >=0.6.0
+    - ipyparallel >=6.0.2
+    - ipython-cluster-helper >=0.6.1
     - joblib
-    # 5.2.1 has incompatibilities with ipyparallel 4.1
-    - jupyter_client >=5.0,<5.2
-    - libsodium >=0.4,<1.0
     - logbook
     - matplotlib
     - mock
     - msgpack-python
-    - numpy
     - openssl
     - pandas
     - path.py
@@ -64,7 +60,6 @@ requirements:
     - pysam >=0.13.0
     - pyvcf
     - pyyaml
-    - pyzmq
     - requests
     - scipy
     - seaborn
@@ -75,7 +70,6 @@ requirements:
     - toolz
     - tornado
     - yamllint
-    - zeromq ==4.2.1
 
 test:
   imports:
@@ -86,7 +80,7 @@ test:
     # ImportError: dlopen(zmq/backend/cython/constants.so, 2): Library not loaded: @rpath/./libzmq.4.dylib
     #   Referenced from: /zmq/backend/cython/constants.so
     #     Reason: image not found
-    #- bcbio.distributed.ipython
+    - bcbio.distributed.ipython # [not osx]
   commands:
     # click requires a unicode locale
     - LANG=C.UTF-8 bcbio_nextgen.py -h


### PR DESCRIPTION
Avoids pinning to lower versions of ipyparallel to mirror improvements
in ipython-cluster-helper and avoid dependency issues.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
