### PR TITLE
Update: delly (boost fix); bcbio, bcbio-vm (CWL fixes)

### DIFF
--- a/recipes/bcbio-nextgen-vm/meta.yaml
+++ b/recipes/bcbio-nextgen-vm/meta.yaml
@@ -3,12 +3,12 @@ package:
   version: '0.1.0a'
 
 build:
-  number: 129
+  number: 130
   skip: True # [not py27]
 
 source:
-  url: https://github.com/bcbio/bcbio-nextgen-vm/archive/9a267e6.tar.gz
-  sha256: b77210a3e94d2ed943bb3d93c96f2abdcc1bb94ad6ba4521cf88ab8a7baf5dce
+  url: https://github.com/bcbio/bcbio-nextgen-vm/archive/54bff09.tar.gz
+  sha256: f74c05aaa0d503001b3570606535386056c5ac697ceeb2dd15764de6d011c857
 
 requirements:
   host:

--- a/recipes/bcbio-nextgen/meta.yaml
+++ b/recipes/bcbio-nextgen/meta.yaml
@@ -3,13 +3,13 @@ package:
   version: '1.1.1a'
 
 build:
-  number: 8
+  number: 9
   skip: true # [not py27]
 
 source:
   #url: https://pypi.io/packages/source/b/bcbio-nextgen/bcbio-nextgen-1.1.0.tar.gz
-  url: https://github.com/bcbio/bcbio-nextgen/archive/fd4dc6f.tar.gz
-  sha256: 2aa9a495cb5f36d86f28946bc8288f4d2437f181282728aba6ee7dd8384f3459
+  url: https://github.com/bcbio/bcbio-nextgen/archive/ace0c88.tar.gz
+  sha256: d9c4902409f0aa81cf691ad672f1583cbd7a28ea1fe6e3697b274566689cd9c4
 
 requirements:
   host:

--- a/recipes/delly/Makefile.patch
+++ b/recipes/delly/Makefile.patch
@@ -1,11 +1,10 @@
-diff --git a/delly/Makefile b/bioconda-recipes/recipes/delly/Makefile
-index a294d80..534ca64 100644
---- a/delly/Makefile
-+++ b/bioconda-recipes/recipes/delly/Makefile
-@@ -9,8 +9,8 @@ BOOST_ROOT ?= ${PWD}/src/modular-boost
+--- a/delly/Makefile	2018-09-19 11:38:49.800327097 -0400
++++ b/delly/Makefile	2018-09-19 11:39:21.980492402 -0400
+@@ -8,9 +8,8 @@
+ BOOST_ROOT ?= ${PWD}/src/modular-boost
  
  # Flags
- CXX=g++
+-CXX=g++
 -CXXFLAGS += -isystem ${SEQTK_ROOT} -isystem ${BOOST_ROOT} -pedantic -W -Wall -Wno-unknown-pragmas -D__STDC_LIMIT_MACROS -fno-strict-aliasing
 -LDFLAGS += -L${SEQTK_ROOT} -L${BOOST_ROOT}/stage/lib -lboost_iostreams -lboost_filesystem -lboost_system -lboost_program_options -lboost_date_time 
 +CXXFLAGS += -isystem ${PREFIX} -isystem ${BOOST_ROOT} -pedantic -W -Wall -Wno-unknown-pragmas -D__STDC_LIMIT_MACROS -fno-strict-aliasing
@@ -13,7 +12,7 @@ index a294d80..534ca64 100644
  
  # Additional flags for release/debug
  ifeq (${PARALLEL}, 1)
-@@ -23,7 +23,7 @@ endif
+@@ -23,7 +22,7 @@
  ifeq (${STATIC}, 1)
  	LDFLAGS += -static -static-libgcc -pthread -lhts -lz -llzma -lbz2
  else
@@ -22,7 +21,7 @@ index a294d80..534ca64 100644
  endif
  ifeq (${DEBUG}, 1)
  	CXXFLAGS += -g -O0 -fno-inline -DDEBUG
-@@ -41,7 +41,7 @@ BOOSTSOURCES = $(wildcard src/modular-boost/libs/iostreams/include/boost/iostrea
+@@ -41,7 +40,7 @@
  DELLYSOURCES = $(wildcard src/*.h) $(wildcard src/*.cpp)
  
  # Targets
@@ -31,7 +30,7 @@ index a294d80..534ca64 100644
  
  all:   	$(TARGETS)
  
-@@ -54,13 +54,13 @@ all:   	$(TARGETS)
+@@ -54,13 +53,13 @@
  .boost: $(BOOSTSOURCES)
  	cd src/modular-boost && ./bootstrap.sh --prefix=${PWD}/src/modular-boost --without-icu --with-libraries=iostreams,filesystem,system,program_options,date_time && ./b2 && ./b2 headers && cd ../../ && touch .boost
  

--- a/recipes/delly/conda_build_config.yaml
+++ b/recipes/delly/conda_build_config.yaml
@@ -1,0 +1,6 @@
+c_compiler:
+  - gcc      # [linux]
+  - clang    # [osx]
+cxx_compiler:
+  - gxx      # [linux]
+  - clangxx  # [osx]

--- a/recipes/delly/meta.yaml
+++ b/recipes/delly/meta.yaml
@@ -11,7 +11,7 @@ source:
     - Makefile.patch
 
 build:
-  number: 3
+  number: 4
   skip: True # [osx]
 
 requirements:
@@ -20,12 +20,12 @@ requirements:
   host:
     - zlib
     - bzip2
-    - boost
+    - libboost
     - htslib
   run:
     - zlib
     - bzip2
-    - boost
+    - libboost
     - htslib
 
 test:


### PR DESCRIPTION
- Fix delly installs with new compiler defaults. Doesn't build with
boost and new compilers like octopus and salmon, so use libboost.
Fixes delly lookup errors with old boost:
```
delly: symbol lookup error: delly: undefined symbol: _ZN5boost15program_options3argE
```
- Update bcbio, bcbio-vm to support CWL builds with reference data
versions enumerated.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
