### PR TITLE
Fixing openjdk version for fastqc container

### DIFF
--- a/recipes/fastqc/meta.yaml
+++ b/recipes/fastqc/meta.yaml
@@ -19,7 +19,11 @@ build:
 
 requirements:
   run:
-    - "conda-forge::openjdk"
+    # Enforce a version requirement on openjdk to ensure
+    # it comes from the conda-forge channel and not default.
+    # Many yaks were shaved to bring us this information.
+    # Version number reference: https://github.com/conda/conda/issues/6948#issuecomment-369360906
+    - openjdk>8.0.121
     - perl
 
 test:

--- a/recipes/fastqc/meta.yaml
+++ b/recipes/fastqc/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     # it comes from the conda-forge channel and not default.
     # Many yaks were shaved to bring us this information.
     # Version number reference: https://github.com/conda/conda/issues/6948#issuecomment-369360906
-    - openjdk>8.0.121
+    - openjdk >8.0.121
     - perl
 
 test:

--- a/recipes/fastqc/meta.yaml
+++ b/recipes/fastqc/meta.yaml
@@ -19,7 +19,7 @@ build:
 
 requirements:
   run:
-    - openjdk
+    - "conda-forge::openjdk"
     - perl
 
 test:


### PR DESCRIPTION
Updating openjdk to come from conda-forge explicitly, rather than default. The openjdk in default is old and does not include fonts; the conda-forge version is the more recent. This change is also discussed in #8586 and #5026.

* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* <s>This PR adds a new recipe.</s>
* [X] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [X] This PR updates an existing recipe.
* <s>This PR does something else (explain below).</s>
