### PR TITLE
pb-assembly: bump ver and req non-broken pb-falcon

### DIFF
--- a/recipes/pb-assembly/meta.yaml
+++ b/recipes/pb-assembly/meta.yaml
@@ -1,8 +1,8 @@
 package:
   name: pb-assembly
-  version: "0.0.0"
+  version: "0.0.1"
 build:
-  number: 9
+  number: 0
   script: echo noop
   skip: True # [not py27 or osx]
 requirements:
@@ -10,7 +10,7 @@ requirements:
     - python
   run:
     - python
-    - pb-falcon>=0.2.0
+    - pb-falcon>=0.2.3
     - pb-dazzler
     - future >=0.16.0 # [not py3k]
     - nim-falcon


### PR DESCRIPTION
The problem was that pb-falcon-phase was built with `-march=native`,
so we needed to update/rebuild a chain of dependencies.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
