### PR TITLE
hclust2: Pin matplotlib-2.0.2

### DIFF
--- a/recipes/hclust2/meta.yaml
+++ b/recipes/hclust2/meta.yaml
@@ -8,7 +8,7 @@ source:
   url: https://bitbucket.org/nsegata/hclust2/get/3d589ab.tar.gz
   md5: {{ md5 }}
 build:
-  number: 0
+  number: 1
   skip: True # [py3k]
 requirements:
   build:
@@ -18,7 +18,7 @@ requirements:
     - python
     - libgcc
     - numpy
-    - matplotlib
+    - matplotlib 2.0.2
     - scipy
     - pandas
 test:


### PR DESCRIPTION
Newer versions of matplotlib have a problem importing functools_lru_cache
https://stackoverflow.com/q/47179433/780188

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
