### PR TITLE
Update to pypeFLOW v1.1.0

### DIFF
--- a/recipes/pypeflow/meta.yaml
+++ b/recipes/pypeflow/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pypeflow" %}
-{% set version = "1.0.0" %}
+{% set version = "1.1.0" %}
 
 package:
   name: {{ name }}
@@ -13,8 +13,8 @@ about:
 source:
   fn: pypeflow_v{{ version }}.tar.gz
   # url: https://github.com/PacificBiosciences/pypeFLOW/archive/v{{ version }}.tar.gz
-  url: https://github.com/PacificBiosciences/pypeFLOW/archive/e331fad50be98d83e95a4a354bed2c81a8351392.tar.gz
-  sha256: 747710682e3d5327f0fc06fd85912989614ee86582f3d784fc66190c9736b3cf
+  url: https://github.com/PacificBiosciences/pypeFLOW/archive/74df164e81a13805d115391492d4d7e2712ccbf7.tar.gz
+  sha256: 585bf3aff6a8898495a5eb482e462994d497caa8ffccbd5483f5ea8e4e0c7fa9
 
 build:
   number: 0
@@ -25,9 +25,11 @@ requirements:
     - python
     - setuptools
     - networkx >=1.7,<=1.11
+    - future >=0.16.0 # [not py3k]
   run:
     - python
     - networkx >=1.7,<=1.11
+    - future >=0.16.0 # [not py3k]
 
 test:
   imports:


### PR DESCRIPTION
* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [X] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

In the absence of an official tag on the upstream repository, this is the commit which merged pull request 20 into the master branch, and that included the version bump.

See PacificBiosciences/pypeFLOW#51

There is a new futures dependency declared in their setup.py, which is a backport for Python 2 only. Given pypeFLOW does not yet support Python 3 this is perhaps not worth noting, but I marked this dependency as conditional.
