### PR TITLE
Added new recipe for perl-perl-ostype

### DIFF
--- a/recipes/perl-perl-ostype/1.010/build.sh
+++ b/recipes/perl-perl-ostype/1.010/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+if [ -f Build.PL ]; then
+    perl Build.PL
+    perl ./Build
+    perl ./Build test
+    perl ./Build install --installdirs site
+elif [ -f Makefile.PL ]; then
+    perl Makefile.PL INSTALLDIRS=site
+    make
+    make test
+    make install
+else
+    echo 'Unable to find Build.PL or Makefile.PL. You need to modify build.sh.'
+    exit 1
+fi
+

--- a/recipes/perl-perl-ostype/1.010/meta.yaml
+++ b/recipes/perl-perl-ostype/1.010/meta.yaml
@@ -1,0 +1,36 @@
+{% set name = "perl-perl-ostype" %}
+{% set version = "1.010" %}
+{% set sha256 = "e7ed4994b5d547cb23aadb84dc6044c5eb085d5a67a6c5624f42542edd3403b2" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: Perl-OSType-{{ version }}.tar.gz
+  url: https://cpan.metacpan.org/authors/id/D/DA/DAGOLDEN/Perl-OSType-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - perl
+    - perl-exporter
+    - perl-constant
+    - perl-extutils-makemaker
+
+  run:
+    - perl
+    - perl-exporter
+
+test:
+  imports:
+    - Perl::OSType
+
+about:
+  home: https://github.com/Perl-Toolchain-Gang/Perl-OSType
+  license: perl_5
+  summary: 'Map Perl operating system names to generic types'
+


### PR DESCRIPTION
* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [X] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Requires perl-extutils-makemaker, perl-constant and perl-exporter which are present in bioconda but not conda-forge, so can not be submitted there...