### PR TITLE
Update: MultiQC, MultiQC-bcbio, Sentieon

### DIFF
--- a/recipes/multiqc-bcbio/meta.yaml
+++ b/recipes/multiqc-bcbio/meta.yaml
@@ -1,4 +1,4 @@
-{% set tag="d46ec9e" %}
+{% set tag="5fbec8c" %}
 
 package:
   name: multiqc-bcbio
@@ -6,11 +6,11 @@ package:
 
 source:
   url: https://github.com/MultiQC/MultiQC_bcbio/archive/{{ tag }}.tar.gz
-  md5: 95360f67a123fe70f68379a1d8569b13
+  md5: 8a8d90d8e3350a621db3ee79ca209d8c
 
 build:
   noarch: python
-  number: 1
+  number: 2
   preserve_egg_dir: True
 
 requirements:

--- a/recipes/multiqc/meta.yaml
+++ b/recipes/multiqc/meta.yaml
@@ -4,12 +4,12 @@ package:
 
 source:
   #url: https://github.com/ewels/MultiQC/archive/49aa22a.tar.gz
-  # Use branch with fix for peddy plot issues with unknown sex check
-  url: https://github.com/chapmanb/MultiQC/archive/51cb819.tar.gz
-  sha256: ea4b09d431e541b2b1a68d46cffdee8b5405e9425a5e64b08ff48f3d03bd8b19
+  # Use development with fixes for peddy
+  url: https://github.com/chapmanb/MultiQC/archive/ae7864f.tar.gz
+  sha256: 13328c9a921d2df822f6a01712b539eb41ee5a1edd2f4ade0198340592d36b7d
 
 build:
-  number: 1
+  number: 2
   preserve_egg_dir: True
 
 requirements:

--- a/recipes/sentieon/meta.yaml
+++ b/recipes/sentieon/meta.yaml
@@ -15,7 +15,7 @@ source:
     - bwa_symlinks.patch
 
 build:
-  number: 0
+  number: 1
   # Currently failing on OSX when copying and fixing shared libraries
   # included with sentieon package. I don't understand problem:
   # https://travis-ci.org/bioconda/bioconda-recipes/jobs/141822657


### PR DESCRIPTION
- MultiQC: fixes for peddy QC table display
- MultiQC-bcbio: improve display of viral QC with no hits
- Sentieon: bump sub-version to force build #9686

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
