### PR TITLE
Updating runtime dependency of vcfpy v0.11

### DIFF
--- a/recipes/vcfpy/meta.yaml
+++ b/recipes/vcfpy/meta.yaml
@@ -13,12 +13,13 @@ source:
 build:
   skip: True # [py27]
   script: python setup.py install --single-version-externally-managed --record record.txt
-  number: 0
+  number: 1
 
 requirements:
   build:
   - python
   run:
+  - python
   - pysam >=0.10.0
 
 test:


### PR DESCRIPTION
`python` is missing

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
