### PR TITLE
pb-falcon: Must bump ver for conda update to work

### DIFF
--- a/recipes/pb-falcon/meta.yaml
+++ b/recipes/pb-falcon/meta.yaml
@@ -32,7 +32,7 @@ source:
     folder: falcon_phase
 
 build:
-  number: 2
+  string: py27_3
   skip: True # [not py27 or osx]
 
 requirements:


### PR DESCRIPTION
Apparently, this is because the build-prefix changed
while the version string did not, so the new builds
are not alphabetically successive.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
