### PR TITLE
Use mktemp instead of tr ... < /dev/urandom for osx compatibility

### DIFF
--- a/.circleci/setup.sh
+++ b/.circleci/setup.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -e
-
 [[ -z $WORKSPACE ]] && WORKSPACE=`pwd`
 [[ -z $BOOTSTRAP ]] && BOOTSTRAP=false
 [[ -z $BASH_ENV ]] && BASH_ENV=`mktemp`
@@ -18,7 +17,7 @@ source $BASH_ENV
 
 # Make sure the CircleCI config is up to date.
 # add upstream as some semi-randomly named temporary remote to diff against
-UPSTREAM_REMOTE=__upstream__$(tr -dc a-z < /dev/urandom | head -c10)
+UPSTREAM_REMOTE=__upstream__$(mktemp XXXXXXXXXX)
 git remote add -t master $UPSTREAM_REMOTE https://github.com/bioconda/bioconda-recipes.git
 git fetch $UPSTREAM_REMOTE
 if ! git diff --quiet HEAD...$UPSTREAM_REMOTE/master -- .circleci/; then

--- a/.circleci/setup.sh
+++ b/.circleci/setup.sh
@@ -17,7 +17,7 @@ source $BASH_ENV
 
 # Make sure the CircleCI config is up to date.
 # add upstream as some semi-randomly named temporary remote to diff against
-UPSTREAM_REMOTE=__upstream__$(mktemp XXXXXXXXXX)
+UPSTREAM_REMOTE=__upstream__$(mktemp -u XXXXXXXXXX)
 git remote add -t master $UPSTREAM_REMOTE https://github.com/bioconda/bioconda-recipes.git
 git fetch $UPSTREAM_REMOTE
 if ! git diff --quiet HEAD...$UPSTREAM_REMOTE/master -- .circleci/; then


### PR DESCRIPTION
* [X ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [ X] This PR does something else (explain below).

On my macOS 10.11.6 workstation, `./bootstrap.py --no-docker /tmp/miniconda` hangs during the `tr` command in .circleci/common.sh, with the `tr` command continuing to consume CPU cycles without terminating due to the SIGPIPE that should result from the subsequent `head -c10`. Executing the command manually at the command line results in an error:

```
$ tr -dc a-z < /dev/urandom | head -c10
tr: Illegal byte sequence
```

A workaround is noted here:
https://unix.stackexchange.com/questions/45404/why-cant-tr-read-from-dev-urandom-on-osx

However, even implementing the LC_ALL/LC_TYPE workaround, `tr` still seems to not terminate. Commenting-out the `set -e` and `set -u` allows the script to continue, so it must be some subtle interaction there.

One alternate approach is to generate 10 pseudorandom alphanumeric characters using `mktemp -u XXXXXXXXXX`, as `mktemp` is used elsewhere in the script and so is already assumed to be on the target system.

[edit: originally specified `mktemp XXXXXXXXXX`, but that leaves a temporary _file_ behind, so adding the `-u` option]