### PR TITLE
Add r-ngsplot package

### DIFF
--- a/recipes/r-ngsplot/build.sh
+++ b/recipes/r-ngsplot/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+export BOOST_ROOT=${PREFIX}
+if [[ $(uname) == "Darwin" ]]; then
+    export LDFLAGS=-L${PREFIX}/lib
+    autoreconf -i
+    $R CMD INSTALL --build . --configure-args="CFLAGS=-ferror-limit=0 CXXFLAGS=-ferror-limit=0"
+else
+    $R CMD INSTALL --build .
+fi

--- a/recipes/r-ngsplot/build.sh
+++ b/recipes/r-ngsplot/build.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
-export BOOST_ROOT=${PREFIX}
-if [[ $(uname) == "Darwin" ]]; then
-    export LDFLAGS=-L${PREFIX}/lib
-    autoreconf -i
-    $R CMD INSTALL --build . --configure-args="CFLAGS=-ferror-limit=0 CXXFLAGS=-ferror-limit=0"
-else
-    $R CMD INSTALL --build .
-fi
+outdir=$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM
+mkdir -p $outdir
+mkdir -p $PREFIX/bin
+cp -R * $outdir 
+#Set up links for 
+for f in $outdir/*; do
+    ln -s $outdir/* $PREFIX/bin
+    fbname=$(basename "$f")
+    chmod 0755 ${PREFIX}/bin/$fbname
+done

--- a/recipes/r-ngsplot/meta.yaml
+++ b/recipes/r-ngsplot/meta.yaml
@@ -5,41 +5,31 @@ package:
 
 source:
   url: https://github.com/shenlab-sinai/ngsplot/archive/{{ version }}.tar.gz
-  md5: bf0d6f42d9461aeb7a20b1ddb12b57bc42d11732ca6f69ec3eb2157364cefd5b
+  md5: 811815e5f5ef7bdc1cb028ecd59fb2a7
 
 build:
   number: 0
-  string: r_{{CONDA_R}}_boost{{CONDA_BOOST}}_{{PKG_BUILDNUM}}
-  skip: True  # [osx]
+  skip: True 
   rpaths:
     - lib/R/lib/
     - lib/
 
 requirements:
-  build:
-    - r-base
-    - r-rcpp
-    - boost {{CONDA_BOOST}}*
-    - r-catools
-    - bioconductor-rsamtools
-    - gcc
-    - zlib {{CONDA_ZLIB}}*
-    - bzip2 {{CONDA_BZIP2}}*
 
   run:
     - r-base
-    - r-rcpp
-    - boost {{CONDA_BOOST}}*
     - r-catools
+    - r-domc
     - bioconductor-rsamtools
-    - libgcc
-    - zlib {{CONDA_ZLIB}}*
-    - bzip2 {{CONDA_BZIP2}}*
+    - bioconductor-bsgenome
+    - bioconductor-shortread
 
 test:
   commands:
-    - ngsplotdb list
-    - ngs.plot.r 2>&1 | true 
+    - ngsplotdb.py list | true
+    - ngs.plot.r 2>&1 | true
+    - replot.r 2>&1 | true
+    - plotCorrGram.r 2>&1 | true
 
 about:
   license: GPL-2.0

--- a/recipes/r-ngsplot/meta.yaml
+++ b/recipes/r-ngsplot/meta.yaml
@@ -42,11 +42,10 @@ test:
     - $R -e "library(spp); read.bam.tags(system.file(\"extdata\", \"ex1.bam\", package=\"Rsamtools\"))"
 
 about:
-  license: GPL
-  summary: 'ChIP-seq peak caller'
-  home: http://compbio.med.harvard.edu/Supplements/ChIP-seq
+  license: GPL-2.0
+  summary: 'Quick mining and visualization of NGS data by integrating genomic databases'
+  home: https://github.com/shenlab-sinai/ngsplot
 
 extra:
   identifiers:
-    - biotools:spp
-    - doi:10.1038/nbt.1508
+    - doi:10.1186/1471-2164-15-284

--- a/recipes/r-ngsplot/meta.yaml
+++ b/recipes/r-ngsplot/meta.yaml
@@ -1,0 +1,52 @@
+{% set version = "2.63" %}
+package:
+  name: r-ngsplot
+  version: {{ version }}
+
+source:
+  url: https://github.com/shenlab-sinai/ngsplot/archive/{{ version }}.tar.gz
+  md5: bf0d6f42d9461aeb7a20b1ddb12b57bc42d11732ca6f69ec3eb2157364cefd5b
+
+build:
+  number: 0
+  string: r_{{CONDA_R}}_boost{{CONDA_BOOST}}_{{PKG_BUILDNUM}}
+  skip: True  # [osx]
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - r-base
+    - r-rcpp
+    - boost {{CONDA_BOOST}}*
+    - r-catools
+    - bioconductor-rsamtools
+    - gcc
+    - zlib {{CONDA_ZLIB}}*
+    - bzip2 {{CONDA_BZIP2}}*
+
+  run:
+    - r-base
+    - r-rcpp
+    - boost {{CONDA_BOOST}}*
+    - r-catools
+    - bioconductor-rsamtools
+    - libgcc
+    - zlib {{CONDA_ZLIB}}*
+    - bzip2 {{CONDA_BZIP2}}*
+
+test:
+  commands:
+    - $R -e "library(spp)"
+    - $R -e "library(spp); read.bam.tags(system.file(\"extdata\", \"ex1.bam\", package=\"Rsamtools\"))"
+
+about:
+  license: GPL
+  summary: 'ChIP-seq peak caller'
+  home: http://compbio.med.harvard.edu/Supplements/ChIP-seq
+
+extra:
+  identifiers:
+    - biotools:spp
+    - doi:10.1038/nbt.1508

--- a/recipes/r-ngsplot/meta.yaml
+++ b/recipes/r-ngsplot/meta.yaml
@@ -38,8 +38,8 @@ requirements:
 
 test:
   commands:
-    - $R -e "library(spp)"
-    - $R -e "library(spp); read.bam.tags(system.file(\"extdata\", \"ex1.bam\", package=\"Rsamtools\"))"
+    - ngsplotdb list
+    - ngs.plot.r 2>&1 | true 
 
 about:
   license: GPL-2.0


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [x] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

So this should hopefully work and provide the base package of ngs.plot as a bioconda package, as requested [here](https://github.com/shenlab-sinai/ngsplot/issues/74) and  [here](https://github.com/nf-core/chipseq/issues/15).

One question regarding the packaging here remains open for me: This is NOT a "real" R package, but instead a bunch of R scripts that are bundled together, so I can't install these e.g. using `R CMD INSTALL --build .` similar to a standard CRAN or BIOCONDUCTOR package. I did this with symlinking the respective scripts (all of them!) in `bin` and that should probably work, however some feedback from @bioconda/core  would be great to be sure this is fine for everyone. Happy to do things differently, just nothing on the docs for such a case... 

Regarding the Databases that come with this, @bgruening suggested using `post-link` scripts. However we don't have a stable URL for these (GDrive only, no versioning): How do I drop these at the Galaxy Servers as you suggested @bgruening ? 
Thanks!



