### PR TITLE
Update: cwltool, cwltest, toil, arvados and deps

### DIFF
--- a/recipes/arvados-cwl-runner/meta.yaml
+++ b/recipes/arvados-cwl-runner/meta.yaml
@@ -1,4 +1,4 @@
-{% set version="1.0.20171211211613" %}
+{% set version="1.0.20180216164101" %}
 package:
   name: arvados-cwl-runner
   version: {{ version }}
@@ -6,7 +6,7 @@ package:
 source:
   fn: arvados-cwl-runner-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/a/arvados-cwl-runner/arvados-cwl-runner-{{ version }}.tar.gz
-  md5: 6cec21519a498497d37d0ba4ee5353e9
+  md5: 056b92bcd9934b7a914ecceac52e42ad
 
 build:
   number: 0
@@ -17,15 +17,15 @@ requirements:
     - python
     - setuptools
     - ruamel.yaml >=0.13.7,<0.15
-    - cwltool >=1.0.20170928192020
-    - schema-salad >=2.6.20171116190026
+    - cwltool >=1.0.20180130110340
+    - schema-salad >=2.6.20171201034858
     - arvados-python-client >=0.1.20171211211613
 
   run:
     - python
     - ruamel.yaml >=0.13.7,<0.15
-    - cwltool >=1.0.20170928192020
-    - schema-salad >=2.6.20171116190026
+    - cwltool >=1.0.20180130110340
+    - schema-salad >=2.6.20171201034858
     - arvados-python-client >=0.1.20171211211613
 
 test:

--- a/recipes/cgcloud-lib/meta.yaml
+++ b/recipes/cgcloud-lib/meta.yaml
@@ -8,7 +8,7 @@ source:
   md5: 76cb2e9b3b6f716c0790bf7a55594c94
 
 build:
-  number: 0
+  number: 1
   skip: True # [not py27]
 
 requirements:
@@ -16,12 +16,12 @@ requirements:
     - python
     - setuptools
     - bd2k-python-lib
-    - boto ==2.38.0
+    - boto >=2.38.0
 
   run:
     - python
     - bd2k-python-lib
-    - boto ==2.38.0
+    - boto >=2.38.0
 
 test:
   imports:

--- a/recipes/cwltest/meta.yaml
+++ b/recipes/cwltest/meta.yaml
@@ -1,11 +1,12 @@
+{% set version = "1.0.20180209171722" %}
 package:
   name: cwltest
-  version: '1.0.20170214185319'
+  version: {{ version }}
 
 source:
-  fn: cwltest-1.0.20170214185319.tar.gz
-  url: https://pypi.python.org/packages/07/b0/c7b2c65152471274e496d1b99635955ba3d51ff389cfca06ec11127412ee/cwltest-1.0.20170214185319.tar.gz
-  md5: 0f4cd403e1cc08a450437c4ab5c5218e
+  fn: cwltest-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/c/cwltest/cwltest-{{ version }}.tar.gz
+  md5: 9ddcc22e76b86492cf2a2a20b67c829a
 
 
 build:
@@ -17,16 +18,20 @@ requirements:
     - python
     - setuptools
     - schema-salad
-    - typing
+    - mistune >=0.7.3,<0.8
+    - typing >=3.5.3,<3.6
     - junit-xml
     - futures
+    - subprocess32
 
   run:
     - python
     - schema-salad
-    - typing
+    - mistune >=0.7.3,<0.8
+    - typing >=3.5.3,<3.6
     - junit-xml
     - futures
+    - subprocess32
 
 test:
   imports:

--- a/recipes/cwltool/meta.yaml
+++ b/recipes/cwltool/meta.yaml
@@ -1,4 +1,4 @@
-{% set version="1.0.20170928192020" %}
+{% set version="1.0.20180130110340" %}
 
 package:
   name: cwltool
@@ -7,7 +7,7 @@ package:
 source:
   fn: cwltool-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/c/cwltool/cwltool-{{ version }}.tar.gz
-  md5: d4b5de52b19366175cab6e606825cf7e
+  md5: c89765e94c8eeeb5c0f61906575a8dec
 
 build:
   number: 0
@@ -19,7 +19,7 @@ requirements:
     - setuptools
     - requests
     - shellescape
-    - cwltest
+    - cwltest >=1.0.20180209171722
     # schema-salad and pinned deps
     - schema-salad >=2.6.20170927145003,<3.0
     - cachecontrol >=0.11.7,<0.12
@@ -33,7 +33,7 @@ requirements:
     - python
     - requests
     - shellescape
-    - cwltest
+    - cwltest >=1.0.20180209171722
     # schema-salad and pinned deps
     - schema-salad >=2.6.20170927145003,<3.0
     - cachecontrol >=0.11.7,<0.12

--- a/recipes/schema-salad/meta.yaml
+++ b/recipes/schema-salad/meta.yaml
@@ -1,4 +1,4 @@
-{% set version="2.6.20171116190026" %}
+{% set version="2.6.20171201034858" %}
 
 package:
   name: schema-salad
@@ -7,7 +7,7 @@ package:
 source:
   fn: schema-salad-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/s/schema-salad/schema-salad-{{ version }}.tar.gz
-  md5: a8909652bf4f764880e7a3275a2596e4
+  md5: 937ce8e3702101e6c0f3711297e6163a
 
 build:
   entry_points:
@@ -23,7 +23,7 @@ requirements:
     - rdflib >=4.2.0
     - rdflib-jsonld >=0.3.0
     - mistune >=0.7.3,<0.8
-    - typing >=3.5.2,<3.6
+    - typing >=3.5.3,<3.6
     - ruamel.yaml >=0.12.4,<0.15
     - cachecontrol >=0.11.7,<0.12
     - lockfile
@@ -35,8 +35,8 @@ requirements:
     - requests
     - rdflib >=4.2.0
     - rdflib-jsonld >=0.3.0
-    - mistune
-    - typing >=3.5.2,<3.6
+    - mistune >=0.7.3,<0.8
+    - typing >=3.5.3,<3.6
     - ruamel.yaml >=0.12.4,<0.15
     - cachecontrol >=0.11.7,<0.12
     - lockfile

--- a/recipes/toil/build.sh
+++ b/recipes/toil/build.sh
@@ -12,10 +12,10 @@ sed -i.bak 's/docker==/docker>=/' setup.py
 sed -i.bak 's/galaxy-lib==/galaxy-lib>=/' setup.py
 sed -i.bak 's/requests==/requests>=/' setup.py
 
-# Avoid needing git/.git for version prep
-sed -i.bak 's/return _version()/return distVersion()/' version_template.py
-sed -i.bak 's/return _version(shorten=True)/return distVersion()/' version_template.py
-sed -i.bak 's/def currentCommit()/def _currentCommit()/' version_template.py
-sed -i.bak 's/def dirty()/def _dirty()/' version_template.py
+# For non-releases only: Avoid needing git/.git for version prep
+#sed -i.bak 's/return _version()/return distVersion()/' version_template.py
+#sed -i.bak 's/return _version(shorten=True)/return distVersion()/' version_template.py
+#sed -i.bak 's/def currentCommit()/def _currentCommit()/' version_template.py
+#sed -i.bak 's/def dirty()/def _dirty()/' version_template.py
 
 $PYTHON setup.py install --single-version-externally-managed --record=record.txt

--- a/recipes/toil/meta.yaml
+++ b/recipes/toil/meta.yaml
@@ -1,14 +1,14 @@
-{% set version="3.13.0a1" %}
+{% set version="3.14.0" %}
 package:
   name: toil
   version: {{ version }}
 
 source:
-  #fn: toil-{{ version }}.tar.gz
-  #url: https://pypi.io/packages/source/t/toil/toil-{{ version }}.tar.gz
-  fn: toil-226abc7.tar.gz
-  url: https://github.com/BD2KGenomics/toil/archive/226abc7.tar.gz
-  md5: 95bef16fc4b6396bcdcda7149032dbaa
+  fn: toil-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/t/toil/toil-{{ version }}.tar.gz
+  #fn: toil-226abc7.tar.gz
+  #url: https://github.com/BD2KGenomics/toil/archive/226abc7.tar.gz
+  md5: 5c44aec8d5f12ae123fb77ef0f3a021f
 
 build:
   number: 0
@@ -24,10 +24,10 @@ requirements:
     - dill
     - psutil
     - cgcloud-lib
-    - boto ==2.38.0
+    - boto >=2.38.0
     - futures # [py27]
     - azure
-    - cwltool ==1.0.20170928192020
+    - cwltool ==1.0.20180130110340
     - gcs-oauth2-boto-plugin ==1.9
     - pynacl ==1.1.2
     - docker-py >=2.5.1
@@ -49,10 +49,10 @@ requirements:
     - dill
     - psutil
     - cgcloud-lib
-    - boto ==2.38.0
+    - boto >=2.38.0
     - futures # [py27]
     - azure
-    - cwltool ==1.0.20170928192020
+    - cwltool ==1.0.20180130110340
     - gcs-oauth2-boto-plugin ==1.9
     - pynacl ==1.1.2
     - docker-py >=2.5.1
@@ -68,7 +68,9 @@ requirements:
 
 test:
   commands:
-    - toil --help
+    # Bug in Toil --help in 3.14.0 release, missing __doc__
+    # - toil --help
+    - toil --version
     - cwltoil --help
 
 about:


### PR DESCRIPTION
Updates cwltool to latest release shared by Toil and Arvados CWL runner.
Includes matching updates to cwltool dependencies: cgcloud, cwltest and
schema-salad.

Unpins boto in toil, avoiding issues with old version of boto. Fixes
chapmanb/bcbio-nextgen-vm#167

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
