### PR TITLE
circleci: use docker-entrypoint-source for local build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
             ssh-keyscan -H github.com >> ~/.ssh/known_hosts
       - run: 
           name: Setup base system
-          command: echo '. /opt/docker/bin/entrypoint_source' >> $BASH_ENV
+          command: echo '. /tmp/repo/docker-entrypoint-source' >> $BASH_ENV
       - *common
       - *setup
       - run:

--- a/.circleci/setup.sh
+++ b/.circleci/setup.sh
@@ -30,10 +30,10 @@ if ! type bioconda-utils > /dev/null; then
     if [[ $OSTYPE == darwin* ]]; then
         tag="MacOSX"
     elif [[ $OSTYPE == linux* ]]; then
-	tag="Linux"
+        tag="Linux"
     else
-	echo "Unsupported OS: $OSTYPE"
-	exit 1
+        echo "Unsupported OS: $OSTYPE"
+        exit 1
     fi
     curl -L -o miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-$MINICONDA_VER-$tag-x86_64.sh
     bash miniconda.sh -b -p $WORKSPACE/miniconda


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

This is a followup to #7684 that just makes local builds source `/tmp/repo/docker-entrypoint-source` instead of `/opt/docker/bin/entrypoint_source`.