### PR TITLE
Patches setup.py to support older architectures

### DIFF
--- a/recipes/moods/build.sh
+++ b/recipes/moods/build.sh
@@ -1,2 +1,17 @@
 #!/bin/bash
+cat >setup_compile.patch << EOF
+--- setup.py    2018-07-18 09:44:45.000000000 -0700
++++ new_setup.py    2018-07-18 09:46:32.000000000 -0700
+@@ -7,7 +7,7 @@
+ from distutils.core import setup, Extension
+ 
+ common_includes = ["core/"]
+-common_compile_args = ['-march=native', '-O3', '-fPIC', '--std=c++11']
++common_compile_args = ['-mtune=generic', '-O3', '-fPIC', '--std=c++11']
+ 
+ 
+ tools_mod = Extension('MOODS._tools',
+EOF
+patch setup.py setup_compile.patch
+rm setup_compile.patch
 $PYTHON setup.py install --record=record.txt


### PR DESCRIPTION
* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

MOODS is currently compiled with '-march=native', using specialized instructions that break compatibility on older architectures.  In particular, the package supplied by bioconda was built on Haswell (AVX2), meaning that machines older than about 2013 can't use the bioconda-provided package.

This PR patches the setup.py script from MOODS to replace the native architecture instruction with a backcompatible one, to produce a widely distributable package.

I have also submitted a PR to MOODS (https://github.com/jhkorhonen/MOODS/pull/20/files) but there's been no activity there in over a year.