### PR TITLE
Bump JBrowse version to 1.15.0

### DIFF
--- a/recipes/jbrowse/meta.yaml
+++ b/recipes/jbrowse/meta.yaml
@@ -1,12 +1,12 @@
+{% set version = "1.15.0" %}
 package:
   name: jbrowse
-  version: "1.12.5"
+  version: {{ version }}
 build:
-  number: 2
-  skip: True # [osx]
+  number: 0
 source:
-  sha256: 5ec3d5c6978a1e10b4126e4a09e711c6275e4d9bb5f5597a09c535b8124a2c78
-  url: https://github.com/GMOD/jbrowse/releases/download/1.12.5-release/JBrowse-1.12.5.zip
+  sha256: 96114b4c09462c7a3fcdd01021a1408b345da135b046913ff15482a895bfc104
+  url: https://github.com/GMOD/jbrowse/releases/download/{{ version }}-release/JBrowse-{{ version }}.zip
 
 requirements:
   build:
@@ -45,12 +45,13 @@ requirements:
     - perl-text-tabs-wrap
     - perl-db-file
     - perl-bio-featureio
+    - perl-io-uncompress-gunzip
 
 test:
   commands:
     - command -v add-json.pl
 about:
-  home: http://jbrowse.org/
+  home: https://jbrowse.org/
   license: LGPL
   summary: The JBrowse Genome Browser
 


### PR DESCRIPTION
Note that Perl module dependencies in general seem to be in a temporary state of disarray due to the Perl version mismatch issue articulated in https://github.com/bioconda/bioconda-recipes/issues/10100, though I assume this will be resolved in the future. 

* [X ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
