### PR TITLE
Unicycler downgrade seqan patch from 2.4.0 to 2.3.2

### DIFF
--- a/recipes/unicycler/meta.yaml
+++ b/recipes/unicycler/meta.yaml
@@ -16,7 +16,7 @@ source:
     folder: 'seqan'
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipes/unicycler/meta.yaml
+++ b/recipes/unicycler/meta.yaml
@@ -11,8 +11,8 @@ source:
     patches:
       - Makefile.patch  #[linux]
       - misc.py.patch
-  - url: https://github.com/seqan/seqan/archive/seqan-v2.4.0.tar.gz
-    sha256: 'd7084d17729214003e84818e0280a16f223c8f1c6a30eeef040c27e0c0047bd7'
+  - url: https://github.com/seqan/seqan/archive/seqan-v2.3.2.tar.gz
+    sha256: '73ce4b344e6a259db1518547544c730f548bc0b32292b30e3a027146e158085e'
     folder: 'seqan'
 
 build:


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Try using Seqan 2.3.2 instead of 2.4.0.
This version should have [improved gcc7 compliance](https://github.com/seqan/seqan/blob/master/CHANGELOG.rst#release-232) compare to 2.3.1 that led to issues building Unicycler 0.4.6 with PR #10510 , but may solve a [blocking issue](https://github.com/rrwick/Unicycler/issues/140) encountered since use of Seqan 2.4.0.