### PR TITLE
lint vawk hash and noarch

### DIFF
--- a/recipes/vawk/build.sh
+++ b/recipes/vawk/build.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-cp vawk $PREFIX/bin

--- a/recipes/vawk/meta.yaml
+++ b/recipes/vawk/meta.yaml
@@ -1,20 +1,21 @@
 package:
   name: vawk
-  version: 0.0.2
+  version: '0.0.2'
 
 source:
   url: https://github.com/cc2qe/vawk/archive/bab8237.tar.gz
+  sha256: 80b923b83308416bd1d97c34bcc9f8be4e3a06154c4a3e0ac7c6e6cb8f34f323
 
 build:
-  number: 2
-  skip: True # [not py27 or osx]
+  number: 3
+  noarch: python
+  script: cp vawk $PREFIX/bin
 
 requirements:
   host:
-    - python
-
+    - python <3
   run:
-    - python
+    - python <3
     - gawk
 
 test:
@@ -24,4 +25,5 @@ test:
 about:
   home: https://github.com/cc2qe/vawk
   license: MIT
+  license_family: MIT
   summary: An awk-like VCF parser


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

The url git commit is an untagged commit made 2 years after the tagged 0.0.2 release. Should the recipe version still be 0.0.2?