### PR TITLE
pin recipe to use java 7, see #4945

### DIFF
--- a/recipes/rna-seqc/meta.yaml
+++ b/recipes/rna-seqc/meta.yaml
@@ -10,11 +10,11 @@ package:
   version: {{ version }}
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   run:
-  - openjdk
+  - openjdk 7*
 
 test:
   commands:


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

ping recipe to use java 7.
rna-seqc is using a version of javassist that is incompatible with java 8.