### PR TITLE
mdasim: attempt at fixing openmpi library linking issue

### DIFF
--- a/recipes/mdasim/meta.yaml
+++ b/recipes/mdasim/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "mdasim" %}
-{% set version = "2.0.0" %}
+{% set version = "2.0.1" %}
 
 package:
     name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
     url: https://github.com/hzi-bifo/{{ name }}/archive/v{{ version }}.tar.gz
-    md5: 754cebc4732e5e11c9f192b69ba24767
+    md5: a3dc379f0c3146635b91d4e4587b4d29
 
 build:
     # omitting OSX as the Makefile wasn't made for this (tried debugging, never ends)


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

This PR tries to resolve this problem that is not caught by circleci:

Package for bioconda worked and the test and building in circleci all passed. However, installing it locally seems to give the following error:
```
mdasim: error while loading shared libraries: libmpi_cxx.so.40: cannot open shared object file: No such file or directory
```
At the same time, this exact file is present in the local miniconda3 libraries, as specified by the `openmpi` dependency -- only the location does not seem to be linked correctly during the build.