### PR TITLE
Allow vt to build on macOS

### DIFF
--- a/recipes/vt/meta.yaml
+++ b/recipes/vt/meta.yaml
@@ -10,8 +10,7 @@ source:
   sha256: 8f06d464ec5458539cfa30f81a034f47fe7f801146fe8ca80c14a3816b704e17
 
 build:
-  number: 0
-  skip: True # [osx]
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION

 I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [X] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
