### PR TITLE
QUAST 5.0.0: circos dependency added

### DIFF
--- a/recipes/quast/meta.yaml
+++ b/recipes/quast/meta.yaml
@@ -32,6 +32,7 @@ requirements:
     - blast
     - zlib
     - glimmerHMM
+    - circos
   run:
     - perl
     - python
@@ -42,6 +43,7 @@ requirements:
     - blast
     - zlib
     - glimmerHMM
+    - circos
 
 test:
   source_files:


### PR DESCRIPTION
Circos dependency added to meta.yaml to prevent bioconda revert back to QUAST 4.6.3 when installing Circos.
The issue is caused by Perl packages required by Circos and built with deprecated Perl 5.22.0 on macOS. See https://github.com/bioconda/bioconda-recipes/issues/10100 for more details. 

Note that QUAST 4.6.3 has pretty the same dependencies as 5.0.0 (at least it also requires Perl) but it was built using the previous version of bioconda and Perl version is not specified there explicitly. 

Also note: if Circos is installed, QUAST can draw Circos plots automatically (--circos option). This functionality was added since version 5.0

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
