### PR TITLE
Fix and test libdeflate in htslib recipe

### DIFF
--- a/recipes/htslib/build.sh
+++ b/recipes/htslib/build.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-./configure CPPFLAGS="-DHAVE_LIBDEFLATE -I$PREFIX/include" --prefix=$PREFIX --enable-libcurl CFLAGS="-I$PREFIX/include" LDFLAGS="-L$PREFIX/lib"
+./configure CFLAGS="-DHAVE_LIBDEFLATE" CPPFLAGS="-DHAVE_LIBDEFLATE -I$PREFIX/include" --prefix=$PREFIX --enable-libcurl CFLAGS="-I$PREFIX/include" LDFLAGS="-L$PREFIX/lib"
 make install prefix=$PREFIX

--- a/recipes/htslib/meta.yaml
+++ b/recipes/htslib/meta.yaml
@@ -27,6 +27,11 @@ requirements:
     - xz {{ CONDA_XZ }}*
     - libdeflate
 
+test:
+  commands:  # We want to make sure that libdeflate is actually linked via HTSLib
+    - "otool -L $PREFIX/bin/bgzip | grep deflate"  # [osx]
+    - "ldd $PREFIX/bin/bgzip | grep deflate"  # [not osx]
+
 about:
   home: https://github.com/samtools/htslib
   license: MIT

--- a/recipes/htslib/meta.yaml
+++ b/recipes/htslib/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 0
+  number: 1
 
 source:
   fn: htslib-{{ version }}.tar.bz2


### PR DESCRIPTION
* [ ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).


In the process of testing my previous PR, I found that somehow the HTSLib binaries and libraries were not linking to libdeflate.  This PR updates the build commands and also adds tests that the binaries are actually linked to libdeflate. 