### PR TITLE
lumpy: trying to fix skipped build

### DIFF
--- a/recipes/lumpy-sv/build.sh
+++ b/recipes/lumpy-sv/build.sh
@@ -1,18 +1,21 @@
 #!/bin/bash
 set -eu -o pipefail
 
-export CPPFLAGS="-I$PREFIX/include"
-export LDFLAGS="-L$PREFIX/lib"
-export C_INCLUDE_PATH=${PREFIX}/include
-export CPLUS_INCLUDE_PATH=${PREFIX}/include
-
 outdir=$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM
 mkdir -p $outdir
 mkdir -p $outdir/scripts
 mkdir -p $outdir/scripts/bamkit
 mkdir -p $PREFIX/bin
 
-make
+make \
+    CC="${CC}" \
+    CXX="${CXX}" \
+    CPPFLAGS="${CPPFLAGS}" \
+    CFLAGS="${CFLAGS}" \
+    CXXFLAGS="${CXXFLAGS}" \
+    LDFLAGS="${LDFLAGS}" \
+    ZLIB_PATH="${PREFIX/lib}"
+
 cp bin/lumpy $PREFIX/bin
 cp bin/lumpy_filter $PREFIX/bin
 cp scripts/lumpyexpress $PREFIX/bin

--- a/recipes/lumpy-sv/build.sh
+++ b/recipes/lumpy-sv/build.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 set -eu -o pipefail
 
+# The project's Makefiles don't use {CPP,C,CXX,LD}FLAGS everywhere.
+# We can try to patch all of those or export the following *_PATH variables.
 export C_INCLUDE_PATH="${PREFIX}/include"
 export CPLUS_INCLUDE_PATH="${PREFIX}/include"
+export LIBRARY_PATH="${PREFIX}/lib"
 
 outdir=$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM
 mkdir -p $outdir

--- a/recipes/lumpy-sv/build.sh
+++ b/recipes/lumpy-sv/build.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -eu -o pipefail
 
+export C_INCLUDE_PATH="${PREFIX}/include"
+export CPLUS_INCLUDE_PATH="${PREFIX}/include"
+
 outdir=$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM
 mkdir -p $outdir
 mkdir -p $outdir/scripts

--- a/recipes/lumpy-sv/build.sh
+++ b/recipes/lumpy-sv/build.sh
@@ -38,6 +38,6 @@ cp scripts/bamkit/* $outdir/scripts/bamkit
 
 cp $RECIPE_DIR/lumpyexpress.config $outdir
 ln -s $outdir/lumpyexpress.config $PREFIX/bin
-ln -s $outdir/extractSplitReads_BwaMem /$PREFIX/bin
+ln -s $outdir/scripts/extractSplitReads_BwaMem $PREFIX/bin
 
 chmod +x $PREFIX/bin/extractSplitReads_BwaMem

--- a/recipes/lumpy-sv/meta.yaml
+++ b/recipes/lumpy-sv/meta.yaml
@@ -1,4 +1,3 @@
-
 package:
   name: lumpy-sv
   version: 0.2.14a
@@ -10,8 +9,7 @@ source:
   #sha256: 1a7a5d18875b297acaa68ee1e864ca048654ebc85348920b518dc689d2b7a3cf
 
 build:
-  number: 3
-  skip: True # [py3k]
+  number: 2
 
 requirements:
   build:
@@ -21,10 +19,9 @@ requirements:
   host:
     - zlib
     - curl
-
   run:
     - zlib
-    - python
+    - python 2.7.*
     - samtools
     - gawk
     - curl


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

The build for gh-10337 gave
```
20:12:37 BIOCONDA INFO Nothing to be done for recipe recipes/lumpy-sv
```
which is not correct of course. Trying to fix it here.
Best guess so far: The run-only `python` requirement picked up `python 3.*` and thus triggered `skip: True # [not py27]`?