### PR TITLE
Fixed wrong project name: changed wtdbg2 to wtdbg

### DIFF
--- a/recipes/wtdbg/meta.yaml
+++ b/recipes/wtdbg/meta.yaml
@@ -1,7 +1,7 @@
 {% set version = "2.0" %}
 
 package:
-  name: wtdbg2
+  name: wtdbg
   version: {{ version }}
 
 source:
@@ -24,4 +24,4 @@ about:
   home: https://github.com/ruanjue/wtdbg2
   license: GPL-3.0+
   license_family: GPL
-  summary: 'Wtdbg2: A fuzzy Bruijn graph approach to noisy long reads assembly'
+  summary: 'Wtdbg2: A fuzzy Bruijn graph approach to long noisy reads assembly'


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

The project name was wrongly spelled in the earlier PR today. I am sorry for this mistake...