### PR TITLE
Fix URL for abundancebin

### DIFF
--- a/recipes/abundancebin/meta.yaml
+++ b/recipes/abundancebin/meta.yaml
@@ -28,7 +28,7 @@ test:
     - abundancebin &> /dev/null || [[ "$?" == "255" ]]
 
 about:
-  home: hhttp://omics.informatics.indiana.edu/AbundanceBin/
+  home: http://omics.informatics.indiana.edu/AbundanceBin/
   license: copyright
   summary: 'Abundance-based tool for binning metagenomic sequences'
   description: |


### PR DESCRIPTION
* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [X] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

This fixes the home page URL for the package. I have not bothered to bump the build number as I don't think this change means we need the package to be rebuilt.

Separately the software's license is not clear - has anyone reached out to the authors to pick a recognised open source license (and suggest hosting on GitHub or similar)?