### PR TITLE
Pin flexmix for bioconductor-scde.

### DIFF
--- a/recipes/bioconductor-scde/meta.yaml
+++ b/recipes/bioconductor-scde/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 'https://depot.galaxyproject.org/software/{{ name }}/{{ name }}_{{ version }}_src_all.tar.gz'
   sha256: 226c6ac1699c507546144313027b844280092e311da1fb4cb10b288d6854aa33
 build:
-  number: 0
+  number: 1
   rpaths:
     - lib/R/lib/
     - lib/
@@ -24,7 +24,7 @@ requirements:
     - r-base
     - r-cairo
     - r-extremes
-    - r-flexmix
+    - r-flexmix <=2.3_13
     - r-mass
     - r-mgcv
     - r-nnet
@@ -47,7 +47,7 @@ requirements:
     - r-base
     - r-cairo
     - r-extremes
-    - r-flexmix
+    - r-flexmix <=2.3_13
     - r-mass
     - r-mgcv
     - r-nnet


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

The latest version of flexmix (2.3-14) broke scde. Needs to be pinned to 2.3-13:

https://hms-dbmi.github.io/scde/help.html?place=msg%2Fsinglecellstats%2FrbFUTOQ9wu4%2Fyg4cxLbeAAAJ

xref: #7859 https://github.com/conda-forge/r-flexmix-feedstock/commit/92f7ee3936cc1dfc5483473fb19524c99f95ccee

Unrelated, but I also learned that the scde has an additional license file that restricts commercial use:

https://github.com/hms-dbmi/scde/blob/master/license.txt

Should I add this file and insert a `license_file` line? Is there anyway to alert users in `meta.yaml` that the software isn't really licensed under GPL-2?