### PR TITLE
Update mgltools to v1.5.7

### DIFF
--- a/recipes/mgltools/meta.yaml
+++ b/recipes/mgltools/meta.yaml
@@ -1,22 +1,22 @@
 about:
     home: http://mgltools.scripps.edu/
-    license_file: LICENSES
+    license_file: LICENSE.txt
     summary: MGLTools is an program for visualization and analisys of molecular structures.
 
 package:
     name: mgltools
-    version: 1.5.6
+    version: 1.5.7
 
 build:
   number: 0
 
 source:
-    fn:  mgltools_x86_64Linux2_1.5.6.tar.gz                                                                             # [linux]
-    url: http://mgltools.scripps.edu/downloads/downloads/tars/releases/REL1.5.6/mgltools_x86_64Linux2_1.5.6.tar.gz      # [linux]
-    md5: e3f62852c4d442a292dedbe6c79540ca                                                                               # [linux]
-    fn:  mgltools_i86Darwin9_1.5.6.tar.gz                                                                               # [osx]
-    url: http://mgltools.scripps.edu/downloads/downloads/tars/releases/REL1.5.6/mgltools_i86Darwin9_1.5.6.tar.gz        # [osx]
-    md5: c515b187cddeec72fe5a81ecb4a92d6b                                                                               # [osx]
+    fn:  mgltools_x86_64Linux2_1.5.7.tar.gz                                                                            # [linux]
+    url: http://mgltools.scripps.edu/downloads/tars/releases/nightly/1.5.7/REL/mgltools_x86_64Linux2_1.5.7.tar.gz      # [linux]
+    md5: 23e0d2ae6dcfbb1e1ff751c6d331b952                                                                              # [linux]
+    fn:  mgltools_x86_64Darwin10_1.5.7.tar.gz                                                                          # [osx]
+    url: http://mgltools.scripps.edu/downloads/tars/releases/nightly/1.5.7/REL/mgltools_x86_64Darwin10_1.5.7.tar.gz    # [osx]
+    md5: c515b187cddeec72fe5a81ecb4a92d6b                                                                              # [osx]
 
 requirements:
   build:


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

`mgltools` was updated to v1.5.7 in 2017/05, but was not properly marked as a release (even though is no longer considered `rc1`). It's not even on the webpage, but this release is important because it no longer requires the `numpy.oldnumeric` stuff, allowing the user to user any recent `numpy`.