### PR TITLE
bump afplot build number

### DIFF
--- a/recipes/afplot/meta.yaml
+++ b/recipes/afplot/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: e345777e40a3822c4a098933336861d99707dc88fe479453f40cb470f37b196b
 
 build:
-  number: 1
+  number: 2
   noarch: python
   script: python -m pip install --no-deps --ignore-installed .
   entry_points:
@@ -42,7 +42,3 @@ about:
   license: MIT
   license_family: MIT
   summary: 'Plot allele frequencies in VCF files'
-
-extra:
-  container:
-    extended-base: true


### PR DESCRIPTION
* [ ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

https://circleci.com/gh/bioconda/bioconda-recipes/15353
> 21:48:27 BIOCONDA ERROR BUILD ERROR: packages with divergent build strings in repository for recipe recipes/afplot. A build number bump is likely needed: ('afplot-0.2.1-py35h24bf2e0_1', 'afplot-0.2.1-py36h24bf2e0_1')