### PR TITLE
Pin bioconductor-monocle dependency version

### DIFF
--- a/recipes/bioconductor-monocle/meta.yaml
+++ b/recipes/bioconductor-monocle/meta.yaml
@@ -87,3 +87,4 @@ about:
 extra:
   identifiers:
     - biotools:monocle
+    - doi:10.1038/nmeth.4402

--- a/recipes/bioconductor-monocle/meta.yaml
+++ b/recipes/bioconductor-monocle/meta.yaml
@@ -11,7 +11,7 @@ source:
     - 'https://depot.galaxyproject.org/software/{{ name }}/{{ name }}_{{ version }}_src_all.tar.gz'
   sha256: 6344d6cd9d3a43ca81c5351f9283e3877d6f1cb4c3b31815362072f9a508505c
 build:
-  number: 1
+  number: 2
   rpaths:
     - lib/R/lib/
     - lib/

--- a/recipes/bioconductor-monocle/meta.yaml
+++ b/recipes/bioconductor-monocle/meta.yaml
@@ -72,7 +72,7 @@ requirements:
     - r-reshape2
     - r-rtsne
     - r-slam
-    - r-stringr
+    - r-stringr=1.2.0
     - r-tibble
     - 'r-vgam >=1.0-1'
     - r-viridis

--- a/recipes/vsearch/meta.yaml
+++ b/recipes/vsearch/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "2.8.3" %}
-{% set sha256 = "4d764d4c12e0f1e013dcce2778cbadd364303de36c00e5e8a7b9cbef8136bd29" %}
+{% set version = "2.8.5" %}
+{% set sha256 = "15f0ca42ba237a51f3b74ffdac9783b74f19a24d6120dded999b1d0da72f12ce" %}
 
 package:
   name: vsearch


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

This PR pins the `r-stringr` dependency to version 1.2.0. Newer versions prevent Monocle from loading.