### PR TITLE
new recipe: gffmunger

### DIFF
--- a/recipes/gffmunger/build.sh
+++ b/recipes/gffmunger/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+python3 setup.py install --single-version-externally-managed --record=record.txt

--- a/recipes/gffmunger/meta.yaml
+++ b/recipes/gffmunger/meta.yaml
@@ -1,0 +1,39 @@
+{% set version = "0.0.1" %}
+{% set sha256 = "191eec5285e6a6d85e1cc6fbe5a05954a106d9c969238acef1dc822a5216f131" %}
+
+package:
+  name: gffmunger
+  version: '{{ version }}'
+
+source:
+  url: https://github.com/sanger-pathogens/gffmunger/archive/v{{ version }}.tar.gz
+  sha256: '{{ sha256 }}'
+
+build:
+  number: 0
+  noarch: python
+
+requirements:
+  build:
+    - python >=3.6
+    - biopython >=1.68
+    - gffutils
+    - pyyaml
+  run:
+    - python >=3.6
+    - biopython >=1.68
+    - gffutils
+    - pyyaml
+
+test:
+  imports:
+    - gffmunger
+  commands:
+    - gffmunger --help
+
+about:
+  home: https://github.com/sanger-pathogens/gffmunger
+  license: GPL-3.0
+  license_family: GPL
+  license_file: LICENSE
+  summary: Munges GFF3 files exported from Chado database to make them suitable for loading into WebApollo

--- a/recipes/gffmunger/meta.yaml
+++ b/recipes/gffmunger/meta.yaml
@@ -14,7 +14,7 @@ build:
   noarch: python
 
 requirements:
-  build:
+  host:
     - python >=3.6
     - biopython >=1.68
     - gffutils


### PR DESCRIPTION
@bioconda/core please review my my first pull request, and first receipe

first commit for gffmunger
(Munges GFF3 files exported from Chado database to make them suitable for loading into WebApollo)
recipe shamelessly ripped off from chado-tools with minimal tweaks

* [y ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [y ] This PR adds a new recipe.
* [y ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [n ] This PR updates an existing recipe.
* [n ] This PR does something else (explain below).
