### PR TITLE
Add dependencies required to run metfrag in batch

### DIFF
--- a/recipes/metfrag/meta.yaml
+++ b/recipes/metfrag/meta.yaml
@@ -13,11 +13,13 @@ source:
   sha256: fa020f4093157647bb6b13d05c8962c82358b1f076b91e22ae116359322d7b47
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   run:
     - openjdk >=7
+    - zip
+    - parallel
 
 test:
   commands:

--- a/recipes/metfrag/meta.yaml
+++ b/recipes/metfrag/meta.yaml
@@ -19,6 +19,7 @@ requirements:
   run:
     - openjdk >=7
     - zip
+    - unzip
     - parallel
 
 test:


### PR DESCRIPTION
* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [X] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

A possible way to use MetFrag is to pass a ZIP file of queries and run MetFrag on all of them. 
This requires the dependencies GNU Parallel and ZIP, which are available as conda packages. 