### PR TITLE
Add libcurl as dependency.

### DIFF
--- a/recipes/bioconductor-genomeinfodb/meta.yaml
+++ b/recipes/bioconductor-genomeinfodb/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 'https://depot.galaxyproject.org/software/{{ name }}/{{ name }}_{{ version }}_src_all.tar.gz'
   sha256: d7db65fe2a494c3a1a0a087a2776eb69cca914024476b920db8f30356b0415ca
 build:
-  number: 0
+  number: 1
   rpaths:
     - lib/R/lib/
     - lib/
@@ -24,6 +24,7 @@ requirements:
     - 'bioconductor-s4vectors >=0.9.25'
     - r-base
     - r-rcurl
+    - libcurl
   run:
     - 'bioconductor-biocgenerics >=0.13.8'
     - bioconductor-genomeinfodbdata
@@ -31,6 +32,7 @@ requirements:
     - 'bioconductor-s4vectors >=0.9.25'
     - r-base
     - r-rcurl
+    - libcurl
 test:
   commands:
     - '$R -e "library(''{{ name }}'')"'


### PR DESCRIPTION
This library does not install correctly on Red Hat 4.4.7-4 without installing libcurl first. I confirmed that installing libcurl fixes this issue.

```
Error: package or namespace load failed for ‘GenomeInfoDb’ in dyn.load(file, DLLpath = DLLpath, ...):
unable to load shared object '/gpfs/ngs/usr/safary/miniconda/envs/bcb_rna/lib/R/library/RCurl/libs/RCurl.so':
/gpfs/ngs/usr/safary/miniconda/envs/bcb_rna/lib/R/library/RCurl/libs/../../../../libcurl.so.4: undefined symbol: SSL_CTX_set_alpn_protos
Error: package ‘GenomeInfoDb’ could not be loaded
```

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
