### PR TITLE
Fix rust-overlaps using the same fix from rust-bio-tools

### DIFF
--- a/build-fail-blacklist
+++ b/build-fail-blacklist
@@ -32,7 +32,10 @@ recipes/r-pscbs/0.61.0
 recipes/openslide
 
 # warning: spurious network error (1 tries remaining): [12/-2] [77] Problem with the SSL CA cert (path? access rights?) (error setting certificate verify locations:
-recipes/rust-overlaps
+# also failing due to a missing trait bound: the trait `rand::distributions::Distribution<N>` is not implemented for `rand::distributions::Standard`
+#   |
+#   = help: consider adding a `where rand::distributions::Standard: rand::distributions::Distribution<N>` bound
+#   = note: required by `rand::random`
 recipes/prosic
 
 # ./configure no such file or directory

--- a/recipes/rust-overlaps/build.sh
+++ b/recipes/rust-overlaps/build.sh
@@ -1,4 +1,9 @@
 #!/bin/bash -e
 
+# circumvent a bug in conda-build >=2.1.18,<3.0.10
+# https://github.com/conda/conda-build/issues/2255
+[[ -z $REQUESTS_CA_BUNDLE && ${REQUESTS_CA_BUNDLE+x} ]] && unset REQUESTS_CA_BUNDLE
+[[ -z $SSL_CERT_FILE && ${SSL_CERT_FILE+x} ]] && unset SSL_CERT_FILE
+
 # build statically linked binary with Rust
 C_INCLUDE_PATH=$PREFIX/include LIBRARY_PATH=$PREFIX/lib cargo install --root $PREFIX

--- a/recipes/rust-overlaps/meta.yaml
+++ b/recipes/rust-overlaps/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{version}}
 
 build:
-  number: 2
+  number: 3
   skip: True # [osx]
 
 source:


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Removes `rust-overlaps` from the blacklist, using the same fix from `rust-bio-tools`.