### PR TITLE
Perl devel stacktrace update

### DIFF
--- a/recipes/perl-devel-stacktrace/meta.yaml
+++ b/recipes/perl-devel-stacktrace/meta.yaml
@@ -12,10 +12,10 @@ build:
 
 requirements:
   build:
-    - perl-threaded
+    - perl
 
   run:
-    - perl-threaded
+    - perl
 
 test:
   imports:

--- a/recipes/perl-devel-stacktrace/meta.yaml
+++ b/recipes/perl-devel-stacktrace/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: perl-devel-stacktrace
-  version: "2.00"
+  version: "2.03"
 
 source:
-  fn: Devel-StackTrace-2.00.tar.gz
-  url: https://cpan.metacpan.org/authors/id/D/DR/DROLSKY/Devel-StackTrace-2.00.tar.gz
-  md5: 826ed2bc7cdd8d852d7d2d8b69aa313c
+  fn: Devel-StackTrace-2.03.tar.gz
+  url: http://search.cpan.org/CPAN/authors/id/D/DR/DROLSKY/Devel-StackTrace-2.03.tar.gz
+  md5: 1eb6874d834f3d5d15fa626dd726df77
 
 build:
   number: 0


### PR DESCRIPTION
Version 2.03 of `Devel::StackTrace` is required by `Moose` 2.2009, which is currently the default version of Moose that is installed with `conda install perl-moose`. This PR also changes the `perl-threaded` requirement to `perl`, according to #3418.


* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).