### PR TITLE
pin_compatible does not pin API compatible versions of numpy. Pin to …

### DIFF
--- a/recipes/pybigwig/meta.yaml
+++ b/recipes/pybigwig/meta.yaml
@@ -19,12 +19,12 @@ requirements:
     - curl
     - libcurl
     - zlib
-    - numpy {{ numpy }}
+    - numpy 1.15.*
   run:
     - python
     - libcurl
     - zlib
-    - numpy {{ numpy }}
+    - numpy 1.15.*
 
 test:
   imports:

--- a/recipes/pybigwig/meta.yaml
+++ b/recipes/pybigwig/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: e01991790ece496bf6d3f00778dcfb136dd9ca0fd28acc1b3fb43051ad9b8403
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -19,12 +19,12 @@ requirements:
     - curl
     - libcurl
     - zlib
-    - {{ pin_compatible('numpy') }}
+    - numpy {{ numpy }}
   run:
     - python
     - libcurl
     - zlib
-    - {{ pin_compatible('numpy') }}
+    - numpy {{ numpy }}
 
 test:
   imports:


### PR DESCRIPTION
…the version used for building to avoid problems.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

@joachimwolff This should resolve numpy version problems in the future, since `pin_compatible()` isn't working properly.