### PR TITLE
bioconda-utils 0.11.4: fix conda dependency

### DIFF
--- a/recipes/bioconda-utils/meta.yaml
+++ b/recipes/bioconda-utils/meta.yaml
@@ -20,28 +20,6 @@ requirements:
   build:
     - python
     - setuptools
-    - anaconda-client 1.6.*
-    - argh 0.26.*
-    - beautifulsoup4 4.6.*
-    - conda 4.3.33
-    - conda-build 2.1.18
-    - galaxy-lib 17.9.*
-    - jinja2 2.10.*
-    - jsonschema 2.6.*
-    - networkx 1.11
-    - pyaml 17.12.*
-    - pydotplus 2.0.*
-    - requests 2.18.*
-    - sphinx
-    - docutils
-    - sphinx_rtd_theme
-    - involucro 1.1.*
-    - pandas 0.22.*
-    - numpy 1.14.*
-    - pygithub 1.34.*
-    - colorlog 3.1.*
-    - six 1.11.*
-    - alabaster 0.7.*
   run:
     - python
     - anaconda-client 1.6.*

--- a/recipes/bioconda-utils/meta.yaml
+++ b/recipes/bioconda-utils/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - anaconda-client 1.6.*
     - argh 0.26.*
     - beautifulsoup4 4.6.*
-    - conda 4.3.29
+    - conda 4.3.33
     - conda-build 2.1.18
     - galaxy-lib 17.9.*
     - jinja2 2.10.*
@@ -47,7 +47,7 @@ requirements:
     - anaconda-client 1.6.*
     - argh 0.26.*
     - beautifulsoup4 4.6.*
-    - conda 4.3.29
+    - conda 4.3.33
     - conda-build 2.1.18
     - galaxy-lib 17.9.*
     - jinja2 2.10.*

--- a/recipes/bioconda-utils/meta.yaml
+++ b/recipes/bioconda-utils/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: a8207f157abf2b8b3a63f2145bbdabd712724dfe246f07237ff9bada38c11934
 
 build:
-  number: 0
+  number: 1
   skip: True  # [not py3k]
   script: python setup.py install --single-version-externally-managed --record record.txt
   entry_points:


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Updates the dependency on `conda`.
Also removes all build requirement apart from `python` and `setuptools` as they are not needed during the actual build.