### PR TITLE
Increase minimal blast version for plant_tribes_gene_family_classifier

### DIFF
--- a/recipes/plant_tribes_gene_family_classifier/1.0.3/meta.yaml
+++ b/recipes/plant_tribes_gene_family_classifier/1.0.3/meta.yaml
@@ -8,11 +8,11 @@ source:
   md5: fadbcc5f105eb05156e5068380840460
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   run:
-    - blast >=2.2.29
+    - blast >=2.5.0
     - hmmer >=3
     - perl
 


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Older versions of blast throw the following exception on some Linux systems, and this PR should correct this problem.

```blastp: error while loading shared libraries: libgomp.so.1: cannot open shared object file: No such file or directory```