### PR TITLE
Update: octopus, multiqc-bcbio

### DIFF
--- a/recipes/multiqc-bcbio/meta.yaml
+++ b/recipes/multiqc-bcbio/meta.yaml
@@ -1,4 +1,4 @@
-{% set tag="f68e0dd" %}
+{% set tag="d6891b9" %}
 
 package:
   name: multiqc-bcbio
@@ -7,10 +7,10 @@ package:
 source:
   fn: multiqc-bcbio-{{ tag }}.tar.gz
   url: https://github.com/MultiQC/MultiQC_bcbio/archive/{{ tag }}.tar.gz
-  md5: d012950d4246130d7810ae506d176ee7
+  md5: fcbeb37db87b13fb480d035ece40aaa5
 
 build:
-  number: 0
+  number: 1
   preserve_egg_dir: True
   # multiqc does not support py3k because of click
   skip: true  # [py3k]

--- a/recipes/octopus/meta.yaml
+++ b/recipes/octopus/meta.yaml
@@ -7,7 +7,7 @@ package:
   name: octopus
   version: {{ version }}
 build:
-  number: 0
+  number: 1
   # We can re-add use of pre-build conda boost when bioconda version 
   # updated to at least 1.65 and compiled with 7.x compilers
   #string: "htslib{{CONDA_HTSLIB}}_boost{{CONDA_BOOST}}_{{PKG_BUILDNUM}}"
@@ -36,7 +36,8 @@ requirements:
     - xz {{CONDA_XZ}}*
     - zlib {{CONDA_ZLIB}}*
   run:
-    - libgcc >=6.3 # [linux]
+    - libgcc >=7.2 # [linux]
+    - libstdcxx-ng >=7.2 # [linux]
     - htslib {{CONDA_HTSLIB}}*
     # - boost {{CONDA_BOOST}}*
     - icu 58.*


### PR DESCRIPTION
- octopus -- ensure libstdc++ available as part of dependencies
  for machines with older gcc
- multiqc-bcbio -- fix ordering and display of viral table

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
