### PR TITLE
Update BioConda pypeFLOW package to v0.1.1

### DIFF
--- a/recipes/pypeflow/meta.yaml
+++ b/recipes/pypeflow/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pypeflow" %}
-{% set version = "0.1.0" %}
+{% set version = "0.1.1" %}
 
 package:
   name: {{ name }}
@@ -12,8 +12,9 @@ about:
 
 source:
   fn: v{{ version }}.tar.gz
-  url: https://github.com/PacificBiosciences/pypeFLOW/archive/v{{ version }}.tar.gz
-  sha256: 23de3db2431d53939fc42302a576cdbc4c75b057f18099c9c2a5d24a3d5bafb3
+  # url: https://github.com/PacificBiosciences/pypeFLOW/archive/v{{ version }}.tar.gz
+  url: https://github.com/PacificBiosciences/pypeFLOW/archive/ff635f4605baac5f66cb000e552ddb3dcf98d34a.tar.gz
+  sha256: 5be652ee80a745f3287ed13a2c115ab78258eb5e782077f5c4458b75d5070f9d
 
 build:
   number: 1

--- a/recipes/pypeflow/meta.yaml
+++ b/recipes/pypeflow/meta.yaml
@@ -11,13 +11,13 @@ about:
   summary: "Light weight and reusable make / flow data process library written in Python"
 
 source:
-  fn: v{{ version }}.tar.gz
+  fn: pypeflow_v{{ version }}.tar.gz
   # url: https://github.com/PacificBiosciences/pypeFLOW/archive/v{{ version }}.tar.gz
   url: https://github.com/PacificBiosciences/pypeFLOW/archive/ff635f4605baac5f66cb000e552ddb3dcf98d34a.tar.gz
   sha256: 5be652ee80a745f3287ed13a2c115ab78258eb5e782077f5c4458b75d5070f9d
 
 build:
-  number: 1
+  number: 0
   skip: True # [py3k]
 
 requirements:


### PR DESCRIPTION
* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [X] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

In the absence of an official tag on the upstream repository, this uses the commit which bumped the version number to 0.1.1 (and at which point their ``setup.py`` dependencies have not changed).

See https://github.com/PacificBiosciences/pypeFLOW/issues/51, comments welcome from @pb-cdunn, @cschin or any of the pypeFLOW contributors.