### PR TITLE
Quote in case of spaces

### DIFF
--- a/recipes/flashlfq/FlashLFQ.sh
+++ b/recipes/flashlfq/FlashLFQ.sh
@@ -6,4 +6,4 @@ while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symli
     [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
 done
 DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
-mono $DIR/CMD.exe $@
+mono $DIR/CMD.exe "$@"

--- a/recipes/flashlfq/meta.yaml
+++ b/recipes/flashlfq/meta.yaml
@@ -11,7 +11,7 @@ package:
   version: '{{version}}'
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipes/pisces/meta.yaml
+++ b/recipes/pisces/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 69f8e2c08c09b9d75a346474305e5cc4adc4713b11f788398a516fa2ab7e834f
 
 build:
-  number: 1
+  number: 2
   skip: False
 
 requirements:

--- a/recipes/pisces/meta.yaml
+++ b/recipes/pisces/meta.yaml
@@ -5,7 +5,6 @@ package:
   version: {{ version }}
 
 source:
-  fn: pisces-{{ version }}.tar.gz
   url: https://github.com/Illumina/Pisces/releases/download/v{{ version }}/Pisces_{{ version }}.tar.gz
   sha256: 69f8e2c08c09b9d75a346474305e5cc4adc4713b11f788398a516fa2ab7e834f
 

--- a/recipes/pisces/pisces.sh
+++ b/recipes/pisces/pisces.sh
@@ -13,4 +13,4 @@ while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symli
 done
 DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
-dotnet $DIR/Pisces.dll $@
+dotnet $DIR/Pisces.dll "$@"

--- a/recipes/pisces/pisces_vqr.sh
+++ b/recipes/pisces/pisces_vqr.sh
@@ -13,4 +13,4 @@ while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symli
 done
 DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
-dotnet $DIR/VariantQualityRecalibration.dll $@
+dotnet $DIR/VariantQualityRecalibration.dll "$@"


### PR DESCRIPTION
* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [X] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Following #8155 where I fixed a problem with the EMBOSS wrappers breaking when used with filenames with spaces, I used the following grep command to identify other cases of the same underlying issue - two cases identified and fixed in this pull request.

```
$ grep " \$\@" */*/*.sh
recipes/perl-html-tidy/build.sh: 	$(RM_F) $@
recipes/perl-html-tidy/build.sh:-	$(LD)  $(LDDLFLAGS) $(LDFROM) $(OTHERLDFLAGS) -o $@ $(MYEXTLIB)	\
recipes/perl-html-tidy/build.sh:+	$(LD) $(LDFROM) $(LDDLFLAGS) $(OTHERLDFLAGS) -o $@ $(MYEXTLIB)	\
recipes/perl-html-tidy/build.sh: 	$(CHMOD) $(PERM_RWX) $@
recipes/watchdog-wms/run_test.sh:function timeoutbash() { bash -c '(sleep 180; kill -9 $$ 2>/dev/null) & exec $@' $0 $@; }
```

The remaining grep matches are in the ``perl-html-tidy`` recipe's patch (the underlying ``Makefile`` fails to quote spaces), and a test in ``watchdog-wms`` where the test file name does not contain spaces.