### PR TITLE
Update: octopus, fix gcc 7.2; bcbio, ensemble support

### DIFF
--- a/build-fail-blacklist
+++ b/build-fail-blacklist
@@ -1879,8 +1879,6 @@ recipes/libbigwig
 recipes/prophyle/0.2.1
 
 # no clue
-recipes/octopus
-
 recipes/portcullis/1.1.1
 recipes/portcullis/1.1.0
 

--- a/recipes/bcbio-nextgen/meta.yaml
+++ b/recipes/bcbio-nextgen/meta.yaml
@@ -3,13 +3,13 @@ package:
   version: '1.1.1a'
 
 build:
-  number: 0
+  number: 1
   skip: true # [not py27]
 
 source:
   #url: https://pypi.io/packages/source/b/bcbio-nextgen/bcbio-nextgen-1.1.0.tar.gz
-  url: https://github.com/bcbio/bcbio-nextgen/archive/cfd2a50.tar.gz
-  sha256: 3feeee8743d960e90a10e97056548d3aead0afc4fde1e5cbd428ba822904ffbc
+  url: https://github.com/bcbio/bcbio-nextgen/archive/affe63d.tar.gz
+  sha256: c3c53d7e3accfb2ee65d76468631dd6862cf7db16d0fbefe850d03a3a52140c7
 
 requirements:
   host:

--- a/recipes/octopus/build.sh
+++ b/recipes/octopus/build.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -eu -o pipefail
 
-cd build
 # BOOST -- need up to date version compiled with gcc 7.2
+cd build
 wget http://dl.bintray.com/boostorg/release/1.65.0/source/boost_1_65_0.tar.gz
 tar -xzpf boost_1_65_0.tar.gz
 cd boost_1_65_0
@@ -20,7 +20,9 @@ EOF
   toolset=gcc \
   cxxflags="${CXXFLAGS}" \
   install
-cd ..
+cd ../..
+
 # octopus
+cd build
 cmake  -DINSTALL_PREFIX=ON -DCMAKE_INSTALL_PREFIX=$PREFIX -DINSTALL_ROOT=ON -DCMAKE_BUILD_TYPE=Release ..
 make install

--- a/recipes/octopus/conda_build_config.yaml
+++ b/recipes/octopus/conda_build_config.yaml
@@ -1,0 +1,6 @@
+c_compiler:
+  - gcc      # [linux]
+  - clang    # [osx]
+cxx_compiler:
+  - gxx      # [linux]
+  - clangxx  # [osx]

--- a/recipes/octopus/meta.yaml
+++ b/recipes/octopus/meta.yaml
@@ -19,8 +19,10 @@ source:
 requirements:
   build:
     - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
     - cmake
   host:
+    #- boost
     - htslib
     - wget
     - icu
@@ -28,6 +30,7 @@ requirements:
     - xz
     - zlib
   run:
+    #- boost
     - htslib
     - icu
     - bzip2


### PR DESCRIPTION
- octopus: Re-enable builds using gcc 7.2, removing from blacklist.
  Thanks to tips from #9904. Still uses custom boost build until
  conda-forge boost available with 7.2 support.
- bcbio: latest development version with CWL ensemble support

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
