### PR TITLE
Add libgcc runtime dependency for libgomp.so

### DIFF
--- a/recipes/plant_tribes_gene_family_classifier/1.0.3/meta.yaml
+++ b/recipes/plant_tribes_gene_family_classifier/1.0.3/meta.yaml
@@ -8,13 +8,14 @@ source:
   md5: fadbcc5f105eb05156e5068380840460
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   run:
     - blast >=2.2.29
     - hmmer >=3
     - perl
+    - libgcc
 
 test:
   commands:


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.

Without this dependency, some tool runs will fail with the message `error while loading shared libraries: libgomp.so.1: cannot open shared object file: No such file or directory`