### PR TITLE
adding Anvio 4 to py36

### DIFF
--- a/recipes/anvio/meta.yaml
+++ b/recipes/anvio/meta.yaml
@@ -14,7 +14,7 @@ source:
 
 build:
   number: 0
-  skip: True # [not py35]
+  skip: True # [py27]
 
 requirements:
   build:
@@ -58,6 +58,7 @@ requirements:
     - mistune ==0.7.4
     - six ==1.10.0
     - pandas ==0.20.1
+    - matplotlib
     - openblas
     - gsl {{ CONDA_GSL }}*
     - sqlite


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

As suggested by @druvus,  after testing that Anvio 4 runs on pytohn 3.6, I'm adding py36 to the build configuration