### PR TITLE
Update: PureCN to latest devel (1.11.13); wrapper scripts

### DIFF
--- a/build-fail-blacklist
+++ b/build-fail-blacklist
@@ -1108,7 +1108,7 @@ recipes/bioconductor-psea
 recipes/bioconductor-psicquic
 recipes/bioconductor-psygenet2r
 recipes/bioconductor-puma
-recipes/bioconductor-purecn
+#recipes/bioconductor-purecn
 recipes/bioconductor-pvac
 recipes/bioconductor-pvca
 recipes/bioconductor-pviz

--- a/recipes/bioconductor-purecn/build.sh
+++ b/recipes/bioconductor-purecn/build.sh
@@ -2,3 +2,15 @@
 mv DESCRIPTION DESCRIPTION.old
 grep -v '^Priority: ' DESCRIPTION.old > DESCRIPTION
 $R CMD INSTALL --build .
+
+extdata=$PREFIX/lib/R/library/PureCN/extdata
+mkdir -p $PREFIX/bin
+
+for S in Coverage.R Dx.R FilterCallableLoci.R IntervalFile.R NormalDB.R
+do
+	perl -pi -e 'print "#!/opt/anaconda1anaconda2anaconda3/bin/Rscript\n" if $. == 1' $extdata/$S
+	ln -s $extdata/$S $PREFIX/bin/PureCN_${S}
+done
+
+perl -pi -e 'print "#!/opt/anaconda1anaconda2anaconda3/bin/Rscript\n" if $. == 1' $extdata/PureCN.R
+ln -s $extdata/PureCN.R $PREFIX/bin/PureCN.R

--- a/recipes/bioconductor-purecn/meta.yaml
+++ b/recipes/bioconductor-purecn/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.8.0" %}
+{% set version = "1.11.13" %}
 {% set name = "PureCN" %}
 {% set bioc = "3.6" %}
 
@@ -6,12 +6,11 @@ package:
   name: 'bioconductor-{{ name|lower }}'
   version: '{{ version }}'
 source:
-  url:
-    - 'http://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/{{ name }}_{{ version }}.tar.gz'
-    - 'https://depot.galaxyproject.org/software/{{ name }}/{{ name }}_{{ version }}_src_all.tar.gz'
-  sha256: 7a27efd5f7997d5cd3ebaba86c237cefb84b9cdd49824d26bcc8701563aa31c2
+  url: https://github.com/lima1/PureCN/archive/a349984.tar.gz
+  #url: https://depot.galaxyproject.org/software/bioconductor-purecn/bioconductor-purecn_{{ version }}_src_all.tar.gz
+  sha256: 0f9b361ec1e452a648fb707ce8d9777f3a43705a845cb196838642a9e4dbcfb6
 build:
-  number: 1
+  number: 0
   rpaths:
     - lib/R/lib/
     - lib/
@@ -26,6 +25,7 @@ requirements:
     - 'bioconductor-genomicranges >=1.20.3'
     - 'bioconductor-iranges >=2.2.1'
     - bioconductor-limma
+    - bioconductor-rhdf5
     - bioconductor-rsamtools
     - bioconductor-rtracklayer
     - bioconductor-s4vectors
@@ -34,7 +34,9 @@ requirements:
     - r-base
     - r-data.table
     - r-futile.logger
+    - r-gridextra
     - r-ggplot2
+    - r-optparse
     - r-rcolorbrewer
     - r-vgam
   run:
@@ -47,6 +49,7 @@ requirements:
     - 'bioconductor-genomicranges >=1.20.3'
     - 'bioconductor-iranges >=2.2.1'
     - bioconductor-limma
+    - bioconductor-rhdf5
     - bioconductor-rsamtools
     - bioconductor-rtracklayer
     - bioconductor-s4vectors
@@ -55,12 +58,15 @@ requirements:
     - r-base
     - r-data.table
     - r-futile.logger
+    - r-gridextra
     - r-ggplot2
+    - r-optparse
     - r-rcolorbrewer
     - r-vgam
 test:
   commands:
     - '$R -e "library(''{{ name }}'')"'
+    - PureCN.R -h
 about:
   home: 'http://bioconductor.org/packages/{{ bioc }}/bioc/html/{{ name }}.html'
   license: Artistic-2.0

--- a/recipes/bioconductor-purecn/meta.yaml
+++ b/recipes/bioconductor-purecn/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - bioconductor-s4vectors
     - bioconductor-summarizedexperiment
     - 'bioconductor-variantannotation >=1.14.1'
-    - r-base
+    - r-base 3.4.*
     - r-data.table
     - r-futile.logger
     - r-gridextra
@@ -55,7 +55,7 @@ requirements:
     - bioconductor-s4vectors
     - bioconductor-summarizedexperiment
     - 'bioconductor-variantannotation >=1.14.1'
-    - r-base
+    - r-base 3.4.*
     - r-data.table
     - r-futile.logger
     - r-gridextra


### PR DESCRIPTION
PureCN development (https://github.com/lima1/PureCN) has several
improvements over the BioC 3.6 release for handling multiple VCF input
types, and is back compatible with R 3.4.1 so still builds cleanly
with two new dependencies.

Also exposes PureCN wrapper scripts for running from the command line.
Prefixes ambiguous scripts with PureCN_.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
