### PR TITLE
Add perl Bio::FeatureIO requirement

### DIFF
--- a/recipes/jbrowse/meta.yaml
+++ b/recipes/jbrowse/meta.yaml
@@ -2,7 +2,7 @@ package:
   name: jbrowse
   version: "1.12.5"
 build:
-  number: 1
+  number: 2
   skip: True # [osx]
 source:
   sha256: 5ec3d5c6978a1e10b4126e4a09e711c6275e4d9bb5f5597a09c535b8124a2c78
@@ -44,6 +44,7 @@ requirements:
     - perl-heap-simple
     - perl-text-tabs-wrap
     - perl-db-file
+    - perl-bio-featureio
 
 test:
   commands:


### PR DESCRIPTION
JBrowse's Bio::JBrowse::Cmd::FlatFileToJson uses Bio::FeatureIO, but this is not on the requirements list. This update adds the requirement and bumps the build version.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
