### PR TITLE
ci: remove workarounds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,8 @@ jobs:
           # above. A workaround or an upstream fix would be welcome.
           command: |
             bioconda-utils build recipes config.yml \
-            --git-range master HEAD
+            --git-range master HEAD \
+            --prelint
 
   lint:
     <<: *linux
@@ -116,7 +117,7 @@ jobs:
             bioconda-utils build recipes config.yml \
               --docker --mulled-test \
               --git-range master HEAD \
-              --lint
+              --prelint
 
   # build and test on macos
   test-macos:
@@ -132,7 +133,7 @@ jobs:
           command: |
             bioconda-utils build recipes config.yml \
             --git-range master HEAD \
-            --lint
+            --prelint
 
   # build, test and upload on linux
   upload-linux:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ variables:
       command: |
         curl -s https://raw.githubusercontent.com/bioconda/bioconda-common/master/common.sh > .circleci/common.sh
         # TODO remove this temporal override before merging the PR into master
-        echo -e 'MINICONDA_VER=4.4.10\nBIOCONDA_UTILS_TAG=cb3-migration' > .circleci/common.sh
+        echo -e 'MINICONDA_VER=4.5.4\nBIOCONDA_UTILS_TAG=cb3-migration' > .circleci/common.sh
   setup: &setup
     run:
       name: Setup bioconda-utils

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,19 +212,17 @@ workflows:
   # workflow for testing pushes and PRs
   bioconda-test:
     jobs:
-      # Linting is now performed just before a recipe is built with
+      # Linting is now also performed just before a recipe is built with
       # bioconda-utils build --prelint.
-      # TODO: remove this section if --prelint ends up working well.
-      # - lint:
-      #     filters:
-      #       branches:
-      #         ignore:
-      #           - master
-      #           - bulk
+      - lint:
+          filters:
+            branches:
+              ignore:
+                - master
+                - bulk
       - test-linux:
-          # TODO: remove if --prelint ends up working well
-          # requires:
-          #   - lint
+          requires:
+            - lint
           filters:
             branches:
               ignore:
@@ -232,8 +230,7 @@ workflows:
                 - bulk
       - test-macos:
           requires:
-            # TODO: remove if --prelint ends up working well
-            # - lint
+            - lint
             - test-linux
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,13 +73,18 @@ jobs:
       - *setup
       - run:
           name: Linting
-          command: bioconda-utils lint --loglevel debug --full-report recipes config.yml --git-range master HEAD
+          command: |
+            bioconda-utils lint recipes config.yml \
+            --loglevel debug --full-report \
+            --git-range master HEAD
       - run:
           name: Testing
           # Currently, using --docker below causes a permission error on Fedora 27,
           # although it should be supported by the setup_remote_docker directive
           # above. A workaround or an upstream fix would be welcome.
-          command: bioconda-utils build recipes config.yml --git-range master HEAD
+          command: |
+            bioconda-utils build recipes config.yml \
+            --git-range master HEAD
 
   lint:
     <<: *linux
@@ -91,7 +96,10 @@ jobs:
       - *save_cache
       - run:
           name: Linting
-          command: bioconda-utils lint --loglevel debug --full-report recipes config.yml --git-range master HEAD
+          command: |
+            bioconda-utils lint recipes config.yml \
+            --loglevel debug --full-report \
+            --git-range master HEAD
 
   # build and test on linux
   test-linux:
@@ -104,7 +112,11 @@ jobs:
       - *save_cache
       - run:
           name: Building and testing
-          command: bioconda-utils build recipes config.yml --git-range master HEAD --docker --mulled-test --prelint
+          command: |
+            bioconda-utils build recipes config.yml \
+              --docker --mulled-test \
+              --git-range master HEAD \
+              --lint
 
   # build and test on macos
   test-macos:
@@ -117,7 +129,10 @@ jobs:
       - *save_cache
       - run:
           name: Building and testing
-          command: bioconda-utils build recipes config.yml --git-range master HEAD --prelint
+          command: |
+            bioconda-utils build recipes config.yml \
+            --git-range master HEAD \
+            --lint
 
   # build, test and upload on linux
   upload-linux:
@@ -132,8 +147,10 @@ jobs:
       # build only current commit (since we use squashed merging, this is safe)
       - run:
           name: Building, testing, and uploading
-          command: bioconda-utils build recipes config.yml --docker --mulled-test --anaconda-upload --mulled-upload-target biocontainers --prelint --git-range $CIRCLE_SHA1~1 $CIRCLE_SHA1
-
+          command: |
+            bioconda-utils build recipes config.yml \
+              --docker --mulled-test --anaconda-upload --mulled-upload-target biocontainers \
+              --git-range $CIRCLE_SHA1~1 $CIRCLE_SHA1
   # build, test and upload on macos
   upload-macos:
     <<: *macos
@@ -147,7 +164,10 @@ jobs:
       # build only current commit (since we use squashed merging, this is safe)
       - run:
           name: Building, testing and uploading
-          command: bioconda-utils build recipes config.yml --anaconda-upload --prelint --git-range $CIRCLE_SHA1~1 $CIRCLE_SHA1
+          command: |
+            bioconda-utils build recipes config.yml \
+              --anaconda-upload \
+              --git-range $CIRCLE_SHA1~1 $CIRCLE_SHA1
 
   # build, test and upload for bulk branch on linux
   bulk-linux:
@@ -161,7 +181,9 @@ jobs:
       - *save_cache
       - run:
           name: Building, testing, and uploading of all unpublished recipes
-          command: bioconda-utils build recipes config.yml --docker --mulled-test --anaconda-upload --mulled-upload-target biocontainers
+          command: |
+            bioconda-utils build recipes config.yml \
+              --docker --mulled-test --anaconda-upload --mulled-upload-target biocontainers
 
   # build, test and upload for bulk branch on macos
   bulk-macos:
@@ -175,7 +197,9 @@ jobs:
       - *save_cache
       - run:
           name: Building, testing and uploading of all unpublished recipes
-          command: bioconda-utils build recipes config.yml --anaconda-upload
+          command: |
+            bioconda-utils build recipes config.yml \
+              --anaconda-upload
 
   # nightly build, test and upload of unpublished recipes on linux
   nightly-upload-linux:
@@ -189,7 +213,9 @@ jobs:
       - *save_cache
       - run:
           name: Building, testing, and uploading of all unpublished recipes
-          command: bioconda-utils build recipes config.yml --docker --mulled-test --anaconda-upload --mulled-upload-target biocontainers --prelint
+          command: |
+            bioconda-utils build recipes config.yml \
+              --docker --mulled-test --anaconda-upload --mulled-upload-target biocontainers
 
   # nightly build, test and upload of unpublished recipes on macos
   nightly-upload-macos:
@@ -203,8 +229,9 @@ jobs:
       - *save_cache
       - run:
           name: Building, testing and uploading of all unpublished recipes
-          command: bioconda-utils build recipes config.yml --anaconda-upload --prelint
-
+          command: |
+            bioconda-utils build recipes config.yml \
+              --anaconda-upload
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,18 +2,14 @@ version: 2
 
 variables:
   restore_cache: &restore_cache
-    # TODO remove this temporal override before merging the PR into master
-    run: { command: echo 'ignoring cache' }
-    #restore_cache:
-    #  keys:
-    #    - miniconda-{{ checksum ".circleci/common.sh" }}-{{ checksum ".circleci/setup.sh" }}-{{ checksum ".circleci/config.yml" }}-{{ arch }}
+    restore_cache:
+      keys:
+        - miniconda-{{ checksum ".circleci/common.sh" }}-{{ checksum ".circleci/setup.sh" }}-{{ checksum ".circleci/config.yml" }}-{{ arch }}
   save_cache: &save_cache
-    # TODO remove this temporal override before merging the PR into master
-    run: { command: echo 'ignoring cache' }
-    #save_cache:
-    #  key: miniconda-{{ checksum ".circleci/common.sh" }}-{{ checksum ".circleci/setup.sh" }}-{{ checksum ".circleci/config.yml" }}-{{ arch }}
-    #  paths:
-    #    - miniconda
+    save_cache:
+      key: miniconda-{{ checksum ".circleci/common.sh" }}-{{ checksum ".circleci/setup.sh" }}-{{ checksum ".circleci/config.yml" }}-{{ arch }}
+      paths:
+        - miniconda
   common: &common
     run:
       name: Download common definitions

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,7 +151,8 @@ jobs:
           command: |
             bioconda-utils build recipes config.yml \
               --docker --mulled-test --anaconda-upload --mulled-upload-target biocontainers \
-              --git-range $CIRCLE_SHA1~1 $CIRCLE_SHA1
+              --git-range $CIRCLE_SHA1~1 $CIRCLE_SHA1 \
+              --prelint
   # build, test and upload on macos
   upload-macos:
     <<: *macos
@@ -168,7 +169,8 @@ jobs:
           command: |
             bioconda-utils build recipes config.yml \
               --anaconda-upload \
-              --git-range $CIRCLE_SHA1~1 $CIRCLE_SHA1
+              --git-range $CIRCLE_SHA1~1 $CIRCLE_SHA1 \
+              --prelint
 
   # build, test and upload for bulk branch on linux
   bulk-linux:
@@ -216,7 +218,8 @@ jobs:
           name: Building, testing, and uploading of all unpublished recipes
           command: |
             bioconda-utils build recipes config.yml \
-              --docker --mulled-test --anaconda-upload --mulled-upload-target biocontainers
+              --docker --mulled-test --anaconda-upload --mulled-upload-target biocontainers \
+              --prelint
 
   # nightly build, test and upload of unpublished recipes on macos
   nightly-upload-macos:
@@ -232,7 +235,8 @@ jobs:
           name: Building, testing and uploading of all unpublished recipes
           command: |
             bioconda-utils build recipes config.yml \
-              --anaconda-upload
+              --anaconda-upload \
+              --prelint
 
 
 workflows:

--- a/.circleci/setup.sh
+++ b/.circleci/setup.sh
@@ -22,8 +22,11 @@ UPSTREAM_REMOTE=__upstream__$(tr -dc a-z < /dev/urandom | head -c10)
 git remote add -t master $UPSTREAM_REMOTE https://github.com/bioconda/bioconda-recipes.git
 git fetch $UPSTREAM_REMOTE
 if ! git diff --quiet HEAD...$UPSTREAM_REMOTE/master -- .circleci/; then
-    echo 'The CI configuration is out of date.'
-    echo 'Please merge in bioconda:master.'
+    echo 'Your bioconda-recipes CI configuration is out of date.'
+    echo 'Please update it to the latest version of the upstream master branch.'
+    echo 'You can do this, e.g., by running:'
+    echo '  git fetch https://github.com/bioconda/bioconda-recipes.git master'
+    echo '  git merge FETCH_HEAD'
     exit 1
 fi
 git remote remove $UPSTREAM_REMOTE

--- a/.circleci/setup.sh
+++ b/.circleci/setup.sh
@@ -29,12 +29,6 @@ fi
 git remote remove $UPSTREAM_REMOTE
 
 
-# TODO: remove this workaround
-if [[ $OSTYPE == linux* && ${CIRCLE_JOB-} != build ]] && [[ $USE_DOCKER == "true" ]]; then
-    docker pull continuumio/miniconda3:4.3.27
-    docker tag continuumio/miniconda3:4.3.27 continuumio/miniconda3:latest
-fi
-
 if ! type bioconda-utils > /dev/null || [[ $BOOTSTRAP == "true" ]]; then
     echo "Setting up bioconda-utils..."
 


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

@bioconda/core
This does:
1. reenable CircleCI cache
2. reinstate the separate lint job for branches other than `master`/`bulk` (i.e., PRs)
3. remove some temporary workarounds
4. improve the error message for outdated CI config
5. update to a newer Miniconda version, because why not :)