### PR TITLE
cromwell uses find during runtime. With a normal conda installation i…

### DIFF
--- a/recipes/cromwell/meta.yaml
+++ b/recipes/cromwell/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 build:
   noarch: python
-  number: 0
+  number: 1
 
 source:
   url: https://github.com/broadinstitute/cromwell/archive/{{ version }}.tar.gz
@@ -21,6 +21,7 @@ requirements:
   run:
     - openjdk >=8
     - python
+    - findutils  
 
 test:
   commands:


### PR DESCRIPTION
…t can fall back on the host installation, but when running in a biocontainer it only has access to the busybox version which lacks some necessary options.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
