### PR TITLE
missing dependency for qualimap

### DIFF
--- a/recipes/qualimap/meta.yaml
+++ b/recipes/qualimap/meta.yaml
@@ -8,12 +8,13 @@ source:
   md5: 2bacc61c0ed0412f09c6f02cae25bb7c
 
 build:
-  number: 1
+  number: 2
   skip: False
 
 requirements:
   run:
     - openjdk
+    - fontconfig
 
 test:
   commands:


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).


When using qualimap inside a vanilla docker image, it would run before I installed some fonts. I used fontconfig. 