### PR TITLE
Update to FALCON 2.1.4

### DIFF
--- a/recipes/pacbio_falcon/meta.yaml
+++ b/recipes/pacbio_falcon/meta.yaml
@@ -28,11 +28,11 @@ requirements:
   build:
     - python
     - setuptools
-    - pypeflow
+    - pypeflow >=2.0.2,<2.1
     - networkx
   run:
     - python
-    - pypeflow
+    - pypeflow >=2.0.2,<2.1
     - rdflib
     - rdfextras
     - networkx

--- a/recipes/pacbio_falcon/meta.yaml
+++ b/recipes/pacbio_falcon/meta.yaml
@@ -34,6 +34,7 @@ requirements:
     - future >=0.16.0 # [not py3k]
   run:
     - python
+    - perl
     - msgpack-python
     - pypeflow >=2.0.2,<2.1
     - networkx >=1.7,<=1.11

--- a/recipes/pacbio_falcon/meta.yaml
+++ b/recipes/pacbio_falcon/meta.yaml
@@ -46,4 +46,4 @@ requirements:
 
 test:
     commands:
-        - fc_run.py 2>&1 | grep fc_run
+        - fc_run.py -h

--- a/recipes/pacbio_falcon/meta.yaml
+++ b/recipes/pacbio_falcon/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pacbio_falcon" %}
-{% set version = "052016" %}
+{% set version = "2.1.4" %}
 
 package:
   name: {{ name }}
@@ -11,9 +11,14 @@ about:
   summary: "A set of tools for fast aligning long reads for consensus and assembly"
 
 source:
-  fn: funzip_052016.tar.gz
-  url: https://github.com/PacificBiosciences/FALCON/archive/funzip_052016.tar.gz
-  md5: be4a225262ee4bd9729b6b7e81a83615
+  fn: falcon.tar.gz
+  # Recent tags are to the FALCON-integrate repository, which uses git submodules
+  # to bundle together the dependencies. That indirectly tells us the hash of the
+  # relevant commit on the main FALCON repository, e.g.
+  # https://github.com/PacificBiosciences/FALCON-integrate/tree/2.1.4
+  # --> FALCON @ c1e0d45
+  url: https://github.com/PacificBiosciences/FALCON/archive/c1e0d45f1b847f572cd9834576154ae44bbd7382.tar.gz
+  sha256: e1dfa387dc4b4304ca6e46a5dfeb3a2ad4e864914ec152d2ba8d9b8300b97ef8
 
 build:
   number: 0
@@ -31,6 +36,10 @@ requirements:
     - rdflib
     - rdfextras
     - networkx
+    - daligner
+    - damasker
+    - dazz_db
+    - dextractor
 
 test:
     commands:

--- a/recipes/pacbio_falcon/meta.yaml
+++ b/recipes/pacbio_falcon/meta.yaml
@@ -11,7 +11,7 @@ about:
   summary: "A set of tools for fast aligning long reads for consensus and assembly"
 
 source:
-  fn: falcon.tar.gz
+  fn: falcon_v{{ version }}.tar.gz
   # Recent tags are to the FALCON-integrate repository, which uses git submodules
   # to bundle together the dependencies. That indirectly tells us the hash of the
   # relevant commit on the main FALCON repository, e.g.

--- a/recipes/pacbio_falcon/meta.yaml
+++ b/recipes/pacbio_falcon/meta.yaml
@@ -28,14 +28,16 @@ requirements:
   build:
     - python
     - setuptools
+    - msgpack-python
     - pypeflow >=2.0.2,<2.1
-    - networkx
+    - networkx >=1.7,<=1.11
+    - future >=0.16.0 # [not py3k]
   run:
     - python
+    - msgpack-python
     - pypeflow >=2.0.2,<2.1
-    - rdflib
-    - rdfextras
-    - networkx
+    - networkx >=1.7,<=1.11
+    - future >=0.16.0 # [not py3k]
     - daligner
     - damasker
     - dazz_db


### PR DESCRIPTION
This is a work in progress, blocked by #8945 on version labelling.

* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [X] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Rather than working directly from FALCON-integrate (which bundles specific versions of the dependencies daligner, damasker, dazz_db, dextractor and pypeflow), still working from the FALCON repository and declaring dependencies via conda.

Previous version of the recipe targeted the tag funzip_052016 (May 2016) which seems to have been between v0.2 and v0.2.2, at least chronologically.

