### PR TITLE
Fixing scrappie blas dependency

### DIFF
--- a/recipes/scrappie/meta.yaml
+++ b/recipes/scrappie/meta.yaml
@@ -10,7 +10,7 @@ source:
   md5: 7a8b80232942c314d2ec19f8d595b627
 
 build:
-  number: 1
+  number: 2
   skip: True # [py2k or osx]
 
 requirements:

--- a/recipes/scrappie/meta.yaml
+++ b/recipes/scrappie/meta.yaml
@@ -10,7 +10,7 @@ source:
   md5: 7a8b80232942c314d2ec19f8d595b627
 
 build:
-  number: 2
+  number: 3
   skip: True # [py2k or osx]
 
 requirements:
@@ -25,7 +25,7 @@ requirements:
     - zlib
     - hdf5
     - cunit
-    - blas
+    - openblas
 
   run:
     - python
@@ -34,7 +34,7 @@ requirements:
     - zlib
     - hdf5
     - cunit
-    - blas
+    - openblas
 
 test:
   commands:

--- a/recipes/scrappie/meta.yaml
+++ b/recipes/scrappie/meta.yaml
@@ -10,7 +10,7 @@ source:
   md5: 7a8b80232942c314d2ec19f8d595b627
 
 build:
-  number: 3
+  number: 2
   skip: True # [py2k or osx]
 
 requirements:


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

The previous recipe had an issue. It listed 'blas' as a dependency which should be 'openblas'. Apparently, that passed the testing the previous time? I reran the test today and now it failed. I replaced 'blas' with 'openblas', which seems to solve the issue.

See also https://github.com/nanoporetech/scrappie/issues/19