### PR TITLE
Add missing libwww dependency

### DIFF
--- a/recipes/krakenhll/meta.yaml
+++ b/recipes/krakenhll/meta.yaml
@@ -29,6 +29,7 @@ requirements:
   run:
     - jellyfish 1.*
     - perl
+    - perl-libwww-perl
     - libgcc
     - zlib {{CONDA_ZLIB}}*
 

--- a/recipes/krakenhll/meta.yaml
+++ b/recipes/krakenhll/meta.yaml
@@ -30,6 +30,7 @@ requirements:
     - jellyfish 1.*
     - perl
     - perl-libwww-perl
+    - perl-lwp-protocol-https
     - libgcc
     - zlib {{CONDA_ZLIB}}*
 


### PR DESCRIPTION
`krakenhll-build --standard` fails if perl's libwww is not installed. This adds the needed dependency.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
