### PR TITLE
New: VerifyBamID2 -- avoid overlapping with VerifyBamID

### DIFF
--- a/recipes/verifybamid2/build.sh
+++ b/recipes/verifybamid2/build.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -eu -o pipefail
+
+export CPLUS_INCLUDE_PATH=${PREFIX}/include
+export LIBRARY_PATH=${PREFIX}/lib
+
+# Avoid htslib test, which require /usr/bin/perl
+sed -i.bak 's/ && make test//' CMakeLists.txt
+mkdir build
+cd build
+cmake -DCMAKE_INSTALL_PREFIX=${PREFIX} ..
+make
+cd ..
+
+TGT="$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM"
+[ -d "$TGT" ] || mkdir -p "$TGT"
+[ -d "${PREFIX}/bin" ] || mkdir -p "${PREFIX}/bin"
+
+mv bin/VerifyBamID $TGT/VerifyBamID
+mkdir -p $TGT/resource
+mv resource/1000g* $TGT/resource
+mv resource/hgdp* $TGT/resource
+cp $RECIPE_DIR/verifybamid2.sh $TGT/verifybamid2
+chmod a+x $TGT/verifybamid2
+ln -s $TGT/verifybamid2 $PREFIX/bin/verifybamid2

--- a/recipes/verifybamid2/meta.yaml
+++ b/recipes/verifybamid2/meta.yaml
@@ -1,0 +1,43 @@
+{% set name = "verifybamid2" %}
+{% set version = "1.0.4" %}
+{% set md5 = "d76c6acb6f774eee4c3463a652d9f068" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+build:
+  number: 0
+  skip: true  # [osx]
+
+source:
+  fn: {{ name }}-version.tar.gz
+  url: https://github.com/Griffan/VerifyBamID/archive/{{ version }}.tar.gz
+  md5: {{ md5 }}
+
+requirements:
+  build:
+    - gcc
+    - cmake
+    - autoconf
+    - zlib {{CONDA_ZLIB}}*
+    - bzip2 {{CONDA_BZIP2}}*
+    - curl
+    - openssl
+
+  run:
+    - libgcc
+    - zlib {{CONDA_ZLIB}}*
+    - bzip2 {{CONDA_BZIP2}}*
+    - curl
+    - openssl
+
+test:
+  commands:
+    - verifybamid2 2>&1 | grep VerifyBamID2
+    - verifybamid2 -h 2>&1 | grep VerifyBamID2
+
+about:
+  home: https://github.com/Griffan/VerifyBamID
+  license: MIT
+  summary: A robust tool for DNA contamination estimation from sequence reads using ancestry-agnostic method.

--- a/recipes/verifybamid2/verifybamid2.sh
+++ b/recipes/verifybamid2/verifybamid2.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Wrapper for VerifyBAMID2
+# Avoids name conflicts with standard VerifyBamID and
+# provides each access to referencing resource files
+# Usage:
+# verifybamid2 <SVD_name> <density> <genome_build> <other> <args>
+set -eu -o pipefail
+
+# Find original directory of bash script, resolving symlinks
+# http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in/246128#246128
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+    DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+    SOURCE="$(readlink "$SOURCE")"
+    [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+
+SVG="${1:-1000g}"
+DENSITY="${2:-100k}"
+GENOME="${3:-b38}"
+if [[ $SVG == "-h" || $SVG == "--help" ]]; then
+	echo "Usage: verifybamid2 <SVG_name> <density> <genome> <other> <VerifyBamID> <args>"
+	echo "<SVG_name> can be 1000g 1000g.phase3 or hgdp"
+	echo "<density> can be 100k or 10k"
+	echo "<genome> can be b37 or b38"
+	$DIR/VerifyBamID --help
+else
+	$DIR/VerifyBamID --SVDPrefix $DIR/resource/$SVG.$DENSITY.$GENOME.vcf.gz.dat "${@:4}"
+fi


### PR DESCRIPTION
Wraps the new version of VerifyBamID, called VerifyBamID2 to avoid
confusion. They have overlapping binary names and confusion versioning
numbers, but are different efforts from the same group to approach
contamination estimation. This provides a shell wrapper, verifybamid2 that
provides access to resource files for 1000g and HGDP as background for
estimating contamination without needing to provide an external VCF
input.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [x] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
