### PR TITLE
Add click dependency for phylotoast

### DIFF
--- a/recipes/phylotoast/meta.yaml
+++ b/recipes/phylotoast/meta.yaml
@@ -29,6 +29,7 @@ requirements:
     - palettable
     - biom-format >=2.1.5
     - h5py
+    - click
 
   run:
     - python

--- a/recipes/phylotoast/meta.yaml
+++ b/recipes/phylotoast/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ hash }}
 
 build:
-  number: 1
+  number: 2
   skip: True  # [not py27]
 
 requirements:
@@ -43,6 +43,7 @@ requirements:
     - palettable
     - biom-format >=2.1.5
     - h5py
+    - click
 
 test:
   imports:


### PR DESCRIPTION
* [ ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Should fix the following error:
```
RuntimeError: Setuptools downloading is disabled in conda build. Be sure to add all dependencies in the meta.yaml  url=https://pypi.org/simple/click/
```