### PR TITLE
Added recipe for Perl package perl-sys-info-driver-linux.

### DIFF
--- a/recipes/perl-sys-info-driver-linux/build.sh
+++ b/recipes/perl-sys-info-driver-linux/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+if [ -f Build.PL ]; then
+    perl Build.PL
+    perl ./Build
+    perl ./Build test
+    perl ./Build install --installdirs site
+elif [ -f Makefile.PL ]; then
+    perl Makefile.PL INSTALLDIRS=site
+    make
+    make test
+    make install
+else
+    echo 'Unable to find Build.PL or Makefile.PL. You need to modify build.sh.'
+    exit 1
+fi
+

--- a/recipes/perl-sys-info-driver-linux/meta.yaml
+++ b/recipes/perl-sys-info-driver-linux/meta.yaml
@@ -1,0 +1,45 @@
+{% set name = "perl-sys-info-driver-linux" %}
+{% set version = "0.7903" %}
+{% set sha256 = "76507907902ab6ef68651629731da3e2100d10ec2c09d5fcdef0346ad747739c" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://cpan.metacpan.org/authors/id/B/BU/BURAK/Sys-Info-Driver-Linux-{{version}}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - perl
+    - perl-config-general
+    - perl-test-sys-info
+    - perl-module-build
+    - perl-unix-processors
+    - perl-sys-info-base
+
+  run:
+    - perl
+    - perl-config-general
+    - perl-unix-processors
+    - perl-sys-info-base
+
+test:
+  imports:
+    - Sys::Info::Driver::Linux
+    - Sys::Info::Driver::Linux::Constants
+    - Sys::Info::Driver::Linux::Device
+    - Sys::Info::Driver::Linux::Device::CPU
+    - Sys::Info::Driver::Linux::OS
+    - Sys::Info::Driver::Linux::OS::Distribution
+    - Sys::Info::Driver::Linux::OS::Distribution::Conf
+
+about:
+  home: http://metacpan.org/pod/Sys::Info::Driver::Linux
+  license: perl_5
+  summary: 'Linux driver for Sys::Info'
+


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [x] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
    * No, this a general purpose package. However, virtually all Perl packages are in Bioconda, including the 58 (recursive) dependencie. Since CondaForge does not allow Bioconda dependencies in their recipes, I decided to upload this recipe here.
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
