### PR TITLE
Bump slicedimage to 0.0.2

### DIFF
--- a/recipes/slicedimage/meta.yaml
+++ b/recipes/slicedimage/meta.yaml
@@ -1,12 +1,12 @@
-{% set SLICEDIMAGE_VERSION = "0.0.1" %}
+{% set SLICEDIMAGE_VERSION = "0.0.2" %}
 
 package:
   name: slicedimage
   version: {{ SLICEDIMAGE_VERSION }}
 
 source:
-  url:  https://github.com/spacetx/slicedimage/archive/ecd91a8d6c91fcd85c283cb40d52c34d18e062a7.zip
-  sha1: 789b6e8c9d46e525c9ac3bc36b9e9d58f2d33d8c
+  url:  https://github.com/spacetx/slicedimage/archive/{{ SLICEDIMAGE_VERSION }}.zip
+  sha1: 528a29199578503b2a57f325f9e76f1b21a34d74
 
 build:
   noarch: python


### PR DESCRIPTION
* [x] This PR updates an existing recipe.

cF. https://github.com/spacetx/slicedimage/pull/48 to fix the underlying enum34 issue

seealso: https://github.com/bioconda/bioconda-recipes/pull/10637