### PR TITLE
 Added recipe for Perl module perl-test-sys-info. 

### DIFF
--- a/recipes/perl-test-sys-info/build.sh
+++ b/recipes/perl-test-sys-info/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+if [ -f Build.PL ]; then
+    perl Build.PL
+    perl ./Build
+    perl ./Build test
+    perl ./Build install --installdirs site
+elif [ -f Makefile.PL ]; then
+    perl Makefile.PL INSTALLDIRS=site
+    make
+    make test
+    make install
+else
+    echo 'Unable to find Build.PL or Makefile.PL. You need to modify build.sh.'
+    exit 1
+fi
+

--- a/recipes/perl-test-sys-info/meta.yaml
+++ b/recipes/perl-test-sys-info/meta.yaml
@@ -1,0 +1,33 @@
+{% set name = "perl-test-sys-info" %}
+{% set version = "0.21" %}
+{% set sha256 = "e397d79c5a9c34730df191867cb87b52b5a579fcdc7c6b69183ac86a0f891c3f" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://cpan.metacpan.org/authors/id/B/BU/BURAK/Test-Sys-Info-{{version}}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - perl
+    - perl-module-build
+
+  run:
+    - perl
+
+test:
+  imports:
+    - Test::Sys::Info
+    - Test::Sys::Info::Driver
+
+about:
+  home: http://metacpan.org/pod/Test::Sys::Info
+  license: perl_5
+  summary: 'Centralized test suite for Sys::Info.'
+


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [x] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
    * No, this a general purpose package. However, virtually all Perl packages are in Bioconda, including the 58 (recursive) dependencie. Since CondaForge does not allow Bioconda dependencies in their recipes, I decided to upload this recipe here.
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
