### PR TITLE
New: python-intervaltree @ 2.1.0

### DIFF
--- a/recipes/python-intervaltree/build.sh
+++ b/recipes/python-intervaltree/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -vex
+$PYTHON setup.py install --single-version-externally-managed --record=record.txt

--- a/recipes/python-intervaltree/meta.yaml
+++ b/recipes/python-intervaltree/meta.yaml
@@ -1,0 +1,26 @@
+{% set version = "2.1.0" %}
+
+package:
+  name: "python-intervaltree"
+  version: {{ version }}
+source:
+  url: https://files.pythonhosted.org/packages/ca/c1/450d109b70fa58ca9d77972b02f69222412f9175ccf99fdeaf167be9583c/intervaltree-2.1.0.tar.gz
+  sha256: aca5804b88f70cb49050c37b6de59090570f77a75aec1932966cf69f6a48810b
+build:
+  number: 0
+  noarch: python
+requirements:
+  host:
+    - python
+    - setuptools
+  run:
+    - python
+    - python-sortedcontainers
+test:
+  imports:
+    - intervaltree
+about:
+  home: https://pypi.org/project/intervaltree/#description
+  dev_uri: https://github.com/chaimleib/intervaltree
+  license: Apache
+  summary: "Faster than intervaltree_bio"

--- a/recipes/python-sortedcontainers/build.sh
+++ b/recipes/python-sortedcontainers/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -vex
+$PYTHON setup.py install --single-version-externally-managed --record=record.txt

--- a/recipes/python-sortedcontainers/meta.yaml
+++ b/recipes/python-sortedcontainers/meta.yaml
@@ -1,0 +1,25 @@
+{% set version = "2.0.4" %}
+
+package:
+  name: "python-sortedcontainers"
+  version: {{ version }}
+source:
+  url: https://files.pythonhosted.org/packages/94/17/39a70184c2dbdb844db6c58c51cb3c9bc572cc08642646e77f0f1bda143c/sortedcontainers-2.0.4.tar.gz
+  sha256: 607294c6e291a270948420f7ffa1fb3ed47384a4c08db6d1e9c92d08a6981982
+build:
+  number: 0
+  noarch: python
+requirements:
+  host:
+    - python
+    - setuptools
+  run:
+    - python
+test:
+  imports:
+    - sortedcontainers
+about:
+  home: https://pypi.org/project/sortedcontainers/#description
+  dev_uri: http://www.grantjenks.com/docs/sortedcontainers/
+  license: Apache 2.0
+  summary: "sorted collections library, written in pure-Python, and fast as C-extensions"


### PR DESCRIPTION
Actual Python package is called 'intervaltree'. Note that bioconda
already has 'intervaltree_bio'

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [x] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
