### PR TITLE
Added amused and brockman 

### DIFF
--- a/recipes/amused/build.sh
+++ b/recipes/amused/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+libloc="$PREFIX/lib/ruby/site_ruby"
+mkdir -p $libloc
+mkdir -p $PREFIX/bin
+cp Ruby-DNA-Tools/*.rb $libloc/. 
+cp AMUSED/NMERTREE.rb $libloc/. 
+cp AMUSED/AMUSED $PREFIX/bin/. 
+cp AMUSED/AMUSED-KS $PREFIX/bin/. 
+cp AMUSED/alignKMers $PREFIX/bin/. 
+cp AMUSED/shuffleCodons.rb $PREFIX/bin/. 
+cp AMUSED/shuffleCodonsAddMotifs.rb $PREFIX/bin/. 

--- a/recipes/amused/meta.yaml
+++ b/recipes/amused/meta.yaml
@@ -1,0 +1,27 @@
+{% set version = "1.0" %}
+
+package:
+  name: amused
+  version: {{ version }}
+
+source:
+  - git_url: https://github.com/Carldeboer/AMUSED
+    folder: AMUSED
+  - git_url: https://github.com/Carldeboer/Ruby-DNA-Tools
+    folder: Ruby-DNA-Tools
+
+
+requirements:
+  build:
+
+  run:
+    - ruby
+
+test:
+    commands:
+      - AMUSED -h
+
+about:
+  home: https://github.com/Carldeboer/AMUSED
+  license: GPL-2.0
+  summary: Auditing Motifs Using Statistical Enrichment & Depletion

--- a/recipes/brockman-pipeline/build.sh
+++ b/recipes/brockman-pipeline/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+mkdir -p $PREFIX/bin
+mkdir -p $PREFIX/etc/Brockman
+cp Brockman/brockman_pipeline $PREFIX/bin/. 
+cp -r Brockman/Resources $PREFIX/etc/Brockman/Resources

--- a/recipes/brockman-pipeline/meta.yaml
+++ b/recipes/brockman-pipeline/meta.yaml
@@ -1,0 +1,33 @@
+{% set version = "1.0" %}
+
+package:
+  name: brockman-pipeline
+  version: {{ version }}
+
+source:
+  - git_url: https://github.com/Carldeboer/Brockman
+    folder: Brockman
+
+
+requirements:
+  build:
+
+  run:
+    - amused
+    - ruby
+    - samtools
+    - bedtools
+    - ucsc-twobittofa
+    - bowtie2
+    - trimmomatic
+    - ncurses
+    - bzip2
+
+test:
+    commands:
+      - which brockman_pipeline
+
+about:
+  home: https://github.com/Carldeboer/Brockman
+  license: GPL-3.0
+  summary: Brockman Representation Of Chromatin by K-mers in Mark-Associated Nucleotides


### PR DESCRIPTION
These are two k-mer based DNA-analysis programs (brockman depends on amused).
As this is my first bioconda pull, I would appreciate someone double checking it @bioconda/core.
I tried a local build and it appeared to work:
```
conda build -c bioconda  -c conda-forge brockman-pipeline
conda create -n BrockmanEnv2
conda install -n BrockmanEnv2 --use-local brockman-pipeline
```
Also tried circleci and it said that it was successful, although I was not sure that it was doing things right; my changes had already been committed to the repo at that time and it said:
```
12:59:31 BIOCONDA INFO No recipe modified according to git, exiting.
Success!
```

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [x] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
