### PR TITLE
Prevent plastid bug with newer numpy versions

### DIFF
--- a/build-fail-blacklist
+++ b/build-fail-blacklist
@@ -62,7 +62,6 @@ recipes/perl-compress-raw-zlib
 recipes/breakdancer
 recipes/cgat-scripts
 recipes/perl-io-compress
-# recipes/plastid
 recipes/shorah
 recipes/smalt
 

--- a/recipes/plastid/meta.yaml
+++ b/recipes/plastid/meta.yaml
@@ -18,7 +18,7 @@ requirements:
     - python
     - setuptools
     - cython >=0.22.0
-    - numpy >=1.9.0,<=1.11.1  # Later numpy causes issue: https://github.com/joshuagryphon/plastid/issues/18
+    - numpy >=1.9.0,<1.12.0  # Later numpy causes issue: https://github.com/joshuagryphon/plastid/issues/18
     - pysam >=0.8.4
     - termcolor
     - scipy >=0.15.1
@@ -34,7 +34,7 @@ requirements:
   run:
     - python
     - cython >=0.22.0
-    - numpy >=1.9.0,<=1.11.1  # Later numpy causes issue: https://github.com/joshuagryphon/plastid/issues/18
+    - numpy >=1.9.0,<1.12.0  # Later numpy causes issue: https://github.com/joshuagryphon/plastid/issues/18
     - pysam >=0.8.4
     - termcolor
     - scipy >=0.15.1

--- a/recipes/plastid/meta.yaml
+++ b/recipes/plastid/meta.yaml
@@ -11,14 +11,14 @@ source:
   sha256: 48c23e07d116417347c335861a8f65cad8921ed0a40a02a4472e1a83476b4450
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
     - python
     - setuptools
     - cython >=0.22.0
-    - numpy >=1.9.0
+    - numpy >=1.9.0,<=1.11.1  # Later numpy causes issue: https://github.com/joshuagryphon/plastid/issues/18
     - pysam >=0.8.4
     - termcolor
     - scipy >=0.15.1
@@ -34,7 +34,7 @@ requirements:
   run:
     - python
     - cython >=0.22.0
-    - numpy >=1.9.0
+    - numpy >=1.9.0,<=1.11.1  # Later numpy causes issue: https://github.com/joshuagryphon/plastid/issues/18
     - pysam >=0.8.4
     - termcolor
     - scipy >=0.15.1


### PR DESCRIPTION
Later versions of numpy are incompatible with the currently released
plastid: https://github.com/joshuagryphon/plastid/issues/18

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
