### PR TITLE
Add biodiff

### DIFF
--- a/recipes/biodiff/build.sh
+++ b/recipes/biodiff/build.sh
@@ -1,0 +1,4 @@
+autoreconf -i \
+    && ./configure --prefix "$PREFIX" \
+    && make \
+    && make install

--- a/recipes/biodiff/meta.yaml
+++ b/recipes/biodiff/meta.yaml
@@ -1,0 +1,41 @@
+{% set version = "0.2.2" %}
+
+package:
+  name: biodiff
+  version: {{ version }}
+
+source:
+  fn: archive.tar.gz
+  url: https://gitlab.com/LPCDRP/biodiff/repository/{{ version }}/archive.tar.gz
+  sha256: 30568afcacdc40581f8b1689f35aee45103aab0ec33dac07b38ab155b1833a5b
+  patches:
+    - osx.patch
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - autoconf
+    - automake
+    - pandoc
+  run:
+    - perl
+
+test:
+  source_files:
+    - test/lambda-phage/*
+  commands:
+    - biodiff test/lambda-phage/reference.fasta test/lambda-phage/snps-indels.fasta
+
+about:
+  home: https://gitlab.com/LPCDRP/biodiff
+  license: GPLv3+
+  license_file: LICENSE
+  summary: 'exact comparison of biological sequences'
+  description: >
+    biodiff is a variant caller that determines the exact differences between two biological sequences.
+    It can operate on DNA and protein sequences, as long as they are in fasta format.
+    The sequences to be compared must have the same fasta header (up to the first whitespace).
+    If the reference and query each have only one sequence, however, the header need not match and the comparison will be done, but a warning will be emitted.
+    Output is in the Variant Call Format.

--- a/recipes/biodiff/osx.patch
+++ b/recipes/biodiff/osx.patch
@@ -1,0 +1,38 @@
+From 0d17c8355bbf19fd6667f9132a4fd21cc1a6aef1 Mon Sep 17 00:00:00 2001
+From: Afif Elghraoui <afif@ghraoui.name>
+Date: Thu, 8 Feb 2018 20:06:14 -0500
+Subject: [PATCH] compatibility with FreeBSD userland
+
+---
+ biodiff | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/biodiff b/biodiff
+index 2885b9e..b04c3fb 100755
+--- a/biodiff
++++ b/biodiff
+@@ -3,12 +3,20 @@
+ set -e
+ 
+ VERSION=0.2.2
++platform="$(uname)"
++
++if [ "${platform}" = "Darwin" ] || [ "${platform}" = "FreeBSD" ]
++then
++    MKTEMP="mktemp"
++else
++    MKTEMP="mktemp -p /tmp"
++fi
+ 
+ reference="$1"
+ query="$2"
+ 
+ unset tmpdir
+-tmpdir=$(mktemp -p /tmp -d biodiff.XXXXXX)
++tmpdir=$(${MKTEMP} -d biodiff.XXXXXX)
+ refdir="$tmpdir/ref"
+ qrydir="$tmpdir/qry"
+ 
+-- 
+2.11.0
+


### PR DESCRIPTION
* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [X] This PR adds a new recipe.
* [X] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

@bioconda/core, this package uses the program `diff` on the system. The implementation that comes with MacOS may not be compatible.  Is there a way to exclude MacOS? I'd rather not maintain a conda package for GNU diff.