### PR TITLE
Fasta splitter 0.2.4

### DIFF
--- a/recipes/fasta-splitter/0.2.4/build.sh
+++ b/recipes/fasta-splitter/0.2.4/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+outdir=$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM
+mkdir -p $outdir
+ln -s $PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM $PREFIX/share/$PKG_NAME
+
+cp ./fasta-splitter.pl $outdir/
+chmod +x $outdir/fasta-splitter.pl
+
+mkdir -p $PREFIX/bin
+ln -s $outdir/fasta-splitter.pl $PREFIX/bin/fasta-splitter

--- a/recipes/fasta-splitter/0.2.4/meta.yaml
+++ b/recipes/fasta-splitter/0.2.4/meta.yaml
@@ -1,0 +1,26 @@
+package:
+  name: fasta-splitter
+  version: 0.2.4
+
+source:
+  fn: fasta-splitter-0.2.4.zip
+  sha256: 1fd3a5e52e7f9033ddd7619db99b42427405ee9177e9eddb3e55a6038ac5d919
+  url: http://kirill-kryukov.com/study/tools/fasta-splitter/files/fasta-splitter-0.2.4.zip
+
+build:
+  number: 0
+  skip: False
+
+requirements:
+  run:
+      - perl
+      - perl-file-util
+
+test:
+    commands:
+      - fasta-splitter --help
+
+about:
+  home: http://kirill-kryukov.com/study/tools/fasta-splitter/
+  license: zlib/libpng
+  summary: 'Divides a large FASTA file into a set of smaller, approximately equally sized files'

--- a/recipes/perl-file-util/build.sh
+++ b/recipes/perl-file-util/build.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# If it has Build.PL use that, otherwise use Makefile.PL
+if [ -f Build.PL ]; then
+    perl Build.PL
+    perl ./Build
+    perl ./Build test
+    # Make sure this goes in site
+    perl ./Build install --installdirs site
+elif [ -f Makefile.PL ]; then
+    # Make sure this goes in site
+    perl Makefile.PL INSTALLDIRS=site
+    make
+    make test
+    make install
+else
+    echo 'Unable to find Build.PL or Makefile.PL. You need to modify build.sh.'
+    exit 1
+fi
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/recipes/perl-file-util/meta.yaml
+++ b/recipes/perl-file-util/meta.yaml
@@ -1,0 +1,57 @@
+{% set name = "perl-file-util" %}
+{% set version = "4.161950" %}
+{% set sha256 = "88507b19da580d595b5c25fe6ba75bbd6096b4359e389ead067a216f766c20ee" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: File-Util-4.161950.tar.gz
+  url: https://cpan.metacpan.org/authors/id/T/TO/TOMMY/File-Util-4.161950.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - perl
+    - perl-constant
+    - perl-module-build
+    - perl-lib
+    - perl-test-nowarnings
+    - perl-test
+    - perl-exporter
+    - perl-file-temp
+    - perl-extutils-makemaker
+    - perl-autoloader
+
+  run:
+    - perl
+    - perl-lib
+    - perl-exporter
+    - perl-constant
+
+test:
+  # Perl 'use' tests
+  imports:
+    - File::Util
+    - File::Util::Definitions
+    - File::Util::Exception
+    - File::Util::Exception::Diagnostic
+    - File::Util::Exception::Standard
+    - File::Util::Interface::Classic
+    - File::Util::Interface::Modern
+
+  # You can also put a file called run_test.pl (or run_test.py) in the recipe
+  # that will be run at test time.
+
+about:
+  home: https://github.com/tommybutler/file-util/wiki
+  license: perl_5
+  summary: 'Easy, versatile, portable file handling'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [x] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

PR adds a new recipe for `fasta-splitter` 0.2.4. The recipe is in a `0.2.4` subdirectory of the `recipes/fasta-splitter` directory as this is not the most recent version.

The PR also adds a recipe for the Perl `File::Util` module, which `fasta-splitter` depends on; although this package is arguably not directly relevant to the biological sciences, it seems there are several similar packages in `bioconda` (do e.g. `conda search -c bioconda "perl-file*"` for examples).