### PR TITLE
bcbio_monitor + eden: update depedency of graphviz python package

### DIFF
--- a/recipes/bcbio_monitor/meta.yaml
+++ b/recipes/bcbio_monitor/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: d4563df1b9fe2d20039a4ec1556d3da1cdd23ebdc8ca10bd698edc35c6f2a2de
 
 build:
-  number: 2
+  number: 3
   skip: True # [not py27]
   entry_points:
     - bcbio_monitor = bcbio_monitor.cli:cli
@@ -21,7 +21,7 @@ requirements:
     - flask >=0.10.1
     - gevent >=1.0
     - requests
-    - py-graphviz
+    - python-graphviz
     - paramiko
     - pyyaml
 
@@ -30,7 +30,7 @@ requirements:
     - flask >=0.10.1
     - gevent >=1.0
     - requests
-    - py-graphviz
+    - python-graphviz
     - paramiko
     - pyyaml
     - pytz

--- a/recipes/eden/meta.yaml
+++ b/recipes/eden/meta.yaml
@@ -7,7 +7,7 @@ source:
   sha256: 1856d79d37d7116c3b33034929be85d5e96dbf584622946b411ecaaec3b3fdac
 
 build:
-  number: 1
+  number: 2
   skip: True # [not py27 or osx]
 
 requirements:
@@ -41,7 +41,7 @@ requirements:
     - scipy >=0.14.0
     - esmre
     - rdkit
-    - py-graphviz
+    - python-graphviz
     - biopython
     - weblogo
     - cvxopt


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Follow up to
https://github.com/bioconda/bioconda-recipes/pull/10527
and
https://github.com/conda-forge/staged-recipes/pull/6532#issuecomment-414265097

gh-10527 removed the recipe for `bioconda::py-graphviz` which is the same package as `conda-forge::python-graphviz` so we should use the latter as a dependency.