### PR TITLE
circleci: skip Docker/Miniconda workaround for local build

### DIFF
--- a/.circleci/setup.sh
+++ b/.circleci/setup.sh
@@ -24,7 +24,8 @@ fi
 git remote remove $UPSTREAM_REMOTE
 
 
-if [[ $OSTYPE == linux* ]]; then
+# TODO: remove this workaround
+if [[ $OSTYPE == linux* && ${CIRCLE_JOB-} != build ]]; then
     docker pull continuumio/miniconda3:4.3.27
     docker tag continuumio/miniconda3:4.3.27 continuumio/miniconda3:latest
 fi


### PR DESCRIPTION
* x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

Fixes https://gitter.im/bioconda/Lobby?at=5a9ae6b56f8b4b9946e55c74
Disables workaround due to bad Miniconda/`conda 4.4.10` for local builds.