### PR TITLE
Adding phyluce 1.6.2

### DIFF
--- a/recipes/phyluce/build.sh
+++ b/recipes/phyluce/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$PYTHON setup.py install --single-version-externally-managed --record=record.txt

--- a/recipes/phyluce/meta.yaml
+++ b/recipes/phyluce/meta.yaml
@@ -1,0 +1,66 @@
+{% set version = "1.6.2" %}
+{% set name = "phyluce" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}_v{{ version }}.tar.gz
+  url: https://github.com/faircloth-lab/{{ name }}/archive/v{{ version }}.tar.gz
+  sha256: 565182df4a360a2163dd3b8a68bc138c1f60e8d05cab7c25a92da0b0fd9e5e2e
+
+build:
+  number: 0
+  skip: True  # [not py27]
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+    - abyss 1.5.2
+    - bcftools
+    - bedtools
+    - biopython
+    - bwa
+    - bx-python
+    - dendropy 3.12.3
+    - gatk
+    - gblocks
+    - lastz
+    - mafft
+    - muscle
+    - pandas
+    - picard
+    - pysam
+    - pyvcf
+    - raxml
+    - samtools
+    - seqtk
+    - trimal
+    - trinity # [not osx]
+    - velvet
+    - illumiprocessor
+    - spades
+    - itero
+
+test:
+    imports:
+      - phyluce
+    commands:
+      - phyluce_assembly_match_contigs_to_probes --help
+      - phyluce_assembly_get_match_counts --help
+      - phyluce_assembly_get_fastas_from_match_counts --help
+      - phyluce_align_seqcap_align --help
+      - phyluce_align_get_align_summary_data --help
+      - phyluce_align_format_nexus_files_for_raxml --help
+
+
+about:
+  home: https://github.com/faircloth-lab/phyluce
+  summary: Software for UCE (and general) phylogenomics.
+  license: BSD
+  license_file: LICENSE


### PR DESCRIPTION
* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [X] This PR adds a new recipe.
* [X] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Adding the python package [phyluce](https://phyluce.readthedocs.io), which is used to analyze target enrichment data collected from ultraconserved elements (e.g. http://ultraconserved.org/) and other genomic targets.  [phyluce](https://phyluce.readthedocs.io) includes lots of 3rd party dependencies, which I previously built and maintained on my own.  Porting over to bioconda makes dealing with those a whole lot easier.