### PR TITLE
Fix issue to do with renamed sourmash_lib -> sourmash

### DIFF
--- a/recipes/sourmash/meta.yaml
+++ b/recipes/sourmash/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "sourmash" %}
-{% set version = "2.0.0a5" %}
-{% set hash = "611a6adcaa2c659a79bd0f111ad75fc25cb0ee0298e53addd1e7aeae00c62b0a" %}
+{% set version = "2.0.0a6" %}
+{% set hash = "6ccce5a8a41b159de06d4918dbad84262811efffbbadc1960ce3880ec0c8b998" %}
 
 package:
   name: {{ name|lower }}
@@ -8,7 +8,7 @@ package:
 
 source:
   fn: {{ name|lower }}-{{ version }}.tar.gz
-  url: https://github.com/dib-lab/sourmash/archive/790dddd65ca9ee599f8a83fd251a198ddc8e9352.tar.gz
+  url: https://github.com/dib-lab/sourmash/archive/41445848b07b09c0ed3bd9a6665f44350a5b601e.tar.gz
   sha256: {{ hash }}
   patches:
     - sourmash.patch

--- a/recipes/sourmash/meta.yaml
+++ b/recipes/sourmash/meta.yaml
@@ -15,7 +15,7 @@ source:
 
 build:
   entry_points:
-    - sourmash = sourmash_lib.__main__:main
+    - sourmash = sourmash.__main__:main
   number: 0
 
 requirements:
@@ -47,7 +47,7 @@ requirements:
 
 test:
   imports:
-    - sourmash_lib
+    - sourmash
 
   commands:
     - sourmash --help


### PR DESCRIPTION
This will hopefully fix https://github.com/dib-lab/sourmash/issues/464#issuecomment-383843225, where `sourmash_lib` has been renamed to `sourmash` (but still exists for backwards compat).

Question - if we update this recipe without changing the hash or version, will new installs get the new recipe?

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
