### PR TITLE
PacBio: Pin exact dependency versions

### DIFF
--- a/recipes/bam2fastx/1.3.0/meta.yaml
+++ b/recipes/bam2fastx/1.3.0/meta.yaml
@@ -22,14 +22,14 @@ extra:
     - mhsieh
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
     - gcc    # [not osx]
     - llvm   # [osx]
-    - pbbam >=0.18.0
-    - pbcopper >=0.4.1
+    - pbbam 0.18.0*
+    - pbcopper 0.4.1*
     - zlib {{ CONDA_ZLIB }}*
     - boost
     - pkg-config
@@ -38,8 +38,8 @@ requirements:
 
   run:
     - libgcc # [not osx]
-    - pbbam >=0.18.0
-    - pbcopper >=0.4.1
+    - pbbam 0.18.0*
+    - pbcopper 0.4.1*
     - zlib {{ CONDA_ZLIB }}*
 
 test:

--- a/recipes/bax2bam/0.0.9/meta.yaml
+++ b/recipes/bax2bam/0.0.9/meta.yaml
@@ -22,15 +22,15 @@ extra:
     - mhsieh
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
     - gcc    # [not osx]
     - llvm   # [osx]
     - hdf5 {{ CONDA_HDF5 }}*
-    - pbbam >=0.18.0
-    - blasr_libcpp >=5.3.1
+    - pbbam 0.18.0*
+    - blasr_libcpp 5.3.1*
     - boost
     - pkg-config
     - meson
@@ -39,8 +39,8 @@ requirements:
   run:
     - libgcc # [not osx]
     - hdf5 {{ CONDA_HDF5 }}*
-    - pbbam >=0.18.0
-    - blasr_libcpp >=5.3.1
+    - pbbam 0.18.0*
+    - blasr_libcpp 5.3.1*
 
 test:
   commands:

--- a/recipes/blasr/5.3.2/meta.yaml
+++ b/recipes/blasr/5.3.2/meta.yaml
@@ -23,7 +23,7 @@ extra:
     - ylipacbio
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -31,8 +31,8 @@ requirements:
     - llvm   # [osx]
     - hdf5 {{ CONDA_HDF5 }}*
     - zlib {{ CONDA_ZLIB }}*
-    - pbbam >=0.18.0
-    - blasr_libcpp >=5.3.1
+    - pbbam 0.18.0*
+    - blasr_libcpp 5.3.1*
     - boost
     - pkg-config
     - meson
@@ -41,8 +41,8 @@ requirements:
   run:
     - libgcc # [not osx]
     - hdf5 {{ CONDA_HDF5 }}*
-    - pbbam >=0.18.0
-    - blasr_libcpp >=5.3.1
+    - pbbam 0.18.0*
+    - blasr_libcpp 5.3.1*
 
 test:
   commands:

--- a/recipes/blasr_libcpp/5.3.1/meta.yaml
+++ b/recipes/blasr_libcpp/5.3.1/meta.yaml
@@ -25,7 +25,7 @@ extra:
     - ylipacbio
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -33,7 +33,7 @@ requirements:
     - llvm   # [osx]
     - hdf5 {{ CONDA_HDF5 }}*
     - zlib {{ CONDA_ZLIB }}*
-    - pbbam >=0.18.0
+    - pbbam 0.18.0*
     - boost
     - pkg-config
     - meson
@@ -42,7 +42,7 @@ requirements:
   run:
     - libgcc # [not osx]
     - hdf5 {{ CONDA_HDF5 }}*
-    - pbbam >=0.18.0
+    - pbbam 0.18.0*
 
 test:
   commands:


### PR DESCRIPTION
* Avoids ABI breakage when upgrading dependencies,
  as all PacBio libraries use the Boost ABI versioning
  scheme, i.e., every change of the version number
  is potentially ABI breaking.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
