### PR TITLE
Recipe for das_tool 1.1.0

### DIFF
--- a/recipes/das_tool/build.sh
+++ b/recipes/das_tool/build.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# install DAStool R package
+R CMD INSTALL "$PREFIX/package/${PKG_NAME}_${PKG_VERSION}.tar.gz"
+
+# unzip SCG marker database
+unzip db.zip
+
+# install DAS_Tool
+DESTDIR=$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM
+mkdir -p $DESTDIR
+cp DAS_Tool $DESTDIR
+cp -r src db $DESTDIR
+chmod +x $DESTDIR/DAS_Tool
+
+ln -s $DESTDIR/DAS_Tool $PREFIX/bin/

--- a/recipes/das_tool/meta.yaml
+++ b/recipes/das_tool/meta.yaml
@@ -7,7 +7,6 @@ package:
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
   url: https://github.com/cmks/{{ name }}/archive/{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
@@ -26,6 +25,7 @@ requirements:
     - pullseq >=1.0.2
     - prodigal >=2.6.3
     - blast >=2.5.0
+    # - diamond >=0.9.22
 
   run:
     - codeutils  # [osx]
@@ -37,6 +37,7 @@ requirements:
     - pullseq >=1.0.2
     - prodigal >=2.6.3
     - blast >=2.5.0
+    # - diamond >=0.9.22
 
 test:
   commands:

--- a/recipes/das_tool/meta.yaml
+++ b/recipes/das_tool/meta.yaml
@@ -1,0 +1,62 @@
+{% set name = "DAS_Tool" %}
+{% set version = "1.1.0" %}
+{% set sha256 = "59cfc8085332397d3a56b78c1345f1f5224a6f0683db915cfe730d846261488d" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://github.com/cmks/{{ name }}/archive/{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  skip: True  # [not linux]
+
+requirements:
+  build:
+    - codeutils  # [osx]
+    - r >=3.2.3
+    - r-data.table >=1.9.6
+    - r-doMC >=1.3.4
+    - r-ggplot2 >=2.1.0
+    - ruby >=v2.3.1
+    - pullseq >=1.0.2
+    - prodigal >=2.6.3
+    - blast >=2.5.0
+
+  run:
+    - codeutils  # [osx]
+    - r >=3.2.3
+    - r-data.table >=1.9.6
+    - r-doMC >=1.3.4
+    - r-ggplot2 >=2.1.0
+    - ruby >=v2.3.1
+    - pullseq >=1.0.2
+    - prodigal >=2.6.3
+    - blast >=2.5.0
+
+test:
+  commands:
+    - DAS_Tool --help || [[ $? == 1 ]]
+    - DAS_Tool --version || [[ $? == 1 ]]
+
+about:
+  home: https://github.com/cmks/DAS_Tool
+  license: BSD  # see https://github.com/cmks/DAS_Tool/issues/23
+  license_file: license.txt
+  summary: |
+    Recovery of genomes from metagenomes via a dereplication,
+    aggregation and scoring strategy.
+  description: |
+   DAS Tool is an automated method that integrates the results of a
+   flexible number of binning algorithms to calculate an optimized,
+   non-redundant set of bins from a single assembly.
+
+extra:
+  identifiers:
+    - doi:10.1038/s41564-018-0171-1
+  recipe-maintainers:
+    - keuv-grvl

--- a/recipes/das_tool/post-link.sh
+++ b/recipes/das_tool/post-link.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+echo "
+####################################################################################
+${PKG_NAME} version ${PKG_VERSION}-${PKG_BUILDNUM} has been successfully installed!
+
+This software also need USEARCH version 8.1 or more. Bioconda can not provide it
+because of its license.
+
+ > Download: http://www.drive5.com/usearch/download.html
+ > Installation instruction: http://www.drive5.com/usearch/manual/install.html
+ " > $PREFIX/.messages.txt


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [x] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Here is an attempt to fix https://github.com/bioconda/bioconda-recipes/pull/10007 (I could not manage to commit directly on this PR). I heavily re-use the work of @SilasK .

Some precisions:
- The single-copy gene marker database is already included in the DAS_Tool repo.
- There is a `post-link.sh` script to inform users that they may want to install USearch manually (DAS_Tool 1.1.0 can use BLAST or USearch).
- I dropped the Diamond dependency as DAS_Tool suspended its support for Diamond in version 1.1.0. It could be easily brought back.
- The `build.sh` installs a R package which is not available through CRAN, I am not sure how this behave within Conda. Does it go somewhere in `$PREFIX/`?
- The main script of `DAS_Tool` use `awk`, does it need to be added as a dependency?
