### PR TITLE
Added recipe for blobtools pipeline

### DIFF
--- a/recipes/blobtools/blobtools-build_nodesdb
+++ b/recipes/blobtools/blobtools-build_nodesdb
@@ -1,0 +1,45 @@
+
+if [ "$#" -ne 0 ]
+then
+    echo '
+    
+    blobtools has installed successfully.
+    
+    However, the blobtools package requires a nodes database to be generated from 
+    the nodes.dmp & names.dmp files found in the NCBI taxonomy taxdump.
+    
+    To generate the nodes database, please execute the "blobtools-build_nodesdb"
+    command without any arguments prior to running blobtools
+    
+    '
+    exit 0;
+fi
+
+curl ftp://ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdump.tar.gz -o $blobtools/data/taxdump.tar.gz 
+curl ftp://ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdump.tar.gz.md5 -o $blobtools/data/taxdump.tar.gz.md5 
+cd $blobtools/data
+md5_line=`openssl dgst -md5 taxdump.tar.gz`
+expected_md5_line="MD5(taxdump.tar.gz)= $(awk '{print $1}' taxdump.tar.gz.md5)"
+
+echo "Calculated checksum: $md5_line"
+echo "Expected checksum: $expected_md5_line"
+
+if [ "$md5_line" != "$expected_md5_line" ]
+then
+    echo "taxdump.tar.gz checksum failure"
+    exit 1;
+fi
+
+tar -xzf $blobtools/data/taxdump.tar.gz nodes.dmp names.dmp
+echo "Generating nodes.db..."
+
+blobtools nodesdb --nodes $blobtools/data/nodes.dmp --names $blobtools/data/names.dmp
+if [ $? -eq 0 ]
+then
+    echo "[+] Removing intermediate files..."
+    rm -f $blobtools/data/taxdump.tar.gz $blobtools/data/taxdump.tar.gz.md5 $blobtools/data/nodes.dmp $blobtools/data/names.dmp
+else
+    echo "[X] - Could not create nodesdb. Please follow installation steps on https://blobtools.readme.io/"
+    echo "blobtools directory location = $blobtools"
+    exit 1;
+fi

--- a/recipes/blobtools/build.sh
+++ b/recipes/blobtools/build.sh
@@ -1,0 +1,29 @@
+#/bin/bash
+
+blobtools=$PREFIX/opt/$PKG_NAME-$PKG_VERSION
+mkdir -p $blobtools
+cp -a ./* $blobtools
+cd $blobtools
+
+if [ $PY3K -eq 1 ]
+then
+    echo "Converting for python3..."
+    2to3 --write lib/*
+fi
+
+cd lib
+sed -i "s~LIBDIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ''))~LIBDIR = \"$blobtools/lib\"~g" blobtools.py
+sed -i "s~SAMTOOLS = os.path.abspath(os.path.join(MAINDIR, 'samtools/bin/samtools'))~SAMTOOLS = \"$PREFIX/bin/samtools\"~g" blobtools.py
+
+cd ..
+
+$PYTHON setup.py install --single-version-externally-managed --record=/tmp/record.txt
+
+echo '#!/usr/bin/env bash' > $PREFIX/bin/blobtools
+echo "$PYTHON $blobtools/lib/blobtools.py \"\$@\"" >> $PREFIX/bin/blobtools
+chmod +x $PREFIX/bin/blobtools
+
+echo '#!/usr/bin/env bash' > $PREFIX/bin/blobtools-build_nodesdb
+echo "blobtools=$blobtools" >> $PREFIX/bin/blobtools-build_nodesdb
+cat $RECIPE_DIR/blobtools-build_nodesdb >> $PREFIX/bin/blobtools-build_nodesdb
+chmod +x $PREFIX/bin/blobtools-build_nodesdb

--- a/recipes/blobtools/build.sh
+++ b/recipes/blobtools/build.sh
@@ -17,6 +17,7 @@ sed -i "s~SAMTOOLS = os.path.abspath(os.path.join(MAINDIR, 'samtools/bin/samtool
 
 cd ..
 
+sed -i -e '4d;16,29d;50d' setup.py
 $PYTHON setup.py install --single-version-externally-managed --record=/tmp/record.txt
 
 echo '#!/usr/bin/env bash' > $PREFIX/bin/blobtools

--- a/recipes/blobtools/meta.yaml
+++ b/recipes/blobtools/meta.yaml
@@ -10,23 +10,23 @@ source:
   md5: cca6193d3155cd2f61e41389197aa3ca
 
 build:
-  number: 1
+  number: 0
   skip: True # [not (linux and py27)]
 
 requirements:
   build:
     - python
-    - docopt ==0.6.2
-    - matplotlib ==2.0.2
-    - ujson ==1.35
-    - samtools ==1.5
+    - docopt
+    - matplotlib
+    - ujson
+    - samtools
 
   run:
     - python
-    - docopt ==0.6.2
-    - matplotlib ==2.0.2
-    - ujson ==1.35
-    - samtools ==1.5
+    - docopt
+    - matplotlib
+    - ujson
+    - samtools
     - curl
     - openssl
 

--- a/recipes/blobtools/meta.yaml
+++ b/recipes/blobtools/meta.yaml
@@ -1,0 +1,46 @@
+{% set version = "1.0.1" %}
+
+package:
+  name: blobtools
+  version: {{ version }}
+
+source:
+  fn: blobtools-{{ version }}.tar.gz
+  url: https://github.com/DRL/blobtools/archive/v{{ version }}.tar.gz
+  md5: cca6193d3155cd2f61e41389197aa3ca
+
+build:
+  number: 1
+  skip: True # [not (linux and py27)]
+
+requirements:
+  build:
+    - python
+    - docopt ==0.6.2
+    - matplotlib ==2.0.2
+    - ujson ==1.35
+    - samtools ==1.5
+
+  run:
+    - python
+    - docopt ==0.6.2
+    - matplotlib ==2.0.2
+    - ujson ==1.35
+    - samtools ==1.5
+    - curl
+    - openssl
+
+
+test:
+  commands:
+    - blobtools -h
+
+about:
+  home: https://blobtools.readme.io/docs/what-is-blobtools
+  license: GPLv3
+  summary: 'Modular command-line solution for visualisation, quality control and taxonomic partitioning of genome datasets'
+  license_family: GPL
+
+extra:
+  identifiers:
+    - doi:10.12688/f1000research.12232.1

--- a/recipes/blobtools/post-link.sh
+++ b/recipes/blobtools/post-link.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # print usage statement for blobtools-build_nodesdb
-$PREFIX/bin/blobtools-build_nodesdb message
+$PREFIX/bin/blobtools-build_nodesdb
 
 # exit 0 so the install is a success
 exit 0 

--- a/recipes/blobtools/post-link.sh
+++ b/recipes/blobtools/post-link.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# print usage statement for blobtools-build_nodesdb
+$PREFIX/bin/blobtools-build_nodesdb message
+
+# exit 0 so the install is a success
+exit 0 


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [x] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

This pull request adds the blobtools package, which is "A modular command-line solution for visualisation, quality control and taxonomic partitioning of genome datasets". I have found this pipeline very useful for assessing the quality of Illumina sequencing data generated from cultured bacterial DNA. It's especially useful for identifying and filtering low concentration contaminating sequences from these datasets.

As the NCBI taxdump db needs to be downloaded for this pipeline I have included a download script and a post-link.sh script to inform users that they need to run this prior to use. I've adapted this from the gatk recipe, however, I've had problems getting this post-link script to run with conda build 3.

Could @bioconda/core please review this new recipe? Especially the post-link.sh script if possible.

Regards,

Daniel