### PR TITLE
Added recipe for Perl package perl-math-random-mt-auto.

### DIFF
--- a/recipes/perl-math-random-mt-auto/build.sh
+++ b/recipes/perl-math-random-mt-auto/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+if [ -f Build.PL ]; then
+    perl Build.PL
+    perl ./Build
+    perl ./Build test
+    perl ./Build install --installdirs site
+elif [ -f Makefile.PL ]; then
+    perl Makefile.PL INSTALLDIRS=site
+    make
+    make test
+    make install
+else
+    echo 'Unable to find Build.PL or Makefile.PL. You need to modify build.sh.'
+    exit 1
+fi
+

--- a/recipes/perl-math-random-mt-auto/meta.yaml
+++ b/recipes/perl-math-random-mt-auto/meta.yaml
@@ -1,0 +1,50 @@
+{% set name = "perl-math-random-mt-auto" %}
+{% set version = "6.22" %}
+{% set sha256 = "1f2ae9752ba908c126dc2bd3c27cb286543121997f87c5bce578fb2e7f51f01f" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://cpan.metacpan.org/authors/id/J/JD/JDHEDDEN/Math-Random-MT-Auto-{{version}}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - make
+    - {{ compiler('c') }}
+  host:
+    - perl
+    - perl-extutils-makemaker
+    - perl-data-dumper
+    - perl-carp
+    - perl-exception-class
+    - perl-object-insideout
+    - perl-xsloader
+
+  run:
+    - perl
+    - perl-data-dumper
+    - perl-object-insideout
+    - perl-carp
+    - perl-exception-class
+    - perl-xsloader
+
+test:
+  imports:
+    - Math::Random::MT::Auto
+    - Math::Random::MT::Auto::Range
+
+about:
+  home: http://metacpan.org/pod/Math::Random::MT::Auto
+  license: unrestricted
+  summary: 'Auto-seeded Mersenne Twister PRNGs'
+
+extra:
+  recipe-maintainers:
+    - xileF1337
+


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [x] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
    * No, this a general purpose package. However, virtually all Perl packages are in Bioconda, including all dependencies of this one. Since CondaForge does not allow Bioconda dependencies in their recipes, I decided to upload this recipe here.
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
