### PR TITLE
update focus to download database

### DIFF
--- a/recipes/focus/meta.yaml
+++ b/recipes/focus/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "1.3" %}
-{% set sha256 = "9f19df55c3f072bffd97cd148c1ad5768b230684f5bb26a44970a9c710b7951a" %}
+{% set version = "1.4" %}
+{% set sha256 = "2c4b308a8eb820bec1bcdc5cc021f3f4d27a2d40a91cfa6801b1248644b85baa" %}
 
 package:
   name: focus
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: $PYTHON -m pip install --no-deps --ignore-installed --no-cache-dir -vvv .
 
 requirements:
@@ -24,6 +24,7 @@ requirements:
     - numpy >=1.12.1
     - scipy >=0.19.0
     - jellyfish
+    - unzip
 
 test:
   commands:


### PR DESCRIPTION
* [ ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x ] This PR updates an existing recipe.
* [] This PR does something else (explain below).

Bioconda was not copying FOCUS database. This version is supposed to copy the database and uncompress it for the user.
