### PR TITLE
Fixing racon

### DIFF
--- a/recipes/racon/build.sh
+++ b/recipes/racon/build.sh
@@ -3,8 +3,7 @@
 mkdir -p $PREFIX/bin
 mkdir build
 cd build
-cmake -DCMAKE_BUILD_TYPE=Release ..
+cmake -DCMAKE_BUILD_TYPE=Release -D CMAKE_INSTALL_PREFIX=${PREFIX} ..
 make
-
-mv bin/racon $PREFIX/bin
+make install 
 

--- a/recipes/racon/build.sh
+++ b/recipes/racon/build.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
 mkdir -p $PREFIX/bin
-
-make -j
+mkdir build
+cd build
+cmake -DCMAKE_BUILD_TYPE=Release ..
+make
 
 mv bin/racon $PREFIX/bin
 

--- a/recipes/racon/meta.yaml
+++ b/recipes/racon/meta.yaml
@@ -18,6 +18,7 @@ source:
 requirements:
   build:
     - gcc
+    - cmake
     - zlib {{ CONDA_ZLIB }}*
 
   run:

--- a/recipes/racon/meta.yaml
+++ b/recipes/racon/meta.yaml
@@ -6,12 +6,14 @@ package:
   version: {{ version }}
 
 build:
-  number: 0
+  number: 1
 
 source:
-  fn: {{ name|lower }}_{{ version }}.tar.gz
-  url: https://github.com/isovic/racon/files/741519/racon-v0.5.0.tar.gz
-  sha256: 298934749d5ce76be3645f62a5cc9194572bb62f5ba646c153df1dac2983e084
+#  fn: {{ name|lower }}_{{ version }}.tar.gz
+#  url: https://github.com/isovic/racon/archive/{{ version }}.tar.gz
+#  sha256: e95d33783789bd28a06f267475c001d46e7068b62755382b3ba124ef7a9e44c9
+  git_url: https://github.com/isovic/racon.git
+  git_tag: 5cfd1499bcec6e8b2a6584717cb6a3e7ae11b85e
 
 requirements:
   build:
@@ -24,10 +26,14 @@ requirements:
 
 test:
   commands:
-    - racon 2>&1 | grep 'options'
+    - racon -h 2>&1 | grep 'options'
 
 about:
   home: https://github.com/isovic/racon
   license: MIT
   license_file: LICENSE
   summary: Ultrafast consensus module for raw de novo genome assembly of long uncorrected reads.
+
+extra:
+  skip-lints:
+    - uses_git_url

--- a/recipes/racon/meta.yaml
+++ b/recipes/racon/meta.yaml
@@ -37,3 +37,4 @@ about:
 extra:
   skip-lints:
     - uses_git_url
+    - missing_hash

--- a/recipes/racon/meta.yaml
+++ b/recipes/racon/meta.yaml
@@ -11,9 +11,9 @@ build:
 source:
 #  fn: {{ name|lower }}_{{ version }}.tar.gz
 #  url: https://github.com/isovic/racon/archive/{{ version }}.tar.gz
-#  sha256: e95d33783789bd28a06f267475c001d46e7068b62755382b3ba124ef7a9e44c9
+#  sha256: 25e30f49b80b6fb20318ff6c6542591757842a86ca9e809d9c22d0f366a87224
   git_url: https://github.com/isovic/racon.git
-  git_tag: 5cfd1499bcec6e8b2a6584717cb6a3e7ae11b85e
+  git_tag: 404122e93a0716c2a2dac9493a86986a2f700be0
 
 requirements:
   build:
@@ -27,7 +27,7 @@ requirements:
 
 test:
   commands:
-    - racon -h 2>&1 | grep 'options'
+    - racon --version
 
 about:
   home: https://github.com/isovic/racon


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

This update uses git_url even if it is not recommended to fix the broken 0 first build. A typo in the recipe made it to download previous version. The reason for using git_url is 5 additional submodules in this updated version of racon. Maybe we could make an exception until the submodules are added to bioconda/conda-forge?