### PR TITLE
Sicer genome update 1

### DIFF
--- a/recipes/sicer/genome_additions_v1.patch
+++ b/recipes/sicer/genome_additions_v1.patch
@@ -1,0 +1,264 @@
+diff --git a/GenomeData.py b/GenomeData.py
+index 5a54c67..7524cfa 100644
+--- a/GenomeData.py
++++ b/GenomeData.py
+@@ -48,27 +48,81 @@ mm9_chroms = ['chr1','chr2','chr3','chr4','chr5','chr6','chr7','chr8','chr9',
+              'chr10','chr11','chr12','chr13','chr14','chr15','chr16','chr17',
+              'chr18','chr19','chrX', 'chrY', 'chrM']
+ 
++mm10_chroms = ['chr1', 'chr2', 'chr3',
++	       'chr4', 'chr5', 'chr6',
++	       'chr7', 'chr8', 'chr9',
++	       'chr10', 'chr11', 'chr12',
++	       'chr13', 'chr14', 'chr15',
++	       'chr16', 'chr17', 'chr18',
++	       'chr19', 'chrM', 'chrX',
++	       'chrY']
+ 
+ rn4_chroms = ['chr1','chr2','chr3','chr4','chr5','chr6','chr7','chr8','chr9',
+-	     'chr10','chr11','chr12','chr13','chr14','chr15','chr16','chr17',
+-	     'chr18','chr19','chr20','chrX','chrM']
++	      'chr10','chr11','chr12','chr13','chr14','chr15','chr16','chr17',
++	      'chr18','chr19','chr20','chrX','chrM']
++
++rn5_chroms = ['chr1', 'chr2', 'chr3',
++	      'chr4', 'chr5', 'chr6',
++	      'chr7', 'chr8', 'chr9',
++	      'chr10', 'chr11', 'chr12',
++	      'chr13', 'chr14', 'chr15',
++	      'chr16', 'chr17', 'chr18',
++	      'chr19', 'chr20', 'chrM',
++	      'chrX']
++
++rn6_chroms = ['chr1', 'chr2', 'chr3',
++	      'chr4', 'chr5', 'chr6',
++	      'chr7', 'chr8', 'chr9',
++	      'chr10', 'chr11', 'chr12',
++	      'chr13', 'chr14', 'chr15',
++	      'chr16', 'chr17', 'chr18',
++	      'chr19', 'chr20', 'chrM',
++	      'chrX', 'chrY']
+ 
+ hg18_chroms = ['chr1','chr2','chr3','chr4','chr5','chr6','chr7','chr8','chr9',
+-	     'chr10','chr11','chr12','chr13','chr14','chr15','chr16','chr17',
+-	     'chr18','chr19','chr20','chr21','chr22','chrX','chrY','chrM']
++	       'chr10','chr11','chr12','chr13','chr14','chr15','chr16','chr17',
++	       'chr18','chr19','chr20','chr21','chr22','chrX','chrY','chrM']
+ 
+ hg19_chroms = ['chr1','chr2','chr3','chr4','chr5','chr6','chr7','chr8','chr9',
+-	     'chr10','chr11','chr12','chr13','chr14','chr15','chr16','chr17',
+-	     'chr18','chr19','chr20','chr21','chr22','chrX','chrY','chrM']
++	       'chr10','chr11','chr12','chr13','chr14','chr15','chr16','chr17',
++	       'chr18','chr19','chr20','chr21','chr22','chrX','chrY','chrM']
++
++hg38_chroms = ['chr1', 'chr2', 'chr3',
++	       'chr4', 'chr5', 'chr6',
++	       'chr7', 'chr8', 'chr9',
++	       'chr10', 'chr11', 'chr12',
++	       'chr13', 'chr14', 'chr15',
++	       'chr16', 'chr17', 'chr18',
++	       'chr19', 'chr20', 'chr21',
++	       'chr22', 'chrM', 'chrX',
++	       'chrY']
+ 
+ sacCer1_chroms = ['chr1','chr2','chr3','chr4','chr5','chr6','chr7','chr8','chr9',
+-		 'chr10','chr11','chr12','chr13','chr14','chr15','chr16','chrM']
++		  'chr10','chr11','chr12','chr13','chr14','chr15','chr16','chrM']
++
++sacCer2_chroms = ['chrI', 'chrII', 'chrIII',
++		  'chrIV', 'chrIX', 'chrM',
++		  'chrV', 'chrVI', 'chrVII',
++		  'chrVIII', 'chrX', 'chrXI',
++		  'chrXII', 'chrXIII', 'chrXIV',
++		  'chrXV', 'chrXVI', '2micron']
++
++sacCer3_chroms = ['chrI', 'chrII', 'chrIII',
++		  'chrIV', 'chrIX', 'chrM',
++		  'chrV', 'chrVI', 'chrVII',
++		  'chrVIII', 'chrX', 'chrXI',
++		  'chrXII', 'chrXIII', 'chrXIV',
++		  'chrXV', 'chrXVI']
+ 
+ dm2_chroms = ['chr2h', 'chr2L', 'chr2R', 'chr3h', 'chr3L',
+-	     'chr3R','chr4','chr4h','chrM','chrU','chrX','chrXh','chrYh']
++	      'chr3R','chr4','chr4h','chrM','chrU','chrX','chrXh','chrYh']
+ 
+ dm3_chroms = ['chr2L', 'chr2LHet', 'chr2R', 'chr2RHet', 'chr3L', 'chr3LHet',
+-	     'chr3R', 'chr3RHet', 'chr4','chrX','chrXHet', 'chrYHet', 'chrU', 'chrUextra', 'chrM']
++	      'chr3R', 'chr3RHet', 'chr4','chrX','chrXHet', 'chrYHet', 'chrU', 'chrUextra', 'chrM']
++
++dm6_chroms = ['chr2L', 'chr2R', 'chr3L',
++              'chr3R', 'chr4', 'chrM',
++	      'chrX', 'chrY']
+ 
+ pombe_chroms = ['chr1','chr2', 'chr3', 'mat'];
+ 
+@@ -92,6 +146,15 @@ mm9_chrom_lengths = {'chr1':197195432, 'chr2':181748087, 'chr3':159599783,
+                      'chr19':61342430, 'chrX':166650296, 'chrY':15902555,
+                      'chrM':16299}
+ 
++mm10_chrom_lengths = {'chr1':195471971, 'chr2':182113224, 'chr3':160039680,
++		      'chr4':156508116, 'chr5':151834684, 'chr6':149736546,
++		      'chr7':145441459, 'chr8':129401213, 'chr9':124595110,
++		      'chr10':130694993, 'chr11':122082543, 'chr12':120129022,
++		      'chr13':120421639, 'chr14':124902244, 'chr15':104043685,
++		      'chr16':98207768, 'chr17':94987271, 'chr18':90702639,
++		      'chr19':61431566, 'chrM':16299, 'chrX':171031299,
++		      'chrY':91744698}
++
+ rn4_chrom_lengths = {'chr1':267910886, 'chr2':258207540, 'chr3':171063335,
+ 		     'chr4':187126005, 'chr5':173096209, 'chr6':147636619,
+ 		     'chr7':143002779, 'chr8':129041809, 'chr9':113440463,
+@@ -101,7 +164,23 @@ rn4_chrom_lengths = {'chr1':267910886, 'chr2':258207540, 'chr3':171063335,
+ 		     'chr19':59218465, 'chr20':55268282, 'chrX':160699376,
+ 		     'chrM':16300}
+ 
+-
++rn5_chrom_lengths = {'chr1':290094216, 'chr2':285068071, 'chr3':183740530,
++		     'chr4':248343840, 'chr5':177180328, 'chr6':156897508,
++		     'chr7':143501887, 'chr8':132457389, 'chr9':121549591,
++		     'chr10':112200500, 'chr11':93518069, 'chr12':54450796,
++		     'chr13':118718031, 'chr14':115151701, 'chr15':114627140,
++		     'chr16':90051983, 'chr17':92503511, 'chr18':87229863,
++		     'chr19':72914587, 'chr20':57791882, 'chrM':16313,
++		     'chrX':154597545}
++
++rn6_chrom_lengths = {'chr1':282763074, 'chr2':266435125, 'chr3':177699992,
++		     'chr4':184226339, 'chr5':173707219, 'chr6':147991367,
++		     'chr7':145729302, 'chr8':133307652, 'chr9':122095297,
++		     'chr10':112626471, 'chr11':90463843, 'chr12':52716770,
++		     'chr13':114033958, 'chr14':115493446, 'chr15':111246239,
++		     'chr16':90668790, 'chr17':90843779, 'chr18':88201929,
++		     'chr19':62275575, 'chr20':56205956, 'chrM':16313,
++		     'chrX':159970021, 'chrY':3310458}
+ 
+ hg18_chrom_lengths = {'chr1':247249719, 'chr2':242951149, 'chr3':199501827,
+ 		      'chr4':191273063, 'chr5':180857866, 'chr6':170899992,
+@@ -123,6 +202,15 @@ hg19_chrom_lengths = {'chr1':249250621,  'chr2':243199373, 'chr3':198022430,
+ 		      'chr22':51304566,  'chrX':155270560,  'chrY':59373566,
+ 		      'chrM':16571}
+ 
++hg38_chrom_lengths = {'chr1':248956422, 'chr2':242193529, 'chr3':198295559,
++		      'chr4':190214555, 'chr5':181538259, 'chr6':170805979,
++		      'chr7':159345973, 'chr8':145138636, 'chr9':138394717,
++		      'chr10':133797422, 'chr11':135086622, 'chr12':133275309,
++		      'chr13':114364328, 'chr14':107043718, 'chr15':101991189,
++		      'chr16':90338345, 'chr17':83257441, 'chr18':80373285,
++		      'chr19':58617616, 'chr20':64444167, 'chr21':46709983,
++		      'chr22':50818468, 'chrM':16569, 'chrX':156040895,
++		      'chrY':57227415}
+ 
+ dm2_chrom_lengths = {'chr2h':1694122, 'chr2L':22407834, 'chr2R':20766785,
+ 		     'chr3h':2955737, 'chr3L':23771897, 'chr3R':27905053,
+@@ -131,21 +219,24 @@ dm2_chrom_lengths = {'chr2h':1694122, 'chr2L':22407834, 'chr2R':20766785,
+ 		     'chrU':8724946}
+ 
+ dm3_chrom_lengths = {'chr2L':23011544, 
+-			'chr2LHet':368872, 
+-			'chr2R':21146708, 
+-			'chr2RHet':3288761, 
+-			'chr3L':24543557, 
+-			'chr3LHet':2555491,
+-			'chr3R':27905053,
+-			'chr3RHet':2517507, 
+-			'chr4':1351857,
+-			'chrX':22422827,
+-			'chrXHet':204112, 
+-			'chrYHet':347038, 
+-			'chrU':10049037, 
+-			'chrUextra':29004656, 
+-			'chrM':19517}
+-
++		     'chr2LHet':368872, 
++		     'chr2R':21146708, 
++		     'chr2RHet':3288761, 
++		     'chr3L':24543557, 
++		     'chr3LHet':2555491,
++		     'chr3R':27905053,
++		     'chr3RHet':2517507, 
++		     'chr4':1351857,
++		     'chrX':22422827,
++		     'chrXHet':204112, 
++		     'chrYHet':347038, 
++		     'chrU':10049037, 
++		     'chrUextra':29004656, 
++		     'chrM':19517}
++
++dm6_chrom_lengths = {'chr2L':23513712, 'chr2R':25286936, 'chr3L':28110227,
++                     'chr3R':32079331, 'chr4':1348131, 'chrM':19524,
++		     'chrX':23542271, 'chrY':3667352}
+ 
+ sacCer1_chrom_lengths = {'chr1':230208, 'chr2':813136, 'chr3':316613,
+ 			 'chr4':1531914, 'chr5':576869, 'chr6':270148,
+@@ -154,6 +245,19 @@ sacCer1_chrom_lengths = {'chr1':230208, 'chr2':813136, 'chr3':316613,
+ 			 'chr13':924430, 'chr14':784328, 'chr15':1091285,
+ 			 'chr16':948060, 'chrM':85779}
+ 
++sacCer2_chrom_lengths = {'chrI':230208, 'chrII':813178, 'chrIII':316617,
++			 'chrIV':1531919, 'chrIX':439885, 'chrM':85779,
++			 'chrV':576869, 'chrVI':270148, 'chrVII':1090947,
++			 'chrVIII':562643, 'chrX':745742, 'chrXI':666454,
++			 'chrXII':1078175, 'chrXIII':924429, 'chrXIV':784333,
++			 'chrXV':1091289, 'chrXVI':948062, '2micron':6318}
++
++sacCer3_chrom_lengths = {'chrI':230218, 'chrII':813184, 'chrIII':316620,
++			 'chrIV':1531933, 'chrIX':439888, 'chrM':85779,
++			 'chrV':576874, 'chrVI':270161, 'chrVII':1090940,
++			 'chrVIII':562643, 'chrX':745751, 'chrXI':666816,
++			 'chrXII':1078177, 'chrXIII':924431, 'chrXIV':784333,
++			 'chrXV':1091291, 'chrXVI':948066}
+ 
+ pombe_chrom_lengths = {'chr1':5580032,'chr2':4541604,'chr3':2453783,
+ 		       'mat':41249}
+@@ -163,27 +267,41 @@ tair8_chrom_lengths = {'chr1':30427671, 'chr2':19698289, 'chr3':23459830,
+ 
+ 
+ species_chroms = {'mm8':mm8_chroms, 
+-			'mm9':mm9_chroms, 
+-			'hg18':hg18_chroms,
+-			'hg19':hg19_chroms,
+-		  	"dm2":dm2_chroms, 
+-			"dm3":dm3_chroms, 
+-			"sacCer1":sacCer1_chroms,
+-		  	"pombe":pombe_chroms, 
+-			'rn4':rn4_chroms,
+-			'tair8':tair8_chroms,
+-		  	'background':background_chroms};
++		  'mm9':mm9_chroms,
++                  'mm10':mm10_chroms,
++		  'hg18':hg18_chroms,
++		  'hg19':hg19_chroms,
++                  'hg38':hg38_chroms,
++		  'dm2':dm2_chroms, 
++		  'dm3':dm3_chroms,
++                  'dm6':dm6_chroms,
++		  'sacCer1':sacCer1_chroms,
++                  'sacCer2':sacCer2_chroms,
++                  'sacCer3':sacCer3_chroms,
++		  'pombe':pombe_chroms, 
++		  'rn4':rn4_chroms,
++                  'rn5':rn5_chroms,
++                  'rn6':rn6_chroms,
++		  'tair8':tair8_chroms,
++		  'background':background_chroms};
+ 
+ 
+ species_chrom_lengths={'mm8':mm8_chrom_lengths,
+ 		       'mm9':mm9_chrom_lengths,
++                       'mm10':mm10_chrom_lengths,
+ 		       'hg18':hg18_chrom_lengths,
+ 		       'hg19':hg19_chrom_lengths,
++                       'hg38':hg38_chrom_lengths,
+ 		       'dm2':dm2_chrom_lengths,
+ 		       'dm3':dm3_chrom_lengths,
++                       'dm6':dm6_chrom_lengths,
+ 		       'sacCer1':sacCer1_chrom_lengths,
++                       'sacCer2':sacCer2_chrom_lengths,
++                       'sacCer3':sacCer3_chrom_lengths,
+ 		       'pombe':pombe_chrom_lengths,
+ 		       'rn4':rn4_chrom_lengths,
++                       'rn5':rn5_chrom_lengths,
++                       'rn6':rn6_chrom_lengths,
+ 		       'tair8':tair8_chrom_lengths,
+ 		       'background':background_chrom_lengths};
+ 

--- a/recipes/sicer/genome_additions_v1.patch
+++ b/recipes/sicer/genome_additions_v1.patch
@@ -1,7 +1,7 @@
 diff --git a/GenomeData.py b/GenomeData.py
 index 5a54c67..7524cfa 100644
---- a/GenomeData.py
-+++ b/GenomeData.py
+--- a/SICER/lib/GenomeData.py
++++ b/SICER/lib/GenomeData.py
 @@ -48,27 +48,81 @@ mm9_chroms = ['chr1','chr2','chr3','chr4','chr5','chr6','chr7','chr8','chr9',
               'chr10','chr11','chr12','chr13','chr14','chr15','chr16','chr17',
               'chr18','chr19','chrX', 'chrY', 'chrM']

--- a/recipes/sicer/meta.yaml
+++ b/recipes/sicer/meta.yaml
@@ -28,9 +28,9 @@ requirements:
 test:
   commands:
     - SICER.sh $PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM/SICER/ex test.bed
-        control.bed . hg18 1 200 150 0.74 600 .01
+        control.bed . hg38 1 200 150 0.74 600 .01
     - SICER-rb.sh $PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM/SICER/ex
-        test.bed . hg18 1 200 150 0.74 400 100
+        test.bed . hg38 1 200 150 0.74 400 100
 about:
   home: http://home.gwu.edu/~wpeng/Software.htm
 

--- a/recipes/sicer/meta.yaml
+++ b/recipes/sicer/meta.yaml
@@ -18,12 +18,12 @@ build:
 
 requirements:
     build:
-        - python >=2.7,<3
+        - python
         - numpy
         - scipy
     run:
         - numpy
-        - python >=2.7,<3
+        - python
         - scipy
 test:
   commands:

--- a/recipes/sicer/meta.yaml
+++ b/recipes/sicer/meta.yaml
@@ -9,6 +9,8 @@ package:
 source:
   url: http://home.gwu.edu/~wpeng/{{ name }}_V{{ version }}.tgz
   sha256: {{ sha256 }}
+  patches:
+     - genome_additions_v1.patch
 
 build:
   skip: True  # [not py27]

--- a/recipes/sicer/meta.yaml
+++ b/recipes/sicer/meta.yaml
@@ -14,16 +14,16 @@ source:
 
 build:
   skip: True  # [not py27]
-  number: 1
+  number: 2
 
 requirements:
     build:
-	- python >=2.7,<3,{{PY_VER}}*
+	- python >=2.7,<3
 	- numpy
 	- scipy
     run:
         - numpy
-        - python >=2.7,<3,{{PY_VER}}*
+        - python >=2.7,<3
         - scipy
 test:
   commands:

--- a/recipes/sicer/meta.yaml
+++ b/recipes/sicer/meta.yaml
@@ -18,9 +18,9 @@ build:
 
 requirements:
     build:
-	- python >=2.7,<3
-	- numpy
-	- scipy
+        - python >=2.7,<3
+        - numpy
+        - scipy
     run:
         - numpy
         - python >=2.7,<3

--- a/recipes/sicer/meta.yaml
+++ b/recipes/sicer/meta.yaml
@@ -17,9 +17,13 @@ build:
   number: 1
 
 requirements:
+    build:
+	- python >=2.7,<3,{{PY_VER}}*
+	- numpy
+	- scipy
     run:
         - numpy
-        - python
+        - python >=2.7,<3,{{PY_VER}}*
         - scipy
 test:
   commands:


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

SICER contains hard-coded, mandatory genome reference data (chromosome codes, names, and lengths) that hasn't been updated in years. This patch adds annotations for all new builds for their included genomes from the intervening years. It also does a better job locking python=2.7