### PR TITLE
.circleci: separate workflows for Linux/macOs jobs on bulk/nightly uploads

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -286,20 +286,22 @@ workflows:
               only:
                 - master
   # workflow for bulk-updates
-  bioconda-upload-bulk:
+  bioconda-upload-bulk-linux:
     jobs:
       - bulk-linux:
           filters:
             branches:
               only:
                 - bulk
+  bioconda-upload-bulk-macos:
+    jobs:
       - bulk-macos:
           filters:
             branches:
               only:
                 - bulk
   # nightly workflow to capture missed recipes
-  bioconda-nightly-upload:
+  bioconda-nightly-upload-linux:
      triggers:
        - schedule:
            cron: "0 0 * * *"
@@ -309,4 +311,13 @@ workflows:
                  - master
      jobs:
        - nightly-upload-linux
+  bioconda-nightly-upload-macos:
+     triggers:
+       - schedule:
+           cron: "0 0 * * *"
+           filters:
+             branches:
+               only:
+                 - master
+     jobs:
        - nightly-upload-macos


### PR DESCRIPTION
* [ ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

From Gitter conversion with @dpryan79:
https://gitter.im/bioconda/Lobby?at=5b30d85ab9c2fb2557097c8b:
>
>> Devon Ryan @dpryan79 13:56
Would it make sense to disable the nightly uploads (at least for OSX) while the bulk branches are getting updated a couple times a day? Since there's only one OSX build at a time on circleci this creates a bit of a backlog.
>
>> Marcel Bargull @mbargull 14:47
I'd rather not disable the nightly builds to keep the rebuild running. But maybe we could separate the Linux and macOS jobs into separate workflows for nightly as well as bulk uploads. That way we could easily restart/reschedule the macOS jobs (on demand) to make room for macOS builds on master and PRs. (If we don't separate them we'd have to needlessly stop running Linux jobs since the CircleCI UI only allows rerunning jobs for finished workflows...)