### PR TITLE
include sqlite support in augustus 3.3 build

### DIFF
--- a/recipes/augustus/build.sh
+++ b/recipes/augustus/build.sh
@@ -22,7 +22,11 @@ mv common.mk common.mk.orig
 sed 's/# COMPGENEPRED = true/COMPGENPRED = true/' < common.mk.orig | sed 's/# SQLITE = true/SQLITE = true/' > common.mk
 
 ## Make the software
-
+if [ "$(uname)" == Linux ] ; then
+    # TODO: remove this when switching to newer compilers
+    export CC=gcc
+    export CXX=g++
+fi
 make CC="${CC}" CXX="${CXX}"
 
 ## Build Perl

--- a/recipes/augustus/build.sh
+++ b/recipes/augustus/build.sh
@@ -22,6 +22,8 @@ mv common.mk common.mk.orig
 sed 's/# COMPGENEPRED = true/COMPGENPRED = true/' < common.mk.orig | sed 's/# SQLITE = true/SQLITE = true/' > common.mk
 
 ## Make the software
+sed -i.bak 's/\<CC\>/CXX/g' auxprogs/homGeneMapping/src/Makefile
+sed -i.bak 's/\<CC\>/CXX/g' auxprogs/joingenes/Makefile
 if [ "$(uname)" == Linux ] ; then
     # TODO: remove this when switching to newer compilers
     export CC=gcc

--- a/recipes/augustus/build.sh
+++ b/recipes/augustus/build.sh
@@ -22,7 +22,8 @@ if [ "$(uname)" == Darwin ] ; then
   # SQLITE disabled due to compile issue, see: https://svn.boost.org/trac10/ticket/13501
   make CC="${CC}" CXX="${CXX}" COMPGENPRED=true
 else
-  make CC="${CC}" CXX="${CXX}" COMPGENPRED=true SQLITE=true
+  # TODO: use 'CC="${CC}" CXX="${CXX}"' when switching to newer compilers
+  make CC=gcc CXX=g++ COMPGENPRED=true SQLITE=true
 fi
 
 ## Build Perl
@@ -52,4 +53,3 @@ chmod a+x $PREFIX/etc/conda/activate.d/augustus-confdir.sh
 mkdir -p $PREFIX/etc/conda/deactivate.d/
 echo "unset AUGUSTUS_CONFIG_PATH" > $PREFIX/etc/conda/deactivate.d/augustus-confdir.sh
 chmod a+x $PREFIX/etc/conda/deactivate.d/augustus-confdir.sh
-

--- a/recipes/augustus/build.sh
+++ b/recipes/augustus/build.sh
@@ -16,10 +16,10 @@ mkdir -p $PREFIX/bin
 mkdir -p $PREFIX/scripts
 mkdir -p $PREFIX/config
 
-## enable augustus CGP mode
+## enable augustus CGP mode and sqlite database support
 
 mv common.mk common.mk.orig
-sed 's/# COMPGENEPRED = true/COMPGENPRED = true/' < common.mk.orig > common.mk
+sed 's/# COMPGENEPRED = true/COMPGENPRED = true/' < common.mk.orig | sed 's/# SQLITE = true/SQLITE = true/' > common.mk
 
 ## Make the software
 

--- a/recipes/augustus/build.sh
+++ b/recipes/augustus/build.sh
@@ -18,8 +18,8 @@ mkdir -p $PREFIX/config
 
 ## Make the software
 
-sed -i.bak 's/\<CC\>/CXX/g' auxprogs/homGeneMapping/src/Makefile
-sed -i.bak 's/\<CC\>/CXX/g' auxprogs/joingenes/Makefile
+sed -i.bak -e 's/^CC *=/CXX=/' -e 's/\$(CC)/$(CXX)/g' auxprogs/homGeneMapping/src/Makefile
+sed -i.bak -e 's/^CC *=/CXX=/' -e 's/\$(CC)/$(CXX)/g' auxprogs/joingenes/Makefile
 # TODO: don't set CC/CXX here when switching to newer compilers
 CC=gcc
 CXX=g++

--- a/recipes/augustus/build.sh
+++ b/recipes/augustus/build.sh
@@ -16,20 +16,14 @@ mkdir -p $PREFIX/bin
 mkdir -p $PREFIX/scripts
 mkdir -p $PREFIX/config
 
-## enable augustus CGP mode and sqlite database support
-
-mv common.mk common.mk.orig
-sed 's/# COMPGENEPRED = true/COMPGENPRED = true/' < common.mk.orig | sed 's/# SQLITE = true/SQLITE = true/' > common.mk
-
 ## Make the software
-sed -i.bak 's/\<CC\>/CXX/g' auxprogs/homGeneMapping/src/Makefile
-sed -i.bak 's/\<CC\>/CXX/g' auxprogs/joingenes/Makefile
-if [ "$(uname)" == Linux ] ; then
-    # TODO: remove this when switching to newer compilers
-    export CC=gcc
-    export CXX=g++
+
+if [ "$(uname)" == Darwin ] ; then
+  # SQLITE disabled due to compile issue, see: https://svn.boost.org/trac10/ticket/13501
+  make CC="${CC}" CXX="${CXX}" COMPGENPRED=true
+else
+  make CC="${CC}" CXX="${CXX}" COMPGENPRED=true SQLITE=true
 fi
-make CC="${CC}" CXX="${CXX}"
 
 ## Build Perl
 

--- a/recipes/augustus/build.sh
+++ b/recipes/augustus/build.sh
@@ -18,6 +18,8 @@ mkdir -p $PREFIX/config
 
 ## Make the software
 
+sed -i.bak 's/\<CC\>/CXX/g' auxprogs/homGeneMapping/src/Makefile
+sed -i.bak 's/\<CC\>/CXX/g' auxprogs/joingenes/Makefile
 if [ "$(uname)" == Darwin ] ; then
   # SQLITE disabled due to compile issue, see: https://svn.boost.org/trac10/ticket/13501
   make CC="${CC}" CXX="${CXX}" COMPGENPRED=true

--- a/recipes/augustus/build.sh
+++ b/recipes/augustus/build.sh
@@ -20,12 +20,14 @@ mkdir -p $PREFIX/config
 
 sed -i.bak 's/\<CC\>/CXX/g' auxprogs/homGeneMapping/src/Makefile
 sed -i.bak 's/\<CC\>/CXX/g' auxprogs/joingenes/Makefile
+# TODO: don't set CC/CXX here when switching to newer compilers
+CC=gcc
+CXX=g++
 if [ "$(uname)" == Darwin ] ; then
   # SQLITE disabled due to compile issue, see: https://svn.boost.org/trac10/ticket/13501
   make CC="${CC}" CXX="${CXX}" COMPGENPRED=true
 else
-  # TODO: use 'CC="${CC}" CXX="${CXX}"' when switching to newer compilers
-  make CC=gcc CXX=g++ COMPGENPRED=true SQLITE=true
+  make CC="${CC}" CXX="${CXX}" COMPGENPRED=true SQLITE=true
 fi
 
 ## Build Perl

--- a/recipes/augustus/build.sh
+++ b/recipes/augustus/build.sh
@@ -23,7 +23,7 @@ sed 's/# COMPGENEPRED = true/COMPGENPRED = true/' < common.mk.orig | sed 's/# SQ
 
 ## Make the software
 
-make
+make CC="${CC}" CXX="${CXX}"
 
 ## Build Perl
 

--- a/recipes/augustus/meta.yaml
+++ b/recipes/augustus/meta.yaml
@@ -1,8 +1,6 @@
 {% set name = "augustus" %}
 {% set version = "3.3" %}
 {% set sha256 = "b5eb811a4c33a2cc3bbd16355e19d530eeac6d1ac923e59f48d7a79f396234ee" %}
-# `clang_*` below should be replaced by `compiler("cxx")` with conda-build 3
-{% set clang_version = "4.0.1" %}
 
 package:
   name: {{ name|lower }}
@@ -24,11 +22,10 @@ build:
 
 requirements:
   build:
-      - gcc  # [linux]
-      - clangxx_osx-64 {{ clang_version }}  # [osx]
-      - clang_osx-64 {{ clang_version }}  # [osx]
+      - gcc  # [not osx]
+      - libgcc  # [not osx]
+      - llvm  # [osx]
       - zlib {{ CONDA_ZLIB }}*
-      - libgcc
       - bamtools {{ CONDA_BAMTOOLS }}*
       - gsl {{ CONDA_GSL }}*
       - lp_solve
@@ -38,8 +35,8 @@ requirements:
       - sqlite
       - suitesparse
   run:
-      - libgcc  # [linux]
-      - libcxx >={{ clang_version }}  # [osx]
+      - libgcc  # [not osx]
+      - libcxx  # [osx]
       - zlib {{ CONDA_ZLIB }}*
       - bamtools {{ CONDA_BAMTOOLS }}*
       - boost {{ CONDA_BOOST }}*

--- a/recipes/augustus/meta.yaml
+++ b/recipes/augustus/meta.yaml
@@ -1,6 +1,8 @@
 {% set name = "augustus" %}
 {% set version = "3.3" %}
 {% set sha256 = "b5eb811a4c33a2cc3bbd16355e19d530eeac6d1ac923e59f48d7a79f396234ee" %}
+# `gxx_*`/`gcc_*`/`clang_*` below should be replaced by `compiler("cxx")` with conda-build 3
+{% set gxx_version = "7.2.0" %}
 {% set clang_version = "4.0.1" %}
 
 package:
@@ -23,7 +25,8 @@ build:
 
 requirements:
   build:
-      - gcc  # [not osx]
+      - gcc_linux-64 {{ gxx_version }}  # [linux]
+      - gxx_linux-64 {{ gxx_version }}  # [linux]
       - clangxx_osx-64 {{ clang_version }}  # [osx]
       - clang_osx-64 {{ clang_version }}  # [osx]
       - zlib {{ CONDA_ZLIB }}*
@@ -37,7 +40,7 @@ requirements:
       - sqlite
       - suitesparse
   run:
-      - libgcc  # [not osx]
+      - libgcc >={{ gxx_version }}  # [linux]
       - libcxx >={{ clang_version }}  # [osx]
       - zlib {{ CONDA_ZLIB }}*
       - bamtools {{ CONDA_BAMTOOLS }}*

--- a/recipes/augustus/meta.yaml
+++ b/recipes/augustus/meta.yaml
@@ -17,8 +17,8 @@ source:
       - patches/compileSpliceCands.Makefile.patch
 
 build:
-  number: 0
-  string: boost{{CONDA_BOOST}}_bamtools{{CONDA_BAMTOOLS}}_{{PKG_BUILDNUM}}
+  number: 1
+  string: cgp_sqlite_{{PKG_BUILDNUM}}
 
 requirements:
   build:
@@ -32,6 +32,8 @@ requirements:
       - perl
       - perl-module-build
       - boost {{CONDA_BOOST}}*
+      - sqlite
+      - suitesparse
   run:
       - libgcc # [not osx]
       - zlib {{CONDA_ZLIB}}*
@@ -45,6 +47,8 @@ requirements:
       - perl-yaml
       - perl-dbi
       - perl-scalar-list-utils
+      - sqlite
+      - suitesparse
 
 test:
   commands:

--- a/recipes/augustus/meta.yaml
+++ b/recipes/augustus/meta.yaml
@@ -1,6 +1,7 @@
 {% set name = "augustus" %}
 {% set version = "3.3" %}
 {% set sha256 = "b5eb811a4c33a2cc3bbd16355e19d530eeac6d1ac923e59f48d7a79f396234ee" %}
+{% set clang_version = "4.0.1" %}
 
 package:
   name: {{ name|lower }}
@@ -18,12 +19,13 @@ source:
 
 build:
   number: 1
-  string: cgp_sqlite_{{PKG_BUILDNUM}}
+  string: boost{{ CONDA_BOOST }}_{{ PKG_BUILDNUM }}
 
 requirements:
   build:
       - gcc # [linux]
-      - llvm # [osx]
+      - clangxx_osx-64 {{ clang_version }}  # [osx]
+      - clang_osx-64 {{ clang_version }} # [osx]
       - zlib {{CONDA_ZLIB}}*
       - libgcc
       - bamtools {{ CONDA_BAMTOOLS }}*

--- a/recipes/augustus/meta.yaml
+++ b/recipes/augustus/meta.yaml
@@ -1,7 +1,8 @@
 {% set name = "augustus" %}
 {% set version = "3.3" %}
 {% set sha256 = "b5eb811a4c33a2cc3bbd16355e19d530eeac6d1ac923e59f48d7a79f396234ee" %}
-# `gcc`/`clang_*` below should be replaced by `compiler("cxx")` with conda-build 3
+# `gxx_*`/`gcc_*`/`clang_*` below should be replaced by `compiler("cxx")` with conda-build 3
+{% set gxx_version = "7.2.0" %}
 {% set clang_version = "4.0.1" %}
 
 package:
@@ -24,7 +25,8 @@ build:
 
 requirements:
   build:
-      - gcc  # [linux]
+      - gxx_linux-64 {{ gxx_version }}  # [linux]
+      - gcc_linux-64 {{ gxx_version }}  # [linux]
       - clangxx_osx-64 {{ clang_version }}  # [osx]
       - clang_osx-64 {{ clang_version }}  # [osx]
       - zlib {{ CONDA_ZLIB }}*
@@ -38,7 +40,8 @@ requirements:
       - sqlite
       - suitesparse
   run:
-      - libgcc  # [linux]
+      - libstdcxx-ng >={{ gxx_version }}  # [linux]
+      - libgcc >={{ gxx_version }}  # [linux]
       - libcxx >={{ clang_version }}  # [osx]
       - zlib {{ CONDA_ZLIB }}*
       - bamtools {{ CONDA_BAMTOOLS }}*

--- a/recipes/augustus/meta.yaml
+++ b/recipes/augustus/meta.yaml
@@ -1,8 +1,7 @@
 {% set name = "augustus" %}
 {% set version = "3.3" %}
 {% set sha256 = "b5eb811a4c33a2cc3bbd16355e19d530eeac6d1ac923e59f48d7a79f396234ee" %}
-# `gxx_*`/`gcc_*`/`clang_*` below should be replaced by `compiler("cxx")` with conda-build 3
-{% set gxx_version = "7.2.0" %}
+# `gcc`/`clang_*` below should be replaced by `compiler("cxx")` with conda-build 3
 {% set clang_version = "4.0.1" %}
 
 package:
@@ -25,8 +24,7 @@ build:
 
 requirements:
   build:
-      - gcc_linux-64 {{ gxx_version }}  # [linux]
-      - gxx_linux-64 {{ gxx_version }}  # [linux]
+      - gcc  # [linux]
       - clangxx_osx-64 {{ clang_version }}  # [osx]
       - clang_osx-64 {{ clang_version }}  # [osx]
       - zlib {{ CONDA_ZLIB }}*
@@ -40,7 +38,7 @@ requirements:
       - sqlite
       - suitesparse
   run:
-      - libgcc >={{ gxx_version }}  # [linux]
+      - libgcc  # [linux]
       - libcxx >={{ clang_version }}  # [osx]
       - zlib {{ CONDA_ZLIB }}*
       - bamtools {{ CONDA_BAMTOOLS }}*

--- a/recipes/augustus/meta.yaml
+++ b/recipes/augustus/meta.yaml
@@ -1,8 +1,7 @@
 {% set name = "augustus" %}
 {% set version = "3.3" %}
 {% set sha256 = "b5eb811a4c33a2cc3bbd16355e19d530eeac6d1ac923e59f48d7a79f396234ee" %}
-# `gxx_*`/`gcc_*`/`clang_*` below should be replaced by `compiler("cxx")` with conda-build 3
-{% set gxx_version = "7.2.0" %}
+# `clang_*` below should be replaced by `compiler("cxx")` with conda-build 3
 {% set clang_version = "4.0.1" %}
 
 package:
@@ -25,8 +24,7 @@ build:
 
 requirements:
   build:
-      - gxx_linux-64 {{ gxx_version }}  # [linux]
-      - gcc_linux-64 {{ gxx_version }}  # [linux]
+      - gcc  # [linux]
       - clangxx_osx-64 {{ clang_version }}  # [osx]
       - clang_osx-64 {{ clang_version }}  # [osx]
       - zlib {{ CONDA_ZLIB }}*
@@ -40,8 +38,7 @@ requirements:
       - sqlite
       - suitesparse
   run:
-      - libstdcxx-ng >={{ gxx_version }}  # [linux]
-      - libgcc >={{ gxx_version }}  # [linux]
+      - libgcc  # [linux]
       - libcxx >={{ clang_version }}  # [osx]
       - zlib {{ CONDA_ZLIB }}*
       - bamtools {{ CONDA_BAMTOOLS }}*

--- a/recipes/augustus/meta.yaml
+++ b/recipes/augustus/meta.yaml
@@ -23,10 +23,10 @@ build:
 
 requirements:
   build:
-      - gcc # [linux]
+      - gcc  # [not osx]
       - clangxx_osx-64 {{ clang_version }}  # [osx]
-      - clang_osx-64 {{ clang_version }} # [osx]
-      - zlib {{CONDA_ZLIB}}*
+      - clang_osx-64 {{ clang_version }}  # [osx]
+      - zlib {{ CONDA_ZLIB }}*
       - libgcc
       - bamtools {{ CONDA_BAMTOOLS }}*
       - gsl {{ CONDA_GSL }}*
@@ -37,10 +37,11 @@ requirements:
       - sqlite
       - suitesparse
   run:
-      - libgcc # [not osx]
-      - zlib {{CONDA_ZLIB}}*
+      - libgcc  # [not osx]
+      - libcxx >={{ clang_version }}  # [osx]
+      - zlib {{ CONDA_ZLIB }}*
       - bamtools {{ CONDA_BAMTOOLS }}*
-      - boost {{CONDA_BOOST}}*
+      - boost {{ CONDA_BOOST }}*
       - gsl {{ CONDA_GSL }}*
       - lp_solve
       - perl

--- a/recipes/augustus/meta.yaml
+++ b/recipes/augustus/meta.yaml
@@ -137,3 +137,4 @@ about:
 extra:
   identifiers:
     - doi: 10.1093/bioinformatics/btr010
+  notes: Builds with sqlite support are currently only available on Linux due to compile issues with macOS


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Need some feedback from @bioconda/core regarding my change to the build string. I recently updated augustus to 3.3 and built it with [CGP support](http://bioinf.uni-greifswald.de/augustus/binaries/README-cgp.txt) and this pull request also adds sqlite support as well. I figured this should be noted in the build string instead of specifying the boost library and bamtools version, but I'm not sure. Maybe this is a job for [conda features](https://conda.io/docs/user-guide/tasks/build-packages/features.html).