### PR TITLE
Circle ci add upstream check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,14 @@ jobs:
             ssh-keyscan -H github.com >> ~/.ssh/known_hosts
       - run: 
           name: Setup base system
-          command: echo '. /tmp/repo/docker-entrypoint-source' >> $BASH_ENV
+          command: |
+            echo >> $BASH_ENV <<EOF
+            if [[ $- == *u* ]] ; then
+                set +u ; . /tmp/repo/docker-entrypoint-source ; set -u
+            else
+                . /tmp/repo/docker-entrypoint-source
+            fi
+            EOF
       - *common
       - *setup
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,8 +59,8 @@ jobs:
       - run: 
           name: Setup base system
           command: |
-            echo >> $BASH_ENV <<EOF
-            if [[ $- == *u* ]] ; then
+            cat >> $BASH_ENV <<EOF
+            if [[ \$- == *u* ]] ; then
                 set +u ; . /tmp/repo/docker-entrypoint-source ; set -u
             else
                 . /tmp/repo/docker-entrypoint-source

--- a/.circleci/setup.sh
+++ b/.circleci/setup.sh
@@ -7,6 +7,10 @@ WORKSPACE=`pwd`
 # This file can be used to set BIOCONDA_UTILS_TAG and MINICONDA_VER.
 source .circleci/common.sh
 
+# Set path
+echo "export PATH=$WORKSPACE/miniconda/bin:$PATH" >> $BASH_ENV
+source $BASH_ENV
+
 # Make sure the CircleCI config is up to date.
 # add upstream as some semi-randomly named temporary remote to diff against
 UPSTREAM_REMOTE=__upstream__$(tr -dc a-z < /dev/urandom | head -c10)
@@ -19,9 +23,6 @@ if ! git diff --quiet HEAD...$UPSTREAM_REMOTE/master -- .circleci/; then
 fi
 git remote remove $UPSTREAM_REMOTE
 
-# Set path
-echo "export PATH=$WORKSPACE/miniconda/bin:$PATH" >> $BASH_ENV
-source $BASH_ENV
 
 if ! type bioconda-utils > /dev/null; then
     echo "Setting up bioconda-utils..."

--- a/.circleci/setup.sh
+++ b/.circleci/setup.sh
@@ -7,23 +7,17 @@ WORKSPACE=`pwd`
 # This file can be used to set BIOCONDA_UTILS_TAG and MINICONDA_VER.
 source .circleci/common.sh
 
-# make sure the CircleCI config is up to date
-if UPSTREAM=$(git remote get-url upstream 2> /dev/null); then
-    if [[ "$UPSTREAM" != "https://github.com/bioconda/bioconda-recipes.git" ]]; then
-        echo 'The remote upstream of the repository'
-        echo 'must be set to:'
-        echo 'https://github.com/bioconda/bioconda-recipes.git'
-        exit 1
-    fi
-else
-    git remote add -t master upstream https://github.com/bioconda/bioconda-recipes.git
-fi
-git fetch upstream
-if ! git diff --quiet HEAD...upstream/master -- .circleci/; then
+# Make sure the CircleCI config is up to date.
+# add upstream as some semi-randomly named temporary remote to diff against
+UPSTREAM_REMOTE=__upstream__$(tr -dc a-z < /dev/urandom | head -c10)
+git remote add -t master $UPSTREAM_REMOTE https://github.com/bioconda/bioconda-recipes.git
+git fetch $UPSTREAM_REMOTE
+if ! git diff --quiet HEAD...$UPSTREAM_REMOTE/master -- .circleci/; then
     echo 'The CI configuration is out of date.'
     echo 'Please merge in bioconda:master.'
     exit 1
 fi
+git remote remove $UPSTREAM_REMOTE
 
 # Set path
 echo "export PATH=$WORKSPACE/miniconda/bin:$PATH" >> $BASH_ENV

--- a/.circleci/setup.sh
+++ b/.circleci/setup.sh
@@ -8,7 +8,16 @@ WORKSPACE=`pwd`
 source .circleci/common.sh
 
 # make sure the CircleCI config is up to date
-git remote add -t master upstream https://github.com/bioconda/bioconda-recipes.git
+if UPSTREAM=$(git remote get-url upstream 2> /dev/null); then
+    if [[ "$UPSTREAM" != "https://github.com/bioconda/bioconda-recipes.git" ]]; then
+        echo 'The remote upstream of the repository'
+        echo 'must be set to:'
+        echo 'https://github.com/bioconda/bioconda-recipes.git'
+        exit 1
+    fi
+else
+    git remote add -t master upstream https://github.com/bioconda/bioconda-recipes.git
+fi
 git fetch upstream
 if ! git diff --quiet HEAD...upstream/master -- .circleci/; then
     echo 'The CI configuration is out of date.'


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

Pointing the remote upstream to the main repository does not work for the local build if it is already set. Here is a simple check, but I'm not sure it solves the problem completely. I still get an error:

```
====>> Setup bioconda-utils
  #!/bin/bash -eo pipefail
.circleci/setup.sh
/usr/bin/scl_source: line 34: _scls[@]: unbound variable
Error: Exited with code 1
Step failed
Task failed

```