### PR TITLE
Enable python3.6 build

### DIFF
--- a/recipes/rgi/meta.yaml
+++ b/recipes/rgi/meta.yaml
@@ -12,8 +12,8 @@ source:
 
 
 build:
-  skip: True # [not py27]
-  number: 2
+  skip: True # [win]
+  number: 3
 
 requirements:
   build:


### PR DESCRIPTION
This recipe should not skip py36, as version 4.0.3 of RGI primarily supports Python3. This change will enable rgi to work in Python3 environments.

* [ ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
