### PR TITLE
Open version numbers constraints

### DIFF
--- a/recipes/mir-prefer/meta.yaml
+++ b/recipes/mir-prefer/meta.yaml
@@ -17,8 +17,8 @@ source:
     - patches/process-reads-fasta.py.patch
 
 build:
-  number: 0
-  skip: True # [not py27]
+  number: 1
+  skip: True # [not py2k]
 
 requirements:
   build:
@@ -26,9 +26,9 @@ requirements:
 
   run:
     - python
-    - viennarna
-    - samtools ==0.1.19
-    - bowtie ==1.2.0
+    - viennarna >=1.8.5
+    - samtools >=0.1.15
+    - bowtie >=1.2.0
 
 test:
   commands:


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

The initial recipe of miR-PREFeR locked samtools and bowtie to single versions which aren't required. This PR allows the version numbers to float upward following the original package's dependencies. 