### PR TITLE
genomeinfodbdata: use https for download

### DIFF
--- a/recipes/bioconductor-genomeinfodbdata/meta.yaml
+++ b/recipes/bioconductor-genomeinfodbdata/meta.yaml
@@ -7,11 +7,11 @@ package:
   version: '{{ version }}'
 source:
   url:
-    - 'http://bioconductor.org/packages/{{ bioc }}/data/annotation/src/contrib/{{ name }}_{{ version }}.tar.gz'
+    - 'https://bioconductor.org/packages/{{ bioc }}/data/annotation/src/contrib/{{ name }}_{{ version }}.tar.gz'
     - 'https://depot.galaxyproject.org/software/bioconductor-{{ name|lower }}/bioconductor-{{ name|lower }}_{{ version }}_src_all.tar.gz'
   sha256: d7bb73db4a76960e65c5f6d8ccdcb9480a48cea529a30ea2399f8e4c9887e876
 build:
-  number: 2
+  number: 3
   rpaths:
     - lib/R/lib/
     - lib/
@@ -25,6 +25,6 @@ test:
   commands:
     - '$R -e "library(''{{ name }}'')"'
 about:
-  home: 'http://bioconductor.org/packages/{{ bioc }}/data/annotation/html/{{ name }}.html'
+  home: 'https://bioconductor.org/packages/{{ bioc }}/data/annotation/html/{{ name }}.html'
   license: Artistic-2.0
   summary: 'Files for mapping between NCBI taxonomy ID and species. Used by functions in the GenomeInfoDb package.'

--- a/recipes/bioconductor-genomeinfodbdata/post-link.sh
+++ b/recipes/bioconductor-genomeinfodbdata/post-link.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 FN="GenomeInfoDbData_1.0.0.tar.gz"
 URLS=(
-  "http://bioconductor.org/packages/3.6/data/annotation/src/contrib/GenomeInfoDbData_1.0.0.tar.gz"
+  "https://bioconductor.org/packages/3.6/data/annotation/src/contrib/GenomeInfoDbData_1.0.0.tar.gz"
   "https://depot.galaxyproject.org/software/bioconductor-genomeinfodbdata/bioconductor-genomeinfodbdata_1.0.0_src_all.tar.gz"
 )
 MD5="3926f72117c49fbee36ab8e9c0b34885"


### PR DESCRIPTION
* [ ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

The specific reason I care about this is that my cluster environment seems to block the tcp port 80 (plain http) but allows 443/https.

While that reason may not be widely applicable, using https is a generally good idea and I see very few downsides to this change.