### PR TITLE
Build umis for py3

### DIFF
--- a/recipes/umis/build.sh
+++ b/recipes/umis/build.sh
@@ -2,4 +2,6 @@
 if [ `uname` == Darwin ]; then
 	export MACOSX_DEPLOYMENT_TARGET=10.9
 fi
+export LC_ALL=C.UTF-8
+export LANG=C.UTF-8
 $PYTHON setup.py install --single-version-externally-managed --record=record.txt

--- a/recipes/umis/build.sh
+++ b/recipes/umis/build.sh
@@ -2,6 +2,5 @@
 if [ `uname` == Darwin ]; then
 	export MACOSX_DEPLOYMENT_TARGET=10.9
 fi
-export LC_ALL=C.UTF-8
-export LANG=C.UTF-8
+
 $PYTHON setup.py install --single-version-externally-managed --record=record.txt

--- a/recipes/umis/meta.yaml
+++ b/recipes/umis/meta.yaml
@@ -36,7 +36,7 @@ requirements:
 test:
   commands:
     # click requires a unicode locale
-    - LANG=en_US.utf8 umis --help
+    - LANG=en_US.UTF-8 umis --help
 
 about:
   home: https://github.com/vals/umis

--- a/recipes/umis/meta.yaml
+++ b/recipes/umis/meta.yaml
@@ -36,7 +36,7 @@ requirements:
 test:
   commands:
     # click requires a unicode locale
-    - LANG=C.UTF-8 umis --help
+    - LANG=en_US.utf8 umis --help
 
 about:
   home: https://github.com/vals/umis

--- a/recipes/umis/meta.yaml
+++ b/recipes/umis/meta.yaml
@@ -3,8 +3,7 @@ package:
   version: '0.9.0b'
 
 build:
-  number: 0
-  skip: true # [not py27]
+  number: 1
 
 source:
   fn: umis-3d662d9.tar.gz

--- a/recipes/umis/meta.yaml
+++ b/recipes/umis/meta.yaml
@@ -42,3 +42,9 @@ about:
   home: https://github.com/vals/umis
   license: MIT
   summary: Tools for processing UMI RNA-tag data
+
+extra:
+  container:
+    # click requires a unicode locale when used with Python 3
+    # extended-base generates en_US.UTF-8 locale and sets LC_ALL, LANG properly
+    extended-base: true  # [py3k]

--- a/recipes/umis/meta.yaml
+++ b/recipes/umis/meta.yaml
@@ -35,8 +35,7 @@ requirements:
     - scipy
 test:
   commands:
-    # click requires a unicode locale
-    - LANG=en_US.UTF-8 umis --help
+    - umis --help
 
 about:
   home: https://github.com/vals/umis


### PR DESCRIPTION
* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [X] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Currently, umis is restricted to py27. This renders a usage within snakemake impossible. Since I was able to install umis==0.7.0 in py3 via pip, building for py3 in general should not be a problem.