### PR TITLE
Update upstream tarball url and remove Augustus from blacklist

### DIFF
--- a/build-fail-blacklist
+++ b/build-fail-blacklist
@@ -1585,8 +1585,6 @@ recipes/abyss
 recipes/abyss/1.9.0
 recipes/abyss/1.5.2
 recipes/abyss/1.5.2
-# missing URL
-recipes/augustus
 
 # boost errors
 recipes/alfred/0.1.5

--- a/recipes/augustus/meta.yaml
+++ b/recipes/augustus/meta.yaml
@@ -41,6 +41,7 @@ requirements:
     - perl
     - perl-app-cpanminus
     - perl-module-build
+    - perl-statistics-r
     - perl-yaml
     - perl-dbi
     - perl-scalar-list-utils

--- a/recipes/augustus/meta.yaml
+++ b/recipes/augustus/meta.yaml
@@ -117,6 +117,7 @@ test:
     - utrgff2gbrowse.pl --help
     - wigchoose.pl --help
     - writeResultsPage.pl --help 2>&1 | grep "writeResultsPage ID species-name db-file grails-out www-out AugustusConfigPath AugustusScriptsPath final-flag"
+    - yaml2gff.1.4.pl --help 2>&1
     - yaml2gff.1.4.pl --help 2>&1 | grep "< scipio.yaml > scipio.gff"
 
 about:

--- a/recipes/augustus/meta.yaml
+++ b/recipes/augustus/meta.yaml
@@ -20,7 +20,7 @@ build:
 
 requirements:
   build:
-    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
   host:
     - zlib
     - bamtools

--- a/recipes/augustus/meta.yaml
+++ b/recipes/augustus/meta.yaml
@@ -7,7 +7,7 @@ package:
   version: {{ version }}
 
 source:
-  url: http://bioinf.uni-greifswald.de/augustus/binaries/{{ name }}-{{ version }}.tar.gz
+  url: http://bioinf.uni-greifswald.de/augustus/binaries/old/{{ name }}-{{ version }}.tar.gz
   sha256: {{ sha256 }}
   patches:
     - patches/bam2hints.Makefile.patch


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

The author doesn't seem to have a stable url to the most recent release; moving the tarballs to a directory called "old" after an updated version is released, so this was causing a break during build. Fixed the path here, and will then update to the newest version once the blacklist is cleared.