### PR TITLE
Update: bcbio; simplifying dependencies

### DIFF
--- a/recipes/bcbio-nextgen/meta.yaml
+++ b/recipes/bcbio-nextgen/meta.yaml
@@ -3,13 +3,13 @@ package:
   version: '1.1.1a'
 
 build:
-  number: 5
+  number: 6
   skip: true # [not py27]
 
 source:
   #url: https://pypi.io/packages/source/b/bcbio-nextgen/bcbio-nextgen-1.1.0.tar.gz
-  url: https://github.com/bcbio/bcbio-nextgen/archive/73b96ae.tar.gz
-  sha256: 561058da3c61e4687c01e1ca51890021993de49b420ef88b242897b9132c8f94
+  url: https://github.com/bcbio/bcbio-nextgen/archive/0018c73.tar.gz
+  sha256: 6d6dde48c4c63fab38009d6c730dc40f3291585221a4b909facb7c3148f35de6
 
 requirements:
   host:
@@ -18,9 +18,7 @@ requirements:
     - pip
   run:
     - python
-    - argparse # [py26]
     - arrow
-    - azure
     - beautifulsoup4
     - bioblend
     - biopython
@@ -43,8 +41,6 @@ requirements:
     - msgpack-python
     - openssl
     - pandas
-    - path.py
-    - patsy
     - pip
     - py
     - pycrypto
@@ -62,11 +58,9 @@ requirements:
     - scipy
     - seaborn
     - seqcluster
-    - sqlalchemy
     - statsmodels
     - tabulate
     - toolz
-    - tornado
     - yamllint
 
 test:


### PR DESCRIPTION
Initial work on simplifying bcbio dependencies to avoid long install
times. Removes:

- azure -- should get pulled in at bcbio-vm level like with boto
- patsy, path.py, sqlalchemy -- do not appear to be used
- tornado -- bcbio server client removed

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
