### PR TITLE
Add extended-base to get libGL

### DIFF
--- a/recipes/poretools/meta.yaml
+++ b/recipes/poretools/meta.yaml
@@ -31,7 +31,7 @@ requirements:
         - pandas
 
 build:
-    number: 4 
+    number: 5 
     skip: True # [not py27]
 
 test:
@@ -44,3 +44,6 @@ about:
     license: MIT
     license_file: LICENSE
 
+extra:
+  container:
+    extended-base: true


### PR DESCRIPTION
Some of the poretools operations require libGL.so, which is provided by extended-base

* [ ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
