### PR TITLE
sqt rebuild

### DIFF
--- a/recipes/sqt/meta.yaml
+++ b/recipes/sqt/meta.yaml
@@ -39,4 +39,4 @@ test:
 build:
   skip: True  # [py27]
   script: python -m pip install --no-deps --ignore-installed .
-  number: 1
+  number: 2


### PR DESCRIPTION
* [ ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

I’m getting this “WARNING” message over at #9581: 
```
Placeholder of length '80' too short in package /opt/conda/conda-bld/igdiscover_1530040000852/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_pl/lib/python3.5/site-packages/sqt/_helpers.cpython-35m-x86_64-linux-gnu.so.
The package must be rebuilt with conda-build > 2.0.
```
It’s not clear to me whether that is the reason for that PR failing, but I’m attempting to force a rebuild of sqt here to fix this.