### PR TITLE
Specify python 2.7 in dexseq meta.yaml

### DIFF
--- a/recipes/bioconductor-dexseq/meta.yaml
+++ b/recipes/bioconductor-dexseq/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: 2db4e0ef43c0d14b4a08fcd012474cea3b6680982501cba84e5b41e7c4b7bc63
 build:
   noarch: python
-  number: 2
+  number: 3
   rpaths:
     - lib/R/lib/
     - lib/
@@ -36,7 +36,7 @@ requirements:
     - r-rcolorbrewer
     - r-statmod
     - r-stringr
-    - python
+    - python 2.7*
   run:
     - bioconductor-annotationdbi
     - bioconductor-biobase
@@ -56,7 +56,7 @@ requirements:
     - r-rcolorbrewer
     - r-statmod
     - r-stringr
-    - python
+    - python 2.7*
 test:
   commands:
     - '$R -e "library(''{{ name }}'')"'


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Proposing to specify python 2.7 in dexseq as otherwise the count reads mode can fail with python 3 with an error like:
`
Fatal error: Exit code 1 () Traceback (most recent call last): File "/usr/local/tools/_conda/envs/mulled-v1-683dc60555985982bcd77839627baa1ef503a6a15fb8cf27f5b492bbedd69ac4/bin/dexseq_count.py", line 98, in <module> features[f.iv] += f File "python3/src/HTSeq/_HTSeq.pyx", line 451, in HTSeq._HTSeq.ChromVector.__iadd__ File "python3/src/HTSeq/_HTSeq.pyx", line 466, in HTSeq._HTSeq.ChromVector.apply File "python3/src/HTSeq/_HTSeq.pyx", line 449, in HTSeq._HTSeq.ChromVector.__iadd__.addval TypeError: unhashable type: 'GenomicFeature'
`

See also here: https://support.bioconductor.org/p/106685/