### PR TITLE
pin against boost 1.65, fix pkg-config library ordering

### DIFF
--- a/recipes/libmems/build.sh
+++ b/recipes/libmems/build.sh
@@ -16,5 +16,7 @@ cd trunk
 ./configure --prefix=$PREFIX 
 make
 make install
-
+  
+# Some boost versions require boost_system to be the last in the list of libraries when linking...
+sed -i -e 's/-lboost_system //' -e 's/-lrt/-lboost_system -lrt/' $PREFIX/lib/pkgconfig/libMems-1.6.pc
 

--- a/recipes/libmems/meta.yaml
+++ b/recipes/libmems/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 build:
   skip: True [osx]
-  number: 0
+  number: 1
 
 source:
   url: https://depot.galaxyproject.org/software/libmems/libmems_1.6.0_src_all.zip
@@ -19,11 +19,10 @@ requirements:
     - autoconf
     - automake
     - libtool
-  host:
     - libgenome
     - libmuscle
   host:
-    - boost 
+    - boost 1.65.0
 
 test:
   commands:


### PR DESCRIPTION
Linking against libmems with boost 1.66 seems to have some problems, but earlier versions seem ok so pin to 1.65. Possible bugfix in 1.67 so pinning can hopefully be removed in future.

Newer boost versions also can not find symbols (e.g. boost::system::system_category) unless boost_system is last in list of libraries to link. libMems-1.6pc modified to provide libraries in appropriate order

* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [X] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
