### PR TITLE
fix doi

### DIFF
--- a/recipes/augustus/meta.yaml
+++ b/recipes/augustus/meta.yaml
@@ -133,5 +133,5 @@ about:
 
 extra:
   identifiers:
-    - doi: 10.1093/bioinformatics/btr010
+    - doi:10.1093/bioinformatics/btr010
   notes: Builds with sqlite support are currently only available on Linux due to compile issues with macOS


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

augustus recipe had an extra space after `doi:`, making it look like a YAML dict which in turn broke the docs generation over in https://github.com/bioconda/bioconda-utils/pull/291