### PR TITLE
This version of star-fusion is incompatible with star 2.6; pin star t…

### DIFF
--- a/recipes/star-fusion/meta.yaml
+++ b/recipes/star-fusion/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   run:
@@ -23,7 +23,7 @@ requirements:
       - perl-io-gzip
       - perl-json-xs
       - perl-uri
-      - star
+      - star <=2.5
       - gmap
       - bowtie
 


### PR DESCRIPTION
…o <=2.5.

Submitted by Cicada Dennis.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

Pins star to 2.5 due to an incompatibility with 2.6.