### PR TITLE
Use updated KrakenHLL code

### DIFF
--- a/recipes/krakenhll/meta.yaml
+++ b/recipes/krakenhll/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "0.3.2" %}
-{% set sha256 = "57815f1d4cfa9b1ecd2bcc608b844341783475d2d19d40b25bd7d5290ffbb66d" %}
+{% set sha256 = "789822f8c06202705dd927396bda13561a14cab6239b07d19721ff98a916f142" %}
 
 package:
   name: krakenhll
@@ -7,11 +7,11 @@ package:
 
 source:
   fn: krakenhll-{{ version }}.tar.gz
-  url: https://github.com/fbreitwieser/krakenhll/archive/f4a2a9309b94aaf21310889a4cdb464d794333bc.tar.gz
+  url: https://github.com/fbreitwieser/krakenhll/archive/d17b6a0aea43774cbe7e559c6ef8cb35fffd1844.tar.gz
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   has_prefix_files:
     - libexec/krakenhll
     - libexec/krakenhll-build

--- a/recipes/krakenhll/meta.yaml
+++ b/recipes/krakenhll/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "0.3.2" %}
-{% set sha256 = "789822f8c06202705dd927396bda13561a14cab6239b07d19721ff98a916f142" %}
+{% set version = "0.4.0_beta" %}
+{% set sha256 = "a8222a42d20382dbf740b34a507cb628c399c90a1f3dc314d58f25364570fe80" %}
 
 package:
   name: krakenhll
@@ -7,11 +7,11 @@ package:
 
 source:
   fn: krakenhll-{{ version }}.tar.gz
-  url: https://github.com/fbreitwieser/krakenhll/archive/d17b6a0aea43774cbe7e559c6ef8cb35fffd1844.tar.gz
+  url: https://github.com/fbreitwieser/krakenhll/archive/v0.4-beta.tar.gz
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 0
   has_prefix_files:
     - libexec/krakenhll
     - libexec/krakenhll-build


### PR DESCRIPTION
Argument mismatch in Bioconda's version where `krakenhll` calls `classify` with nonexistent `-r` option. Updated to the most recent commit.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
