### PR TITLE
Update: cromwell, ngs-disambiguate, sentieon

### DIFF
--- a/recipes/cromwell/build.sh
+++ b/recipes/cromwell/build.sh
@@ -8,7 +8,7 @@ mkdir -p $PREFIX/bin
 cd $SRC_DIR
 sbt assembly
 
-cp target/scala-*/cromwell-*.jar $outdir/cromwell.jar
+cp server/target/scala-*/cromwell-*.jar $outdir/cromwell.jar
 cp $RECIPE_DIR/cromwell.py $outdir/cromwell
 chmod +x $outdir/cromwell
 ln -s $outdir/cromwell $PREFIX/bin/cromwell

--- a/recipes/cromwell/meta.yaml
+++ b/recipes/cromwell/meta.yaml
@@ -1,4 +1,5 @@
-{% set version="30" %}
+{% set version="32a" %}
+{% set revision="c3c9a21" %}
 about:
     home: https://github.com/broadinstitute/cromwell
     license: "BSD"
@@ -9,9 +10,9 @@ package:
 build:
   number: 0
 source:
-    fn: cromwell-0.{{ version }}.tar.gz
-    url: https://github.com/broadinstitute/cromwell/archive/{{ version }}.tar.gz
-    md5: 44d32e2adc2c2462783a20927783d771 
+    fn: cromwell-0.{{ version }}-{{ revision }}.tar.gz
+    url: https://github.com/broadinstitute/cromwell/archive/{{ revision }}.tar.gz
+    md5: 76424f95cf8e7be49b2dd8612931d501
 requirements:
   build:
     - openjdk >=8
@@ -23,4 +24,4 @@ requirements:
 
 test:
     commands:
-      - cromwell --version 2>&1 | grep "cromwell {{ version }}"
+      - cromwell --version 2>&1 | grep "cromwell "

--- a/recipes/ngs-disambiguate/meta.yaml
+++ b/recipes/ngs-disambiguate/meta.yaml
@@ -1,4 +1,5 @@
-{% set version = "1.0.0" %}
+{% set version = "2018.05.03" %}
+{% set revision = "55c3f78" %}
 
 package:
   name: ngs-disambiguate
@@ -6,8 +7,8 @@ package:
 
 source:
   fn: ngs-disambiguate-{{ version }}.tar.gz
-  url: https://github.com/AstraZeneca-NGS/disambiguate/archive/v{{ version }}.tar.gz
-  sha256: fae1385c57f249226eebd942e54aabbf92b8f8d575d228a874f64cdfdc45e21b
+  url: https://github.com/AstraZeneca-NGS/disambiguate/archive/{{ revision }}.tar.gz
+  sha256: d5b05caec68db7596fc31564f44afdce27c4d5215785f9c97581d58e87d9cc94
 
 build:
   number: 0

--- a/recipes/sentieon/meta.yaml
+++ b/recipes/sentieon/meta.yaml
@@ -1,12 +1,12 @@
-{% set version="201711.02" %}
+{% set version="201711.03" %}
 
 package:
   name: sentieon
   version: {{ version }}
 source:
-  fn: sentieon-genomics-{{ version }}-linux.tar.gz # [linux]
-  url: https://s3.amazonaws.com/sentieon-release/software/sentieon-genomics-201711.02.tar.gz
-  md5: 33aaf36e566abd7c437f7d16645ebaf2 # [linux]
+  fn: sentieon-genomics-{{ version }}-linux.tar.gz  # [linux]
+  url: https://s3.amazonaws.com/sentieon-release/software/sentieon-genomics-{{ version }}.tar.gz  # [linux]
+  md5: d8f4fd7020d72917f5bdd15eb4e8f2a7  # [linux]
   #fn: sentieon-genomics-{{ version }}-mac.tar.gz # [osx]
   #url: https://sentieon.sharepoint.com/Release/_layouts/15/guestaccess.aspx?guestaccesstoken=xV%2bluck4cIhDqLGmeVzLT5p1%2b67SiarhwZqRUx%2fOK5w%3d&docid=0b3cf62ebe0fc4cc78615b5a1989b0108 # [osx]
   #md5: notavailable # [osx]


### PR DESCRIPTION
- ngs-disambiguate: provide new date based package compiled against
  bamtools 2.4.1 to avoid library issues. 1.0.0 did not resolve
  after 2016.11.10 so does not get installed. Fixes AstraZeneca-NGS/disambiguate#11
- cromwell: latest development version with support for CWL running
- sentieon: latest release

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
