### PR TITLE
slicedimage: skip enum34 on py2k

### DIFF
--- a/recipes/slicedimage/meta.yaml
+++ b/recipes/slicedimage/meta.yaml
@@ -9,17 +9,18 @@ source:
   sha1: 789b6e8c9d46e525c9ac3bc36b9e9d58f2d33d8c
 
 build:
-  skip: True # [py27]
+  noarch: python
   number: 1
 
 requirements:
   build:
-    - python >=3.6
     - setuptools
+    - python
   run:
     - python
     - numpy !=1.13.0
     - diskcache
+    - enum34 # [py2k]
     - packaging
     - requests
     - scikit-image

--- a/recipes/slicedimage/meta.yaml
+++ b/recipes/slicedimage/meta.yaml
@@ -9,18 +9,17 @@ source:
   sha1: 789b6e8c9d46e525c9ac3bc36b9e9d58f2d33d8c
 
 build:
-  noarch: python
+  skip: True # [py27]
   number: 0
 
 requirements:
   build:
+    - python >=3.6
     - setuptools
-    - python
   run:
     - python
     - numpy !=1.13.0
     - diskcache
-    - enum34
     - packaging
     - requests
     - scikit-image

--- a/recipes/slicedimage/meta.yaml
+++ b/recipes/slicedimage/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   skip: True # [py27]
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

The `slicedimage` recipe is primarily intended as a prerequisite for `starfish`. While testing a development environment.yml file:

```
name: starfish
channels:
- defaults
- bioconda
- conda-forge
dependencies:
- python>=3.6
- click
- pandas>=0.23.4
- pytest>=3.6.3
- regional
- scikit-image>=0.14.0
- scikit-learn
- semantic_version
- showit==1.1.4
- slicedimage==0.0.1
- tqdm
- trackpy
- validators
- xarray
```

this error was raised:

```
UnsatisfiableError: The following specifications were found to be in conflict:
  - python >=3.6
  - slicedimage ==0.0.1 -> enum34 -> python 3.3* -> xz 5.0.5
Use "conda info <package>" to see the dependencies for each package.
```
