### PR TITLE
Update RGI recipe to fix dependency problems

### DIFF
--- a/recipes/rgi/meta.yaml
+++ b/recipes/rgi/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   skip: True # [not py27]
-  number: 1
+  number: 2
 
 requirements:
   build:

--- a/recipes/rgi/meta.yaml
+++ b/recipes/rgi/meta.yaml
@@ -22,17 +22,18 @@ requirements:
     - python
     - setuptools
     - biopython
-    - six >=1.7.0
+    - six ==1.7.0
     - zlib
   run:
+    # RGI requires these exact versions of blast prodigal and diamond, or else --alignment_mode DIAMOND fails
     - python
     - filetype
-    - blast
+    - blast ==2.6.0
     - biopython
     - six >=1.7.0
     - zlib
-    - prodigal
-    - diamond >=0.8.24.86
+    - prodigal ==2.6.3
+    - diamond ==0.8.36
 
 test:
   commands:

--- a/recipes/rgi/meta.yaml
+++ b/recipes/rgi/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - python
     - setuptools
     - biopython
-    - six ==1.7.0
+    - six >=1.7.0
     - zlib
   run:
     # RGI requires these exact versions of blast prodigal and diamond, or else --alignment_mode DIAMOND fails


### PR DESCRIPTION
* [ ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Though my own testing, I found that using a newer version of blast like 2.7.1, or a newer version of diamond like 9.2.2 will break RGI version 4.0.3 when running resistance gene detection using the `--alignment_mode DIAMOND` flag of `rgi main`

These exact matches should fix the aforementioned dependency issues.
