### PR TITLE
Update to itero v1.1.1

### DIFF
--- a/recipes/itero/meta.yaml
+++ b/recipes/itero/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.1.0" %}
+{% set version = "1.1.1" %}
 {% set name = "itero" %}
 
 package:
@@ -8,7 +8,7 @@ package:
 source:
   fn: {{ name }}_v{{ version }}.tar.gz
   url: https://github.com/faircloth-lab/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: 23054d714e4ef39d3685652354fac3447b67f3f7f0d74d1335e22661cbe8d251
+  sha256: 6e4f1bf6aec78955216400e21074680a2072aa9a924ad34c8bccd2b9cbf69cec
 
 build:
   number: 0
@@ -21,6 +21,7 @@ requirements:
 
   run:
     - python
+    - nomkl
     - numpy
     - argcomplete
     - biopython


### PR DESCRIPTION
Update fixes an error that could cause MPI to hang.  It also adds
nomkl to package.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

