### PR TITLE
Jcvi is python 2 only

### DIFF
--- a/recipes/jcvi/meta.yaml
+++ b/recipes/jcvi/meta.yaml
@@ -14,7 +14,7 @@ source:
 
 build:
   number: 1
-  skip: True  # [py27]
+  skip: True  # [not py27]
   script: python setup.py install --single-version-externally-managed --record=record.txt
 
 requirements:

--- a/recipes/jcvi/meta.yaml
+++ b/recipes/jcvi/meta.yaml
@@ -13,7 +13,8 @@ source:
   '{{ hash_type }}': '{{ hash_value }}'
 
 build:
-  number: 0
+  number: 1
+  skip: True  # [py27]
   script: python setup.py install --single-version-externally-managed --record=record.txt
 
 requirements:


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

It turns out JCVI module (from #10152) is python 2.7 only...
Does anybody need to delete the 0 build for python 3 on anaconda.org? It is broken