### PR TITLE
bulk hash-hunt, adding a bunch of missing hashes 

### DIFF
--- a/recipes/cancerit-allelecount/meta.yaml
+++ b/recipes/cancerit-allelecount/meta.yaml
@@ -4,6 +4,7 @@ package:
 source:
   fn: alleleCount-v2.1.2.tar.gz
   url: https://github.com/cancerit/alleleCount/archive/v2.1.2.tar.gz
+  sha256: 2c7fd5521d4dd3353a3937949007ba8b0b0ad6025ea06f82ee351e837f1dd625
 build:
   number: 2
   skip: True # [osx]

--- a/recipes/genblastg/meta.yaml
+++ b/recipes/genblastg/meta.yaml
@@ -10,7 +10,7 @@ build:
 
 package:
   name: genblastg
-  version: '1.38'
+  version: '1.39'
 
 requirements:
   build:
@@ -23,8 +23,9 @@ requirements:
     - blast
 
 source:
-  fn: genblast_v138.zip
+  fn: genblast_v139.zip
   url: http://genome.sfu.ca/genblast/latest/genblast_v139.zip
+  sha256: 7934ef446d9b2f8fa80a6b53a2f001e2531edf2a2749545390e739ffa878e8d4
 
 test:
   commands:

--- a/recipes/gvcftools/meta.yaml
+++ b/recipes/gvcftools/meta.yaml
@@ -6,6 +6,7 @@ package:
 source:
   fn: gvcftools-0.17.0.tar.gz
   url: https://github.com/sequencing/gvcftools/releases/download/v0.17.0/gvcftools-0.17.0.tar.gz
+  sha256: 4da569ada463bd2e8ce9b5da4f0bbb1996829a7d52fb216737a4b76af74840e2
 
 build:
   number: 2

--- a/recipes/leptonica/1.73/meta.yaml
+++ b/recipes/leptonica/1.73/meta.yaml
@@ -7,6 +7,7 @@ build:
 source:
   fn: leptonica-1.73.tar.gz
   url: https://github.com/DanBloomberg/leptonica/archive/v1.73.tar.gz
+  sha256: f5669ce2e30f873833474df005f606e96bdcaa9aa43aead21b6709ecaec1fc05
 requirements:
   build:
     - gcc       # [linux]

--- a/recipes/lighter/meta.yaml
+++ b/recipes/lighter/meta.yaml
@@ -5,6 +5,7 @@ package:
 source:
   fn: v1.1.1.tar.gz
   url: https://github.com/mourisl/Lighter/archive/v1.1.1.tar.gz
+  sha256: 9b29b87cd87f6d57ef8c39d22fb8679977128a1bdf557d8c161eae2816e374b7
 
 build:
   number: 2

--- a/recipes/megagta/meta.yaml
+++ b/recipes/megagta/meta.yaml
@@ -5,6 +5,7 @@ package:
 source:
   fn: megagta-v0.1alpha-src.tar.gz
   url: https://github.com/HKU-BAL/megagta/releases/download/v0.1-alpha/megagta-v0.1alpha-src.tar.gz
+  sha256: 0c4361a15002798117011c58186d2e3b88119de46742ee9cd10bd9c8594b69d3
 
 build:
   number: 1

--- a/recipes/metavelvet/1.1.01/meta.yaml
+++ b/recipes/metavelvet/1.1.01/meta.yaml
@@ -25,6 +25,7 @@ requirements:
 source:
   fn: metavelvet-1.1.01.tgz
   url: http://metavelvet.dna.bio.keio.ac.jp/src/MetaVelvet-1.1.01.tgz
+  sha256: 7c7c71b383ea73876dae824829e32130d10c222f849aa35c3d79e68facdc1e6b
   patches:
       - metavelvet.velvet.makefile.patch
 

--- a/recipes/metavelvet/meta.yaml
+++ b/recipes/metavelvet/meta.yaml
@@ -28,6 +28,7 @@ requirements:
 source:
   fn: metavelvet-1.2.02.tgz
   url: http://metavelvet.dna.bio.keio.ac.jp/src/MetaVelvet-1.2.02.tgz
+  sha256: 80999b1cb6b533719d258f4c3d8517cf2a72dcfadd19c088470432382a8e0ecf
   patches:
       - metavelvet.velvet.makefile.patch
       - run-annoIS.pl.patch

--- a/recipes/perl-compress-raw-zlib/meta.yaml
+++ b/recipes/perl-compress-raw-zlib/meta.yaml
@@ -5,6 +5,7 @@ package:
 source:
   fn: Compress-Raw-Zlib-2.069.tar.gz
   url: https://cpan.metacpan.org/authors/id/P/PM/PMQS/Compress-Raw-Zlib-2.069.tar.gz
+  sha256: 9a647fe7d2e6122370372a11c1e3a2e2b54c90bba595cad170854fdaa8a64619
 
 build:
   number: 4

--- a/recipes/soapdenovo2-prepare/meta.yaml
+++ b/recipes/soapdenovo2-prepare/meta.yaml
@@ -22,6 +22,7 @@ requirements:
 source:
   fn: soapdenovo2-prepare.tar.gz
   url: https://sourceforge.net/projects/soapdenovo2/files/Prepare/Prepare-src-v2.0.tgz/download
+  sha256: 97bfccede6bd138365d466f2d71685abaccd366ea69ae0a9d90598e4547f291f
   patches:
       - Makefile.osx.patch # [osx]
 

--- a/recipes/soapdenovo2/meta.yaml
+++ b/recipes/soapdenovo2/meta.yaml
@@ -24,7 +24,9 @@ requirements:
 source:
   fn: soapdenovo2-t240.tgz
   url: https://sourceforge.net/projects/soapdenovo2/files/SOAPdenovo2/src/r240/SOAPdenovo2-src-r240.tgz/download # [linux]
+  sha256: b58fdb9b14766a122992d23dba5e91bd733c86e0062b432181aa5c1e7f052bb7 # [linux]
   url: https://sourceforge.net/projects/soapdenovo2/files/SOAPdenovo2/src/r240/SOAPdenovo2-src-r240-mac.tgz/download # [osx]
+  sha256: db7fbde57ddab0255d966f875f1d41e61a5cf8ad79e8d1c5411c79fc2cd062ce # [osx]
   patches:
       - makefile.patch # [linux]
       - sparsePregraph.main.cpp.patch # [linux]

--- a/recipes/soapec/meta.yaml
+++ b/recipes/soapec/meta.yaml
@@ -22,7 +22,7 @@ requirements:
 source:
   fn: soapec_v2.03.tar.gz
   url: https://sourceforge.net/projects/soapdenovo2/files/ErrorCorrection/SOAPec_src_v2.03.tgz
-
+  sha256: d95faa1ebffc785bca134a72d88b336dd1a4797c526f5d66095db3d4c3ec3d24
 
 test:
   commands:

--- a/recipes/somatic-sniper/meta.yaml
+++ b/recipes/somatic-sniper/meta.yaml
@@ -5,6 +5,7 @@ package:
 source:
   fn: v1.0.5.0.tar.gz
   url: https://github.com/genome/somatic-sniper/archive/v1.0.5.0.tar.gz
+  sha256: fc41e90237b059fcc591e404830c4b1be678642dd5afd76ce545b97b4b7b3de1
 
 build:
   number: 1

--- a/recipes/tesseract/3.04.01/meta.yaml
+++ b/recipes/tesseract/3.04.01/meta.yaml
@@ -7,6 +7,7 @@ build:
 source:
   fn: 3.04.01.tar.gz
   url: https://github.com/tesseract-ocr/tesseract/archive/3.04.01.tar.gz
+  sha256: 57f63e1b14ae04c3932a2683e4be4954a2849e17edd638ffe91bc5a2156adc6a
 requirements:
   build:
     - gcc       # [linux]

--- a/recipes/variant-effect-predictor/meta.yaml
+++ b/recipes/variant-effect-predictor/meta.yaml
@@ -5,6 +5,7 @@ package:
 source:
   fn: vep-87.zip
   url: https://github.com/Ensembl/ensembl-tools/archive/release/87.zip
+  sha256: e0675f21e102335e973fc3641b946adb5c9082d833fe22c7e1515326b3a08cfb
 
 build:
   number: 1


### PR DESCRIPTION
cancerit-allelecount:
- add hash

genebastg:
- add hash
- corrected version number that didn't agree with downloaded file

gvcftools:
- add hash

leptonica:
- add hash

lighter:
- add hash

megagta:
- add hash

metavelvet (and legacy version):
- add hash

perl-compress-raw-zlib:
- add hash

soapdenovo2:
- add hash

soapdenovo2-prepare:
- add hash

soapec:
- add hash

somatic-sniper:
- add hash

tesseract:
- add hash

variant-effect-predictor:
- add hash

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
