### PR TITLE
Fix Augustus build errors on OSX

### DIFF
--- a/recipes/augustus/3.2.3_boost1.57/meta.yaml
+++ b/recipes/augustus/3.2.3_boost1.57/meta.yaml
@@ -69,7 +69,7 @@ test:
     - exonerate2hints.pl --help
     - echo "hello" | exoniphyDb2hints.pl
     - echo "hello" | extractTranscriptEnds.pl | grep ">seq1"
-    - filterBam --help
+    - filterBam --help 2>&1 | grep "filterBam --in in.bam --out out.bam"
     - filterGenesIn_mRNAname.pl --help
     - filterGenesOut_mRNAname.pl --help
     - filterGenes.pl --help 2>&1 | grep "usage:filterGenes.pl namefile dbfile"

--- a/recipes/augustus/3.2.3_boost1.57/meta.yaml
+++ b/recipes/augustus/3.2.3_boost1.57/meta.yaml
@@ -14,7 +14,7 @@ package:
 
 source:
   fn: {{ name }}-{{ version }}.tar.gz
-  url: http://bioinf.uni-greifswald.de/augustus/binaries/old/augustus-3.2.3.tar.gz
+  url: http://bioinf.uni-greifswald.de/augustus/binaries/old/{{ name }}-{{ version }}.tar.gz
   sha256: {{ sha256 }}
   patches:
       - patches/bam2hints.Makefile.patch
@@ -23,9 +23,8 @@ source:
       - patches/compileSpliceCands.Makefile.patch
 
 build:
-  number: 0
+  number: 1
   string: boost{{ boost }}_{{PKG_BUILDNUM}}
-  skip: True # [osx]
 
 requirements:
   build:

--- a/recipes/augustus/3.2.3_boost1.57/meta.yaml
+++ b/recipes/augustus/3.2.3_boost1.57/meta.yaml
@@ -23,7 +23,7 @@ source:
       - patches/compileSpliceCands.Makefile.patch
 
 build:
-  number: 1
+  number: 0
   string: boost{{ boost }}_{{PKG_BUILDNUM}}
 
 requirements:
@@ -69,6 +69,7 @@ test:
     - exonerate2hints.pl --help
     - echo "hello" | exoniphyDb2hints.pl
     - echo "hello" | extractTranscriptEnds.pl | grep ">seq1"
+    - filterBam --help
     - filterGenesIn_mRNAname.pl --help
     - filterGenesOut_mRNAname.pl --help
     - filterGenes.pl --help 2>&1 | grep "usage:filterGenes.pl namefile dbfile"

--- a/recipes/augustus/3.2.3_boost1.57/patches/filterBam.src.Makefile.patch
+++ b/recipes/augustus/3.2.3_boost1.57/patches/filterBam.src.Makefile.patch
@@ -12,8 +12,9 @@
 +INCLUDES =  -I${PREFIX}/include/bamtools/ -Iheaders -I./bamtools
 +#LIBS = -lbamtools -lz
 +LIBS = ${PREFIX}/lib/libbamtools.a -lz
- CFLAGS = -std=c++0x
+-CFLAGS = -std=c++0x
++CFLAGS = -std=c++11
 +CXXFLAGS += -Wall -O2 # -g -p -g -ggdb 
  VPATH = functions
- 
+
  all : $(PROGRAM) $(OBJECTS) CHECKBAM BIN

--- a/recipes/augustus/3.2.3_boost1.57/patches/filterBam.src.Makefile.patch
+++ b/recipes/augustus/3.2.3_boost1.57/patches/filterBam.src.Makefile.patch
@@ -13,8 +13,7 @@
 +#LIBS = -lbamtools -lz
 +LIBS = ${PREFIX}/lib/libbamtools.a -lz
 -CFLAGS = -std=c++0x
-+CFLAGS = -std=c++11
-+CXXFLAGS += -Wall -O2 # -g -p -g -ggdb 
++CFLAGS += -std=c++11 -Wall -O2 # -g -p -g -ggdb
  VPATH = functions
 
  all : $(PROGRAM) $(OBJECTS) CHECKBAM BIN

--- a/recipes/augustus/3.2.3_boost1.57/patches/filterBam.src.Makefile.patch
+++ b/recipes/augustus/3.2.3_boost1.57/patches/filterBam.src.Makefile.patch
@@ -1,6 +1,6 @@
 --- auxprogs/filterBam/src/Makefile	2016-03-30 18:35:01.000000000 +0400
 +++ auxprogs/filterBam/src/Makefile	2016-05-25 17:07:13.875931702 +0400
-@@ -8,10 +8,13 @@
+@@ -8,10 +8,12 @@
  			printElapsedTime.cc sumMandIOperations.cc sumDandIOperations.cc PairednessCoverage.cc
  PROGRAM = filterBam
  OBJECTS = $(SOURCES:.cc=.o)

--- a/recipes/augustus/meta.yaml
+++ b/recipes/augustus/meta.yaml
@@ -63,7 +63,7 @@ test:
     - exonerate2hints.pl --help
     - echo "hello" | exoniphyDb2hints.pl
     - echo "hello" | extractTranscriptEnds.pl | grep ">seq1"
-    - filterBam --help
+    - filterBam --help 2>&1 | grep "filterBam --in in.bam --out out.bam"
     - filterGenesIn_mRNAname.pl --help
     - filterGenesOut_mRNAname.pl --help
     - filterGenes.pl --help 2>&1 | grep "usage:filterGenes.pl namefile dbfile"

--- a/recipes/augustus/meta.yaml
+++ b/recipes/augustus/meta.yaml
@@ -17,7 +17,7 @@ source:
       - patches/compileSpliceCands.Makefile.patch
 
 build:
-  number: 4
+  number: 3
   string: boost{{CONDA_BOOST}}_{{PKG_BUILDNUM}}
 
 requirements:
@@ -63,6 +63,7 @@ test:
     - exonerate2hints.pl --help
     - echo "hello" | exoniphyDb2hints.pl
     - echo "hello" | extractTranscriptEnds.pl | grep ">seq1"
+    - filterBam --help
     - filterGenesIn_mRNAname.pl --help
     - filterGenesOut_mRNAname.pl --help
     - filterGenes.pl --help 2>&1 | grep "usage:filterGenes.pl namefile dbfile"

--- a/recipes/augustus/meta.yaml
+++ b/recipes/augustus/meta.yaml
@@ -8,7 +8,7 @@ package:
 
 source:
   fn: {{ name }}-{{ version }}.tar.gz
-  url: http://bioinf.uni-greifswald.de/augustus/binaries/old/augustus-3.2.3.tar.gz
+  url: http://bioinf.uni-greifswald.de/augustus/binaries/old/{{ name }}-{{ version }}.tar.gz
   sha256: {{ sha256 }}
   patches:
       - patches/bam2hints.Makefile.patch
@@ -17,9 +17,8 @@ source:
       - patches/compileSpliceCands.Makefile.patch
 
 build:
-  number: 3
+  number: 4
   string: boost{{CONDA_BOOST}}_{{PKG_BUILDNUM}}
-  skip: True # [osx]
 
 requirements:
   build:

--- a/recipes/augustus/patches/filterBam.src.Makefile.patch
+++ b/recipes/augustus/patches/filterBam.src.Makefile.patch
@@ -12,8 +12,9 @@
 +INCLUDES =  -I${PREFIX}/include/bamtools/ -Iheaders -I./bamtools
 +#LIBS = -lbamtools -lz
 +LIBS = ${PREFIX}/lib/libbamtools.a -lz
- CFLAGS = -std=c++0x
-+CXXFLAGS += -Wall -O2 # -g -p -g -ggdb 
+-CFLAGS = -std=c++0x
++CFLAGS = -std=c++11
++CXXFLAGS += -Wall -O2 # -g -p -g -ggdb
  VPATH = functions
- 
+
  all : $(PROGRAM) $(OBJECTS) CHECKBAM BIN

--- a/recipes/augustus/patches/filterBam.src.Makefile.patch
+++ b/recipes/augustus/patches/filterBam.src.Makefile.patch
@@ -13,8 +13,7 @@
 +#LIBS = -lbamtools -lz
 +LIBS = ${PREFIX}/lib/libbamtools.a -lz
 -CFLAGS = -std=c++0x
-+CFLAGS = -std=c++11
-+CXXFLAGS += -Wall -O2 # -g -p -g -ggdb
++CFLAGS += -std=c++11 -Wall -O2 # -g -p -g -ggdb
  VPATH = functions
 
  all : $(PROGRAM) $(OBJECTS) CHECKBAM BIN

--- a/recipes/augustus/patches/filterBam.src.Makefile.patch
+++ b/recipes/augustus/patches/filterBam.src.Makefile.patch
@@ -1,6 +1,6 @@
 --- auxprogs/filterBam/src/Makefile	2016-03-30 18:35:01.000000000 +0400
 +++ auxprogs/filterBam/src/Makefile	2016-05-25 17:07:13.875931702 +0400
-@@ -8,10 +8,13 @@
+@@ -8,10 +8,12 @@
  			printElapsedTime.cc sumMandIOperations.cc sumDandIOperations.cc PairednessCoverage.cc
  PROGRAM = filterBam
  OBJECTS = $(SOURCES:.cc=.o)


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Finishes @jerowe 's work in #3500 to get Augustus compiling on OSX; this patches the filterBam Makefile to use  c++11 which fixes the "fatal error: 'unordered_map' file not found" also listed in #3284.