### PR TITLE
Added recipe for perl-sys-info-base.

### DIFF
--- a/recipes/perl-sys-info-base/build.sh
+++ b/recipes/perl-sys-info-base/build.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+if [ -f Build.PL ]; then
+    perl Build.PL
+    perl ./Build
+    perl ./Build test
+    perl ./Build install --installdirs site
+elif [ -f Makefile.PL ]; then
+    perl Makefile.PL INSTALLDIRS=site
+    make
+    make test
+    make install
+else
+    echo 'Unable to find Build.PL or Makefile.PL. You need to modify build.sh.'
+    exit 1
+fi

--- a/recipes/perl-sys-info-base/meta.yaml
+++ b/recipes/perl-sys-info-base/meta.yaml
@@ -1,0 +1,34 @@
+{% set name = "perl-sys-info-base" %}
+{% set version = "0.7804" %}
+{% set sha256 = "96ca63d624aaf658aa6869df61cac11df93353041958a3821ed0ca34b6d4611c" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://cpan.metacpan.org/authors/id/B/BU/BURAK/Sys-Info-Base-{{version}}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - perl
+    - perl-module-build
+  run:
+    - perl
+
+test:
+  imports:
+    - Sys::Info::Base
+
+about:
+  home: http://metacpan.org/pod/Sys::Info::Base
+  license: perl_5
+  summary: 'Base class for Sys::Info'
+
+extra:
+  recipe-maintainers:
+    - xileF1337


### PR DESCRIPTION
This recipe builds a conda package for the Perl module Sys::Info::Base.
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [x] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
    * No, this a general purpose package. However, virtually all Perl packages are in Bioconda, including the 58 (recursive) dependencie. Since CondaForge does not allow Bioconda dependencies in their recipes, I decided to upload this recipe here.
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
