### PR TITLE
Patch mummerplot to work with gnuplot 5

### DIFF
--- a/recipes/mummer/meta.yaml
+++ b/recipes/mummer/meta.yaml
@@ -16,9 +16,9 @@ source:
     - patches/gnuplot_mouse_clipboardformat.patch
 requirements:
   build:
-    - perl-threaded # [not osx]
+    - perl # [not osx]
   run:
-    - perl-threaded # [not osx]
+    - perl # [not osx]
 test:
     commands:
         - "mummer -h &> /dev/null"

--- a/recipes/mummer/meta.yaml
+++ b/recipes/mummer/meta.yaml
@@ -22,18 +22,18 @@ requirements:
     - libstdcxx-ng # [linux]
 test:
     commands:
-        - "mummer -h"
-        #- "delta-filter -h"
-        #- "dnadiff -h"
-        #- "mapview -h"
-        - "mummerplot -h"
-        - "nucmer -h"
-        - "promer -h"
-        - "show-aligns -h"
-        #- "show-coords -h"
-        #- "show-diff -h"
-        #- "show-snps -h"
-        #- "show-tiling -h"
+        - "mummer -h &> /dev/null"
+        #- "delta-filter -h &> /dev/null"
+        #- "dnadiff -h &> /dev/null"
+        #- "mapview -h &> /dev/null"
+        - "mummerplot -h &> /dev/null"
+        - "nucmer -h &> /dev/null"
+        - "promer -h &> /dev/null"
+        - "show-aligns -h &> /dev/null"
+        #- "show-coords -h &> /dev/null"
+        #- "show-diff -h &> /dev/null"
+        #- "show-snps -h &> /dev/null"
+        #- "show-tiling -h &> /dev/null"
 
 extra:
   identifiers:

--- a/recipes/mummer/meta.yaml
+++ b/recipes/mummer/meta.yaml
@@ -19,6 +19,7 @@ requirements:
     - perl # [not osx]
   run:
     - perl # [not osx]
+    - libstdcxx-ng # [linux]
 test:
     commands:
         - "mummer -h"

--- a/recipes/mummer/meta.yaml
+++ b/recipes/mummer/meta.yaml
@@ -3,7 +3,7 @@ about:
     license: "The Artistic License"
     summary: "MUMmer is a system for rapidly aligning entire genomes"
 build:
-  number: 4
+  number: 5
   skip: False
 package:
   name: mummer
@@ -12,6 +12,8 @@ source:
   fn: MUMmer3.23.tar.gz
   sha256: 1efad4f7d8cee0d8eaebb320a2d63745bb3a160bb513a15ef7af46f330af662f
   url: https://downloads.sourceforge.net/project/mummer/mummer/3.23/MUMmer3.23.tar.gz
+  patches:
+    - patches/gnuplot_mouse_clipboardformat.patch
 requirements:
   build:
     - perl-threaded # [not osx]

--- a/recipes/mummer/meta.yaml
+++ b/recipes/mummer/meta.yaml
@@ -21,18 +21,18 @@ requirements:
     - perl # [not osx]
 test:
     commands:
-        - "mummer -h &> /dev/null"
-        #- "delta-filter -h &> /dev/null"
-        #- "dnadiff -h &> /dev/null"
-        #- "mapview -h &> /dev/null"
-        - "mummerplot -h &> /dev/null"
-        - "nucmer -h &> /dev/null"
-        - "promer -h &> /dev/null"
-        - "show-aligns -h &> /dev/null"
-        #- "show-coords -h &> /dev/null"
-        #- "show-diff -h &> /dev/null"
-        #- "show-snps -h &> /dev/null"
-        #- "show-tiling -h &> /dev/null"
+        - "mummer -h"
+        #- "delta-filter -h"
+        #- "dnadiff -h"
+        #- "mapview -h"
+        - "mummerplot -h"
+        - "nucmer -h"
+        - "promer -h"
+        - "show-aligns -h"
+        #- "show-coords -h"
+        #- "show-diff -h"
+        #- "show-snps -h"
+        #- "show-tiling -h"
 
 extra:
   identifiers:

--- a/recipes/mummer/patches/gnuplot_mouse_clipboardformat.patch
+++ b/recipes/mummer/patches/gnuplot_mouse_clipboardformat.patch
@@ -1,5 +1,5 @@
---- scripts/mummerplot	2018-05-22 17:01:01.000000000 +0100
-+++ scripts/mummerplot.new	2018-05-22 17:01:52.000000000 +0100
+--- MUMmer3.23/scripts/mummerplot	2018-05-22 17:01:01.000000000 +0100
++++ MUMmer3.23/scripts/mummerplot.new	2018-05-22 17:01:52.000000000 +0100
 @@ -1151,7 +1151,7 @@
          $P_KEY = "unset key";
          $P_FORMAT .= "\nset mouse format \"$TFORMAT\"";

--- a/recipes/mummer/patches/gnuplot_mouse_clipboardformat.patch
+++ b/recipes/mummer/patches/gnuplot_mouse_clipboardformat.patch
@@ -1,5 +1,5 @@
---- MUMmer3.23/scripts/mummerplot	2018-05-22 17:01:01.000000000 +0100
-+++ MUMmer3.23/scripts/mummerplot.new	2018-05-22 17:01:52.000000000 +0100
+--- MUMmer3.23/scripts/mummerplot.pl	2018-05-22 17:01:01.000000000 +0100
++++ MUMmer3.23/scripts/mummerplot.pl.new	2018-05-22 17:01:52.000000000 +0100
 @@ -1151,7 +1151,7 @@
          $P_KEY = "unset key";
          $P_FORMAT .= "\nset mouse format \"$TFORMAT\"";

--- a/recipes/mummer/patches/gnuplot_mouse_clipboardformat.patch
+++ b/recipes/mummer/patches/gnuplot_mouse_clipboardformat.patch
@@ -1,0 +1,11 @@
+--- mummerplot	2018-05-22 17:01:01.000000000 +0100
++++ mummerplot.new	2018-05-22 17:01:52.000000000 +0100
+@@ -1151,7 +1151,7 @@
+         $P_KEY = "unset key";
+         $P_FORMAT .= "\nset mouse format \"$TFORMAT\"";
+         $P_FORMAT .= "\nset mouse mouseformat \"$MFORMAT\"";
+-        $P_FORMAT .= "\nset mouse clipboardformat \"$MFORMAT\"";
++        $P_FORMAT .= "\nif(GPVAL_VERSION < 5) set mouse clipboardformat \"$MFORMAT\"";
+     }
+     else {
+         $P_LS = "set linestyle";

--- a/recipes/mummer/patches/gnuplot_mouse_clipboardformat.patch
+++ b/recipes/mummer/patches/gnuplot_mouse_clipboardformat.patch
@@ -1,5 +1,5 @@
---- mummerplot	2018-05-22 17:01:01.000000000 +0100
-+++ mummerplot.new	2018-05-22 17:01:52.000000000 +0100
+--- scripts/mummerplot	2018-05-22 17:01:01.000000000 +0100
++++ scripts/mummerplot.new	2018-05-22 17:01:52.000000000 +0100
 @@ -1151,7 +1151,7 @@
          $P_KEY = "unset key";
          $P_FORMAT .= "\nset mouse format \"$TFORMAT\"";


### PR DESCRIPTION
Patch is based on changes in mummerplot v4 to cope with being run on gnuplot 5, with a tweak to still work on older versions of gnuplot. See also: https://github.com/mummer4/mummer/pull/64

* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [X] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
