### PR TITLE
change jellyfish on focus

### DIFF
--- a/recipes/focus/meta.yaml
+++ b/recipes/focus/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - python >=3
     - numpy >=1.12.1
     - scipy >=0.19.0
-    - jellyfish
+    - jellyfish ==2.2.3
     - unzip
 
 test:

--- a/recipes/focus/meta.yaml
+++ b/recipes/focus/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: $PYTHON -m pip install --no-deps --ignore-installed --no-cache-dir -vvv .
 
 requirements:
@@ -23,7 +23,7 @@ requirements:
     - python >=3
     - numpy >=1.12.1
     - scipy >=0.19.0
-    - jellyfish ==2.2.3
+    - jellyfish ==2.2.6
     - unzip
 
 test:


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [x] This PR does something else (explain below).


Sorry @bgruening. I believe this may be the last update until FOCUS a new release comes up. The current recipe works fine, but when i try to create a conda enviroment (e.g. `conda create -n focus_run -c bioconda focus`), Jellyfish `2.2.6` is giving me a `Segmentation fault: 11` error when counting k-mers on the enviroment I created (outside of the enviroment it works fine). So I tested it with Jellyfish `2.2.3`, and it worked fine.