### PR TITLE
patch for idba allowing for longer short read sizes

### DIFF
--- a/recipes/idba/idba-kmer.patch
+++ b/recipes/idba/idba-kmer.patch
@@ -1,0 +1,24 @@
+diff -rupN idba-1.1.3/src/basic/kmer.h idba-1.1.3-new/src/basic/kmer.h
+--- idba-1.1.3/src/basic/kmer.h	2016-04-01 07:52:56.000000000 +0200
++++ idba-1.1.3-new/src/basic/kmer.h	2018-05-02 14:17:59.607555356 +0200
+@@ -197,7 +197,7 @@ public:
+     { return kMaxSize; }
+ 
+ 
+-    static const uint32_t kNumUint64 = 4;
++    static const uint32_t kNumUint64 = 10;
+     static const uint32_t kBitsForSize = ((kNumUint64 <= 2) ? 6 : ((kNumUint64 <= 8) ? 8 : 16));
+     static const uint32_t kBitsForKmer = (kNumUint64 * 64 - kBitsForSize);
+     static const uint32_t kMaxSize = kBitsForKmer / 2;
+diff -rupN idba-1.1.3/src/sequence/short_sequence.h idba-1.1.3-new/src/sequence/short_sequence.h
+--- idba-1.1.3/src/sequence/short_sequence.h	2016-04-01 07:52:56.000000000 +0200
++++ idba-1.1.3-new/src/sequence/short_sequence.h	2018-05-02 14:18:01.671539022 +0200
+@@ -99,7 +99,7 @@ public:
+         return size() < seq.size();
+     }
+ 
+-    static const uint32_t kMaxShortSequence = 128;
++    static const uint32_t kMaxShortSequence = 600;
+     static const uint32_t kNumBytes = (kMaxShortSequence + 3) / 4 + 2;
+ 
+ private:

--- a/recipes/idba/meta.yaml
+++ b/recipes/idba/meta.yaml
@@ -7,7 +7,7 @@ about:
   summary: 'IDBA is a practical iterative De Bruijn Graph De Novo Assembler for sequence assembly in bioinformatics.'
 
 build:
-  number: 0
+  number: 1
 
 package:
   name: {{ name }}

--- a/recipes/idba/meta.yaml
+++ b/recipes/idba/meta.yaml
@@ -28,7 +28,8 @@ source:
   fn: {{ version }}.tar.gz
   url: https://github.com/loneknightpy/idba/archive/{{ version }}.tar.gz
   md5: 303d9b4af7a7498b56ac9698028b4e15
-
+  patches:
+    - idba-kmer.patch # https://github.com/loneknightpy/idba/pull/41 
 test:
     commands:
         - idba --help 2>&1 | grep "Iterative de Bruijn Graph Assembler"

--- a/recipes/idba/meta.yaml
+++ b/recipes/idba/meta.yaml
@@ -3,7 +3,7 @@
 
 about:
   home: http://i.cs.hku.hk/~alse/hkubrg/projects/idba_ud/
-  license: ''
+  license: GPL2
   summary: 'IDBA is a practical iterative De Bruijn Graph De Novo Assembler for sequence assembly in bioinformatics.'
 
 build:
@@ -20,7 +20,7 @@ requirements:
     - gcc
     - gawk
     - python
-    - perl-threaded
+    - perl
   run:
     - libgcc
 


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Patches idba such that also larger read length are possible for the short read input (250->600) and the separation for the Minimum/Maximum k value is increased (124->312). The patch has been submitted upstream: https://github.com/loneknightpy/idba/pull/41

The idea for the patch originated in the discussion on updating idba_ud for Galaxy: https://github.com/galaxyproject/tools-iuc/pull/1850 ping @bgruening 

Please note that this is more or less my first contact with conda. I read the docs only partially and made the changes more or less based on intuition (hoping for help by the community). I hope that this is OK .. and I can learn by doing (mistakes).