### PR TITLE
Quote arguments in EMBOSS wrapper scripts.

### DIFF
--- a/recipes/emboss/fix_acd_path.py
+++ b/recipes/emboss/fix_acd_path.py
@@ -14,7 +14,7 @@ export EMBOSS_ACDROOT=../share/EMBOSS/acd/
 export EMBOSS_DATA=../share/EMBOSS/data
 export PLPLOT_LIB=../share/EMBOSS
 
-_water $@
+_water "$@"
 
 --------------------------------------------
 
@@ -268,5 +268,4 @@ for filename in os.listdir(sys.argv[1]):
             handle.write('export EMBOSS_ACDROOT=$BIN_DIR/../share/EMBOSS/acd/\n')
             handle.write('export EMBOSS_DATA=$BIN_DIR/../share/EMBOSS/data/\n')
             handle.write('export PLPLOT_LIB=$BIN_DIR/../share/EMBOSS/\n')
-            handle.write('_%s $@\n' % filename)
-
+            handle.write('_%s "$@"\n' % filename)

--- a/recipes/emboss/meta.yaml
+++ b/recipes/emboss/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: "6.5.7"
 
 build:
-  number: 3
+  number: 4
 
 source:
   fn: EMBOSS-6.5.7.tar.gz


### PR DESCRIPTION
This fixes examples where filenames include spaces, e.g. https://github.com/biopython/biopython/issues/1523

```
$ needle -outfile="Emboss/temp with space.needle" -asequence=asis:ACCCGGGCGCGGT -bsequence=asis:ACCCGAGCGCGGT -gapopen=10 -gapextend=0.5 -snucleotide=True

$ water -outfile="Emboss/temp with space.water" -asequence=asis:ACCCGGGCGCGGT -bsequence=asis:ACCCGAGCGCGGT -gapopen=10 -gapextend=0.5
```

Without the fix, these examples used "Emboss/temp" as the output filename.

* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [X] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
