### PR TITLE
Update motus to build only for python3

### DIFF
--- a/recipes/motus/meta.yaml
+++ b/recipes/motus/meta.yaml
@@ -10,8 +10,9 @@ source:
   sha256: '{{ sha256 }}'
 
 build:
-  number: 1
-  noarch: True
+  number: 2
+  # motus requires python3
+  skip: True # [not py3k]
 
 requirements:
   host:


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Using `noarch: True` made the package compatible with all platforms (#10125) but caused all [containers](https://quay.io/repository/biocontainers/motus?tab=tags) to default to building with python 2.7. 
In light of the limitations mentioned in https://github.com/conda/conda-build/issues/542#issuecomment-130870047 this pull request sets the requirement to python 3.