### PR TITLE
PacBio: rebuild `bax2bam` for new pbbam

### DIFF
--- a/recipes/bax2bam/meta.yaml
+++ b/recipes/bax2bam/meta.yaml
@@ -21,7 +21,7 @@ extra:
     - mhsieh
 
 build:
-  number: 3
+  number: 4
 
 requirements:
   build:
@@ -34,10 +34,12 @@ requirements:
     - hdf5
     - zlib
     - blasr_libcpp 5.3.1*
+    - pbbam 0.19.0*
   run:
     - hdf5
     - zlib
     - blasr_libcpp 5.3.1*
+    - pbbam 0.19.0*
 
 test:
   commands:


### PR DESCRIPTION
* bax2bam has an implicit dependency on pbbam
  and hence needs to pin the version too.

Fixes PacificBiosciences/pbbioconda#17

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
