### PR TITLE
New: octopus, a haplotype based variant caller

### DIFF
--- a/recipes/octopus/build.sh
+++ b/recipes/octopus/build.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -eu -o pipefail
+
+cd build
+# BOOST -- need up to date version compiled with gcc 7.2
+wget http://dl.bintray.com/boostorg/release/1.65.0/source/boost_1_65_0.tar.gz
+tar -xzpf boost_1_65_0.tar.gz
+cd boost_1_65_0
+
+export BOOST_BUILD_PATH=`pwd`
+cat <<EOF > ./user-config.jam
+using gcc : : ${CXX} ;
+EOF
+
+./bootstrap.sh --prefix=$PREFIX --without-libraries=python --without-libraries=wave --with-icu=${PREFIX}
+./b2 \
+  --debug-configuration \
+  runtime-link=shared \
+  link=static,shared \
+  toolset=gcc \
+  cxxflags="${CXXFLAGS}" \
+  install
+cd ..
+# octopus
+cmake  -DINSTALL_PREFIX=ON -DCMAKE_INSTALL_PREFIX=$PREFIX -DINSTALL_ROOT=ON ..
+make install

--- a/recipes/octopus/meta.yaml
+++ b/recipes/octopus/meta.yaml
@@ -1,0 +1,52 @@
+{% set version="0.3.3a" %}
+about:
+  home: https://github.com/luntergroup/octopus
+  license: MIT
+  summary: Bayesian haplotype-based mutation calling
+package:
+  name: octopus
+  version: {{ version }}
+build:
+  number: 0
+  # We can re-add use of pre-build conda boost when bioconda version 
+  # updated to at least 1.65 and compiled with 7.x compilers
+  #string: "htslib{{CONDA_HTSLIB}}_boost{{CONDA_BOOST}}_{{PKG_BUILDNUM}}"
+  string: "htslib{{CONDA_HTSLIB}}_{{PKG_BUILDNUM}}"
+  # Not building on osx CircleCI and unsure how to fix; does not pick
+  # up 7.2 compilers
+  skip: true # [osx]
+source:
+  fn: octopus-{{ version }}.tar.gz
+  url: https://github.com/luntergroup/octopus/archive/v0.3.3-alpha.tar.gz
+  md5: 5c35ea21b5c31aa792f054b5f65484e7
+requirements:
+  build:
+    - gcc_linux-64 # [linux64]
+    - gxx_linux-64 # [linux64]
+    - gcc_linux-32 # [linux32]
+    - gxx_linux-32 # [linux32]
+    - clang_osx-64 # [osx]
+    - clangxx_osx-64 # [osx]
+    - cmake
+    - htslib {{CONDA_HTSLIB}}*
+    - wget
+    # - boost {{CONDA_BOOST}}*
+    - icu 58.*
+    - bzip2 {{CONDA_BZIP2}}*
+    - xz {{CONDA_XZ}}*
+    - zlib {{CONDA_ZLIB}}*
+  run:
+    - libgcc >=6.3 # [linux]
+    - htslib {{CONDA_HTSLIB}}*
+    # - boost {{CONDA_BOOST}}*
+    - icu 58.*
+    - bzip2 {{CONDA_BZIP2}}*
+    - xz {{CONDA_XZ}}*
+    - zlib {{CONDA_ZLIB}}*
+test:
+   commands:
+     - octopus -h
+
+extra:
+  skip-lints:
+    - boost_not_pinned


### PR DESCRIPTION
This requires a recent compiler (7.2) and a newer boost (>=1.65) compiled
with this so uses a custom boost build. Once conda-forge and bioconda
migrate to conda-build 3 with support for these we can use a standard
package.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [x] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
