### PR TITLE
Unblacklist prosolo

### DIFF
--- a/build-fail-blacklist
+++ b/build-fail-blacklist
@@ -31,7 +31,6 @@ recipes/preseq
 
 # warning: spurious network error (1 tries remaining): [12/-2] [77] Problem with the SSL CA cert (path? access rights?) (error setting certificate verify locations:
 recipes/rust-bio-tools
-recipes/prosolo
 recipes/rust-overlaps
 recipes/prosic
 

--- a/recipes/prosolo/build.sh
+++ b/recipes/prosolo/build.sh
@@ -1,7 +1,10 @@
 #!/bin/bash -euo
 
-unset REQUESTS_CA_BUNDLE ## TODO: remove these `unset` lines, once the following issue in `conda-build` is resolved:
-unset SSL_CERT_FILE      ##       <https://github.com/conda/conda-build/issues/2255>
+# circumvent a bug in conda-build >=2.1.18,<3.0.10
+# https://github.com/conda/conda-build/issues/2255
+# TODO: remove once CI uses conda-build >=3.0.10
+[[ -z $REQUESTS_CA_BUNDLE && ${REQUESTS_CA_BUNDLE+x} ]] && unset REQUESTS_CA_BUNDLE
+[[ -z $SSL_CERT_FILE && ${SSL_CERT_FILE+x} ]] && unset SSL_CERT_FILE
 
 # build statically linked binary with Rust
 C_INCLUDE_PATH=$PREFIX/include LIBRARY_PATH=$PREFIX/lib:/usr/lib64 cargo install --root $PREFIX --verbose --debug

--- a/recipes/prosolo/build.sh
+++ b/recipes/prosolo/build.sh
@@ -1,4 +1,7 @@
 #!/bin/bash -euo
 
+unset REQUESTS_CA_BUNDLE ## TODO: remove these `unset` lines, once the following issue in `conda-build` is resolved:
+unset SSL_CERT_FILE      ##       <https://github.com/conda/conda-build/issues/2255>
+
 # build statically linked binary with Rust
 C_INCLUDE_PATH=$PREFIX/include LIBRARY_PATH=$PREFIX/lib:/usr/lib64 cargo install --root $PREFIX --verbose --debug

--- a/recipes/prosolo/meta.yaml
+++ b/recipes/prosolo/meta.yaml
@@ -8,7 +8,7 @@ build:
   # only on OSX, `cargo install` fails with: `thread 'main' panicked at 'assertion failed: src_path.is_absolute()', src/tools/cargo/src/cargo/core/manifest.rs:311`
   # looks like a `cargo` bug, that may go away with newer `rust` versions; check osx with rust>1.21 when available
   skip: True # [not linux64]
-  number: 0
+  number: 1
   string: "gsl{{CONDA_GSL}}_{{PKG_BUILDNUM}}"
 
 source:


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

This PR unblacklists this recipe from the bulk updates here:
https://github.com/bioconda/bioconda-recipes/issues/7712#issuecomment-366089958

A quick shout out to @johanneskoester as a major commiter of rust recipse: Do you approve the fix I am committing here? If yes, feel free to merge it directly -- I would then go about unblacklisting the other three recipes with the same failure. Some background and cross-references on the fix:

It seems the failures are down to this bug in conda build:
https://github.com/conda/conda-build/issues/2255

And the workaround is taken from here:
https://github.com/conda-forge/mosfit-feedstock/issues/23#issuecomment-349112622
(especially [this commit](https://github.com/guillochon/mosfit-feedstock/commit/7a3a9ca4236f7aa6e722d5b14dcb18b99f3de503) that is mentioned there)