### PR TITLE
Update: cromwell (35), bcbio

### DIFF
--- a/recipes/bcbio-nextgen/meta.yaml
+++ b/recipes/bcbio-nextgen/meta.yaml
@@ -3,13 +3,13 @@ package:
   version: '1.1.1a'
 
 build:
-  number: 10
+  number: 11
   skip: true # [not py27]
 
 source:
   #url: https://pypi.io/packages/source/b/bcbio-nextgen/bcbio-nextgen-1.1.0.tar.gz
-  url: https://github.com/bcbio/bcbio-nextgen/archive/314b4ec.tar.gz
-  sha256: 449a326f440ed71d1d57b334e7aebf7b97300c3c7560f236a806b11eb4994942
+  url: https://github.com/bcbio/bcbio-nextgen/archive/3f436af.tar.gz
+  sha256: d445fbc9a46bb8d3e6a6d06893154b6cdba0239d12e5aa691ae78ed6d1480807
 
 requirements:
   host:

--- a/recipes/cromwell/meta.yaml
+++ b/recipes/cromwell/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "34" %}
-{% set sha256 = "502da5dfd5ea4de991d48e6eefa35aaf299be79c61c6137dc074d3aa09925862" %}
+{% set version = "35" %}
+{% set sha256 = "5ef5afb286a04bf63ab175082597bd9ced5001db35ef34f9a596232aaf2a132c" %}
 
 package:
   name: cromwell
@@ -7,7 +7,7 @@ package:
 
 build:
   noarch: python
-  number: 1
+  number: 0
 
 source:
   url: https://github.com/broadinstitute/cromwell/archive/{{ version }}.tar.gz


### PR DESCRIPTION
- cromwell: adds support for gs and http URLs in workflows
- bcbio: supports cromwell 35 with back compatibility for older
  version. Avoids speed issue on 35 pre-processing. Fixes
  chapmanb/bcbio-nextgen#2527

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
