### PR TITLE
Update meta.yaml

### DIFF
--- a/recipes/mageck/meta.yaml
+++ b/recipes/mageck/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: mageck
-  version: "0.5.7a"
+  version: "0.5.7"
 
 source:
   fn: liulab-mageck-af89046a812b.tar.gz
@@ -8,7 +8,7 @@ source:
   md5: 3ab8665f32da9bb4293a6f1175c9b8a4
 
 build:
-  number: 0
+  number: 4
 
 requirements:
   build:


### PR DESCRIPTION
Version 0.5.7a is updated after 0.5.7, but somehow conda still considers 0.5.7 as the latest version. Don't know why but changing the version number back to 0.5.7 in conda. This will make sure conda has the latest mageck.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
