### PR TITLE
PacBio: require Meson 0.48.1 for all recipes

### DIFF
--- a/recipes/bam2fastx/meta.yaml
+++ b/recipes/bam2fastx/meta.yaml
@@ -26,7 +26,7 @@ build:
 requirements:
   build:
     - {{ compiler('cxx') }}
-    - meson ==0.46*
+    - meson >=0.48.1
     - ninja
     - pkg-config
   host:

--- a/recipes/bax2bam/meta.yaml
+++ b/recipes/bax2bam/meta.yaml
@@ -26,7 +26,7 @@ build:
 requirements:
   build:
     - {{ compiler('cxx') }}
-    - meson
+    - meson >=0.48.1
     - ninja
     - pkg-config
   host:

--- a/recipes/blasr/meta.yaml
+++ b/recipes/blasr/meta.yaml
@@ -26,7 +26,7 @@ build:
 requirements:
   build:
     - {{ compiler('cxx') }}
-    - meson ==0.46*
+    - meson >=0.48.1
     - ninja
     - pkg-config
   host:

--- a/recipes/blasr_libcpp/meta.yaml
+++ b/recipes/blasr_libcpp/meta.yaml
@@ -26,7 +26,7 @@ build:
 requirements:
   build:
     - {{ compiler('cxx') }}
-    - meson ==0.46*
+    - meson >=0.48.1
     - ninja
     - pkg-config
   host:

--- a/recipes/pbbam/meta.yaml
+++ b/recipes/pbbam/meta.yaml
@@ -26,7 +26,7 @@ build:
 requirements:
   build:
     - {{ compiler('cxx') }}
-    - meson ==0.46*
+    - meson >=0.48.1
     - ninja
     - pkg-config
   host:

--- a/recipes/pbcopper/meta.yaml
+++ b/recipes/pbcopper/meta.yaml
@@ -26,7 +26,7 @@ build:
 requirements:
   build:
     - {{ compiler('cxx') }}
-    - meson
+    - meson >=0.48.1
     - ninja
   host:
     - boost

--- a/recipes/pbmm2/meta.yaml
+++ b/recipes/pbmm2/meta.yaml
@@ -28,7 +28,7 @@ requirements:
   build:
     - {{ compiler('cxx') }}
     - {{ compiler('c') }}
-    - meson ==0.46.0*
+    - meson >=0.48.1
     - ninja
     - pkg-config
   host:

--- a/recipes/python-consensuscore/meta.yaml
+++ b/recipes/python-consensuscore/meta.yaml
@@ -27,7 +27,7 @@ build:
 requirements:
   build:
     - {{ compiler('cxx') }}
-    - meson
+    - meson >=0.48.1
     - ninja
     - pkg-config
     - swig


### PR DESCRIPTION
* Meson 0.47 inserted duplicate RPATHs in
  macOS binaries, causing `install_name_tool`
  failures when installing the package.
  Requiring 0.48 ensures we do not run into
  these issues anymore in the future.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
