### PR TITLE
Remove ngsplot/ngsplotdbs from blacklist

### DIFF
--- a/build-fail-blacklist
+++ b/build-fail-blacklist
@@ -270,10 +270,6 @@ recipes/r-mutoss
 #recipes/r-nanostringnorm
 recipes/r-nastiseq
 recipes/r-ncbit
-recipes/r-ngsplot
-recipes/r-ngsplot-hg19
-recipes/r-ngsplot-hg38
-recipes/r-ngsplot-mm10
 recipes/r-oai
 recipes/r-pamr
 recipes/r-patpro

--- a/recipes/r-ngsplot-hg19/meta.yaml
+++ b/recipes/r-ngsplot-hg19/meta.yaml
@@ -5,6 +5,7 @@ package:
   name: 'r-{{ name|lower }}'
   version: '{{ version }}'
 build:
+  skip: True  # [not py27]
   number: 5
 requirements:
   run:

--- a/recipes/r-ngsplot-hg38/meta.yaml
+++ b/recipes/r-ngsplot-hg38/meta.yaml
@@ -5,6 +5,7 @@ package:
   name: 'r-{{ name|lower }}'
   version: '{{ version }}'
 build: 
+  skip: True  # [not py27]
   number: 5 
 requirements:
   run:

--- a/recipes/r-ngsplot-mm10/meta.yaml
+++ b/recipes/r-ngsplot-mm10/meta.yaml
@@ -5,6 +5,7 @@ package:
   name: 'r-{{ name|lower }}'
   version: '{{ version }}'
 build:
+  skip: True  # [not py27]
   number: 4
 requirements:
   run:

--- a/recipes/r-ngsplot/meta.yaml
+++ b/recipes/r-ngsplot/meta.yaml
@@ -8,7 +8,8 @@ source:
   md5: 811815e5f5ef7bdc1cb028ecd59fb2a7
 
 build:
-  number: 1
+  skip: True  # [not py27]
+  number: 2
   rpaths:
     - lib/R/lib/
     - lib/

--- a/recipes/r-ngsplot/meta.yaml
+++ b/recipes/r-ngsplot/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - bioconductor-rsamtools
     - bioconductor-bsgenome
     - bioconductor-shortread
-    - python <3.0a0
+    - python<3.0a0
 
 test:
   commands:


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [x] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

This removes the ngsplot, ngsplotdb-[hg19,hg38,mm10] recipes from the blacklist. They're all fine, but had a small issue with the installation of the datasets unfortunately, which I fixed in a separate PR yesterday. 