### PR TITLE
Maker: precompile inline C code for MPI support

### DIFF
--- a/recipes/maker/build.sh
+++ b/recipes/maker/build.sh
@@ -24,6 +24,6 @@ mv perl/lib/* $PREFIX/perl/lib/
 mv lib/* $PREFIX/lib/
 
 # Run a first time MPI_Init() to pre compile inline C code
-perl $PREFIX/bin/maker_mpi_init
+mpirun -n 1 $PREFIX/bin/maker_mpi_init
 # This is not needed anymore
 rm $PREFIX/bin/maker_mpi_init

--- a/recipes/maker/build.sh
+++ b/recipes/maker/build.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-cd src/
-
 # We will need this script to precompile inline C code for MPI support
 cp maker_mpi_init $PREFIX/bin/
 rm maker_mpi_init
 chmod a+x $PREFIX/bin/maker_mpi_init
+
+cd src/
 
 # enable mpi
 echo "yes" | perl Build.PL

--- a/recipes/maker/build.sh
+++ b/recipes/maker/build.sh
@@ -24,6 +24,6 @@ mv perl/lib/* $PREFIX/perl/lib/
 mv lib/* $PREFIX/lib/
 
 # Run a first time MPI_Init() to pre compile inline C code
-mpirun -n 1 $PREFIX/bin/maker_mpi_init
+mpirun --allow-run-as-root -n 1 $PREFIX/bin/maker_mpi_init || true
 # This is not needed anymore
 rm $PREFIX/bin/maker_mpi_init

--- a/recipes/maker/build.sh
+++ b/recipes/maker/build.sh
@@ -2,6 +2,11 @@
 
 cd src/
 
+# We will need this script to precompile inline C code for MPI support
+cp maker_mpi_init $PREFIX/bin/
+rm maker_mpi_init
+chmod a+x $PREFIX/bin/maker_mpi_init
+
 # enable mpi
 echo "yes" | perl Build.PL
 
@@ -17,3 +22,8 @@ mv bin/* $PREFIX/bin
 mkdir -p $PREFIX/perl/lib/
 mv perl/lib/* $PREFIX/perl/lib/
 mv lib/* $PREFIX/lib/
+
+# Run a first time MPI_Init() to pre compile inline C code
+perl $PREFIX/bin/maker_mpi_init
+# This is not needed anymore
+rm $PREFIX/bin/maker_mpi_init

--- a/recipes/maker/meta.yaml
+++ b/recipes/maker/meta.yaml
@@ -7,9 +7,10 @@ source:
   md5: 30e3ff1b4bad0218ebf20d049638e864
   patches:
     - "repeatmasker_check.patch"
+    - "mpi_init.patch"
 
 build:
-  number: 7
+  number: 8
 
 requirements:
   build:

--- a/recipes/maker/mpi_init.patch
+++ b/recipes/maker/mpi_init.patch
@@ -1,0 +1,21 @@
+--- maker_mpi_init	1970-01-01 01:00:00.000000000 +0100
++++ maker_mpi_init	2018-09-20 17:01:25.041188751 +0200
+@@ -0,0 +1,18 @@
++#!/usr/bin/env perl
++
++use FindBin;
++use lib "$FindBin::RealBin/../src/inc/perl/lib"; #micelaneous
++use lib "$FindBin::RealBin/../lib";
++use lib "$FindBin::RealBin/../perl/lib";
++
++
++#now load everyting else
++use strict "vars";
++use strict "refs";
++use Carp;
++use Parallel::Application::MPI qw(:all);
++
++#--Start MPI
++carp "Calling MPI_Init";
++MPI_Init();
++


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

This should fix a problem with Maker: currently, the first time running Maker with MPI, some C code is compiled by perl-inline-c in the install directory. This is a problem in multiuser env = fails with permission denied
with this patch, the code is compiled when building the conda package