### PR TITLE
Bumped comb-p version to 0.48

### DIFF
--- a/recipes/combined-pvalues/meta.yaml
+++ b/recipes/combined-pvalues/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.46" %}
+{% set version = "0.48" %}
 
 package:
   name: combined-pvalues
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/brentp/combined-pvalues/archive/v{{ version }}.tar.gz
-  md5: 807d3adb4bc8d61a0e7dbe7248b202cd
+  md5: 2ed642df0222a36dfce13e98c35f1b9f
 
 build:
   skip: True # [not py27]


### PR DESCRIPTION
* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [X] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Due to some deprecated functions in scipy, a subcommand of comb-p failed on recent versions from scipy. This is fixed in v0.48.

Best,
Jens