### PR TITLE
Rmblast: update to 2.6.0

### DIFF
--- a/recipes/rmblast/boost_106400.patch
+++ b/recipes/rmblast/boost_106400.patch
@@ -1,0 +1,116 @@
+diff -Naur ncbi-blast-2.6.0+-src.old/c++/src/corelib/teamcity_boost.cpp ncbi-blast-2.6.0+-src/c++/src/corelib/teamcity_boost.cpp
+--- ncbi-blast-2.6.0+-src.old/c++/src/corelib/teamcity_boost.cpp	2017-09-12 19:57:11.390617575 +0100
++++ ncbi-blast-2.6.0+-src/c++/src/corelib/teamcity_boost.cpp	2017-09-12 19:57:55.787781855 +0100
+@@ -91,7 +91,7 @@
+         if (underTeamcity()) {
+             boost::unit_test::unit_test_log.set_formatter(new TeamcityBoostLogFormatter());
+             boost::unit_test::unit_test_log.set_threshold_level
+-                (RTCFG(but::log_level, LOG_LEVEL, log_level));
++                (RTCFG(but::log_level, LOG_LEVEL));
+         }
+     }
+ };
+diff -Naur ncbi-blast-2.6.0+-src.old/c++/src/corelib/test_boost.cpp ncbi-blast-2.6.0+-src/c++/src/corelib/test_boost.cpp
+--- ncbi-blast-2.6.0+-src.old/c++/src/corelib/test_boost.cpp	2017-09-12 19:57:11.390617575 +0100
++++ ncbi-blast-2.6.0+-src/c++/src/corelib/test_boost.cpp	2017-09-12 19:57:55.787781855 +0100
+@@ -93,12 +93,31 @@
+ #  define IGNORE_STATUS
+ #endif
+ 
++#if BOOST_VERSION >= 106400
++#  define LIST_CONTENT      btrt_list_content
++#  define LIST_LABELS       btrt_list_labels
++#  define LOG_FORMAT        btrt_log_format
++#  define LOG_LEVEL         btrt_log_level
++#  define REPORT_FORMAT     btrt_report_format
++#  define RESULT_CODE       btrt_result_code
++#  define RUN_FILTERS       btrt_run_filters
++#  define WAIT_FOR_DEBUGGER btrt_wait_for_debugger
++#elif BOOST_VERSION < 106000
++#  define LIST_CONTENT      list_content
++#  define LIST_LABELS       list_labels
++#  define LOG_FORMAT        log_format
++#  define LOG_LEVEL         log_level
++#  define REPORT_FORMAT     report_format
++#  define RUN_FILTERS       test_to_run
++#  define WAIT_FOR_DEBUGGER wait_for_debugger
++#endif
++
+ #if BOOST_VERSION >= 106000
+ #  define attr_value utils::attr_value
+-#  define RTCFG(type, new_name, old_name) \
+-    but::runtime_config::get<type >(but::runtime_config::new_name)
++#  define RTCFG(type, name) \
++    but::runtime_config::get<type >(but::runtime_config::name)
+ #else
+-#  define RTCFG(type, new_name, old_name) but::runtime_config::old_name()
++#  define RTCFG(type, name) but::runtime_config::name()
+ #  if BOOST_VERSION >= 105900
+ #    define BOOST_TEST_I_TRY      BOOST_TEST_IMPL_TRY
+ #    define BOOST_TEST_I_CATCH    BOOST_TEST_IMPL_CATCH
+@@ -113,7 +132,7 @@
+ #endif
+ 
+ #define CONFIGURED_FILTERS \
+-    RTCFG(std::vector<std::string>, RUN_FILTERS, test_to_run)
++    RTCFG(std::vector<std::string>, RUN_FILTERS)
+ 
+ #ifdef NCBI_COMPILER_MSVC
+ #  pragma warning(pop)
+@@ -1657,8 +1676,7 @@
+ inline void
+ CNcbiTestApplication::x_SetupBoostReporters(void)
+ {
+-    but::output_format format = RTCFG(but::output_format, REPORT_FORMAT,
+-                                      report_format);
++    but::output_format format = RTCFG(but::output_format, REPORT_FORMAT);
+ 
+     CNcbiEnvironment env;
+     string is_autobuild = env.Get("NCBI_AUTOMATED_BUILD");
+@@ -1685,8 +1703,7 @@
+     m_Reporter->SetOutputFormat(format);
+     but::results_reporter::set_format(m_Reporter);
+ 
+-    m_Logger->SetOutputFormat(RTCFG(but::output_format, LOG_FORMAT,
+-                                    log_format));
++    m_Logger->SetOutputFormat(RTCFG(but::output_format, LOG_FORMAT));
+     but::unit_test_log.set_formatter(m_Logger);
+ }
+ 
+@@ -2241,7 +2258,7 @@
+         ncbi::s_GetTestApp().InitTestsBeforeRun();
+ 
+ #if BOOST_VERSION >= 105900
+-        if( RTCFG(bool, WAIT_FOR_DEBUGGER, wait_for_debugger) ) {
++        if( RTCFG(bool, WAIT_FOR_DEBUGGER) ) {
+             results_reporter::get_stream() << "Press any key to continue..." << std::endl;
+ 
+             std::getchar();
+@@ -2250,8 +2267,7 @@
+ 
+         framework::finalize_setup_phase();
+ 
+-        output_format list_cont = RTCFG(output_format, LIST_CONTENT,
+-                                        list_content);
++        output_format list_cont = RTCFG(output_format, LIST_CONTENT);
+         if( list_cont != but::OF_INVALID ) {
+             if( list_cont == but::OF_DOT ) {
+                 ut_detail::dot_content_reporter reporter( results_reporter::get_stream() );
+@@ -2267,7 +2283,7 @@
+             return boost::exit_success;
+         }
+ 
+-        if( RTCFG(bool, LIST_LABELS, list_labels) ) {
++        if( RTCFG(bool, LIST_LABELS) ) {
+             ut_detail::labels_collector collector;
+ 
+             traverse_test_tree( framework::master_test_suite().p_id, collector, true );
+@@ -2294,7 +2310,7 @@
+ 
+         if (
+ #if BOOST_VERSION >= 106000
+-            runtime_config::get<bool>( runtime_config::RESULT_CODE )
++            RTCFG(bool, RESULT_CODE)
+ #else
+             !runtime_config::no_result_code()
+ #endif

--- a/recipes/rmblast/boost_106500.patch
+++ b/recipes/rmblast/boost_106500.patch
@@ -1,0 +1,89 @@
+--- c++/src/corelib/test_boost.cpp	2017-04-27 11:53:27.000000000 +0000
++++ c++/src/corelib/test_boost.cpp.new	2018-07-10 22:01:48.108080764 +0000
+@@ -274,11 +274,16 @@
+     virtual
+     void log_entry_finish (ostream& ostr);
+ 
+-#if BOOST_VERSION >= 105900
+     virtual
+     void entry_context_start(ostream& ostr, but::log_level l);
++#if BOOST_VERSION >= 106500
++    virtual
++    void log_entry_context(ostream& ostr, but::log_level l, but::const_string value);
+ 
+     virtual
++    void entry_context_finish (ostream& ostr,  but::log_level l);
++#elif BOOST_VERSION >= 105900
++    virtual
+     void log_entry_context(ostream& ostr, but::const_string value);
+ 
+     virtual
+@@ -2118,7 +2123,24 @@
+     m_Upper->log_entry_finish(ostr);
+ }
+ 
+-#if BOOST_VERSION >= 105900
++#if BOOST_VERSION >= 106500
++void CNcbiBoostLogger::entry_context_start(ostream& ostr, but::log_level l)
++{
++    m_Upper->entry_context_start(ostr, l);
++}
++
++void CNcbiBoostLogger::log_entry_context(ostream& ostr,
++                                         but::log_level l,
++                                         but::const_string value)
++{
++    m_Upper->log_entry_context(ostr, l, value);
++}
++
++void CNcbiBoostLogger::entry_context_finish (ostream& ostr, but::log_level l)
++{
++    m_Upper->entry_context_finish(ostr, l);
++}
++#elif BOOST_VERSION >= 105900
+ void CNcbiBoostLogger::entry_context_start(ostream& ostr, but::log_level l)
+ {
+     m_Upper->entry_context_start(ostr, l);
+--- c++/src/corelib/teamcity_boost.cpp	2017-05-03 11:23:39.000000000 +0000
++++ c++/src/corelib/teamcity_boost.cpp.new	2018-07-10 22:19:09.597784663 +0000
+@@ -81,8 +81,14 @@
+     virtual void log_entry_finish(std::ostream&);
+ 
+     virtual void entry_context_start(std::ostream&, boost::unit_test::log_level);
++#if BOOST_VERSION >= 106500
++    virtual void log_entry_context(std::ostream&, boost::unit_test::log_level, boost::unit_test::const_string);
++    virtual void entry_context_finish (std::ostream&,  boost::unit_test::log_level);
++#else
+     virtual void log_entry_context(std::ostream&, boost::unit_test::const_string);
+     virtual void entry_context_finish(std::ostream&);
++
++#endif
+ };
+ 
+ // Fake fixture to register formatter
+@@ -205,14 +211,24 @@
+     currentContextDetails = initial_msg;
+ }
+ 
++#if BOOST_VERSION >= 106500
++void TeamcityBoostLogFormatter::log_entry_context(std::ostream &out, boost::unit_test::log_level l, boost::unit_test::const_string ctx) {
++    out << "\n " << ctx;
++    currentContextDetails += "\n " + toString(ctx);
++}
++void TeamcityBoostLogFormatter::entry_context_finish(std::ostream &out, boost::unit_test::log_level l) {
++    out.flush();
++    messages.testOutput(CURRENT_TEST_NAME, currentContextDetails, flowId, TeamcityMessages::StdErr);
++}
++#else
+ void TeamcityBoostLogFormatter::log_entry_context(std::ostream &out, boost::unit_test::const_string ctx) {
+     out << "\n " << ctx;
+     currentContextDetails += "\n " + toString(ctx);
+ }
+-
+ void TeamcityBoostLogFormatter::entry_context_finish(std::ostream &out) {
+     out.flush();
+     messages.testOutput(CURRENT_TEST_NAME, currentContextDetails, flowId, TeamcityMessages::StdErr);
+ }
++#endif
+ 
+ }}                                                          // namespace teamcity, jetbrains

--- a/recipes/rmblast/build.sh
+++ b/recipes/rmblast/build.sh
@@ -18,10 +18,7 @@ elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
     cd $SRC_DIR/c++
     ./configure --prefix=$PREFIX --with-mt --without-debug
 
-    make > make.log 2>&1
-
-    echo "Last 1000 lines of make log"
-    tail -1000 make.log
+    make
 
     cp $SRC_DIR/c++/GCC*-ReleaseMT*/bin/rmblastn $PREFIX/bin
 fi

--- a/recipes/rmblast/build.sh
+++ b/recipes/rmblast/build.sh
@@ -1,31 +1,92 @@
 #!/bin/bash
 
-set -e -x -o pipefail
+cd $SRC_DIR/c++/
 
-mkdir -p $PREFIX/bin
+export CFLAGS="$CFLAGS -O2"
+export CXXFLAGS="$CXXFLAGS -O2"
+export CPPFLAGS="$CPPFLAGS -I$PREFIX/include"
+export LDFLAGS="$LDFLAGS -L$PREFIX/lib"
 
-if [ "$(uname)" == "Darwin" ]; then
-    echo "Platform: Mac"
-
-    # export CFLAGS='-O3'
-    # export CXXFLAGS='-O3'
-
-    cp $SRC_DIR/bin/rmblastn $PREFIX/bin
-
-elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
-    echo "Platform: Linux"
-
-    cd $SRC_DIR/c++
-    ./configure --prefix=$PREFIX --with-mt --without-debug
-
-    make
-
-    cp $SRC_DIR/c++/GCC*-ReleaseMT*/bin/rmblastn $PREFIX/bin
+if test x"`uname`" = x"Linux"; then
+    # only add things needed; not supported by OSX ld
+    LDFLAGS="$LDFLAGS -Wl,-as-needed"
 fi
+
+if [ `uname` == Darwin ]; then
+    export LDFLAGS="${LDFLAGS} -Wl,-rpath,$PREFIX/lib -lz -lbz2"
+fi
+
+LIB_INSTALL_DIR=$PREFIX/lib/ncbi-blast+
+
+# with/without options:
+#
+# dll: enable dynamic linking
+# mt: enable multi-threading
+# -autodep: no automatic dependency build (one time build)
+# -makefile-auto-update: no rebuild of makefile (one time build)
+# flat-makefile: use single makefile
+# -caution: disable configure script warnings
+# -dbapi: don't build database connectivity libs
+# -lzo: don't add lzo support
+# runpath: set runpath for installed $PREFIX location
+# hard-runpath: disable new dtags (disallow LD_LIBRARY_PATH override on Linux)
+# -debug: disable debug
+# strip: remove debugging symbols (size!)
+# -vdb: disable VDB/SRA toolkit
+# z: set zlib
+# bz2: set libbz2
+# boost: set boost
+# -openssl: disable openssl
+# -gcrypt: disable gcrypt (needed on OSX)
+# gnutls: set gnutls (preferred over openssl for -remote support)
+# nettle: set nettle
+# -krb5: disable kerberos (needed on OSX)
+
+if [ `uname` == Linux ]; then
+  CONFIG_ARGS="--without-openssl --with-gnutls=$PREFIX"
+else
+  CONFIG_ARGS="--without-gnutls --with-openssl=$PREFIX"
+fi
+
+./configure \
+    --with-dll \
+    --with-mt \
+    --without-autodep \
+    --without-makefile-auto-update \
+    --with-flat-makefile \
+    --without-caution \
+    --without-dbapi \
+    --without-lzo \
+    --with-hard-runpath \
+    --with-runpath=$LIB_INSTALL_DIR \
+    --without-debug \
+    --with-strip \
+    --without-vdb \
+    --with-z=$PREFIX \
+    --with-bz2=$PREFIX \
+    --with-boost=$PREFIX \
+    --without-gcrypt \
+    --with-nettle=$PREFIX \
+    --with-z=$PREFIX \
+    --without-krb5 $CONFIG_ARGS
+
+projects="algo/blast/ app/ objmgr/ objtools/align_format/ objtools/blast/"
+cd ReleaseMT
+
+# The "datatool" binary needs the libs at build time, create
+# link from final install path to lib build dir:
+ln -s $SRC_DIR/c++/ReleaseMT/lib $LIB_INSTALL_DIR
+
+cd build
+make -j${CPU_COUNT} -f Makefile.flat all_projects="$projects"
+
+# remove temporary link
+rm $LIB_INSTALL_DIR
+
+mkdir -p $PREFIX/bin $LIB_INSTALL_DIR
+rm $SRC_DIR/c++/ReleaseMT/bin/*_unit_test
+cp $SRC_DIR/c++/ReleaseMT/bin/* $PREFIX/bin/
+cp $SRC_DIR/c++/ReleaseMT/lib/* $LIB_INSTALL_DIR
 
 chmod +x $PREFIX/bin/*
-
-# if we only have libbz2.so.1.0, make a symlink to libbz2.so.1
-if [[ ! -e $PREFIX/lib/libbz2.so.1 && -e $PREFIX/lib/libbz2.so.1.0 ]] ; then
-  ln -s $PREFIX/lib/libbz2.so.1.0 $PREFIX/lib/libbz2.so.1
-fi
+sed -i.bak '1 s|^.*$|#!/usr/bin/env perl|g' $PREFIX/bin/update_blastdb.pl

--- a/recipes/rmblast/isb-2.6.0+-changes-vers2.patch
+++ b/recipes/rmblast/isb-2.6.0+-changes-vers2.patch
@@ -1,0 +1,333 @@
+--- ncbi-blast-2.6.0+-src/c++/src/algo/blast/blastinput/blast_fasta_input.cpp	2016-10-27 12:13:57.000000000 -0700
++++ ncbi-blast-2.6.0+-src/c++/src/algo/blast/blastinput/blast_fasta_input.cpp	2017-02-07 11:56:27.299726089 -0800
+@@ -292,6 +292,12 @@ CBlastFastaInputSource::x_InitInputReade
+                                     CFastaReader::fAllSeqIds :
+                                     (CFastaReader::fNoParseID |
+                                      CFastaReader::fDLOptional);
++
++    // Allow CFastaReader fSkipCheck flag to be set based
++    // on new CBlastInputSourceConfig property - GetSkipSeqCheck() -RMH-
++    flags += ( m_Config.GetSkipSeqCheck() ?
++               CFastaReader::fSkipCheck : 0 );
++
+     flags += (m_ReadProteins
+               ? CFastaReader::fAssumeProt 
+               : CFastaReader::fAssumeNuc);
+--- ncbi-blast-2.6.0+-src/c++/src/algo/blast/blastinput/blast_input.cpp	2016-06-20 08:45:40.000000000 -0700
++++ ncbi-blast-2.6.0+-src/c++/src/algo/blast/blastinput/blast_input.cpp	2017-02-07 11:56:27.300726093 -0800
+@@ -53,12 +53,14 @@ CBlastInputSourceConfig::CBlastInputSour
+      TSeqRange range                    /* = TSeqRange() */,
+      bool retrieve_seq_data             /* = true */,
+      int local_id_counter               /* = 1 */,
+-     unsigned int seqlen_thresh2guess   /* = numeric_limits<unsigned int>::max()*/ )
++     unsigned int seqlen_thresh2guess   /* = numeric_limits<unsigned int>::max()*/,
++     bool skip_seq_check                /* = false -RMH- */ )
+ : m_Strand(strand), m_LowerCaseMask(lowercase), 
+   m_BelieveDeflines(believe_defline), m_Range(range), m_DLConfig(dlconfig),
+   m_RetrieveSeqData(retrieve_seq_data),
+   m_LocalIdCounter(local_id_counter),
+   m_SeqLenThreshold2Guess(seqlen_thresh2guess),
++  m_SkipSeqCheck(skip_seq_check), /* -RMH- */
+   m_GapsToNs(false)
+ {
+     // Set an appropriate default for the strand
+--- ncbi-blast-2.6.0+-src/c++/include/algo/blast/blastinput/blast_input.hpp	2016-06-20 08:45:40.000000000 -0700
++++ ncbi-blast-2.6.0+-src/c++/include/algo/blast/blastinput/blast_input.hpp	2017-02-07 11:56:27.394726411 -0800
+@@ -93,6 +93,8 @@ public:
+     ///                 type guessing (see @ref kSeqLenThreshold2Guess) [in]
+     /// @param local_id_counter counter used to create the CSeqidGenerator to
+     ///                 create local identifiers for sequences read [in]
++    /// @param skip_seq_check When set this will avoid the sequence 
++    ///                       validation step when using the CFastaReader. -RMH-
+     CBlastInputSourceConfig(const SDataLoaderConfig& dlconfig,
+                   objects::ENa_strand strand = objects::eNa_strand_other,
+                   bool lowercase = false,
+@@ -101,7 +103,8 @@ public:
+                   bool retrieve_seq_data = true,
+                   int local_id_counter = 1,
+                   unsigned int seqlen_thresh2guess = 
+-                    numeric_limits<unsigned int>::max());
++                    numeric_limits<unsigned int>::max(),
++                  bool skip_seq_check = false /* -RMH- */ );
+ 
+     /// Destructor
+     ///
+@@ -136,6 +139,18 @@ public:
+     ///
+     bool GetBelieveDeflines() const { return m_BelieveDeflines; }
+ 
++    /// Retrieve status of sequence alphabet validation
++    /// @return boolean to toggle validation of seq data 
++    /// -RMH-
++    ///
++    bool GetSkipSeqCheck() const { return m_SkipSeqCheck; }
++    
++    /// Turn validation of sequence on/off
++    /// @param skip boolean to toggle validation of sequence
++    /// -RMH-
++    ///
++    void SetSkipSeqCheck(bool skip) { m_SkipSeqCheck = skip; }
++
+     /// Set range for all sequences
+     /// @param r range to use [in]
+     void SetRange(const TSeqRange& r) { m_Range = r; }
+@@ -201,6 +216,8 @@ private:
+     bool m_LowerCaseMask;          
+     /// Whether to parse sequence IDs
+     bool m_BelieveDeflines;        
++    /// Whether to validate sequence data -RMH-
++    bool m_SkipSeqCheck;
+     /// Sequence range
+     TSeqRange m_Range;             
+     /// Configuration object for data loaders, used by CBlastInputReader
+diff -rupN ncbi-blast-2.6.0+-src/c++/src/app/rmblastn/Makefile.in ncbi-blast-2.6.0+-src/c++/src/app/rmblastn/Makefile.in
+--- ncbi-blast-2.6.0+-src/c++/src/app/rmblastn/Makefile.in	1969-12-31 16:00:00.000000000 -0800
++++ ncbi-blast-2.6.0+-src/c++/src/app/rmblastn/Makefile.in	2017-02-07 11:56:27.408726459 -0800
+@@ -0,0 +1,16 @@
++# $Id: Makefile.in 371962 2012-08-14 09:45:56Z coulouri $
++
++# Meta-makefile("APP" project)
++#################################
++
++REQUIRES = objects algo
++
++APP_PROJ = rmblastn
++
++srcdir = @srcdir@
++include @builddir@/Makefile.meta
++
++.PHONY: all $(APP_PROJ)
++
++rmblastn:
++	${MAKE} ${MFLAGS} -f Makefile.rmblastn_app
+diff -rupN ncbi-blast-2.6.0+-src/c++/src/app/rmblastn/Makefile.rmblastn.app ncbi-blast-2.6.0+-src/c++/src/app/rmblastn/Makefile.rmblastn.app
+--- ncbi-blast-2.6.0+-src/c++/src/app/rmblastn/Makefile.rmblastn.app	1969-12-31 16:00:00.000000000 -0800
++++ ncbi-blast-2.6.0+-src/c++/src/app/rmblastn/Makefile.rmblastn.app	2017-02-07 11:56:27.426726519 -0800
+@@ -0,0 +1,16 @@
++WATCHERS = camacho madden maning
++
++APP = rmblastn
++SRC = rmblastn_app
++LIB_ = $(BLAST_INPUT_LIBS) $(BLAST_LIBS) $(OBJMGR_LIBS)
++LIB = blast_app_util $(LIB_:%=%$(STATIC))
++
++# De-universalize Mac builds to work around a PPC toolchain limitation
++CFLAGS   = $(FAST_CFLAGS:ppc=i386)
++CXXFLAGS = $(FAST_CXXFLAGS:ppc=i386)
++LDFLAGS  = $(FAST_LDFLAGS:ppc=i386)
++
++CPPFLAGS = $(ORIG_CPPFLAGS)
++LIBS = $(CMPRS_LIBS) $(DL_LIBS) $(PCRE_LIBS) $(NETWORK_LIBS) $(ORIG_LIBS)
++
++REQUIRES = objects -Cygwin
+diff -rupN ncbi-blast-2.6.0+-src/c++/src/app/rmblastn/rmblastn_app.cpp ncbi-blast-2.6.0+-src/c++/src/app/rmblastn/rmblastn_app.cpp
+--- ncbi-blast-2.6.0+-src/c++/src/app/rmblastn/rmblastn_app.cpp	1969-12-31 16:00:00.000000000 -0800
++++ ncbi-blast-2.6.0+-src/c++/src/app/rmblastn/rmblastn_app.cpp	2017-02-07 11:56:27.434726546 -0800
+@@ -0,0 +1,183 @@
++/*  $Id: rmblastn_app.cpp 371962 2012-08-14 09:45:56Z coulouri $
++ * ===========================================================================
++ *
++ *                            PUBLIC DOMAIN NOTICE
++ *
++ * ===========================================================================
++ *
++ * Authors:  Robert M. Hubley
++ *           Christiam Camacho ( original blastn_app.cpp )
++ *
++ */
++
++/** @file rmblastn_app.cpp
++ * RMBLASTN command line application
++ */
++
++#ifndef SKIP_DOXYGEN_PROCESSING
++static char const rcsid[] = 
++	"$Id: rmblastn_app.cpp 371962 2012-08-14 09:45:56Z coulouri $";
++#endif /* SKIP_DOXYGEN_PROCESSING */
++
++#include <ncbi_pch.hpp>
++#include <corelib/ncbiapp.hpp>
++#include <algo/blast/api/local_blast.hpp>
++#include <algo/blast/api/remote_blast.hpp>
++#include <algo/blast/blastinput/blast_fasta_input.hpp>
++#include <algo/blast/blastinput/rmblastn_args.hpp>
++#include <algo/blast/api/objmgr_query_data.hpp>
++#include <algo/blast/format/blast_format.hpp>
++#include "../blast/blast_app_util.hpp"
++
++#ifndef SKIP_DOXYGEN_PROCESSING
++USING_NCBI_SCOPE;
++USING_SCOPE(blast);
++USING_SCOPE(objects);
++#endif
++
++class CRMBlastnApp : public CNcbiApplication
++{
++public:
++    /** @inheritDoc */
++    CRMBlastnApp() {
++        CRef<CVersion> version(new CVersion());
++        version->SetVersionInfo(new CBlastVersion());
++        SetFullVersion(version);
++    }
++private:
++    /** @inheritDoc */
++    virtual void Init();
++    /** @inheritDoc */
++    virtual int Run();
++
++    /// This application's command line args
++    CRef<CRMBlastnAppArgs> m_CmdLineArgs; 
++};
++
++
++
++void CRMBlastnApp::Init()
++{
++    // formulate command line arguments
++    m_CmdLineArgs.Reset(new CRMBlastnAppArgs());
++
++    // read the command line
++
++    HideStdArgs(fHideLogfile | fHideConffile | fHideFullVersion | fHideXmlHelp | fHideDryRun);
++    SetupArgDescriptions(m_CmdLineArgs->SetCommandLine());
++}
++
++int CRMBlastnApp::Run(void)
++{
++    int status = BLAST_EXIT_SUCCESS;
++
++    try {
++
++        // Allow the fasta reader to complain on invalid sequence input
++        SetDiagPostLevel(eDiag_Warning);
++
++        /*** Get the BLAST options ***/
++        const CArgs& args = GetArgs();
++        CRef<CBlastOptionsHandle> opts_hndl;
++        if(RecoverSearchStrategy(args, m_CmdLineArgs)) {
++           	opts_hndl.Reset(&*m_CmdLineArgs->SetOptionsForSavedStrategy(args));
++        }
++        else {
++           	opts_hndl.Reset(&*m_CmdLineArgs->SetOptions(args));
++        }
++        const CBlastOptions& opt = opts_hndl->GetOptions();
++
++        /*** Get the query sequence(s) ***/
++        CRef<CQueryOptionsArgs> query_opts = 
++            m_CmdLineArgs->GetQueryOptionsArgs();
++        SDataLoaderConfig dlconfig(query_opts->QueryIsProtein());
++        dlconfig.OptimizeForWholeLargeSequenceRetrieval();
++        CBlastInputSourceConfig iconfig(dlconfig, query_opts->GetStrand(),
++                                     query_opts->UseLowercaseMasks(),
++                                     query_opts->GetParseDeflines(),
++                                     query_opts->GetRange());
++        iconfig.SetSkipSeqCheck(true);
++        CBlastFastaInputSource fasta(m_CmdLineArgs->GetInputStream(), iconfig);
++        CBlastInput input(&fasta, m_CmdLineArgs->GetQueryBatchSize());
++
++        /*** Initialize the database/subject ***/
++        CRef<CBlastDatabaseArgs> db_args(m_CmdLineArgs->GetBlastDatabaseArgs());
++        CRef<CLocalDbAdapter> db_adapter;
++        CRef<CScope> scope;
++        InitializeSubject(db_args, opts_hndl, m_CmdLineArgs->ExecuteRemotely(),
++                         db_adapter, scope);
++        _ASSERT(db_adapter && scope);
++
++        // Initialize the megablast database index now so we can know whether an indexed search will be run.
++        // This is only important for the reference in the report, but would be done anyway.
++        if (opt.GetUseIndex() && !m_CmdLineArgs->ExecuteRemotely()) {
++            CRef<CBlastOptions> my_options(&(opts_hndl->SetOptions()));
++            CSetupFactory::InitializeMegablastDbIndex(my_options);
++        }
++
++        /*** Get the formatting options ***/
++        CRef<CFormattingArgs> fmt_args(m_CmdLineArgs->GetFormattingArgs());
++        CBlastFormat formatter(opt, *db_adapter,
++                               fmt_args->GetFormattedOutputChoice(),
++                               query_opts->GetParseDeflines(),
++                               m_CmdLineArgs->GetOutputStream(),
++                               fmt_args->GetNumDescriptions(),
++                               fmt_args->GetNumAlignments(),
++                               *scope,
++                               opt.GetMatrixName(),
++                               fmt_args->ShowGis(),
++                               fmt_args->DisplayHtmlOutput(),
++                               opt.GetQueryGeneticCode(),
++                               opt.GetDbGeneticCode(),
++                               opt.GetSumStatisticsMode(),
++                               m_CmdLineArgs->ExecuteRemotely(),
++                               db_adapter->GetFilteringAlgorithm(),
++                               fmt_args->GetCustomOutputFormatSpec(),
++                               m_CmdLineArgs->GetTask() == "megablast",
++                               opt.GetMBIndexLoaded());
++                               
++        
++        formatter.PrintProlog();
++        
++        /*** Process the input ***/
++        for (; !input.End(); formatter.ResetScopeHistory()) {
++
++            CRef<CBlastQueryVector> query_batch(input.GetNextSeqBatch(*scope));
++            CRef<IQueryFactory> queries(new CObjMgr_QueryFactory(*query_batch));
++
++            SaveSearchStrategy(args, m_CmdLineArgs, queries, opts_hndl);
++
++            CRef<CSearchResultSet> results;
++
++            if (m_CmdLineArgs->ExecuteRemotely()) {
++                CRef<CRemoteBlast> rmt_blast = 
++                    InitializeRemoteBlast(queries, db_args, opts_hndl,
++                          m_CmdLineArgs->ProduceDebugRemoteOutput());
++                results = rmt_blast->GetResultSet();
++            } else {
++                CLocalBlast lcl_blast(queries, opts_hndl, db_adapter);
++                lcl_blast.SetNumberOfThreads(m_CmdLineArgs->GetNumThreads());
++                results = lcl_blast.Run();
++            }
++
++            ITERATE(CSearchResultSet, result, *results) {
++                formatter.PrintOneResultSet(**result, query_batch);
++            }
++        }
++
++        formatter.PrintEpilog(opt);
++
++        if (m_CmdLineArgs->ProduceDebugOutput()) {
++            opts_hndl->GetOptions().DebugDumpText(NcbiCerr, "BLAST options", 1);
++        }
++
++    } CATCH_ALL(status)
++    return status;
++}
++
++#ifndef SKIP_DOXYGEN_PROCESSING
++int main(int argc, const char* argv[] /*, const char* envp[]*/)
++{
++    return CRMBlastnApp().AppMain(argc, argv, 0, eDS_Default, 0);
++}
++#endif /* SKIP_DOXYGEN_PROCESSING */
+--- ncbi-blast-2.6.0+-src/c++/src/objtools/blast/seqdb_reader/seqdbimpl.cpp	2016-10-12 07:27:34.000000000 -0700
++++ ncbi-blast-2.6.0+-src/c++/src/objtools/blast/seqdb_reader/seqdbimpl.cpp	2017-03-29 11:14:01.852864789 -0700
+@@ -1813,6 +1813,9 @@ void CSeqDBImpl::HashToOids(unsigned has
+ 
+ CSeqDBIdSet CSeqDBImpl::GetIdSet()
+ {
++    // RMH: Added to eliminate race condition for vector garbage collection
++    CFastMutexGuard guard(m_MutexForIdSet);
++    
+     if (m_IdSet.Blank()) {
+         if (! m_UserGiList.Empty()) {
+             // Note: this returns a 'blank' IdSet list for positive
+--- ncbi-blast-2.6.0+-src/c++/src/objtools/blast/seqdb_reader/seqdbimpl.hpp	2016-02-03 07:19:38.000000000 -0800
++++ ncbi-blast-2.6.0+-src/c++/src/objtools/blast/seqdb_reader/seqdbimpl.hpp	2017-03-29 11:12:33.521480161 -0700
+@@ -1133,6 +1133,9 @@ public:
+ private:
+     CLASS_MARKER_FIELD("IMPL")
+ 
++    // RMH
++    CFastMutex m_MutexForIdSet;
++
+     /// Adjust string length to offset of first embedded NUL byte.
+     ///
+     /// This is a work-around for bad data in the database; probably

--- a/recipes/rmblast/meta.yaml
+++ b/recipes/rmblast/meta.yaml
@@ -1,38 +1,54 @@
 package:
   name: rmblast
-  version: 2.2.28
+  version: 2.6.0
 source:
-  url: ftp://ftp.ncbi.nlm.nih.gov/blast/executables/rmblast/2.2.28/ncbi-rmblastn-2.2.28-src.tar.gz # [linux]
-  md5: fb5f4e2e02ffcb1b17af2e9f206c5c22 # [linux]
-  url: ftp://ftp.ncbi.nlm.nih.gov/blast/executables/rmblast/2.2.28/ncbi-rmblastn-2.2.28-universal-macosx.tar.gz # [osx]
-  md5: 421c5ddf2c425800d934562c965e8706 # [osx]
+  url: ftp://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/2.6.0/ncbi-blast-2.6.0+-src.tar.gz
+  sha256: 0510e1d607d0fb4389eca50d434d5a0be787423b6850b3a4f315abc2ef19c996
+  patches:
+    - boost_106400.patch
+    - boost_106500.patch
+    # patch taken from http://www.repeatmasker.org/isb-2.6.0+-changes-vers2.patch.gz
+    - isb-2.6.0+-changes-vers2.patch
 
 build:
-  number: 5
+  number: 0
 
 requirements:
   build:
+    - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
-    - boost  # [linux]
+    - boost
     - bzip2
     - zlib
+    - gnutls # [linux]
+    - openssl # [osx]
+    - nettle 3.3|3.3.*
+    - pcre
+    - time
   run:
-    - boost  # [linux]
+    - boost
     - bzip2
     - zlib
-    - blast
+    - gnutls # [linux]
+    - openssl # [osx]
+    - nettle 3.3|3.3.*
+    - pcre
+    - perl
+    - perl-list-moreutils
+    - perl-archive-tar
 
 test:
   commands:
     - rmblastn -help > /dev/null
     - makeblastdb -help > /dev/null
+    - blastn -help
+    - blastp -help
+    # test that BLAST ignores LD_LIBRARY_PATH
+    - touch libstdc++.so.6; LD_LIBRARY_PATH=. makeblastdb -help && rm libstdc++.so.6
+    - update_blastdb.pl --help
 
 about:
   home: http://www.repeatmasker.org/RMBlast.html
   license: OSL-2.1
   summary: RMBlast is a RepeatMasker compatible version of the standard NCBI BLAST suite.
-
-extra:
-  skip-lints:
-    - boost_not_pinned

--- a/recipes/rmblast/meta.yaml
+++ b/recipes/rmblast/meta.yaml
@@ -14,11 +14,11 @@ requirements:
   build:
     - {{ compiler('cxx') }}
   host:
-    - boost <=1.58  # [linux]
+    - boost  # [linux]
     - bzip2
     - zlib
   run:
-    - boost <=1.58  # [linux]
+    - boost  # [linux]
     - bzip2
     - zlib
     - blast

--- a/recipes/rmblast/meta.yaml
+++ b/recipes/rmblast/meta.yaml
@@ -8,7 +8,7 @@ source:
   md5: 421c5ddf2c425800d934562c965e8706 # [osx]
 
 build:
-  number: 4
+  number: 5
 
 requirements:
   build:


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Rmblast is using an old boost version which creates dep problems with repeatmasker, maker and perl.
As there's a 2.6.0 version, let's update it... Now it's just a patch on top of standard blast, so I just adapted the blast recipe