### PR TITLE
Weeder2 fix wrapper script

### DIFF
--- a/recipes/weeder/meta.yaml
+++ b/recipes/weeder/meta.yaml
@@ -11,7 +11,7 @@ build:
 
 requirements:
   build:
-    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
   run:
     - python
 

--- a/recipes/weeder/meta.yaml
+++ b/recipes/weeder/meta.yaml
@@ -7,7 +7,7 @@ source:
   md5: 3401675b24ca928b7cc54ce9ebf18b6a
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:

--- a/recipes/weeder/weeder2.py
+++ b/recipes/weeder/weeder2.py
@@ -7,11 +7,11 @@ import argparse
 import subprocess as sp
 
 # Weeder install dir
-weeder_dir = os.path.dirname(os.path.realpath(__file__))
+weeder_dir = os.path.realpath(os.path.join(os.path.dirname(__file__), "..", "share", "weeder2"))
 weeder_exe = "weeder2"
 
 weeder_help = sp.check_output(
-        os.path.realpath(os.path.join(weeder_dir, "..", "share", "weeder2", weeder_exe)), 
+        os.path.join(weeder_dir, weeder_exe),
         stderr=sp.STDOUT).decode()
 parser = argparse.ArgumentParser()
 parser.add_argument("-f", dest="fname")

--- a/recipes/weeder/weeder2.py
+++ b/recipes/weeder/weeder2.py
@@ -23,5 +23,4 @@ if not args.fname:
 fname = os.path.abspath(args.fname)
 rest = " ".join(unknownargs)
 cmd = "./{} -f {} {}".format(weeder_exe, fname, rest)
-p = sp.Popen(cmd, shell=True, cwd=weeder_dir)
-p.communicate()
+sys.exit(sp.call(cmd, shell=True, cwd=weeder_dir))


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

PR to update recipe for the `weeder` package, specifically it updates the Python wrapper script to fix an egregious bug whereby any valid non-trivial command line (i.e. anything except the `-h`/`--help` or any empty argument list) resulted in the wrapper calling itself with the same arguments, and so on *ad infinitum*.

As an aside: when I first encountered this bug, the infinite recursion ultimately consumed all available memory and effectively crashed the workstation I was running on. AFAIK this would happen for any non-trivial usage of the program, which would suggest that the original changes were never tested by their author.

There are a couple of other changes:

* Updates `meta.yml` to include C++ compiler as a build requirement (C compiler didn't seem to be enough when I tried to build locally)
* Updates the wrapper script to capture and return the exit status of the underlying `weeder` executable.