### PR TITLE
idr-py: add recipe from PyPI

### DIFF
--- a/recipes/idr-py/meta.yaml
+++ b/recipes/idr-py/meta.yaml
@@ -33,9 +33,9 @@ requirements:
     - seaborn
 
 test:
-  imports:
-    - idr
-    - idr.tests
+  commands:
+    - env MPLBACKEND=Agg python -c "import idr"
+    - env MPLBACKEND=Agg python -c "import idr.tests"
 
 about:
   home: https://github.com/IDR/idr-py

--- a/recipes/idr-py/meta.yaml
+++ b/recipes/idr-py/meta.yaml
@@ -1,0 +1,48 @@
+{% set name = "idr-py" %}
+{% set version = "0.2.0" %}
+{% set file_ext = "tar.gz" %}
+{% set hash_type = "sha256" %}
+{% set hash_value = "af50a517b2fa324a1030830d95803cda18ecf2f9381550f401651f8c25d2f322" %}
+
+package:
+  name: '{{ name|lower }}'
+  version: '{{ version }}'
+
+source:
+  fn: '{{ name }}-{{ version }}.{{ file_ext }}'
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ file_ext }}
+  '{{ hash_type }}': '{{ hash_value }}'
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  host:
+    - python
+    - setuptools
+  run:
+    - python
+    - python-omero=5.3.3
+
+test:
+  imports:
+    - idr
+    - idr.tests
+
+about:
+  home: https://github.com/IDR/idr-py
+  license: GPL-2.0+
+  license_family: GPL2
+  license_file: ''
+  summary: Helper methods for accessing the Image Data Resource (IDR)
+  description: ".. image:: https://travis-ci.org/IDR/idr-py.svg?branch=master\n    :target: https://travis-ci.org/IDR/idr-py\n\n.. image:: https://badge.fury.io/py/idr-py.svg\n    :target: https://badge.fury.io/py/idr-py\n\
+    \nIDR-PY\n======\n\nLibrary with helper methods for accessing the Image Data Resource (IDR).\n\nRequirements\n============\n\n * OMERO.py 5.3.x\n * Python 2.6+\n\nInstalling from PyPI\n====================\n\
+    \nThis section assumes that an OMERO.web is already installed.\n\n\nInstall the app using `pip <https://pip.pypa.io/en/stable/>`_:\n\n::\n\n    $ pip install -U idr-py\n\n\nLicense\n-------\n\nThis\
+    \ project, similar to many Open Microscopy Environment (OME) projects, is licensed under the terms of the GNU General Public License (GPL) v2 or later.\n\nCopyright\n---------\n\n2017, The Open Microscopy\
+    \ Environment"
+  doc_url: ''
+  dev_url: ''
+
+extra:
+  recipe-maintainers: ''

--- a/recipes/idr-py/meta.yaml
+++ b/recipes/idr-py/meta.yaml
@@ -16,14 +16,21 @@ source:
 build:
   number: 0
   script: python setup.py install --single-version-externally-managed --record=record.txt
+  skip: true  # [py3k]
 
 requirements:
   host:
     - python
     - setuptools
   run:
-    - python
-    - python-omero=5.3.3
+    - python >=2.7,<3
+    - python-omero <5.4
+    - ipython
+    - ipywidgets
+    - matplotlib
+    - pandas
+    - requests
+    - seaborn
 
 test:
   imports:

--- a/recipes/idr-py/meta.yaml
+++ b/recipes/idr-py/meta.yaml
@@ -19,7 +19,7 @@ build:
   skip: True  # [not py27]
 
 requirements:
-  host:
+  build:
     - python
     - setuptools
   run:

--- a/recipes/idr-py/meta.yaml
+++ b/recipes/idr-py/meta.yaml
@@ -16,14 +16,14 @@ source:
 build:
   number: 0
   script: python setup.py install --single-version-externally-managed --record=record.txt
-  skip: true  # [py3k]
+  skip: True  # [not py27]
 
 requirements:
   host:
     - python
     - setuptools
   run:
-    - python >=2.7,<3
+    - python
     - python-omero <5.4
     - ipython
     - ipywidgets


### PR DESCRIPTION
This library is used for accessing https://idr.openmicroscopy.org, will be used in concert with an environment file: https://github.com/IDR/idr-py/pull/11, and depends on `python-omero` which we [maintain](https://github.com/bioconda/bioconda-recipes/pull/8187).

 * Created via `conda skeleton pypi idr-py`
 * Dependency on python-omero added manually


----

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [x] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
