### PR TITLE
Update sourmash recipe (fix khmer version)

### DIFF
--- a/recipes/sourmash/build.sh
+++ b/recipes/sourmash/build.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-$PYTHON setup.py install --single-version-externally-managed --record=record.txt

--- a/recipes/sourmash/meta.yaml
+++ b/recipes/sourmash/meta.yaml
@@ -13,33 +13,27 @@ source:
 build:
   entry_points:
     - sourmash = sourmash.__main__:main
-  number: 0
+  number: 1
+  script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
   build:
-    - {{ compiler('c') }}
+    - '{{ compiler("c") }}'
+    - '{{ compiler("cxx") }}'
   host:
     - python
-    - setuptools
-    - cython >=0.25.2
-    - screed >=0.9
-    - pyyaml >=3.11
-    - ijson
-    - numpy
-    - matplotlib
-    - scipy
-    - khmer >=2.1
+    - pip
+    - setuptools >=38.6.0
+    - Cython >=0.25.2
 
   run:
     - python
-    - cython >=0.25.2
     - screed >=0.9
-    - pyyaml >=3.11
     - ijson
     - numpy
     - matplotlib
     - scipy
-    - khmer >=2.1
+    - khmer >=2.1,<3
 
 test:
   imports:
@@ -54,3 +48,8 @@ about:
   license: BSD License
   summary: 'Compute and compare MinHash signatures for DNA data sets.'
   license_family: BSD
+  dev_url: https://github.com/dib-lab/sourmash
+
+extra:
+  identifiers:
+    - doi:10.21105/joss.00027


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

Turns out #9533 broke sourmash because #9391 bumped the khmer version to `3.0.0a1` and we still don't support it in sourmash (yes, I see the irony). Instead of just fixing the khmer version and bumping the version number I also updated the recipe with other similar changes I saw in the khmer recipe.

I'll ping @corburn since he did the last khmer recipe changes.
