### PR TITLE
Added (not yet working) recipe for MaSuRCA

### DIFF
--- a/recipes/masurca/build.sh
+++ b/recipes/masurca/build.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -x -e
+
+export BOOST_ROOT=${PREFIX}
+
+#../install.sh
+

--- a/recipes/masurca/meta.yaml
+++ b/recipes/masurca/meta.yaml
@@ -1,0 +1,36 @@
+{% set name = "masurca" %}
+{% set version = "3.2.4" %}
+
+about:
+    home: http://masurca.blogspot.co.uk/
+    license: GNU General Public License, Version 3.0
+    summary: | 
+        MaSuRCA (Maryland Super-Read Celera Assembler) genome assembly software.
+        MaSuRCA requires Illimina data, and supports third-generation PacBio/Nanopore
+        MinION reads for hybrid assembly.
+
+package:
+    name: {{ name }}
+    version: {{ version }}
+
+build:
+    number: 0
+
+source:
+    fn: {{ name }}-{{ version }}.tar.gz
+    url: https://github.com/alekseyzimin/masurca/files/1668918/MaSuRCA-{{ version }}.tar.gz
+    sha256: 759d5b0411b048d996df1ca6daadf1cc49ff88f4436a21cd81d7f191a8bd80b0
+
+requirements:
+    build:
+        - gcc
+        - boost
+        - perl
+    run:
+       - boost
+       - perl
+
+#test:
+#    commands:
+#        - cgview 2>&1 | grep ^Please
+


### PR DESCRIPTION
* [*] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [*] This PR adds a new recipe.
* [*] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

This PR is to allow investigation of a problem with a source tarball containing absolute paths:

I'm trying to create a recipe for masurca, which it looks like has been tried unsuccessfully before bioconda/bioconda-recipes#3017, and I'm hitting the same problem. The cause seems to be that the tarball contains paths prefixed with '/', but conda-build extracts these equivalent to 'tar -P' and tries to create an absolute path of /MaSuRCA-3.2.4