### PR TITLE
[WIP] Add bwa 0.7.3a with feature flag

### DIFF
--- a/recipes/bwa/0.7.3a_haswell/Makefile.patch
+++ b/recipes/bwa/0.7.3a_haswell/Makefile.patch
@@ -3,7 +3,7 @@
 @@ -1,5 +1,5 @@
  CC=			gcc
 -CFLAGS=		-g -Wall -O2
-+CFLAGS=		-g -Wall -Ofast -march=sandybridge
++CFLAGS=		-g -Wall -Ofast -march=core-avx2
  AR=			ar
  DFLAGS=		-DHAVE_PTHREAD
  LOBJS=		utils.o kstring.o ksw.o bwt.o bntseq.o bwa.o bwamem.o bwamem_pair.o

--- a/recipes/bwa/0.7.3a_haswell/Makefile.patch
+++ b/recipes/bwa/0.7.3a_haswell/Makefile.patch
@@ -3,7 +3,7 @@
 @@ -1,5 +1,5 @@
  CC=			gcc
 -CFLAGS=		-g -Wall -O2
-+CFLAGS=		-g -Wall -Ofast -march=haswell
++CFLAGS=		-g -Wall -Ofast -march=sandybridge
  AR=			ar
  DFLAGS=		-DHAVE_PTHREAD
  LOBJS=		utils.o kstring.o ksw.o bwt.o bntseq.o bwa.o bwamem.o bwamem_pair.o

--- a/recipes/bwa/0.7.3a_haswell/Makefile.patch
+++ b/recipes/bwa/0.7.3a_haswell/Makefile.patch
@@ -1,0 +1,9 @@
+--- Makefile.bak	2018-02-27 10:26:19.000000000 -0800
++++ Makefile	2018-02-27 10:26:31.000000000 -0800
+@@ -1,5 +1,5 @@
+ CC=			gcc
+-CFLAGS=		-g -Wall -O2
++CFLAGS=		-g -Wall -Ofast -march=haswell
+ AR=			ar
+ DFLAGS=		-DHAVE_PTHREAD
+ LOBJS=		utils.o kstring.o ksw.o bwt.o bntseq.o bwa.o bwamem.o bwamem_pair.o

--- a/recipes/bwa/0.7.3a_haswell/build.sh
+++ b/recipes/bwa/0.7.3a_haswell/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+export C_INCLUDE_PATH=${PREFIX}/include
+export LIBRARY_PATH=${PREFIX}/lib
+
+make
+mkdir -p $PREFIX/bin
+cp bwa $PREFIX/bin

--- a/recipes/bwa/0.7.3a_haswell/meta.yaml
+++ b/recipes/bwa/0.7.3a_haswell/meta.yaml
@@ -1,0 +1,36 @@
+{% set version = "0.7.3a" %}
+{% set sha256 = "5093e39b83f64b9bb348a86d4fd129abc4797c5b4472bc110e16fc67ab920e56" %}
+
+package:
+  name: bwa
+  version: {{ version }}
+
+build:
+  number: 0
+  features:
+    - haswell
+
+source:
+  fn: bwa-{{ version }}.tar.bz2
+  url: http://downloads.sourceforge.net/project/bio-bwa/bwa-{{ version }}.tar.bz2
+  sha256: {{ sha256 }}
+  patches:
+      - Makefile.patch
+
+requirements:
+  build:
+    - gcc                       # [not osx]
+    - llvm                      # [osx]
+    - zlib {{CONDA_ZLIB}}*
+  run:
+    - libgcc                    # [not osx]
+    - zlib {{CONDA_ZLIB}}*
+
+test:
+  commands:
+    - bwa 2>&1 | grep "index sequences in the"
+
+about:
+  home: http://bio-bwa.sourceforge.net
+  license: MIT
+  summary: The BWA read mapper.


### PR DESCRIPTION
* [ ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

This is my proposal for how we might add builds with additional compiler optimized flags, primarily in an ad hoc manner (rather than building a grid of all tuples of (version, feature_flag).  I don't necessarily want to merge this now, as I think it may as well wait until the new CB3 compilers are ready. 