### PR TITLE
Circleci fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,13 +52,17 @@ jobs:
       - *setup
       - run:
           name: Linting
-          command: bioconda-utils lint recipes config.yml --git-range master HEAD
+          command: |
+            source .setup_bash_env
+            bioconda-utils lint recipes config.yml --git-range master HEAD
       - run:
           name: Testing
           # Currently, using --docker below causes a permission error on Fedora 27, 
           # although it should be supported by the setup_remote_docker directive 
           # above. A workaround or an upstream fix would be welcome.
-          command: bioconda-utils build recipes config.yml --git-range master HEAD
+          command: |
+            source .setup_bash_env
+            bioconda-utils build recipes config.yml --git-range master HEAD
 
   lint:
     <<: *linux
@@ -70,7 +74,9 @@ jobs:
       - *save_cache
       - run:
           name: Linting
-          command: bioconda-utils lint recipes config.yml --git-range master HEAD
+          command: |
+            source .setup_bash_env
+            bioconda-utils lint recipes config.yml --git-range master HEAD
 
   # build and test on linux
   test-linux:
@@ -83,7 +89,9 @@ jobs:
       - *save_cache
       - run:
           name: Building and testing
-          command: bioconda-utils build recipes config.yml --git-range master HEAD --docker --mulled-test
+          command: |
+            source .setup_bash_env
+            bioconda-utils build recipes config.yml --git-range master HEAD --docker --mulled-test
 
   # build and test on macos
   test-macos:
@@ -96,7 +104,9 @@ jobs:
       - *save_cache
       - run:
           name: Building and testing
-          command: bioconda-utils build recipes config.yml --git-range master HEAD
+          command: |
+            source .setup_bash_env
+            bioconda-utils build recipes config.yml --git-range master HEAD
   
   # build, test and upload on linux
   upload-linux:
@@ -110,7 +120,9 @@ jobs:
       # build only current commit (since we use squashed merging, this is safe)
       - run:
           name: Building, testing, and uploading
-          command: bioconda-utils build recipes config.yml --docker --mulled-test --anaconda-upload --mulled-upload-target biocontainers --git-range $CIRCLE_SHA1~1 $CIRCLE_SHA1
+          command: |
+            source .setup_bash_env
+            bioconda-utils build recipes config.yml --docker --mulled-test --anaconda-upload --mulled-upload-target biocontainers --git-range $CIRCLE_SHA1~1 $CIRCLE_SHA1
 
   # build, test and upload on macos
   upload-macos:
@@ -124,7 +136,9 @@ jobs:
       # build only current commit (since we use squashed merging, this is safe)
       - run:
           name: Building, testing and uploading
-          command: bioconda-utils build recipes config.yml --anaconda-upload --git-range $CIRCLE_SHA1~1 $CIRCLE_SHA1
+          command: |
+            source .setup_bash_env
+            bioconda-utils build recipes config.yml --anaconda-upload --git-range $CIRCLE_SHA1~1 $CIRCLE_SHA1
 
   # build, test and upload for bulk branch on linux
   bulk-linux:
@@ -138,7 +152,9 @@ jobs:
       # build everything that differs compared to master
       - run:
           name: Building, testing, and uploading of all unpublished recipes
-          command: bioconda-utils build recipes config.yml --docker --mulled-test --anaconda-upload --mulled-upload-target biocontainers --git-range master HEAD
+          command: |
+            source .setup_bash_env
+            bioconda-utils build recipes config.yml --docker --mulled-test --anaconda-upload --mulled-upload-target biocontainers --git-range master HEAD
 
   # build, test and upload for bulk branch on macos
   bulk-macos:
@@ -152,7 +168,9 @@ jobs:
       # build everything that differs compared to master
       - run:
           name: Building, testing and uploading of all unpublished recipes
-          command: bioconda-utils build recipes config.yml --anaconda-upload --git-range master HEAD
+          command: |
+            source .setup_bash_env
+            bioconda-utils build recipes config.yml --anaconda-upload --git-range master HEAD
 
 
   # nightly build, test and upload of unpublished recipes on linux
@@ -167,7 +185,9 @@ jobs:
       - *save_cache
       - run:
           name: Building, testing, and uploading of all unpublished recipes
-          command: bioconda-utils build recipes config.yml --docker --mulled-test --anaconda-upload --mulled-upload-target biocontainers
+          command: |
+            source .setup_bash_env
+            bioconda-utils build recipes config.yml --docker --mulled-test --anaconda-upload --mulled-upload-target biocontainers
 
   # nightly build, test and upload of unpublished recipes on macos
   nightly-upload-macos:
@@ -181,7 +201,9 @@ jobs:
       - *save_cache
       - run:
           name: Building, testing and uploading of all unpublished recipes
-          command: bioconda-utils build recipes config.yml --anaconda-upload
+          command: |
+            source .setup_bash_env
+            bioconda-utils build recipes config.yml --anaconda-upload
 
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,8 +30,19 @@ variables:
     run:
       name: Check for fork
       command: |
-        [[ CIRCLE_PROJECT_USERNAME == bioconda ]] || \
-        (echo "Skipping build for fork '$CIRCLE_PROJECT_USERNAME'" && circleci step halt)
+        [[ CIRCLE_PROJECT_USERNAME == bioconda ]] || (
+            echo "Skipping build for fork '$CIRCLE_PROJECT_USERNAME'"
+            circleci step halt
+        )
+  fail_fork: &fail_fork
+    run:
+      name: Check for fork
+      command: |
+        [[ CIRCLE_PROJECT_USERNAME == bioconda ]] || (
+            echo "Aborting build for fork '$CIRCLE_PROJECT_USERNAME'"
+            echo "Please use a branch other than 'master' or 'bulk' on your fork"
+            exit 1
+        )
 
 jobs:
   # When running CircleCI locally, we put everything in one job.
@@ -102,7 +113,7 @@ jobs:
   upload-linux:
     <<: *linux
     steps:
-      - *skip_fork
+      - *fail_fork
       - checkout
       - *common
       - *restore_cache
@@ -117,7 +128,7 @@ jobs:
   upload-macos:
     <<: *macos
     steps:
-      - *skip_fork
+      - *fail_fork
       - checkout
       - *common
       - *restore_cache
@@ -132,7 +143,7 @@ jobs:
   bulk-linux:
     <<: *linux
     steps:
-      - *skip_fork
+      - *fail_fork
       - checkout
       - *common
       - *restore_cache
@@ -147,7 +158,7 @@ jobs:
   bulk-macos:
     <<: *macos
     steps:
-      - *skip_fork
+      - *fail_fork
       - checkout
       - *common
       - *restore_cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,12 @@ variables:
       LANG: en_US.UTF-8
   linux: &linux
     machine: true
+  skip_fork: &skip_fork
+    run:
+      name: Check for fork
+      command: |
+        [[ CIRCLE_PROJECT_USERNAME == bioconda ]] || \
+        (echo "Skipping build for fork '$CIRCLE_PROJECT_USERNAME'" && circleci step halt)
 
 jobs:
   # When running CircleCI locally, we put everything in one job.
@@ -153,6 +159,7 @@ jobs:
   nightly-upload-linux:
     <<: *linux
     steps:
+      - *skip_fork
       - checkout
       - *common
       - *restore_cache
@@ -166,6 +173,7 @@ jobs:
   nightly-upload-macos:
     <<: *macos
     steps:
+      - *skip_fork
       - checkout
       - *common
       - *restore_cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,6 +102,7 @@ jobs:
   upload-linux:
     <<: *linux
     steps:
+      - *skip_fork
       - checkout
       - *common
       - *restore_cache
@@ -116,6 +117,7 @@ jobs:
   upload-macos:
     <<: *macos
     steps:
+      - *skip_fork
       - checkout
       - *common
       - *restore_cache
@@ -130,6 +132,7 @@ jobs:
   bulk-linux:
     <<: *linux
     steps:
+      - *skip_fork
       - checkout
       - *common
       - *restore_cache
@@ -144,6 +147,7 @@ jobs:
   bulk-macos:
     <<: *macos
     steps:
+      - *skip_fork
       - checkout
       - *common
       - *restore_cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,8 +46,8 @@ jobs:
             mkdir -p ~/.ssh
             ssh-keyscan -H github.com >> ~/.ssh/known_hosts
       - run: 
-          name: linking conda
-          command: ln -s /opt/conda $HOME/miniconda
+          name: Setup base system
+          command: echo '. /opt/docker/bin/entrypoint_source' >> .setup_bash_env
       - *common
       - *setup
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,22 +47,18 @@ jobs:
             ssh-keyscan -H github.com >> ~/.ssh/known_hosts
       - run: 
           name: Setup base system
-          command: echo '. /opt/docker/bin/entrypoint_source' >> .setup_bash_env
+          command: echo '. /opt/docker/bin/entrypoint_source' >> $BASH_ENV
       - *common
       - *setup
       - run:
           name: Linting
-          command: |
-            source .setup_bash_env
-            bioconda-utils lint recipes config.yml --git-range master HEAD
+          command: bioconda-utils lint recipes config.yml --git-range master HEAD
       - run:
           name: Testing
           # Currently, using --docker below causes a permission error on Fedora 27, 
           # although it should be supported by the setup_remote_docker directive 
           # above. A workaround or an upstream fix would be welcome.
-          command: |
-            source .setup_bash_env
-            bioconda-utils build recipes config.yml --git-range master HEAD
+          command: bioconda-utils build recipes config.yml --git-range master HEAD
 
   lint:
     <<: *linux
@@ -74,9 +70,7 @@ jobs:
       - *save_cache
       - run:
           name: Linting
-          command: |
-            source .setup_bash_env
-            bioconda-utils lint recipes config.yml --git-range master HEAD
+          command: bioconda-utils lint recipes config.yml --git-range master HEAD
 
   # build and test on linux
   test-linux:
@@ -89,9 +83,7 @@ jobs:
       - *save_cache
       - run:
           name: Building and testing
-          command: |
-            source .setup_bash_env
-            bioconda-utils build recipes config.yml --git-range master HEAD --docker --mulled-test
+          command: bioconda-utils build recipes config.yml --git-range master HEAD --docker --mulled-test
 
   # build and test on macos
   test-macos:
@@ -104,9 +96,7 @@ jobs:
       - *save_cache
       - run:
           name: Building and testing
-          command: |
-            source .setup_bash_env
-            bioconda-utils build recipes config.yml --git-range master HEAD
+          command: bioconda-utils build recipes config.yml --git-range master HEAD
   
   # build, test and upload on linux
   upload-linux:
@@ -120,9 +110,7 @@ jobs:
       # build only current commit (since we use squashed merging, this is safe)
       - run:
           name: Building, testing, and uploading
-          command: |
-            source .setup_bash_env
-            bioconda-utils build recipes config.yml --docker --mulled-test --anaconda-upload --mulled-upload-target biocontainers --git-range $CIRCLE_SHA1~1 $CIRCLE_SHA1
+          command: bioconda-utils build recipes config.yml --docker --mulled-test --anaconda-upload --mulled-upload-target biocontainers --git-range $CIRCLE_SHA1~1 $CIRCLE_SHA1
 
   # build, test and upload on macos
   upload-macos:
@@ -136,9 +124,7 @@ jobs:
       # build only current commit (since we use squashed merging, this is safe)
       - run:
           name: Building, testing and uploading
-          command: |
-            source .setup_bash_env
-            bioconda-utils build recipes config.yml --anaconda-upload --git-range $CIRCLE_SHA1~1 $CIRCLE_SHA1
+          command: bioconda-utils build recipes config.yml --anaconda-upload --git-range $CIRCLE_SHA1~1 $CIRCLE_SHA1
 
   # build, test and upload for bulk branch on linux
   bulk-linux:
@@ -152,9 +138,7 @@ jobs:
       # build everything that differs compared to master
       - run:
           name: Building, testing, and uploading of all unpublished recipes
-          command: |
-            source .setup_bash_env
-            bioconda-utils build recipes config.yml --docker --mulled-test --anaconda-upload --mulled-upload-target biocontainers --git-range master HEAD
+          command: bioconda-utils build recipes config.yml --docker --mulled-test --anaconda-upload --mulled-upload-target biocontainers --git-range master HEAD
 
   # build, test and upload for bulk branch on macos
   bulk-macos:
@@ -168,9 +152,7 @@ jobs:
       # build everything that differs compared to master
       - run:
           name: Building, testing and uploading of all unpublished recipes
-          command: |
-            source .setup_bash_env
-            bioconda-utils build recipes config.yml --anaconda-upload --git-range master HEAD
+          command: bioconda-utils build recipes config.yml --anaconda-upload --git-range master HEAD
 
 
   # nightly build, test and upload of unpublished recipes on linux
@@ -185,9 +167,7 @@ jobs:
       - *save_cache
       - run:
           name: Building, testing, and uploading of all unpublished recipes
-          command: |
-            source .setup_bash_env
-            bioconda-utils build recipes config.yml --docker --mulled-test --anaconda-upload --mulled-upload-target biocontainers
+          command: bioconda-utils build recipes config.yml --docker --mulled-test --anaconda-upload --mulled-upload-target biocontainers
 
   # nightly build, test and upload of unpublished recipes on macos
   nightly-upload-macos:
@@ -201,9 +181,7 @@ jobs:
       - *save_cache
       - run:
           name: Building, testing and uploading of all unpublished recipes
-          command: |
-            source .setup_bash_env
-            bioconda-utils build recipes config.yml --anaconda-upload
+          command: bioconda-utils build recipes config.yml --anaconda-upload
 
 
 

--- a/.circleci/setup.sh
+++ b/.circleci/setup.sh
@@ -7,6 +7,15 @@ WORKSPACE=`pwd`
 # This file can be used to set BIOCONDA_UTILS_TAG and MINICONDA_VER.
 source .circleci/common.sh
 
+# make sure the CircleCI config is up to date
+git remote add -t master upstream https://github.com/bioconda/bioconda-recipes.git
+git fetch upstream
+if ! git diff --quiet HEAD...upstream/master -- .circleci/; then
+    echo 'The CI configuration is out of date.'
+    echo 'Please merge in bioconda:master.'
+    exit 1
+fi
+
 # Set path
 cat >> $BASH_ENV << EOF
 if ! [[ "\$PATH" =~ (^|:)"$WORKSPACE/miniconda/bin"(|/)(:|\$) ]]; then

--- a/.circleci/setup.sh
+++ b/.circleci/setup.sh
@@ -17,11 +17,7 @@ if ! git diff --quiet HEAD...upstream/master -- .circleci/; then
 fi
 
 # Set path
-cat >> $BASH_ENV << EOF
-if ! [[ "\$PATH" =~ (^|:)"$WORKSPACE/miniconda/bin"(|/)(:|\$) ]]; then
-    export PATH=$WORKSPACE/miniconda/bin:\$PATH
-fi
-EOF
+echo "export PATH=$WORKSPACE/miniconda/bin:$PATH" >> $BASH_ENV
 source $BASH_ENV
 
 if ! type bioconda-utils > /dev/null; then

--- a/.circleci/setup.sh
+++ b/.circleci/setup.sh
@@ -35,7 +35,7 @@ if ! type bioconda-utils > /dev/null; then
     conda config --add channels bioconda
 
     # step 3: install bioconda-utils
-    conda install -y --file https://raw.githubusercontent.com/bioconda/bioconda-utils/$BIOCONDA_UTILS_TAG/bioconda_utils/bioconda_utils-requirements.txt
+    conda install -y git pip --file https://raw.githubusercontent.com/bioconda/bioconda-utils/$BIOCONDA_UTILS_TAG/bioconda_utils/bioconda_utils-requirements.txt
     pip install git+https://github.com/bioconda/bioconda-utils.git@$BIOCONDA_UTILS_TAG
 
     # step 4: configure local channel

--- a/.circleci/setup.sh
+++ b/.circleci/setup.sh
@@ -30,9 +30,9 @@ if ! type bioconda-utils > /dev/null; then
     bash miniconda.sh -b -p $WORKSPACE/miniconda
 
     # step 2: setup channels
-    conda config --add channels defaults
-    conda config --add channels conda-forge
-    conda config --add channels bioconda
+    conda config --system --add channels defaults
+    conda config --system --add channels conda-forge
+    conda config --system --add channels bioconda
 
     # step 3: install bioconda-utils
     conda install -y git pip --file https://raw.githubusercontent.com/bioconda/bioconda-utils/$BIOCONDA_UTILS_TAG/bioconda_utils/bioconda_utils-requirements.txt
@@ -40,7 +40,7 @@ if ! type bioconda-utils > /dev/null; then
 
     # step 4: configure local channel
     conda index $WORKSPACE/miniconda/conda-bld/linux-64 $WORKSPACE/miniconda/conda-bld/osx-64 $WORKSPACE/miniconda/conda-bld/noarch
-    conda config --add channels file://$WORKSPACE/miniconda/conda-bld
+    conda config --system --add channels file://$WORKSPACE/miniconda/conda-bld
 
     # step 5: cleanup
     conda clean -y --all

--- a/.circleci/setup.sh
+++ b/.circleci/setup.sh
@@ -8,8 +8,9 @@ WORKSPACE=`pwd`
 source .circleci/common.sh
 
 # Set path
-echo "export PATH=$WORKSPACE/miniconda/bin:$PATH" >> $BASH_ENV
-source $BASH_ENV
+cat $BASH_ENV >> .setup_bash_env
+echo "export PATH=$WORKSPACE/miniconda/bin:$PATH" >> .setup_bash_env
+source .setup_bash_env
 
 if ! type bioconda-utils > /dev/null; then
     echo "Setting up bioconda-utils..."

--- a/.circleci/setup.sh
+++ b/.circleci/setup.sh
@@ -8,9 +8,12 @@ WORKSPACE=`pwd`
 source .circleci/common.sh
 
 # Set path
-cat $BASH_ENV >> .setup_bash_env
-echo "export PATH=$WORKSPACE/miniconda/bin:$PATH" >> .setup_bash_env
-source .setup_bash_env
+cat >> $BASH_ENV << EOF
+if ! [[ "\$PATH" =~ (^|:)"$WORKSPACE/miniconda/bin"(|/)(:|\$) ]]; then
+    export PATH=$WORKSPACE/miniconda/bin:\$PATH
+fi
+EOF
+source $BASH_ENV
 
 if ! type bioconda-utils > /dev/null; then
     echo "Setting up bioconda-utils..."


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

This does a couple of small things in regard to the CircleCI configuration:
1. Explicitly installs `git` and `pip` to our Conda environment. Should be a no-op since `python` (and thus `pip`) and `git` are dependencies of `bioconda-utils`. But since we `pip install git+https://...` it doesn't hurt to be sure we have those dependencies in place.
2. Uses `--system` parameter for `conda config`. Without that parameter, I think, the configuration is written to the home directory and not `$WORKSPACE`. Since we cache `$WORKSPACE`, we should write it there. \[NOTE: I'm a little confused as to why we didn't already run into problems on macOS since the cache was activated there...\]
3. Checks `CIRCLE_PROJECT_USERNAME == bioconda` for the nightly uploads and exits early on forks.
4. ~\[**EDIT**: Added another commit to make the `PATH` changes conditional. I think that should be fine and is definitely nicer to look at.\]
   Instead of `$BASH_ENV`, uses a custom `.setup_bash_env` script. It's a little ugly since we need to run that for every `run/command` explicitly -- does anyone have a better idea? We shouldn't use `$BASH_ENV` since this resets `PATH` for every `bash` execution, which includes `post-link.sh` scripts and the like. \[NOTE: again, I'm surprised we didn't run into problems on macOS already.\]~ [nvm](https://github.com/bioconda/bioconda-recipes/pull/7684#discussion_r168213812)
5. Sources the `condaforge/linux-anvil` `entrypoint_source` which will enable `devtoolset-2` and thus be a little more like when run with `--docker`, I think. But still, the local configuration doesn't mirror the one on CircleCI -- I've yet to try out some other things.