### PR TITLE
Added k8 javascript shell

### DIFF
--- a/recipes/k8/build.sh
+++ b/recipes/k8/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+mkdir -p $PREFIX/bin
+
+cp k8-`uname -s|tr [A-Z] [a-z]` $PREFIX/bin/k8

--- a/recipes/k8/meta.yaml
+++ b/recipes/k8/meta.yaml
@@ -1,0 +1,28 @@
+{% set name = "k8" %}
+{% set version = "0.2.3" %}
+{% set hash = "e178cd0073bdeb1907b9b73beea1ad5ff7a09b318d67cc44205fb4f248107214" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/attractivechaos/k8/releases/download/v{{ version }}/{{ name }}-{{ version }}.tar.bz2
+  fn: {{ name|lower }}_{{ version }}.tar.bz2
+  sha256: {{ hash }}
+
+build:
+    number: 0
+
+requirements:
+    run:
+        - libgcc
+        - zlib {{ CONDA_ZLIB }}*
+test:
+  commands:
+    - k8 -v | grep 'K8'
+
+about:
+  home: https://github.com/attractivechaos/k8
+  license: MIT
+  summary: 'Lightweight javascript shell based on V8.'


### PR DESCRIPTION
This recipe adds the interpreter needed to run multiple scripts written by me. These scripts include converting GFF to BED12, converting long-read spliced alignment to BED12, calling variants from contig-to-genome alignment, evaluating mapping accuracy, beautifying long-read alignment, etc. The applications are directly relevant to biological sequence analyses.

It is non-trivial to compile k8 because it is built on top of an old version of V8 and compiling V8 is complicated by itself. As a result, this recipe does not compile k8. Instead, it downloads portable precompiled binaries from the k8 github repo. These binaries are known to work on CentOS5 and Mac OSX 10.6.

I am sending this pull request to see the test. It is likely that the PR does not work on my first try. In that case, I may need the help from more experienced users. Please don't merge even if the test passes. I will do that myself. Thank you.

* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [X] This PR adds a new recipe.
* [X] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
