### PR TITLE
indroduce run_exports, so we do not need to add run-time deps

### DIFF
--- a/recipes/bamtools/meta.yaml
+++ b/recipes/bamtools/meta.yaml
@@ -1,40 +1,39 @@
 {% set version = "2.4.1" %}
 
 package:
-  name: bamtools
-  version: {{ version }}
+    name: bamtools
+    version: {{ version }}
 
 source:
-  fn: v{{ version }}.tar.gz
-  url: https://github.com/pezmaster31/bamtools/archive/v{{ version  }}.tar.gz
-  sha256: 933a0c1a83c88c1dac8078c0c0e82f6794c75cb927265399404bc2cc2611204b
-  patches:
-    # Install bamtools in lib instead of bamtools lib, thanks to homebrew-science:
-    # https://github.com/Homebrew/homebrew-science/blob/master/bamtools.rb
-    - bamtools_lib.diff
+    fn: v{{ version }}.tar.gz
+    url: https://github.com/pezmaster31/bamtools/archive/v{{ version  }}.tar.gz
+    sha256: 933a0c1a83c88c1dac8078c0c0e82f6794c75cb927265399404bc2cc2611204b
+    patches:
+        # Install bamtools in lib instead of bamtools lib, thanks to homebrew-science:
+        # https://github.com/Homebrew/homebrew-science/blob/master/bamtools.rb
+        - bamtools_lib.diff
 
 build:
-  number: 1
+    number: 2
+    run_exports:
+        - {{ pin_subpackage('bamtools', max_pin='x.x.x') }}
 
 requirements:
-  build:
-    - gcc   # [linux]
-    - llvm  # [osx]
-    - cmake
-    - zlib {{CONDA_ZLIB}}*
-  run:
-    - zlib {{CONDA_ZLIB}}*
-    - libgcc  # [linux]
+    build:
+        - {{ compiler('cxx') }}
+    host:
+        - cmake
+        - zlib
 
 test:
-  commands:
-    - bamtools --help
+    commands:
+        - bamtools --help
 
 about:
-  home: https://github.com/pezmaster31/bamtools
-  license: MIT
-  summary: C++ API & command-line toolkit for working with BAM data
+    home: https://github.com/pezmaster31/bamtools
+    license: MIT
+    summary: C++ API & command-line toolkit for working with BAM data
 
 extra:
-  identifiers:
-    - biotools:bamtools
+    identifiers:
+        - biotools:bamtools

--- a/recipes/htslib/meta.yaml
+++ b/recipes/htslib/meta.yaml
@@ -1,42 +1,40 @@
 {% set version = "1.8" %}
 
 package:
-  name: htslib
-  version: {{ version }}
+    name: htslib
+    version: {{ version }}
 
 build:
-  number: 1
+    number: 2
+    run_exports:
+        - {{ pin_subpackage('htslib', max_pin='x.x') }}
 
 source:
-  fn: htslib-{{ version }}.tar.bz2
-  url: https://github.com/samtools/htslib/releases/download/{{ version }}/htslib-{{ version }}.tar.bz2
-  sha256: c0ef1eec954a98cc708e9f99f6037db85db45670b52b6ab37abcc89b6c057ca1
+    fn: htslib-{{ version }}.tar.bz2
+    url: https://github.com/samtools/htslib/releases/download/{{ version }}/htslib-{{ version }}.tar.bz2
+    sha256: c0ef1eec954a98cc708e9f99f6037db85db45670b52b6ab37abcc89b6c057ca1
 
 requirements:
-  build:
-    - gcc  # [not osx]
-    - llvm  # [osx]
-    - curl
-    - bzip2 {{ CONDA_BZIP2 }}*
-    - xz {{ CONDA_XZ }}*
-    - libdeflate
-  run:
-    - libgcc  # [not osx]
-    - curl
-    - bzip2 {{ CONDA_BZIP2 }}*
-    - xz {{ CONDA_XZ }}*
-    - libdeflate
+    build:
+        - {{ compiler('c') }}
+    host:
+        - curl
+        - bzip2
+        - xz
+        - libdeflate
+    run:
+        - curl
 
 test:
-  commands:  # We want to make sure that libdeflate is actually linked via HTSLib
-    - "otool -L $PREFIX/bin/bgzip | grep deflate"  # [osx]
-    - "ldd $PREFIX/bin/bgzip | grep deflate"  # [not osx]
+    commands:  # We want to make sure that libdeflate is actually linked via HTSLib
+        - "otool -L $PREFIX/bin/bgzip | grep deflate"  # [osx]
+        - "ldd $PREFIX/bin/bgzip | grep deflate"  # [not osx]
 
 about:
-  home: https://github.com/samtools/htslib
-  license: MIT
-  summary: C library for high-throughput sequencing data formats.
+    home: https://github.com/samtools/htslib
+    license: MIT
+    summary: C library for high-throughput sequencing data formats.
 
 extra:
-  identifiers:
-    - biotools:HTSlib
+    identifiers:
+        - biotools:HTSlib

--- a/recipes/libdeflate/meta.yaml
+++ b/recipes/libdeflate/meta.yaml
@@ -2,29 +2,28 @@
 {% set sha256 = "4b27e55226db9f47a53bc51df732c9d4aba674cf64594f9c4e253e6dae4f3688" %}
 
 package:
-  name: libdeflate
-  version: {{ version }}
+    name: libdeflate
+    version: {{ version }}
 
 source:
-  fn: bwa-{{ version }}.tar.gz
-  url: https://github.com/ebiggers/libdeflate/archive/v{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+    fn: bwa-{{ version }}.tar.gz
+    url: https://github.com/ebiggers/libdeflate/archive/v{{ version }}.tar.gz
+    sha256: {{ sha256 }}
 
 build:
-  number: 0
+    number: 1
+    run_exports:
+        - {{ pin_subpackage('libdeflate', max_pin='x.x') }}
 
 requirements:
-  build:
-    - gcc   # [not osx]
-    - llvm  # [osx]
-  run:
-    - libgcc  # [not osx]
+    build:
+        - {{ compiler('c') }}
 
 test:
-  commands:
-    - echo "hey"
+    commands:
+        - echo "hey"
 
 about:
-  home: https://github.com/ebiggers/libdeflate
-  license: MIT
-  summary: libdeflate is a library for fast, whole-buffer DEFLATE-based compression and decompression.
+    home: https://github.com/ebiggers/libdeflate
+    license: MIT
+    summary: libdeflate is a library for fast, whole-buffer DEFLATE-based compression and decompression.


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

This PR, or a similar one needs to be merged before we start the cb3 recipes changes. It introduces a new concept called run-exports, which will automatically include run-time dependencies if needed and specified in the run-time-dependent recipe.

@kyleabeauchamp any reason to not move libdeflate to conda-forge? Imho it should be in conda-forge and in the corresponding conda_build_config.yaml + conda-forge-pinning.
