### PR TITLE
[WIP] Add specialized OSX recipe for augustus

### DIFF
--- a/recipes/augustus/3.2.1_osx/Build.PL
+++ b/recipes/augustus/3.2.1_osx/Build.PL
@@ -1,0 +1,69 @@
+use strict;
+use warnings;
+
+use Module::Build 0.28;
+use File::Find;
+
+our @files = ();
+find( \&wanted, ".");
+
+sub wanted {
+	my $file = $_;
+
+	return unless $file;
+	return unless -e $file;
+
+	#print "File $file\n";
+	if($file =~ m/.*\.pl$/){
+		push(@files, $file);
+	}
+}
+
+foreach my $file (@files){
+    my $tfile = "$file.t";
+    #    print STDERR "Change shebang line to #!perl $file\n";
+    open my $in,  "<$file" or die $!;
+    open my $out, ">$tfile" or die $!;
+    while (<$in>) {
+        s|^#!/usr/bin/perl -w|#!perl|;    # so MakeMaker can fix it
+        s|^#!/usr/bin/env perl|#!perl|;    # so MakeMaker can fix it
+        s|^#!/usr/bin/perl|#!perl|;    # so MakeMaker can fix it
+        print $out $_;
+    }
+    close($in);
+    close($out);
+    system("mv $tfile $file");
+}
+
+my %module_build_args = (
+    "build_requires"     => { "Module::Build" => "0.28" },
+    "configure_requires" => { "Module::Build" => "0.28" },
+    "dist_abstract"      => "Base Build Script for perl scripts",
+    "dist_author"          => [ "" ],
+    "dist_name"            => "BiocondaPerlExecs",
+    "dist_version"         => "1.9",
+    "license"              => "perl",
+    "module_name"          => "BiocondaPerlExecs",
+    "recursive_test_files" => 1,
+    "requires"             => { "perl" => "5.008005" },
+    "script_files"         => \@files,
+    "test_requires"        => {
+        "Test::More"    => 0,
+        "strict"        => 0
+    }
+);
+
+my %fallback_build_requires = (
+    "Module::Build" => "0.28",
+    "Test::More"    => 0,
+    "strict"        => 0
+);
+
+unless ( eval { Module::Build->VERSION(0.4004) } ) {
+    delete $module_build_args{test_requires};
+    $module_build_args{build_requires} = \%fallback_build_requires;
+}
+
+my $build = Module::Build->new(%module_build_args);
+
+$build->create_build_script;

--- a/recipes/augustus/3.2.1_osx/build.sh
+++ b/recipes/augustus/3.2.1_osx/build.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+set -x -e
+
+export INCLUDE_PATH="${PREFIX}/include"
+export LIBRARY_PATH="${PREFIX}/lib"
+export LD_LIBRARY_PATH="${PREFIX}/lib"
+export BOOST_INCLUDE_DIR=${PREFIX}/include
+export BOOST_LIBRARY_DIR=${PREFIX}/lib
+
+#export CXXFLAGS=" -std=c++11 -stdlib=libstdc++ -stdlib=libc++ -DUSE_BOOST -I${BOOST_INCLUDE_DIR} -L${BOOST_LIBRARY_DIR}"
+export CXXFLAGS=" -std=c++11  -DUSE_BOOST -I${BOOST_INCLUDE_DIR} -L${BOOST_LIBRARY_DIR}"
+export LDFLAGS="-L${BOOST_LIBRARY_DIR}"
+
+mkdir -p $PREFIX/bin
+mkdir -p $PREFIX/scripts
+mkdir -p $PREFIX/config
+
+## Make the software
+
+make CC=gcc CXX=g++ BAMTOOLS_CC=clang BAMTOOLS_CXX=clang++
+
+## Build Perl
+
+mkdir perl-build
+find scripts -name "*.pl" | xargs -I {} mv {} perl-build
+cd perl-build
+cp ${RECIPE_DIR}/Build.PL ./
+perl ./Build.PL
+perl ./Build manifest
+perl ./Build install --installdirs site
+
+cd ..
+## End build perl
+
+
+mv bin/* $PREFIX/bin/
+mv scripts/* $PREFIX/bin/
+mv config/* $PREFIX/config/
+
+#Add some options to activate
+
+mkdir -p $PREFIX/etc/conda/activate.d/
+echo "export AUGUSTUS_CONFIG_PATH=$PREFIX/config/" > $PREFIX/etc/conda/activate.d/augustus-confdir.sh
+chmod a+x $PREFIX/etc/conda/activate.d/augustus-confdir.sh
+
+mkdir -p $PREFIX/etc/conda/deactivate.d/
+echo "unset AUGUSTUS_CONFIG_PATH" > $PREFIX/etc/conda/deactivate.d/augustus-confdir.sh
+chmod a+x $PREFIX/etc/conda/deactivate.d/augustus-confdir.sh
+
+#exit 1

--- a/recipes/augustus/3.2.1_osx/meta.yaml
+++ b/recipes/augustus/3.2.1_osx/meta.yaml
@@ -1,0 +1,127 @@
+{% set name = "augustus" %}
+{% set version = "3.2.1.osx" %}
+{% set sha256 = "c75c53afcc2fd55c3941049e1eec8499d0805091ac2635be88b1b9a7f6f3ec9a" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://github.com/dib-lab/augustus/archive/v{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+  patches:
+      - patches/bam2hints.Makefile.patch
+      - patches/compileSpliceCands.Makefile.patch
+      - patches/filterBam.patch
+      - patches/auxprogs.Makefile.patch
+      - patches/homGeneMapping.src.Makefile.patch
+
+build:
+  skip: True # [linux]
+  number: 1
+
+requirements:
+  build:
+      - gcc
+      - llvm
+      - zlib {{CONDA_ZLIB}}*
+      - libgcc
+      - bamtools {{ CONDA_BAMTOOLS }}*
+      - gsl {{ CONDA_GSL }}*
+      - lp_solve
+      - perl
+      - perl-module-build
+      - boost {{CONDA_BOOST}}*
+  run:
+      - libgcc
+      - zlib {{CONDA_ZLIB}}*
+      - bamtools {{ CONDA_BAMTOOLS }}*
+      - boost {{CONDA_BOOST}}*
+      - gsl {{ CONDA_GSL }}*
+      - lp_solve
+      - perl
+      - perl-app-cpanminus
+      - perl-module-build
+      - perl-yaml
+      - perl-dbi
+      - perl-scalar-list-utils
+
+test:
+  commands:
+    - augustus --version
+    - autoAug.pl --help &>/dev/null
+    - bedgraph2wig.pl --help &>/dev/null
+    - blat2gbrowse.pl --help 2>&1 | grep "convert blat file to gbrowse file" &>/dev/null
+    - blat2hints.pl --help
+    - cegma2gff.pl --help 2>&1 | grep "Could not open CEGMA file --help"
+    - checkParamArchive.pl --help 2>&1 | grep "checkParamArchive.pl param-archive.tar.gz projectDir > utrPossible 2> errors"
+    - cleanDOSfasta.pl --help 2>&1 | grep "Could not open file --help"
+    - clusterAndSplitGenes.pl --help
+    - createAugustusJoblist.pl --help
+    - del_from_prfl.pl --help 2>&1 | grep "Need two arguments"
+    - evalCGP.pl --help
+    - exonerate2hints.pl --help
+    - echo "hello" | exoniphyDb2hints.pl
+    - echo "hello" | extractTranscriptEnds.pl | grep ">seq1"
+    - filterBam --help 2>&1 | grep "filterBam --in in.bam --out out.bam"
+    - filterGenesIn_mRNAname.pl --help
+    - filterGenesOut_mRNAname.pl --help
+    - filterGenes.pl --help 2>&1 | grep "usage:filterGenes.pl namefile dbfile"
+    - filterInFrameStopCodons.pl --help 2>&1 | grep "Could not open protein file"
+    - filterMaf.pl --help 2>&1 | grep "filter blocks from a MAF alignment that intersect with a given genomic interval"
+    - echo "hello" | filter-ppx.pl | grep "hello"
+    - filterPSL.pl --help
+    - filterShrimp.pl --help
+    - filterSpliceHints.pl --help
+    - gbrowseold2gff3.pl --help 2>&1 | grep "gbrowseold2gff3.pl format convert a GFF file"
+    - gbSmallDNA2gff.pl --help 2>&1 | grep "Could not open genbank input file --help"
+    - getAnnoFasta.pl --help 2>&1 | grep "Makes a fasta file with protein sequences (augustus.aa)"
+    - gff2gbSmallDNA.pl --help 2>&1 | grep "convert GFF file and sequence fasta file to minimal genbank format"
+    - gffGetmRNA.pl --help
+    - gp2othergp.pl --help 2>&1 | grep "t open --help"
+    - gtf2gff.pl --help 2>&1 | grep "gtf2gff.pl format convert a GTF file"
+    - hal2maf_split.pl --help 2>&1 | grep "this script works on top of the "
+    - intron2exex.pl --help | grep "intron2exex.pl make a fasta file with exon-exon sequences"
+    - join_mult_hints.pl --help
+    - joinPeptides.pl --help 2>&1 | grep "joinPeptides.pl in1.fa in2.fa > out.fa"
+    - maf2conswig.pl --help | grep "maf2conswig.pl convert maf alignment format"
+    - makeMatchLists.pl --help  2>&1 | grep "t open --help"
+    - makeUtrTrainingSet.pl --help 2>&1 | grep "./makeUtrTrainingSet.pl -- make a genbank or gff training file with "
+    - maskNregions.pl --help 2>&1 | grep "could not open file --help"
+    - moveParameters.pl --help
+    - msa2prfl.pl --help 2>&1 | grep "Converts a Multiple Sequence Alignment"
+    - new_species.pl --help
+    - optimize_augustus.pl --help
+    - partition_gtf2gb.pl --help 2>&1 | grep "Partition a gtf file into gene clusters"
+    - pasapolyA2hints.pl --help 2>&1 | grep "PASA-Output file in fasta-format"
+    - peptides2alternatives.pl --help 2>&1 | grep "peptides2alternatives.pl peptides.aa augustus-genes.aa"
+    - peptides2hints.pl --help 2>&1 | grep "peptides2hints.pl psl-file gff-file fa-file src pri"
+    - polyA2hints.pl --help 2>&1 | grep "transcript end at position p gives rise to a tts hint"
+    - randomSplit.pl --help
+    - ratewig.pl --help 2>&1 | grep "ratewig /path/to/refseqfile/ /path/to/wigfile"
+    - rmRedundantHints.pl --help 2>&1 | grep "rmRedundantHints.pl list1.hints list2.hints > nonredundant.hints"
+    - runAllSim4.pl --help
+    - samMap.pl --help
+    - scipiogff2gff.pl --help 2>&1 | grep "convert a gff from scipio to a gff file"
+    - simpleFastaHeaders.pl --help 2>&1 | grep "in.fa prefix out.fa mapping.txt"
+    - simplifyFastaHeaders.pl --help 2>&1 | grep "in.fa nameStem out.fa header.map"
+    - splitMfasta.pl --help 2>&1 | grep "Unknown option"
+    - split_wiggle.pl --help
+    - summarizeACGTcontent.pl --help 2>&1 | grep "Couldn"
+    - transMap2hints.pl --help 2>&1 | grep "convert transmap alignments to hints file"
+    - uniquePeptides.pl --help 2>&1 | grep "uniquePeptides.pl in.fa prefix > out.fa"
+    - utrgff2gbrowse.pl --help
+    - wigchoose.pl --help
+    - writeResultsPage.pl --help 2>&1 | grep "writeResultsPage ID species-name db-file grails-out www-out AugustusConfigPath AugustusScriptsPath final-flag"
+    - yaml2gff.1.4.pl --help 2>&1 | grep "< scipio.yaml > scipio.gff"
+
+about:
+  home: http://bioinf.uni-greifswald.de/augustus/
+  license: MIT
+  license_family: MIT
+  summary: 'AUGUSTUS is a gene prediction program for eukaryotes written by Mario
+    Stanke and Oliver Keller. It can be used as an ab initio program, which means
+    it bases its prediction purely on the sequence. AUGUSTUS may also incorporate
+    hints on the gene structure coming from extrinsic sources such as EST, MS/MS,
+    protein alignments and synthenic genomic alignments.'

--- a/recipes/augustus/3.2.1_osx/patches/auxprogs.Makefile.patch
+++ b/recipes/augustus/3.2.1_osx/patches/auxprogs.Makefile.patch
@@ -1,0 +1,54 @@
+From 4885671fd72bd5c449bc1223ff67c1021af3f3e3 Mon Sep 17 00:00:00 2001
+From: Camille Scott <camille.scott.w@gmail.com>
+Date: Fri, 9 Mar 2018 19:34:20 -0800
+Subject: [PATCH 1/2] Remove references to BAMTOOLS in auxprog Makefile
+
+---
+ auxprogs/Makefile | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/auxprogs/Makefile b/auxprogs/Makefile
+index f534b0d..d060787 100644
+--- a/auxprogs/Makefile
++++ b/auxprogs/Makefile
+@@ -4,9 +4,9 @@
+ # Last modified on: 16-October-2016 by Katharina Hoff (katharina.hoff@gmail.com)
+ 
+ all:
+-	cd bam2hints; make CXX=$(BAMTOOLS_CXX) CC=$(BAMTOOLS_CC) BAMTOOLS=$(BAMTOOLS);
++	cd bam2hints; make CXX=$(BAMTOOLS_CXX) CC=$(BAMTOOLS_CC);
+ 	cd compileSpliceCands; make CXX=$(BAMTOOLS_CXX) CC=$(BAMTOOLS_CC);
+-	cd filterBam; make CXX=$(BAMTOOLS_CXX) CC=$(BAMTOOLS_CC) BAMTOOLS=$(BAMTOOLS);
++	cd filterBam; make CXX=$(BAMTOOLS_CXX) CC=$(BAMTOOLS_CC);
+     cd homGeneMapping; make CXX=$(BAMTOOLS_CXX) CC=$(BAMTOOLS_CC);
+ 	cd joingenes; make CXX=$(BAMTOOLS_CXX) CC=$(BAMTOOLS_CC);
+ clean:
+-- 
+2.14.3 (Apple Git-98)
+
+
+From 31c5acf0e501d73017f81f02c905053c5e58dc13 Mon Sep 17 00:00:00 2001
+From: Camille Scott <camille.scott.w@gmail.com>
+Date: Fri, 9 Mar 2018 19:39:07 -0800
+Subject: [PATCH 2/2]  fix tab
+
+---
+ auxprogs/Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/auxprogs/Makefile b/auxprogs/Makefile
+index d060787..d1733fb 100644
+--- a/auxprogs/Makefile
++++ b/auxprogs/Makefile
+@@ -7,7 +7,7 @@ all:
+ 	cd bam2hints; make CXX=$(BAMTOOLS_CXX) CC=$(BAMTOOLS_CC);
+ 	cd compileSpliceCands; make CXX=$(BAMTOOLS_CXX) CC=$(BAMTOOLS_CC);
+ 	cd filterBam; make CXX=$(BAMTOOLS_CXX) CC=$(BAMTOOLS_CC);
+-    cd homGeneMapping; make CXX=$(BAMTOOLS_CXX) CC=$(BAMTOOLS_CC);
++	cd homGeneMapping; make CXX=$(BAMTOOLS_CXX) CC=$(BAMTOOLS_CC);
+ 	cd joingenes; make CXX=$(BAMTOOLS_CXX) CC=$(BAMTOOLS_CC);
+ clean:
+ 	cd bam2hints; make clean;
+-- 
+2.14.3 (Apple Git-98)
+

--- a/recipes/augustus/3.2.1_osx/patches/bam2hints.Makefile.patch
+++ b/recipes/augustus/3.2.1_osx/patches/bam2hints.Makefile.patch
@@ -1,0 +1,65 @@
+From b328b8de0d43e0750c8eb81a5d1727d942648f25 Mon Sep 17 00:00:00 2001
+From: Camille Scott <camille.scott.w@gmail.com>
+Date: Fri, 9 Mar 2018 18:13:39 -0800
+Subject: [PATCH 1/2] patch bam2hints Makefile
+
+---
+ auxprogs/bam2hints/Makefile | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/auxprogs/bam2hints/Makefile b/auxprogs/bam2hints/Makefile
+index 9eff1ac..ef2431c 100644
+--- a/auxprogs/bam2hints/Makefile
++++ b/auxprogs/bam2hints/Makefile
+@@ -9,11 +9,11 @@
+ 
+ # Variable definition
+ BAMTOOLS=/usr/local/bamtools
+-INCLUDES = $(BAMTOOLS)/include
+-LIBS = $(BAMTOOLS)/lib/libbamtools.a -lz
++INCLUDES =  ${PREFIX}/include/bamtools/
++LIBS = ${PREFIX}/lib/libbamtools.a -lz
+ SOURCES = bam2hints.cc 
+ OBJECTS = $(SOURCES:.cc=.o)
+-CFLAGS = -Wall -O0 -g -ggdb # -g -p
++CFLAGS = -Wall -g -p -O0
+ 
+ # Recipe(s)
+ # $@: full target name of current target. 
+@@ -25,7 +25,7 @@ bam2hints : $(OBJECTS)
+ all:$(OBJECTS) # Compiles each foo.cc into foo.o
+ 
+ bam2hints.o : $(SOURCES)
+-	$(CXX) $(CFLAGS) -c $< -o $@ -I$(INCLUDES) 
++	$(CXX) $(CFLAGS) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) -c $< -o $@ -I$(INCLUDES) 
+ 
+ clean: 
+ 	rm -f bam2hints.o bam2hints ../../bin/bam2hints
+-- 
+2.14.3 (Apple Git-98)
+
+
+From a2a60e12fcbc2dd4cfc310c730eaf93511df5669 Mon Sep 17 00:00:00 2001
+From: Camille Scott <camille.scott.w@gmail.com>
+Date: Fri, 9 Mar 2018 18:45:13 -0800
+Subject: [PATCH 2/2] Patch out another def
+
+---
+ auxprogs/bam2hints/Makefile | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/auxprogs/bam2hints/Makefile b/auxprogs/bam2hints/Makefile
+index ef2431c..2340db8 100644
+--- a/auxprogs/bam2hints/Makefile
++++ b/auxprogs/bam2hints/Makefile
+@@ -8,7 +8,6 @@
+ #	Last modified:	23-October-2017 by Jon Palmer
+ 
+ # Variable definition
+-BAMTOOLS=/usr/local/bamtools
+ INCLUDES =  ${PREFIX}/include/bamtools/
+ LIBS = ${PREFIX}/lib/libbamtools.a -lz
+ SOURCES = bam2hints.cc 
+-- 
+2.14.3 (Apple Git-98)
+

--- a/recipes/augustus/3.2.1_osx/patches/compileSpliceCands.Makefile.patch
+++ b/recipes/augustus/3.2.1_osx/patches/compileSpliceCands.Makefile.patch
@@ -1,0 +1,25 @@
+From 8db5d7a51c93c9b757550891de5c6768ad4d05d4 Mon Sep 17 00:00:00 2001
+From: Camille Scott <camille.scott.w@gmail.com>
+Date: Fri, 9 Mar 2018 18:16:46 -0800
+Subject: [PATCH] patch compilesplicecands
+
+---
+ auxprogs/compileSpliceCands/Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/auxprogs/compileSpliceCands/Makefile b/auxprogs/compileSpliceCands/Makefile
+index d2bbb54..73a44f1 100644
+--- a/auxprogs/compileSpliceCands/Makefile
++++ b/auxprogs/compileSpliceCands/Makefile
+@@ -2,7 +2,7 @@ compileSpliceCands : compileSpliceCands.o list.h list.o
+ 	$(CC) -o compileSpliceCands compileSpliceCands.o list.o;
+ #	cp compileSpliceCands ../../bin
+ compileSpliceCands.o : compileSpliceCands.c 
+-	$(CC) -Wall -pedantic -ansi -c compileSpliceCands.c 
++	$(CC) -Wall -pedantic -ansi $(CPPFLAGS) -c compileSpliceCands.c 
+ 
+ all : compileSpliceCands
+ 
+-- 
+2.14.3 (Apple Git-98)
+

--- a/recipes/augustus/3.2.1_osx/patches/filterBam.2.patch
+++ b/recipes/augustus/3.2.1_osx/patches/filterBam.2.patch
@@ -1,0 +1,62 @@
+From 6aa653a0eb7d5ce913f191a05feb08283fc89684 Mon Sep 17 00:00:00 2001
+From: Camille Scott <camille.scott.w@gmail.com>
+Date: Fri, 9 Mar 2018 19:16:04 -0800
+Subject: [PATCH] Remove other BAMTOOLS env references
+
+---
+ auxprogs/filterBam/Makefile     |  2 +-
+ auxprogs/filterBam/src/Makefile | 15 +++------------
+ 2 files changed, 4 insertions(+), 13 deletions(-)
+
+diff --git a/auxprogs/filterBam/Makefile b/auxprogs/filterBam/Makefile
+index dbb6ad8..0fda30f 100644
+--- a/auxprogs/filterBam/Makefile
++++ b/auxprogs/filterBam/Makefile
+@@ -11,7 +11,7 @@ CFLAGS = -Wall -g -p -O0
+ CXXFLAGS += -Wall -O2 # -g -p -g -ggdb 
+ 
+ all: 
+-	(cd src;make CXX=$(BAMTOOLS_CXX) CC=$(BAMTOOLS_CC) BAMTOOLS=$(BAMTOOLS))
++	(cd src;make CXX=$(BAMTOOLS_CXX) CC=$(BAMTOOLS_CC)
+ 
+ clean:
+ 	(cd src; make clean; cd ../bin; rm -f filterBam; cd ../../../bin; rm -f filterBam)
+diff --git a/auxprogs/filterBam/src/Makefile b/auxprogs/filterBam/src/Makefile
+index f96e240..aae8c12 100644
+--- a/auxprogs/filterBam/src/Makefile
++++ b/auxprogs/filterBam/src/Makefile
+@@ -8,28 +8,19 @@ SOURCES = filterBam.cc MatePairs.cc getReferenceName.cc initOptions.cc SingleAli
+ 			printElapsedTime.cc sumMandIOperations.cc sumDandIOperations.cc PairednessCoverage.cc
+ PROGRAM = filterBam
+ OBJECTS = $(SOURCES:.cc=.o)
+-BAMTOOLS = /usr/local/bamtools
+-INCLUDES = -I$(BAMTOOLS)/include -Iheaders -I./bamtools
+-LIBS = $(BAMTOOLS)/lib/libbamtools.a -lz
++INCLUDES = -I$(PREFIX)/include -Iheaders -I./bamtools
++LIBS = $(PREFIX)/lib/libbamtools.a -lz
+ CFLAGS = -std=c++0x
+ VPATH = functions 
+ INSTDIR = ../bin
+ 
+ all : $(PROGRAM) $(OBJECTS) CHECKBAM BIN
+ 
+-BIN : $(PROGRAM) CHECKBAM
++BIN : $(PROGRAM) 
+ 	mkdir -p $(INSTDIR);\
+ 	mv filterBam $(INSTDIR);
+ 	cp $(INSTDIR)/filterBam ../../../bin/filterBam
+ 
+-CHECKBAM: 
+-	@if [ -z "${BAMTOOLS}" ]; then \
+-		echo '[Makefile]: $${BAMTOOLS} has not been set.'; \
+-		exit 101; \
+-	elif [ "${BAMTOOLS}" ]; then \
+-		echo "filterBam compiled with BAMTOOLS=${BAMTOOLS}"; \
+-	fi
+-
+ $(PROGRAM) : $(OBJECTS) 
+ 	$(CXX) $(CFLAGS) $^ -o $@ $(LIBS) 
+ 
+-- 
+2.14.3 (Apple Git-98)
+

--- a/recipes/augustus/3.2.1_osx/patches/filterBam.Makefile.patch
+++ b/recipes/augustus/3.2.1_osx/patches/filterBam.Makefile.patch
@@ -1,0 +1,30 @@
+From 2af9c2187abb15e5b1d4903e55352d6a21641fdd Mon Sep 17 00:00:00 2001
+From: Camille Scott <camille.scott.w@gmail.com>
+Date: Fri, 9 Mar 2018 18:20:28 -0800
+Subject: [PATCH] Patch filterBam
+
+---
+ auxprogs/filterBam/Makefile | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/auxprogs/filterBam/Makefile b/auxprogs/filterBam/Makefile
+index ac69dd4..dbb6ad8 100644
+--- a/auxprogs/filterBam/Makefile
++++ b/auxprogs/filterBam/Makefile
+@@ -3,6 +3,13 @@
+ # 	Created: 28-February-2012
+ #	Last modified: 15-October-2015
+ 
++INCLUDES =  ${PREFIX}/include/bamtools/
++LIBS = ${PREFIX}/lib/libbamtools.a -lz
++SOURCES = bam2hints.cc
++OBJECTS = $(SOURCES:.cc=.o)
++CFLAGS = -Wall -g -p -O0
++CXXFLAGS += -Wall -O2 # -g -p -g -ggdb 
++
+ all: 
+ 	(cd src;make CXX=$(BAMTOOLS_CXX) CC=$(BAMTOOLS_CC) BAMTOOLS=$(BAMTOOLS))
+ 
+-- 
+2.14.3 (Apple Git-98)
+

--- a/recipes/augustus/3.2.1_osx/patches/filterBam.patch
+++ b/recipes/augustus/3.2.1_osx/patches/filterBam.patch
@@ -1,0 +1,146 @@
+From 2af9c2187abb15e5b1d4903e55352d6a21641fdd Mon Sep 17 00:00:00 2001
+From: Camille Scott <camille.scott.w@gmail.com>
+Date: Fri, 9 Mar 2018 18:20:28 -0800
+Subject: [PATCH 1/4] Patch filterBam
+
+---
+ auxprogs/filterBam/Makefile | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/auxprogs/filterBam/Makefile b/auxprogs/filterBam/Makefile
+index ac69dd4..dbb6ad8 100644
+--- a/auxprogs/filterBam/Makefile
++++ b/auxprogs/filterBam/Makefile
+@@ -3,6 +3,13 @@
+ # 	Created: 28-February-2012
+ #	Last modified: 15-October-2015
+ 
++INCLUDES =  ${PREFIX}/include/bamtools/
++LIBS = ${PREFIX}/lib/libbamtools.a -lz
++SOURCES = bam2hints.cc
++OBJECTS = $(SOURCES:.cc=.o)
++CFLAGS = -Wall -g -p -O0
++CXXFLAGS += -Wall -O2 # -g -p -g -ggdb 
++
+ all: 
+ 	(cd src;make CXX=$(BAMTOOLS_CXX) CC=$(BAMTOOLS_CC) BAMTOOLS=$(BAMTOOLS))
+ 
+-- 
+2.14.3 (Apple Git-98)
+
+
+From 9cccd5bbffddadd9be9413f7a790ec7f4cbdca46 Mon Sep 17 00:00:00 2001
+From: Camille Scott <camille.scott.w@gmail.com>
+Date: Fri, 9 Mar 2018 18:22:47 -0800
+Subject: [PATCH 2/4] patch filterbam src Makefile
+
+---
+ auxprogs/filterBam/src/Makefile | 9 +++++----
+ 1 file changed, 5 insertions(+), 4 deletions(-)
+
+diff --git a/auxprogs/filterBam/src/Makefile b/auxprogs/filterBam/src/Makefile
+index f96e240..a166157 100644
+--- a/auxprogs/filterBam/src/Makefile
++++ b/auxprogs/filterBam/src/Makefile
+@@ -7,11 +7,12 @@
+ SOURCES = filterBam.cc MatePairs.cc getReferenceName.cc initOptions.cc SingleAlignment.cc \
+ 			printElapsedTime.cc sumMandIOperations.cc sumDandIOperations.cc PairednessCoverage.cc
+ PROGRAM = filterBam
++BAMTOOLS = ${PREFIX}/include/bamtools
+ OBJECTS = $(SOURCES:.cc=.o)
+-BAMTOOLS = /usr/local/bamtools
+-INCLUDES = -I$(BAMTOOLS)/include -Iheaders -I./bamtools
+-LIBS = $(BAMTOOLS)/lib/libbamtools.a -lz
+-CFLAGS = -std=c++0x
++INCLUDES =  -I${PREFIX}/include/bamtools/ -Iheaders -I./bamtools
++
++LIBS = ${PREFIX}/lib/libbamtools.a -lz
++CFLAGS += -std=c++11 -Wall -O2 # -g -p -g -ggdb
+ VPATH = functions 
+ INSTDIR = ../bin
+ 
+-- 
+2.14.3 (Apple Git-98)
+
+
+From df0e8f3894aabbac32032b1cf0cb196f55c0b387 Mon Sep 17 00:00:00 2001
+From: Camille Scott <camille.scott.w@gmail.com>
+Date: Fri, 9 Mar 2018 19:44:43 -0800
+Subject: [PATCH 3/4] Remove BAMTOOLS references in filterBam Makefile
+
+---
+ auxprogs/filterBam/Makefile     | 2 +-
+ auxprogs/filterBam/src/Makefile | 8 --------
+ 2 files changed, 1 insertion(+), 9 deletions(-)
+
+diff --git a/auxprogs/filterBam/Makefile b/auxprogs/filterBam/Makefile
+index dbb6ad8..bbdb60d 100644
+--- a/auxprogs/filterBam/Makefile
++++ b/auxprogs/filterBam/Makefile
+@@ -11,7 +11,7 @@ CFLAGS = -Wall -g -p -O0
+ CXXFLAGS += -Wall -O2 # -g -p -g -ggdb 
+ 
+ all: 
+-	(cd src;make CXX=$(BAMTOOLS_CXX) CC=$(BAMTOOLS_CC) BAMTOOLS=$(BAMTOOLS))
++	(cd src;make CXX=$(BAMTOOLS_CXX) CC=$(BAMTOOLS_CC))
+ 
+ clean:
+ 	(cd src; make clean; cd ../bin; rm -f filterBam; cd ../../../bin; rm -f filterBam)
+diff --git a/auxprogs/filterBam/src/Makefile b/auxprogs/filterBam/src/Makefile
+index a166157..d3118c2 100644
+--- a/auxprogs/filterBam/src/Makefile
++++ b/auxprogs/filterBam/src/Makefile
+@@ -7,7 +7,6 @@
+ SOURCES = filterBam.cc MatePairs.cc getReferenceName.cc initOptions.cc SingleAlignment.cc \
+ 			printElapsedTime.cc sumMandIOperations.cc sumDandIOperations.cc PairednessCoverage.cc
+ PROGRAM = filterBam
+-BAMTOOLS = ${PREFIX}/include/bamtools
+ OBJECTS = $(SOURCES:.cc=.o)
+ INCLUDES =  -I${PREFIX}/include/bamtools/ -Iheaders -I./bamtools
+ 
+@@ -23,13 +22,6 @@ BIN : $(PROGRAM) CHECKBAM
+ 	mv filterBam $(INSTDIR);
+ 	cp $(INSTDIR)/filterBam ../../../bin/filterBam
+ 
+-CHECKBAM: 
+-	@if [ -z "${BAMTOOLS}" ]; then \
+-		echo '[Makefile]: $${BAMTOOLS} has not been set.'; \
+-		exit 101; \
+-	elif [ "${BAMTOOLS}" ]; then \
+-		echo "filterBam compiled with BAMTOOLS=${BAMTOOLS}"; \
+-	fi
+ 
+ $(PROGRAM) : $(OBJECTS) 
+ 	$(CXX) $(CFLAGS) $^ -o $@ $(LIBS) 
+-- 
+2.14.3 (Apple Git-98)
+
+
+From 3b98e77b1e01697145795d4f3cb0fc5b0c72be26 Mon Sep 17 00:00:00 2001
+From: Camille Scott <camille.scott.w@gmail.com>
+Date: Fri, 9 Mar 2018 22:44:14 -0800
+Subject: [PATCH 4/4] Remove CHECKBAM refs from filterBam src Makefile
+
+---
+ auxprogs/filterBam/src/Makefile | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/auxprogs/filterBam/src/Makefile b/auxprogs/filterBam/src/Makefile
+index d3118c2..56aa395 100644
+--- a/auxprogs/filterBam/src/Makefile
++++ b/auxprogs/filterBam/src/Makefile
+@@ -15,9 +15,9 @@ CFLAGS += -std=c++11 -Wall -O2 # -g -p -g -ggdb
+ VPATH = functions 
+ INSTDIR = ../bin
+ 
+-all : $(PROGRAM) $(OBJECTS) CHECKBAM BIN
++all : $(PROGRAM) $(OBJECTS) BIN
+ 
+-BIN : $(PROGRAM) CHECKBAM
++BIN : $(PROGRAM) 
+ 	mkdir -p $(INSTDIR);\
+ 	mv filterBam $(INSTDIR);
+ 	cp $(INSTDIR)/filterBam ../../../bin/filterBam
+-- 
+2.14.3 (Apple Git-98)
+

--- a/recipes/augustus/3.2.1_osx/patches/filterBam.src.Makefile.patch
+++ b/recipes/augustus/3.2.1_osx/patches/filterBam.src.Makefile.patch
@@ -1,0 +1,33 @@
+From 9cccd5bbffddadd9be9413f7a790ec7f4cbdca46 Mon Sep 17 00:00:00 2001
+From: Camille Scott <camille.scott.w@gmail.com>
+Date: Fri, 9 Mar 2018 18:22:47 -0800
+Subject: [PATCH] patch filterbam src Makefile
+
+---
+ auxprogs/filterBam/src/Makefile | 9 +++++----
+ 1 file changed, 5 insertions(+), 4 deletions(-)
+
+diff --git a/auxprogs/filterBam/src/Makefile b/auxprogs/filterBam/src/Makefile
+index f96e240..a166157 100644
+--- a/auxprogs/filterBam/src/Makefile
++++ b/auxprogs/filterBam/src/Makefile
+@@ -7,11 +7,12 @@
+ SOURCES = filterBam.cc MatePairs.cc getReferenceName.cc initOptions.cc SingleAlignment.cc \
+ 			printElapsedTime.cc sumMandIOperations.cc sumDandIOperations.cc PairednessCoverage.cc
+ PROGRAM = filterBam
++BAMTOOLS = ${PREFIX}/include/bamtools
+ OBJECTS = $(SOURCES:.cc=.o)
+-BAMTOOLS = /usr/local/bamtools
+-INCLUDES = -I$(BAMTOOLS)/include -Iheaders -I./bamtools
+-LIBS = $(BAMTOOLS)/lib/libbamtools.a -lz
+-CFLAGS = -std=c++0x
++INCLUDES =  -I${PREFIX}/include/bamtools/ -Iheaders -I./bamtools
++
++LIBS = ${PREFIX}/lib/libbamtools.a -lz
++CFLAGS += -std=c++11 -Wall -O2 # -g -p -g -ggdb
+ VPATH = functions 
+ INSTDIR = ../bin
+ 
+-- 
+2.14.3 (Apple Git-98)
+

--- a/recipes/augustus/3.2.1_osx/patches/homGeneMapping.src.Makefile.patch
+++ b/recipes/augustus/3.2.1_osx/patches/homGeneMapping.src.Makefile.patch
@@ -1,0 +1,24 @@
+From c1723f20c0601e5600ecf41ae89488a41db8ffea Mon Sep 17 00:00:00 2001
+From: Camille Scott <camille.scott.w@gmail.com>
+Date: Mon, 12 Mar 2018 18:08:10 -0700
+Subject: [PATCH] Add mkdir -p call to homegene src
+
+---
+ auxprogs/homGeneMapping/src/Makefile | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/auxprogs/homGeneMapping/src/Makefile b/auxprogs/homGeneMapping/src/Makefile
+index c3eaae1..1a2810e 100644
+--- a/auxprogs/homGeneMapping/src/Makefile
++++ b/auxprogs/homGeneMapping/src/Makefile
+@@ -28,6 +28,7 @@ all: homGeneMapping
+ 
+ homGeneMapping: main.cc $(OBJS)
+ 	 $(CXX) $(CFLAGS) -o $@ $^ $(INCLS)
++	mkdir -p ../bin
+ 	mv homGeneMapping ../bin/
+ 	cp ../bin/homGeneMapping ../../../bin/homGeneMapping
+ clean:	
+-- 
+2.14.3 (Apple Git-98)
+


### PR DESCRIPTION
The existing Augustus recipe (v3.2.3) is not skipped for OSX, yet it suffers from runtime errors in its auxiliary scripts after installation. This PR introduces a version of Augusts 3.2.1 specialized for OSX by @nextgenusfs.

* [ ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
