### PR TITLE
Fasttreecondbuild3

### DIFF
--- a/build-fail-blacklist
+++ b/build-fail-blacklist
@@ -1513,9 +1513,6 @@ recipes/discovar-denovo
 recipes/blast/2.2.21
 recipes/blast-legacy/2.2.22
 
-# clang: error: no such file or directory: 'FastTree.c'
-recipes/fasttree
-
 # seqan errors
 recipes/bowtie/1.0.0
 

--- a/recipes/fasttree/2.1.3/build.sh
+++ b/recipes/fasttree/2.1.3/build.sh
@@ -1,8 +1,17 @@
 #!/bin/bash
 
-gcc -O3 -DUSE_DOUBLE -finline-functions -funroll-loops -Wall -o FastTree FastTree.c -lm
-gcc -DOPENMP -fopenmp -O3 -finline-functions -funroll-loops -Wall -o FastTreeMP FastTree.c -lm
 
 mkdir -p $PREFIX/bin
-cp FastTree $PREFIX/bin
-cp FastTreeMP $PREFIX/bin
+
+# build FastTree
+gcc -O3 -DUSE_DOUBLE -finline-functions -funroll-loops -Wall -o FastTree $SRC_DIR/FastTree-2.1.3.c -lm
+chmod +x FastTree
+cp ./FastTree $PREFIX/bin/fasttree
+
+
+# Build FastTreeMP on Linux
+if [ "$(uname)" == "Linux" ]; then
+    gcc -DOPENMP -fopenmp -O3 -DUSE_DOUBLE -finline-functions -funroll-loops -Wall -o FastTreeMP $SRC_DIR/FastTree-2.1.3.c -lm
+    chmod +x FastTreeMP
+    mv -v ./FastTree* $PREFIX/bin
+fi

--- a/recipes/fasttree/2.1.3/build.sh
+++ b/recipes/fasttree/2.1.3/build.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-
 mkdir -p $PREFIX/bin
 
 # build FastTree

--- a/recipes/fasttree/2.1.3/meta.yaml
+++ b/recipes/fasttree/2.1.3/meta.yaml
@@ -7,7 +7,7 @@ source:
   md5: "a204fbe70bf9e787509b9433ec371892"
 
 build:
-  number: 1
+  number: 2
   skip: True # [osx]
 
 requirements:

--- a/recipes/fasttree/2.1.8/build.sh
+++ b/recipes/fasttree/2.1.8/build.sh
@@ -1,11 +1,17 @@
 #!/bin/bash
 
-gcc -O3 -DUSE_DOUBLE -finline-functions -funroll-loops -Wall -o FastTree FastTree.c -lm
-gcc -DOPENMP -fopenmp -O3 -finline-functions -funroll-loops -Wall -o FastTreeMP FastTree.c -lm
 
 mkdir -p $PREFIX/bin
-cp FastTree $PREFIX/bin
-cp FastTreeMP $PREFIX/bin
 
-#gcc -DNO_SSE -O3 -finline-functions -funroll-loops -Wall -o FastTree FastTree.c -lm
-#gcc -DNO_SSE -O3 -funroll-loops -Wall -o FastTree FastTree.c -lm
+# build FastTree
+gcc -O3 -DUSE_DOUBLE -finline-functions -funroll-loops -Wall -o FastTree $SRC_DIR/FastTree-2.1.8.c -lm
+chmod +x FastTree
+cp ./FastTree $PREFIX/bin/fasttree
+
+
+# Build FastTreeMP on Linux
+if [ "$(uname)" == "Linux" ]; then
+    gcc -DOPENMP -fopenmp -O3 -DUSE_DOUBLE -finline-functions -funroll-loops -Wall -o FastTreeMP $SRC_DIR/FastTree-2.1.8.c -lm
+    chmod +x FastTreeMP
+    mv -v ./FastTree* $PREFIX/bin
+fi

--- a/recipes/fasttree/2.1.8/meta.yaml
+++ b/recipes/fasttree/2.1.8/meta.yaml
@@ -12,7 +12,7 @@ build:
 
 test:
   commands:
-    - FastTree | cat
+    - FastTree -help
 
 about:
   home: http://www.microbesonline.org/fasttree/

--- a/recipes/fasttree/2.1.8/meta.yaml
+++ b/recipes/fasttree/2.1.8/meta.yaml
@@ -7,7 +7,7 @@ source:
   md5: "c7e85689a26cabba241378d4f633c2fa"
 
 build:
-  number: 3
+  number: 4
   skip: True # [osx]
 
 test:

--- a/recipes/fasttree/build.sh
+++ b/recipes/fasttree/build.sh
@@ -1,11 +1,17 @@
 #!/bin/bash
 
-gcc -O3 -DUSE_DOUBLE -finline-functions -funroll-loops -Wall -o FastTree FastTree.c -lm
-gcc -DOPENMP -fopenmp -O3 -DUSE_DOUBLE -finline-functions -funroll-loops -Wall -o FastTreeMP FastTree.c -lm
 
 mkdir -p $PREFIX/bin
-chmod +x FastTree
-chmod +x FastTreeMP
 
+# build FastTree
+gcc -O3 -DUSE_DOUBLE -finline-functions -funroll-loops -Wall -o FastTree $SRC_DIR/FastTree-2.1.10.c -lm
+chmod +x FastTree
 cp ./FastTree $PREFIX/bin/fasttree
-mv -v ./FastTree* $PREFIX/bin
+
+
+# Build FastTreeMP on Linux
+if [ "$(uname)" == "Linux" ]; then
+    gcc -DOPENMP -fopenmp -O3 -DUSE_DOUBLE -finline-functions -funroll-loops -Wall -o FastTreeMP $SRC_DIR/FastTree-2.1.10.c -lm
+    chmod +x FastTreeMP
+    mv -v ./FastTree* $PREFIX/bin
+fi

--- a/recipes/fasttree/meta.yaml
+++ b/recipes/fasttree/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: "54cb89fc1728a974a59eae7a7ee6309cdd3cddda9a4c55b700a71219fc6e926d"
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:

--- a/recipes/fasttree/meta.yaml
+++ b/recipes/fasttree/meta.yaml
@@ -22,7 +22,6 @@ test:
   commands:
     - fasttree -help
     - FastTree -help
-    - FastTreeMP -help
 
 about:
   home: http://www.microbesonline.org/fasttree/


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Fix FastTree build.

Because FastTree is a single file it gets put into the `SRC_DIR` and we must change the build script accordingly. IN doing so I can see that CLANG will not build FastTreeMP so I moved that into a linux specif portion of the build