### PR TITLE
PeptideShaker: updated version to 1.16.29

### DIFF
--- a/recipes/peptide-shaker/meta.yaml
+++ b/recipes/peptide-shaker/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "PeptideShaker" %}
-{% set version = "1.16.26" %}
+{% set version = "1.16.29" %}
 # Do not forget to update the version string in the peptide-shaker.py file
 
 about:
@@ -22,7 +22,7 @@ build:
 
 source:
   url: http://genesis.ugent.be/maven2/eu/isas/peptideshaker/{{ name }}/{{ version }}/{{ name }}-{{ version }}.zip
-  sha256: a60b13a5547f869fd24e3be0bbdbf1e7908daf58ae615972291fac50bc588846
+  sha256: 777d0aa838f4d21d1ea8afd10d199249e1d26ebc66c3bb593671a5d647dd1008
 
 requirements:
   host:

--- a/recipes/peptide-shaker/peptide-shaker.py
+++ b/recipes/peptide-shaker/peptide-shaker.py
@@ -13,7 +13,7 @@ import shutil
 from os import access
 from os import getenv
 from os import X_OK
-jar_file = 'PeptideShaker-1.16.26.jar'
+jar_file = 'PeptideShaker-1.16.29.jar'
 
 
 default_jvm_mem_opts = ['-Xms512m', '-Xmx1g']


### PR DESCRIPTION
Internal improvements:
- Added default protein, peptide and PSM reports that also include the non-validated hits. Note: Some of the numbers used to refer to the previous reports have changed and that you may need to update your command lines. Check PeptideShaker documentation for the new ids.
- Updated utilities to version 4.12.8 (better management of gene-mappings).
- Bugfixes

* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [X] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
