### PR TITLE
Bump perl DBI version to 1.640

### DIFF
--- a/recipes/perl-dbi/meta.yaml
+++ b/recipes/perl-dbi/meta.yaml
@@ -11,15 +11,11 @@ source:
 build:
   number: 0
 
-
 requirements:
   build:
-    - gcc # [not osx]
-    - llvm # [osx]
     - perl
     - perl-module-build
   run:
-    - libgcc # [not osx]
     - perl
 
 test:

--- a/recipes/perl-dbi/meta.yaml
+++ b/recipes/perl-dbi/meta.yaml
@@ -1,11 +1,12 @@
+{% set version = "1.640" %}
 package:
   name: perl-dbi
-  version: '1.636'
+  version: {{ version }}
 
 source:
-  fn: DBI-1.636.tar.gz
-  url: https://cpan.metacpan.org/authors/id/T/TI/TIMB/DBI-1.636.tar.gz
-  md5: 60f291e5f015550dde71d1858dfe93ba
+  fn: DBI-{{ version }}.tar.gz
+  url: https://cpan.metacpan.org/authors/id/T/TI/TIMB/DBI-{{ version }}.tar.gz
+  sha256: 327e1bd92cd8ca2539b307b6d8c9d9527e5e707da99b87d52020841bc049a14a
 
 build:
   number: 0
@@ -15,13 +16,15 @@ requirements:
   build:
     - gcc # [not osx]
     - llvm # [osx]
-    - perl-threaded
-    - perl-app-cpanminus
+    - perl
     - perl-module-build
   run:
-    - libgcc
-    - perl-threaded
+    - libgcc # [not osx]
+    - perl
 
+test:
+  imports:
+    - DBI
 about:
   home: https://metacpan.org/pod/DBI
   license: Perl


### PR DESCRIPTION
Note that I still see https://github.com/bioconda/bioconda-recipes/issues/7415 upon issuing `circleci build`, even after a `docker pull bioconda/bioconda-utils-build-env:latest` to try to incorporate https://github.com/bioconda/bioconda-utils/pull/262 . Submitting this so someone can help troubleshoot.

* [X ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
