### PR TITLE
Fix stringtie recipe

### DIFF
--- a/recipes/stringtie/1.0.3/build.sh
+++ b/recipes/stringtie/1.0.3/build.sh
@@ -1,4 +1,11 @@
 #!/bin/sh
+
+export C_INCLUDE_PATH=$PREFIX/include
+export CPLUS_INCLUDE_PATH=$PREFIX/include
+export CFLAGS="-I$PREFIX/include"
+export LDFLAGS="-L$PREFIX/lib"
+export CPATH=${PREFIX}/include
+
 make release
 mkdir -p $PREFIX/bin
 mv stringtie $PREFIX/bin

--- a/recipes/stringtie/1.0.3/meta.yaml
+++ b/recipes/stringtie/1.0.3/meta.yaml
@@ -3,14 +3,21 @@ about:
   license: Artistic License 2.0
   summary: Transcriptome assembly and quantification for RNA-seq
 build:
-  number: 1
+  number: 2
   skip: True # [osx]
 package:
   name: stringtie
   version: 1.0.3
 requirements:
-  build: []
-  run: []
+  build:
+    - {{ compiler('c') }}
+  host:
+    - zlib
+    - gnu-wget
+  run:
+    - zlib
+    - python
+
 source:
   sha256: 1567d9d87d9375a3db03fa0b682eaef4e89899df64fd001c14d475cc9e737e08
   url: http://ccb.jhu.edu/software/stringtie/dl/stringtie-1.0.3.tar.gz

--- a/recipes/stringtie/1.0.4/build.sh
+++ b/recipes/stringtie/1.0.4/build.sh
@@ -1,4 +1,11 @@
 #!/bin/sh
+
+export C_INCLUDE_PATH=$PREFIX/include
+export CPLUS_INCLUDE_PATH=$PREFIX/include
+export CFLAGS="-I$PREFIX/include"
+export LDFLAGS="-L$PREFIX/lib"
+export CPATH=${PREFIX}/include
+
 make release
 mkdir -p $PREFIX/bin
 mv stringtie $PREFIX/bin

--- a/recipes/stringtie/1.0.4/meta.yaml
+++ b/recipes/stringtie/1.0.4/meta.yaml
@@ -8,9 +8,17 @@ build:
 package:
   name: stringtie
   version: 1.0.4
+
 requirements:
-  build: []
-  run: []
+  build:
+    - {{ compiler('c') }}
+  host:
+    - zlib
+    - gnu-wget
+  run:
+    - zlib
+    - python
+
 source:
   sha256: 635099d543bfaf0ec1c84020eb4aa3375714c12e2d0d435dae44901d49fe3ef2
   url: http://ccb.jhu.edu/software/stringtie/dl/stringtie-1.0.4.tar.gz

--- a/recipes/stringtie/meta.yaml
+++ b/recipes/stringtie/meta.yaml
@@ -4,6 +4,7 @@ package:
 
 build:
   number: 1
+  skip: True  # [not py27]
 
 requirements:
   build:


### PR DESCRIPTION
* [ ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).


Stringtie uses (and the recipe tests) a python script that has python27 only features (e.g., print as a statement).  This skips the recipe on py3x