### PR TITLE
Add recipe for cistrome-ceas

### DIFF
--- a/recipes/cistrome-ceas/build.sh
+++ b/recipes/cistrome-ceas/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cd published-packages/CEAS
+$PYTHON setup.py install
+

--- a/recipes/cistrome-ceas/disable_no_mysqldb_warning.patch
+++ b/recipes/cistrome-ceas/disable_no_mysqldb_warning.patch
@@ -1,0 +1,12 @@
+diff -r d8c075170bb5 published-packages/CEAS/lib/inout.py
+--- a/published-packages/CEAS/lib/inout.py	Mon Sep 29 10:11:06 2014 -0500
++++ b/published-packages/CEAS/lib/inout.py	Tue Feb 27 14:33:54 2018 +0000
+@@ -61,7 +61,7 @@ try:
+     import MySQLdb
+ except ImportError:
+     MYSQL=False
+-    warnings.warn("sqlite3 is used instead of MySQLdb because MySQLdb is not installed")
++    #warnings.warn("sqlite3 is used instead of MySQLdb because MySQLdb is not installed")
+ 
+ # ------------------------------------
+ # some literals

--- a/recipes/cistrome-ceas/meta.yaml
+++ b/recipes/cistrome-ceas/meta.yaml
@@ -5,6 +5,8 @@ package:
 source:
   url: https://bitbucket.org/cistrome/cistrome-applications-harvard/get/d8c0751.tar.gz
   sha256: acab26bd38ff6ead9991c5b2c20b8d901f801994a19d0f22e93086867e4fe59d
+  patches:
+    - disable_no_mysqldb_warning.patch
 
 build:
   number: 0
@@ -13,11 +15,9 @@ build:
 requirements:
   build:
     - python
-    - mysql-python
     - bx-python
   run:
     - python
-    - mysql-python
     - bx-python
     - r-base
 
@@ -45,8 +45,10 @@ extra:
   notes: |
     Installs version 1.0.2 of CEAS from cistrome (commit id d8c0751,
     datestamp 20140929), which includes ceasBW (a version of ceas which
-    can handle bigWig file input from MACS2.)
-    Cistrome code is at
+    can handle bigWig file input from MACS2).
+    This version is also patched to suppress warnings about using sqlite3
+    rather than MySQLdb.
+    The Cistrome code is at
     https://bitbucket.org/cistrome/cistrome-applications-harvard/overview
     The CEAS code is under the published-packages/CEAS/ subdirectory
     Cistrome data files and documentation can be found at

--- a/recipes/cistrome-ceas/meta.yaml
+++ b/recipes/cistrome-ceas/meta.yaml
@@ -1,0 +1,53 @@
+package:
+  name: cistrome-ceas
+  version: 1.0.2b1
+
+source:
+  url: https://bitbucket.org/cistrome/cistrome-applications-harvard/get/d8c0751.tar.gz
+  sha256: acab26bd38ff6ead9991c5b2c20b8d901f801994a19d0f22e93086867e4fe59d
+
+build:
+  number: 0
+  skip: True  # [not py27]
+
+requirements:
+  build:
+    - python
+    - mysql-python
+    - bx-python
+  run:
+    - python
+    - mysql-python
+    - bx-python
+    - r-base
+
+test:
+  commands:
+    - ceas --version 2>&1 > /dev/null
+    - ceasBW --version 2>&1 > /dev/null
+    - build_genomeBG --version 2>&1 > /dev/null
+    - sitepro --version 2>&1 > /dev/null
+    - siteproBW --version 2>&1 > /dev/null
+    - ChIPAssoc --version 2>&1 > /dev/null
+    - gca --version 2>&1 > /dev/null
+
+about:
+  home: https://bitbucket.org/cistrome/cistrome-applications-harvard/overview
+  license: Artistic Licence
+  summary: Cistrome-CEAS -- Cis-regulatory Element Annotation System
+  description: |
+    Tool to characterize genome-wide protein-DNA interaction patterns
+    from ChIP-chip and ChIP-Seq of both sharp and broad binding factors
+  doc_url: http://liulab.dfci.harvard.edu/CEAS/
+  dev_url: https://bitbucket.org/cistrome/cistrome-applications-harvard
+
+extra:
+  notes: |
+    Installs version 1.0.2 of CEAS from cistrome (commit id d8c0751,
+    datestamp 20140929), which includes ceasBW (a version of ceas which
+    can handle bigWig file input from MACS2.)
+    Cistrome code is at
+    https://bitbucket.org/cistrome/cistrome-applications-harvard/overview
+    The CEAS code is under the published-packages/CEAS/ subdirectory
+    Cistrome data files and documentation can be found at
+    http://liulab.dfci.harvard.edu/CEAS/index.html


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [x] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

@bioconda/core please review - this is my first recipe.

This PR submits a new recipe for the version of the CEAS 1.0.2 package which is available as part of the Cistrome project (https://bitbucket.org/cistrome/cistrome-applications-harvard).

The Cistrome version differs from the 'official' CEAS release as it adds support for bigWig-formatted files, and has been recommended by CEAS co-authors Tao Lui on the MACS mailing list: https://groups.google.com/d/msg/macs-announcement/LBhAtmC-Zho/AJCp5dmgkPYJ

As the source code on Bitbucket doesn't have an associated release tag, I've added the trailing `b1` to the version number (i.e. it's `1.0.2b1`) to indicate this. The commit ID is noted in the meta.yml file.

Please let me know if there are any issues that I need to address - many thanks!