### PR TITLE
Version 0.7.4 of BWA

### DIFF
--- a/recipes/bwa/0.7.4/build.sh
+++ b/recipes/bwa/0.7.4/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+export C_INCLUDE_PATH=${PREFIX}/include
+export LIBRARY_PATH=${PREFIX}/lib
+
+make
+mkdir -p $PREFIX/bin
+cp bwa $PREFIX/bin

--- a/recipes/bwa/0.7.4/meta.yaml
+++ b/recipes/bwa/0.7.4/meta.yaml
@@ -1,0 +1,34 @@
+{% set version = "0.7.4" %}
+{% set sha256 = "58b4e5934b0de9fb432b4513f327ff9a1df86f6abfe9fe14f1a25ffbeb347b20" %}
+
+package:
+  name: bwa
+  version: {{ version }}
+
+build:
+  number: 0
+
+source:
+  url: http://downloads.sourceforge.net/project/bio-bwa/bwa-{{ version }}.tar.bz2
+  sha256: {{ sha256 }}
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+  host:
+    - zlib
+  run:
+    - zlib
+
+test:
+  commands:
+    - bwa 2>&1 | grep "index sequences in the"
+
+about:
+  home: http://bio-bwa.sourceforge.net
+  license: MIT
+  summary: The BWA read mapper.
+
+extra:
+  identifiers:
+    - biotools:bwa


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.

Hello @bioconda/core, I have updated BWA to include version 0.7.4. This version is used heavily for McClintock a TE finding software https://github.com/bergmanlab/mcclintock . This update should allow us to be able to more easily create environments for mcClintlock. 

I modified the current recipe in BWA to include the new version and abided by the best practices as outlined by the bioconda guides. 

Best,
Pablo Mendieat 
