### PR TITLE
FastQC: Update the openjdk dependency.

### DIFF
--- a/recipes/fastqc/meta.yaml
+++ b/recipes/fastqc/meta.yaml
@@ -14,7 +14,7 @@ source:
 
 build:
   detect_binary_files_with_prefix: true
-  number: 3
+  number: 4
 
 requirements:
   run:
@@ -22,7 +22,7 @@ requirements:
     # it comes from the conda-forge channel and not default.
     # Many yaks were shaved to bring us this information.
     # Version number reference: https://github.com/conda/conda/issues/6948#issuecomment-369360906
-    - openjdk >8.0.121
+    - openjdk >=8.0.122
     - perl
 
 test:


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

The "defaults" build was bumped, leading to the defaults version of openjdk be installed, instead of the conda-forge one.  See #5026. To prevent the next build bump causing this issue again, increment the minimum version by one.