### PR TITLE
Update to fastp v0.17.1

### DIFF
--- a/recipes/fastp/meta.yaml
+++ b/recipes/fastp/meta.yaml
@@ -1,4 +1,4 @@
-{% set version="0.17.0" %}
+{% set version="0.17.1" %}
 
 package:
   name: fastp
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/OpenGene/fastp/archive/v{{ version }}.tar.gz
-  sha256: 06e1dfbc1c1def39ce6548e28dea51add46355bdc904b7fe1c3d5de1f71355aa
+  sha256: 11efb24f18fc1498ddcc82e6ed5b4b51a7b11ffa47d089b7e12dc6bf721cbb2b
   patches:
     - Makefile.patch
 


### PR DESCRIPTION
The old version v0.17.0 has a small bug in the HTML report. I fixed it several days ago and released v0.17.1

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
