### PR TITLE
Fix bioconda-utils invocation in case of local circleci client usage.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,8 +84,7 @@ jobs:
           # above. A workaround or an upstream fix would be welcome.
           command: |
             bioconda-utils build recipes config.yml \
-            --git-range master HEAD \
-            --prelint
+            --git-range master HEAD
 
   lint:
     <<: *linux

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,16 +59,8 @@ jobs:
           command: |
             mkdir -p ~/.ssh
             ssh-keyscan -H github.com >> ~/.ssh/known_hosts
-      - run:
-          name: Setup base system
-          command: |
-            cat >> $BASH_ENV <<EOF
-            if [[ \$- == *u* ]] ; then
-                set +u ; . /tmp/repo/docker-entrypoint-source ; set -u
-            else
-                . /tmp/repo/docker-entrypoint-source
-            fi
-            EOF
+      - run: echo ". /opt/conda/etc/profile.d/conda.sh" >> $BASH_ENV
+      - run: echo "conda activate" >> $BASH_ENV
       - *common
       - *setup
       - run:


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

The local `circleci build` based testing recently failed because the `--prelint` option has been removed from bioconda-utils. This is fixed here.