### PR TITLE
updates to bootstrap to reflect the current build settings

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -46,10 +46,13 @@ args = ap.parse_args()
 
 # This is the "common" step in the CircleCI config which gets the versions of
 # Miniconda and bioconda-utils that we're using.
-#urlretrieve(
-#    'https://raw.githubusercontent.com/bioconda/bioconda-common/master/common.sh',
-#    filename='.circleci/common.sh')
+urlretrieve(
+    'https://raw.githubusercontent.com/bioconda/bioconda-common/master/common.sh',
+    filename='.circleci/common.sh')
 
+# TODO: this mimics the override in the "common" job in .circleci/config.yaml
+with open('.circleci/common.sh', 'w') as fout:
+    fout.write("MINICONDA_VER=4.5.4\nBIOCONDA_UTILS_TAG=cb3-migration\n")
 
 local_config_path = os.path.expanduser('~/.config/bioconda/activate')
 
@@ -67,29 +70,32 @@ def _write_custom_activate(install_path):
     activate = os.path.join(install_path, 'miniconda/bin/activate')
     lines = [i.rstrip() for i in open(activate)]
 
-    # Exact matches to lines we want to replace in the activate script, leading
-    # space included.
-    substitutions = [
-        (
-            '_CONDA_DIR=$(dirname "$_SCRIPT_LOCATION")',
-            '_CONDA_DIR="{0}/miniconda/bin"'.format(install_path)
-        ),
-        (
-            '                export PS1="(${CONDA_DEFAULT_ENV}) $PS1"',
-            '                export PS1="(BIOCONDA-UTILS) $PS1"',
-        )
-    ]
 
-    for orig, sub in substitutions:
-        # Be very picky so that we'll know if/when the activate script changes.
-        try:
-            pos = lines.index(orig)
-        except ValueError:
-            raise ValueError(
-                "Expecting '{0}' to be in {1} but couldn't find it"
-                .format(orig, activate)
+    # The following is code from cb2; disabling but keeping it around for now:
+    if 0:
+        # Exact matches to lines we want to replace in the activate script, leading
+        # space included.
+        substitutions = [
+            (
+                '_CONDA_DIR=$(dirname "$_SCRIPT_LOCATION")',
+                '_CONDA_DIR="{0}/miniconda/bin"'.format(install_path)
+            ),
+            (
+                '                export PS1="(${CONDA_DEFAULT_ENV}) $PS1"',
+                '                export PS1="(BIOCONDA-UTILS) $PS1"',
             )
-        lines[pos] = sub
+        ]
+
+        for orig, sub in substitutions:
+            # Be very picky so that we'll know if/when the activate script changes.
+            try:
+                pos = lines.index(orig)
+            except ValueError:
+                raise ValueError(
+                    "Expecting '{0}' to be in {1} but couldn't find it"
+                    .format(orig, activate)
+                )
+            lines[pos] = sub
 
     with open(local_config_path, 'w') as fout:
         for line in lines:


### PR DESCRIPTION
* [ ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [X] This PR does something else (explain below).

This updates bootstrap.py so that local tests work correctly for the cb3 migration build settings. Specifically it patches `.circleci/common.sh` like the `common` task does in the circleci config, and it no longer checks for cb2-style activate script formatting.

ping @ignaciot and xref #9534