### PR TITLE
Ensure umis gets click 7.0 along with it.

### DIFF
--- a/recipes/umis/meta.yaml
+++ b/recipes/umis/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: '1.0.0'
 
 build:
-  number: 1
+  number: 2
 
 source:
   url: https://github.com/vals/umis/archive/b02a113.tar.gz
@@ -15,17 +15,11 @@ requirements:
   host:
     - python
     - setuptools
-    - pandas
-    - click
-    - pysam
-    - regex
     - cython
-    - toolz
-    - scipy
   run:
     - python
     - pandas
-    - click
+    - "click>=7.0"
     - pysam
     - regex
     - cython


### PR DESCRIPTION
New version of click changes the way subcommands are named, so cb_filter ->
cb-filter which affects downstream stuff built on top of this repo. This moves
umis to that version of click, since it seems like it will be the default
behavior going forward.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

click changed the way subcommands are named, _ separators go to - in 0.7.0. This ensures umis is distributed with the right version of click.