### PR TITLE
Added recipe for Perl package perl-sys-info-driver-osx.

### DIFF
--- a/recipes/perl-sys-info-driver-osx/build.sh
+++ b/recipes/perl-sys-info-driver-osx/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+if [ -f Build.PL ]; then
+    perl Build.PL
+    perl ./Build
+    perl ./Build test
+    perl ./Build install --installdirs site
+elif [ -f Makefile.PL ]; then
+    perl Makefile.PL INSTALLDIRS=site
+    make
+    make test
+    make install
+else
+    echo 'Unable to find Build.PL or Makefile.PL. You need to modify build.sh.'
+    exit 1
+fi
+

--- a/recipes/perl-sys-info-driver-osx/meta.yaml
+++ b/recipes/perl-sys-info-driver-osx/meta.yaml
@@ -1,0 +1,47 @@
+{% set name = "perl-sys-info-driver-osx" %}
+{% set version = "0.7958" %}
+{% set sha256 = "875c34cd2f596a83c01ba7572ab98cbe6dd0ccff4a3b9e4192e1c35a2c0f3989" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://cpan.metacpan.org/authors/id/B/BU/BURAK/Sys-Info-Driver-OSX-{{version}}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  skip: true # [not osx]
+
+requirements:
+  build:
+    - perl
+    - perl-sys-info-base
+    - perl-mac-propertylist
+    - perl-test-sys-info
+    - perl-capture-tiny
+    - perl-module-build
+
+  run:
+    - perl
+    - perl-mac-propertylist
+    - perl-capture-tiny
+    - perl-sys-info-base
+
+test:
+  imports:
+    - Sys::Info::Driver::OSX
+    - Sys::Info::Driver::OSX::Device
+    - Sys::Info::Driver::OSX::Device::CPU
+    - Sys::Info::Driver::OSX::OS
+
+about:
+  home: http://metacpan.org/pod/Sys::Info::Driver::OSX
+  license: perl_5
+  summary: 'OSX driver for Sys::Info'
+
+extra:
+  recipe-maintainers:
+    - xileF1337
+


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [x] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
    * No, this a general purpose package. However, virtually all Perl packages are in Bioconda, including all dependencies of this one. Since CondaForge does not allow Bioconda dependencies in their recipes, I decided to upload this recipe here.
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
