### PR TITLE
Add recipe for version of CEAS 1.0.2 from Cistrome (cistrome-ceas)

### DIFF
--- a/recipes/cistrome-ceas/build.sh
+++ b/recipes/cistrome-ceas/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cd published-packages/CEAS
+$PYTHON setup.py install
+

--- a/recipes/cistrome-ceas/meta.yaml
+++ b/recipes/cistrome-ceas/meta.yaml
@@ -1,0 +1,53 @@
+package:
+  name: cistrome-ceas
+  version: 1.0.2b1
+
+source:
+  url: https://bitbucket.org/cistrome/cistrome-applications-harvard/get/d8c0751.tar.gz
+  sha256: acab26bd38ff6ead9991c5b2c20b8d901f801994a19d0f22e93086867e4fe59d
+
+build:
+  number: 0
+  skip: True  # [not py27]
+
+requirements:
+  build:
+    - python
+    - mysql-python
+    - bx-python
+  run:
+    - python
+    - mysql-python
+    - bx-python
+    - r-base
+
+test:
+  commands:
+    - ceas --version 2>&1 > /dev/null
+    - ceasBW --version 2>&1 > /dev/null
+    - build_genomeBG --version 2>&1 > /dev/null
+    - sitepro --version 2>&1 > /dev/null
+    - siteproBW --version 2>&1 > /dev/null
+    - ChIPAssoc --version 2>&1 > /dev/null
+    - gca --version 2>&1 > /dev/null
+
+about:
+  home: https://bitbucket.org/cistrome/cistrome-applications-harvard/overview
+  license: Artistic Licence
+  summary: Cistrome-CEAS -- Cis-regulatory Element Annotation System
+  description: |
+    Tool to characterize genome-wide protein-DNA interaction patterns
+    from ChIP-chip and ChIP-Seq of both sharp and broad binding factors
+  doc_url: http://liulab.dfci.harvard.edu/CEAS/
+  dev_url: https://bitbucket.org/cistrome/cistrome-applications-harvard
+
+extra:
+  notes: |
+    Installs version 1.0.2 of CEAS from cistrome (commit id d8c0751,
+    datestamp 20140929), which includes ceasBW (a version of ceas which
+    can handle bigWig file input from MACS2.)
+    Cistrome code is at
+    https://bitbucket.org/cistrome/cistrome-applications-harvard/overview
+    The CEAS code is under the published-packages/CEAS/ subdirectory
+    Cistrome data files and documentation can be found at
+    http://liulab.dfci.harvard.edu/CEAS/index.html


### PR DESCRIPTION

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [x] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

This PR submits a new recipe for a version of the CEAS package which is available as part of the Cistrome project.

This Cistrome version extends the original CEAS version by including support for `bigWig`-formatted files, and has been recommended by one of the CEAS authors (Tao Lui) on the MACS mailing list:

https://groups.google.com/d/msg/macs-announcement/LBhAtmC-Zho/AJCp5dmgkPYJ

* **Version number:** I've added the trailing `b1` to the version number (i.e. it's `1.0.2b1`), as there isn't a release tag associated with the source code on Bitbucket. The commit ID is noted in the `meta.yml` file.

* **Tests:** the tests for the Linux builds have passed but cancelling the MacOS builds (as I don't have a plan which will allow me to run them) has caused the tests to be flagged as 'failed' (i.e. red cross).

This is my first submission to `bioconda-recipes` repo. Please review and let me know if there are any problems or fixes that are required.