### PR TITLE
pb-falon: htslib=1.7

### DIFF
--- a/recipes/pb-falcon/meta.yaml
+++ b/recipes/pb-falcon/meta.yaml
@@ -32,7 +32,7 @@ source:
     folder: falcon_phase
 
 build:
-  number: 0
+  number: 1
   skip: True # [not py27 or osx]
 
 requirements:
@@ -43,11 +43,11 @@ requirements:
     - pkg-config
   host:
     - zlib
-    - htslib
+    - htslib==1.7
     - python
     - setuptools
   run:
-    - htslib
+    - htslib==1.7
     - python
     - networkx >=1.9.1
     - future >=0.16.0 # [not py3k]


### PR DESCRIPTION
Attempting to solve this problem:
```
% conda install pb-falcon=0.2.1
Solving environment: failed

UnsatisfiableError: The following specifications were found to be in
conflict:
  - pb-falcon=0.2.1
  - pbalign -> pbbam[version='>=0.18.0'] -> htslib=1.7
```

* [ ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
