### PR TITLE
Update openmpi to version 3.x

### DIFF
--- a/recipes/phyml/meta.yaml
+++ b/recipes/phyml/meta.yaml
@@ -24,10 +24,10 @@ requirements:
     - autoconf
     - automake
     - pkg-config
-    - openmpi 2.*
+    - openmpi 3.*
     - beagle-lib
   run:
-    - openmpi 2.*
+    - openmpi 3.*
     - beagle-lib
 test:
   requirements:


### PR DESCRIPTION
Update openmpi to version 3.x since all 2.x versions are marked as `old_feature_broken`.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
