### PR TITLE
Add llvm as runtime req for osx (libc++ fail without it)

### DIFF
--- a/recipes/sga/meta.yaml
+++ b/recipes/sga/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - zlib {{ CONDA_ZLIB }}*
   run:
     - libgcc  # [not osx]
-    - llvm  # [osx]
+    - libcxx  # [osx]
     - sparsehash
     - bamtools
     - zlib {{ CONDA_ZLIB }}*

--- a/recipes/sga/meta.yaml
+++ b/recipes/sga/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 1b18996e6ec47985bc4889a8cbc3cd4dd3a8c7d385ae9f450bd474e36342558b
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -24,6 +24,7 @@ requirements:
     - zlib {{ CONDA_ZLIB }}*
   run:
     - libgcc  # [not osx]
+    - llvm  # [osx]
     - sparsehash
     - bamtools
     - zlib {{ CONDA_ZLIB }}*


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

When running MacOS 10.13 (at least), llvm is required at runtime - without it you get the standard:

    dyld: Library not loaded: @rpath/libc++.1.dylib
      Referenced from: /Users/kastman/miniconda/envs/agape/bin/sga
      Reason: image not found
    Abort trap: 6
