### PR TITLE
Update BioConda pypeFLOW package to v1.0.0

### DIFF
--- a/recipes/pypeflow/meta.yaml
+++ b/recipes/pypeflow/meta.yaml
@@ -24,10 +24,10 @@ requirements:
   build:
     - python
     - setuptools
-    - networkx >=1.7, <=1.11
+    - networkx >=1.7,<=1.11
   run:
     - python
-    - networkx >=1.7, <=1.11
+    - networkx >=1.7,<=1.11
 
 test:
   imports:

--- a/recipes/pypeflow/meta.yaml
+++ b/recipes/pypeflow/meta.yaml
@@ -13,8 +13,8 @@ about:
 source:
   fn: pypeflow_v{{ version }}.tar.gz
   # url: https://github.com/PacificBiosciences/pypeFLOW/archive/v{{ version }}.tar.gz
-  url: https://github.com/PacificBiosciences/pypeFLOW/archive/79c77235eb10e7b36a98ada891e1e6ef454aed58.tar.gz
-  sha256: b3815c56b47522a5b74035235acddd748b41f273d8138520b3008bc101897bf5
+  url: https://github.com/PacificBiosciences/pypeFLOW/archive/e331fad50be98d83e95a4a354bed2c81a8351392.tar.gz
+  sha256: 747710682e3d5327f0fc06fd85912989614ee86582f3d784fc66190c9736b3cf
 
 build:
   number: 0
@@ -24,10 +24,10 @@ requirements:
   build:
     - python
     - setuptools
-    - networkx >=1.7, <=1.10
+    - networkx >=1.7, <=1.11
   run:
     - python
-    - networkx >=1.7, <=1.10
+    - networkx >=1.7, <=1.11
 
 test:
   imports:

--- a/recipes/pypeflow/meta.yaml
+++ b/recipes/pypeflow/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pypeflow" %}
-{% set version = "0.1.1" %}
+{% set version = "1.0.0" %}
 
 package:
   name: {{ name }}
@@ -13,8 +13,8 @@ about:
 source:
   fn: pypeflow_v{{ version }}.tar.gz
   # url: https://github.com/PacificBiosciences/pypeFLOW/archive/v{{ version }}.tar.gz
-  url: https://github.com/PacificBiosciences/pypeFLOW/archive/ff635f4605baac5f66cb000e552ddb3dcf98d34a.tar.gz
-  sha256: 5be652ee80a745f3287ed13a2c115ab78258eb5e782077f5c4458b75d5070f9d
+  url: https://github.com/PacificBiosciences/pypeFLOW/archive/79c77235eb10e7b36a98ada891e1e6ef454aed58.tar.gz
+  sha256: b3815c56b47522a5b74035235acddd748b41f273d8138520b3008bc101897bf5
 
 build:
   number: 0
@@ -24,12 +24,13 @@ requirements:
   build:
     - python
     - setuptools
-    - rdfextras >=0.1
+    - networkx >=1.7, <=1.10
   run:
     - python
-    - rdflib >=3.1.0
-    - rdfextras >=0.1
+    - networkx >=1.7, <=1.10
 
 test:
   imports:
     - pypeflow
+    - pwatcher
+    - pwatcher.mains


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

This follows on from pull request #9016 for v0.1.1

In the absence of an official tag on the upstream repository,
this is the commit which bumped the version number to 1.0.0

See PacificBiosciences/pypeFLOW#51

Note that the dependencies declared in the setup.py changed,
which is reflected in the meta.yaml dependencies. It now
requires networkx.

Also, the updated setup.py declares additional python libraries
which we now test can be imported.