### PR TITLE
Fixing dependency issues with numpy

### DIFF
--- a/recipes/hicexplorer/meta.yaml
+++ b/recipes/hicexplorer/meta.yaml
@@ -7,41 +7,40 @@ source:
   sha256: 83dec8e0388cb185a51fa6cfb055be084be0f8a2912bba18f5bc159d19831698
 
 build:
-  number: 2
-  skip: True  # [py3k]
+  number: 3
 
 requirements:
   host:
     - python
     - setuptools
-    - numpy 1.13.*
-    - scipy 1.0.*
+    - numpy
+    - scipy
     - matplotlib 2.1.*
     - pysam
     - intervaltree
-    - biopython >=1.71
+    - biopython
     - pytables
     - pybigwig
     - pandas
     - jinja2
-    - configparser >=3.5.*  # [not py>34]
+    - configparser  # [not py>34]
     - cooler <=0.7.6
     - six
     - future
     - unidecode
   run:
     - python
-    - numpy 1.13.*
-    - scipy 1.0.*
+    - numpy
+    - scipy
     - matplotlib 2.1.*
     - pysam
     - intervaltree
-    - biopython >=1.71
+    - biopython
     - pytables
     - pybigwig
     - pandas
     - jinja2
-    - configparser >=3.5.*  # [not py>34]
+    - configparser  # [not py>34]
     - cooler <=0.7.6
     - six
     - future


### PR DESCRIPTION
Fixing dependency issues with numpy caused by wrong conda-forge compatibility declaration of numpy versions.

* [ ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
