### PR TITLE
nextgenmap 0.4.13 (old version for reproducability)

### DIFF
--- a/recipes/nextgenmap/0.4.13/build.sh
+++ b/recipes/nextgenmap/0.4.13/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+mkdir -p build
+cd build
+cmake -DCMAKE_INSTALL_PREFIX=${PREFIX} -DCMAKE_EXE_LINKER_FLAGS=-L${PREFIX}/lib ..
+make
+
+mkdir -p $PREFIX/bin
+cp -r ../bin/ngm-${PKG_VERSION}/* $PREFIX/bin/

--- a/recipes/nextgenmap/0.4.13/meta.yaml
+++ b/recipes/nextgenmap/0.4.13/meta.yaml
@@ -1,0 +1,29 @@
+package:
+  name: nextgenmap
+  version: '0.4.13'
+
+source:
+  fn: ngm-v0.4.13.tar.gz
+  url: "https://github.com/Cibiv/NextGenMap/archive/0.4.13.tar.gz"
+  md5: "423fbc9dd0baebc82a039dc60b9dede1"
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - gcc # [linux]
+    - llvm # [osx]
+    - cmake
+  run:
+    - libgcc # [linux]
+
+test:
+  commands:
+    - ngm 2>&1 | grep "NextGenMap"
+    - ngm-utils 2>&1 | grep "ngm-utils"
+
+about:
+  home: https://github.com/philres/NextGenMap
+  license: MIT
+  summary: NextGenMap is a flexible highly sensitive short read mapping tool that handles much higher mismatch rates than comparable algorithms while still outperforming them in terms of runtime.


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

This PR adds an older version of NextGenMap, which is needed for reproducability since newer versions (> 0.5) seems to map some reads differently.