### PR TITLE
Initial recipe for pdb2pqr

### DIFF
--- a/recipes/pdb2pqr/build.sh
+++ b/recipes/pdb2pqr/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+mkdir -p $PREFIX/pdb2pqr
+mkdir -p $PREFIX/bin
+$PYTHON scons/scons.py PREFIX=$PREFIX/pdb2pqr
+$PYTHON scons/scons.py install PREFIX=$PREFIX/pdb2pqr
+mv $PREFIX/pdb2pqr/pdb2pqr.py  $PREFIX/pdb2pqr/pdb2pqr.py.tmp
+echo '#! /usr/bin/env python' > $PREFIX/pdb2pqr/pdb2pqr.py
+tail -n +2 $PREFIX/pdb2pqr/pdb2pqr.py.tmp >> $PREFIX/pdb2pqr/pdb2pqr.py
+chmod 0766 $PREFIX/pdb2pqr/pdb2pqr.py
+ln -s $PREFIX/pdb2pqr/pdb2pqr.py $PREFIX/bin/pdb2pqr

--- a/recipes/pdb2pqr/conda_build_config.yaml
+++ b/recipes/pdb2pqr/conda_build_config.yaml
@@ -1,0 +1,6 @@
+c_compiler:
+  - gcc      # [linux]
+  - clang    # [osx]
+cxx_compiler:
+  - gxx      # [linux]
+  - clangxx  # [osx]

--- a/recipes/pdb2pqr/meta.yaml
+++ b/recipes/pdb2pqr/meta.yaml
@@ -20,7 +20,7 @@ requirements:
   run:
     - python
     - numpy
-    -zlib
+    - zlib
 
 test:
   commands:

--- a/recipes/pdb2pqr/meta.yaml
+++ b/recipes/pdb2pqr/meta.yaml
@@ -1,0 +1,31 @@
+package:
+  name: pdb2pqr
+  version: "2.1.1"
+
+source:
+  fn: pdb2pqr-src-2.1.1.tar.gz
+  url: https://github.com/Electrostatics/apbs-pdb2pqr/releases/download/pdb2pqr-2.1.1_release/pdb2pqr-src-2.1.1.tar.gz
+  md5: 266dd7614de4adb0981d50471d38083a
+
+build:
+  skip: True  # [not py27]
+  number: 0
+
+requirements:
+  build:
+    - python
+    - numpy
+
+  run:
+    - python
+    - numpy
+
+test:
+  commands:
+    - pdb2pqr --version
+
+about:
+  home: 
+  license: MIT
+  summary: 'Prepare PDB structures for continuum solvation calculations'
+  license_family: MIT

--- a/recipes/pdb2pqr/meta.yaml
+++ b/recipes/pdb2pqr/meta.yaml
@@ -11,12 +11,16 @@ build:
   number: 0
 
 requirements:
+  build:
+    - {{ compiler('cxx') }}
   host:
     - python
     - numpy
+    - zlib
   run:
     - python
     - numpy
+    -zlib
 
 test:
   commands:

--- a/recipes/pdb2pqr/meta.yaml
+++ b/recipes/pdb2pqr/meta.yaml
@@ -3,7 +3,6 @@ package:
   version: "2.1.1"
 
 source:
-  fn: pdb2pqr-src-2.1.1.tar.gz
   url: https://github.com/Electrostatics/apbs-pdb2pqr/releases/download/pdb2pqr-2.1.1_release/pdb2pqr-src-2.1.1.tar.gz
   md5: 266dd7614de4adb0981d50471d38083a
 

--- a/recipes/pdb2pqr/meta.yaml
+++ b/recipes/pdb2pqr/meta.yaml
@@ -25,7 +25,7 @@ test:
     - pdb2pqr --version
 
 about:
-  home: 
+  home: 'https://github.com/Electrostatics/apbs-pdb2pqr/tree/master/pdb2pqr'
   license: MIT
   summary: 'Prepare PDB structures for continuum solvation calculations'
   license_family: MIT

--- a/recipes/pdb2pqr/meta.yaml
+++ b/recipes/pdb2pqr/meta.yaml
@@ -11,10 +11,9 @@ build:
   number: 0
 
 requirements:
-  build:
+  host:
     - python
     - numpy
-
   run:
     - python
     - numpy


### PR DESCRIPTION
PDB2PQR is a Python software package that automates many of the common
tasks of preparing structures for continuum electrostatics
calculations, providing a platform-independent utility for converting
protein files in PDB format to PQR format.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [x] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
