### PR TITLE
Use mktemp on osx for bootstrap

### DIFF
--- a/.circleci/setup.sh
+++ b/.circleci/setup.sh
@@ -1,10 +1,19 @@
 #!/bin/bash
-set -eu
+set -e
 
-set +u
 [[ -z $WORKSPACE ]] && WORKSPACE=`pwd`
-[[ -z $BASH_ENV ]] && BASH_ENV=`tempfile`
 [[ -z $BOOTSTRAP ]] && BOOTSTRAP=false
+if [[ -z $BASH_ENV ]]; then
+    if [[ $OSTYPE == darwin* ]]; then
+        BASH_ENV=`mktemp`
+    elif [[ $OSTYPE == linux* ]]; then
+        BASH_ENV=`tempfile`
+    else
+        echo "Unsupported OS: $OSTYPE"
+        exit 1
+    fi
+fi
+
 set -u
 
 # Common definitions from latest bioconda-utils master have to be downloaded before setup.sh is executed.

--- a/recipes/augustus/meta.yaml
+++ b/recipes/augustus/meta.yaml
@@ -133,5 +133,5 @@ about:
 
 extra:
   identifiers:
-    - doi: 10.1093/bioinformatics/btr010
+    - doi:10.1093/bioinformatics/btr010
   notes: Builds with sqlite support are currently only available on Linux due to compile issues with macOS


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

As mentioned in https://github.com/bioconda/bioconda-recipes/issues/8549#issuecomment-379310530, MacOS uses `mktemp`, Linux uses `tempfile`.