### PR TITLE
Change path quoting in case of special chars like '@'

### DIFF
--- a/recipes/kraken/build.sh
+++ b/recipes/kraken/build.sh
@@ -7,5 +7,7 @@ chmod u+x install_kraken.sh
 for bin in kraken kraken-build kraken-filter kraken-mpa-report kraken-report kraken-translate; do
     chmod +x "$PREFIX/libexec/$bin"
     ln -s "$PREFIX/libexec/$bin" "$PREFIX/bin/$bin"
+    # Change from double quotes to single in case of special chars
+    sed -i.bak "s#my \$KRAKEN_DIR = \"$PREFIX/libexec\";#my \$KRAKEN_DIR = '$PREFIX/libexec';#g" "$PREFIX/libexec/${bin}"
+    rm -rf "$PREFIX/libexec/${bin}.bak"
 done
-

--- a/recipes/kraken/meta.yaml
+++ b/recipes/kraken/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   has_prefix_files:
     - libexec/kraken
     - libexec/kraken-build
@@ -35,6 +35,10 @@ test:
   commands:
     - kraken --version
     - kraken-build --version
+    - kraken-filter --version
+    - kraken-mpa-report --version
+    - kraken-report --version
+    - kraken-translate --version
 
 about:
   home: http://ccb.jhu.edu/software/kraken/


### PR DESCRIPTION
If the recipe is used with a conda environment with an at sign in the directory name, given the double quotes Perl would try to interpret this - and fail.

Note given the way the recipe works there will be no dollar signs present to worry about.

* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [X] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

This is intended to fix a bug seen under Galaxy which used the form ``__prefix@_uv_`` in an environment name, and thus in the path. Perl didn't like this:

```
Global symbol "@_uv_" requires explicit package name (did you forget to declare "my @_uv_"?)
```

Cross reference https://github.com/galaxyproject/galaxy/pull/5498