### PR TITLE
fix hmmer version

### DIFF
--- a/recipes/anvio/meta.yaml
+++ b/recipes/anvio/meta.yaml
@@ -48,7 +48,7 @@ requirements:
     - prodigal
     - mcl
     - muscle
-    - hmmer
+    - hmmer ===3.1b2
 
 test:
   commands:


### PR DESCRIPTION
The latest hmmer version gives an error in the self-test, but it works with 3.1b2

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
