### PR TITLE
 Set PLUGINS_4_TCOFFEE env variable 

### DIFF
--- a/recipes/t_coffee/meta.yaml
+++ b/recipes/t_coffee/meta.yaml
@@ -8,7 +8,7 @@ source:
   md5: 2e375405c9ebb977adf87c145ca698bb
 
 build:
-  number: 4
+  number: 5
   skip: True # [osx]
   entry_points:
     - t_coffee = t_coffee.__main__:main
@@ -32,6 +32,7 @@ test:
   commands:
     - HOME=/tmp t_coffee
     - HOME=/tmp t_coffee --help
+    - HOME=/tmp t_coffee 2>&1 |grep "mafft is  Installed" >/dev/null
 
 about:
     home: http://www.tcoffee.org/Projects/tcoffee/

--- a/recipes/t_coffee/meta.yaml
+++ b/recipes/t_coffee/meta.yaml
@@ -21,6 +21,7 @@ requirements:
     - zlib {{CONDA_ZLIB}}*
   run:
     - curl
+    - libgcc  # [not osx]
     - openssl
     - perl
     - python

--- a/recipes/t_coffee/meta.yaml
+++ b/recipes/t_coffee/meta.yaml
@@ -30,8 +30,8 @@ test:
   imports:
     - t_coffee
   commands:
-    - t_coffee
-    - t_coffee --help
+    - HOME=/tmp t_coffee
+    - HOME=/tmp t_coffee --help
 
 about:
     home: http://www.tcoffee.org/Projects/tcoffee/

--- a/recipes/t_coffee/t_coffee/__main__.py
+++ b/recipes/t_coffee/t_coffee/__main__.py
@@ -25,6 +25,7 @@ def main():
     print("Result: {}".format(result))
     print("Error message: {}".format(error_message))
     print("*" * 80 + "\n")
+    return child_process.returncode
 
 
 if __name__ == '__main__':

--- a/recipes/t_coffee/t_coffee/config.py
+++ b/recipes/t_coffee/t_coffee/config.py
@@ -1,11 +1,18 @@
 import os
 import os.path as op
+import sys
 import tempfile
 
 tcoffee_install_dir = op.normpath(op.join(op.dirname(__file__), '..', '..', '..', '{{TCOFFEE_FOLDER_NAME}}'))
 tcoffee_bin_dir = op.join(tcoffee_install_dir, 'bin')
 tcoffee_exe_file = op.join(tcoffee_bin_dir, 't_coffee')
-tcoffee_plugins_dir = op.join(tcoffee_install_dir, 'plugins', 'linux')
+if sys.platform.startswith('linux'):
+    platform = 'linux'
+elif sys.platform == 'darwin':
+    platform = 'macosx'
+else:
+    raise Exception("Unsupported platform '%s'" % sys.platform)
+tcoffee_plugins_dir = op.join(tcoffee_install_dir, 'plugins', platform)
 tcoffee_perl_dir = op.join(tcoffee_install_dir, 'perl', 'lib', 'perl5')
 tcoffee_default_email = 'username@example.org'
 

--- a/recipes/t_coffee/t_coffee/config.py
+++ b/recipes/t_coffee/t_coffee/config.py
@@ -21,10 +21,10 @@ def get_tcoffee_environ():
     env = os.environ.copy()
     if 'TMP_4_TCOFFEE' not in env:
         env['TMP_4_TCOFFEE'] = tempfile.mkdtemp()
+    if 'PLUGINS_4_TCOFFEE' not in env:
+        env['PLUGINS_4_TCOFFEE'] = tcoffee_plugins_dir
     if 'MAFFT_BINARIES' not in env:
         env['MAFFT_BINARIES'] = tcoffee_plugins_dir
-    elif tcoffee_plugins_dir not in env['MAFFT_BINARIES']:
-        env['MAFFT_BINARIES'] = env['MAFFT_BINARIES'] + ':' + tcoffee_plugins_dir
     if 'PERL5LIB' not in env:
         env['PERL5LIB'] = tcoffee_perl_dir
     elif tcoffee_perl_dir not in env['PERL5LIB']:


### PR DESCRIPTION
In #8715 I removed the setting of `DIR_4_TCOFFEE` env variable, but failed to notice that `PLUGINS_4_TCOFFEE` was not set, so `t_coffee` was searching the plugins in `~/.t_coffee/plugins/linux` , as per https://tcoffee.readthedocs.io/en/latest/tcoffee_technical_documentation.html#setting-up-the-variables .

Also:
- fix `MAFFT_BINARIES` env variable setting (multiple colon-separated paths are not supported)
- test that `t_coffee` can find the mafft plugin
- return the proper exit code from `t_coffee`
- find the correct `plugins` dir under macOS
- add missing `libgcc` run requirement

* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [X] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
