### PR TITLE
Changed micro versioning scheme for ont-tombo (release 1.2.1.2)

### DIFF
--- a/recipes/ont-tombo/meta.yaml
+++ b/recipes/ont-tombo/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "ont-tombo" %}
-{% set version = "1.2.1b" %}
-{% set hash = "cfc7c5dc234a7feefd77b6ca30a4c2b7c28cd860f1d2da0d5ba76356516a2b48" %}
+{% set version = "1.2.1.2" %}
+{% set hash = "db9613ac15d99eb174d00f0dfbb83a561fe3c93f292bdf1ab488f8d31f55242f" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
Changed micro versioning scheme so the most recent version is the default download from conda. Currently the 1.2.1b version is not downloaded by default since it is interpreted as a beta release.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
