### PR TITLE
[WIP]  Use new compilers and CB3 syntax in BWA recipe

### DIFF
--- a/recipes/bwa/meta.yaml
+++ b/recipes/bwa/meta.yaml
@@ -11,16 +11,15 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 2
+  number: 3
 
 requirements:
   build:
-    - gcc   # [not osx]
-    - llvm  # [osx]
+    - {{ compiler('c') }}
+  host:
     - zlib {{CONDA_ZLIB}}*
   run:
     - zlib {{CONDA_ZLIB}}*
-    - libgcc  # [not osx]
     - perl
 
 test:


### PR DESCRIPTION
* [ ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

This PR is an attempt at updating our BWA recipe to use the latest config settings from conda-build 3, as well as the updated compilers that they rely on.  

AFAIK the libgcc runtime dependency is no longer explicitly necessary, as it is implicitly added by the GCC compiler (https://conda.io/docs/user-guide/tasks/build-packages/define-metadata.html).  