### PR TITLE
Revert "Update recipe for Segtools 1.2.1 for both Python 2 and Python 3"

### DIFF
--- a/recipes/segtools/meta.yaml
+++ b/recipes/segtools/meta.yaml
@@ -1,13 +1,29 @@
 package:
   name: segtools
-  version: "1.2.1"
+  version: "1.1.14"
 
 source:
-  url: https://files.pythonhosted.org/packages/1e/c0/f83633350a855e7fd2385f3b824bd5cfdd5bc1cda87b4bfba2eef5a969ac/segtools-1.2.1.tar.gz
-  sha256: 741f409020f91cee422949ccfbbcdf30dae7722083d83f1f1f27340e39d3d7d9 
+  url: https://pypi.python.org/packages/79/51/95ffd8d01b29aa6a3546c7138f0afc24b683f356b112015b32a539ee4a08/segtools-1.1.14.tar.gz
+  md5: 55e42e724b32f6914122164127aa5b23
 
 build:
-  number: 0
+  number: 2
+  preserve_egg_dir: True
+  skip: True # [not py27]
+  entry_points:
+    - segtools-aggregation = segtools.aggregation:main
+    - segtools-compare = segtools.compare:main
+    - segtools-feature-distance = segtools.feature_distance:main
+    - segtools-flatten = segtools.flatten:main
+    - segtools-gmtk-parameters = segtools.gmtk_parameters:main
+    - segtools-html-report = segtools.html:main
+    - segtools-length-distribution = segtools.length_distribution:main
+    - segtools-nucleotide-frequency = segtools.nucleotide_frequency:main
+    - segtools-overlap = segtools.overlap:main
+    - segtools-preprocess = segtools.preprocess:main
+    - segtools-relabel = segtools.relabel:main
+    - segtools-signal-distribution = segtools.signal_distribution:main
+    - segtools-transition = segtools.transition:main
 
 requirements:
   host:
@@ -17,6 +33,7 @@ requirements:
     - rpy2 >=2.6.0,<2.9
     - numpy
     - gmtk
+    - genomedata
 
   run:
     - python
@@ -28,8 +45,7 @@ requirements:
     - r-reshape2
     - r-cluster
     - gmtk
-    - textinput
-    - genomedata # [py2k]
+    - genomedata
     - graphviz
     - pygraphviz
 


### PR DESCRIPTION
Reverts bioconda/bioconda-recipes#9073 as the merge build failed due to the pinned rpy2 versions not being available for R3.5.

https://circleci.com/gh/bioconda/bioconda-recipes/29151