### PR TITLE
perl-uri: remove unnecessary build/run dependencies

### DIFF
--- a/recipes/perl-uri/1.71/meta.yaml
+++ b/recipes/perl-uri/1.71/meta.yaml
@@ -1,21 +1,24 @@
+{% set version = "1.71" %}
+{% set sha256 = "9c8eca0d7f39e74bbc14706293e653b699238eeb1a7690cc9c136fb8c2644115" %}
+
 package:
   name: perl-uri
-  version: "1.71"
+  version: {{ version }}
 
 source:
-  fn: URI-1.71.tar.gz
-  url: https://cpan.metacpan.org/authors/id/E/ET/ETHER/URI-1.71.tar.gz
-  md5: 247c3da29a794f72730e01aa5a715daf
+  fn: URI-{{ version }}.tar.gz
+  url: https://cpan.metacpan.org/authors/id/E/ET/ETHER/URI-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
-    - perl-threaded
+    - perl
 
   run:
-    - perl-threaded
+    - perl
 
 test:
   # Perl 'use' tests: relying on "run_test.pl" due to version differences

--- a/recipes/perl-uri/meta.yaml
+++ b/recipes/perl-uri/meta.yaml
@@ -1,28 +1,26 @@
+{% set version = "1.69" %}
+{% set sha256 = "b74b16ea626b6f8061821bb350674c638a98be1fc766eadb24fec6635998b42d" %}
 package:
   name: perl-uri
-  version: "1.69"
+  version: {{ version }}
 
 source:
-  fn: URI-1.69.tar.gz
-  url: https://cpan.metacpan.org/authors/id/E/ET/ETHER/URI-1.69.tar.gz
-  md5: 3c56aee0300bce5a440ccbd558277ea0
+  fn: URI-{{ version }}.tar.gz
+  url: https://cpan.metacpan.org/authors/id/E/ET/ETHER/URI-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
 #  patches:
    # List any patch files here
    # - fix.patch
 
 build:
-  number: 3
+  number: 4
 
 requirements:
   build:
-    - gcc
-    - perl-threaded
-    - perl-scalar-list-utils
+    - perl
 
   run:
-    - libgcc
-    - perl-threaded
-    - perl-scalar-list-utils
+    - perl
 
 test:
   imports:


### PR DESCRIPTION
Remove unnecessary build/run dependencies that bloat install size, especially on macOS.

Not updated to latest version (1.73), as that would require Test::Needs (not on bioconda-recipes). 

* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
