### PR TITLE
Fixes to meme-chip with python3.

### DIFF
--- a/recipes/meme/build.sh
+++ b/recipes/meme/build.sh
@@ -19,3 +19,11 @@ make AM_CFLAGS='-DNAN="(0.0/0.0)"'
 make install
 
 ln -s $PREFIX/libexec/meme*/* $PREFIX/bin/
+
+# if building with python3,
+# modify meme-chip script to use python3 version of DREME
+if [[ $PGK_BUILDNUM == *"py3"* ]]
+then
+   sed -i '994s/dreme/dreme-py3/' $PREFIX/bin/meme-chip
+fi
+

--- a/recipes/meme/meta.yaml
+++ b/recipes/meme/meta.yaml
@@ -11,7 +11,7 @@ source:
     - mast.patch
 
 build:
-  number: 3
+  number: 4
   detect_binary_files_with_prefix: True
 
 requirements:
@@ -38,6 +38,7 @@ requirements:
     - perl-html-tree
     - perl-math-cdf
     - perl-log-log4perl
+    - perl-json
     - openmpi
 
   run:
@@ -59,6 +60,7 @@ requirements:
     - perl-html-tree
     - perl-math-cdf
     - perl-log-log4perl
+    - perl-json
     - openmpi
 
 test:


### PR DESCRIPTION
This PR is for two changes that allow `meme-chip` to run smoothly when built with python 3. The first change is to add `perl-json` to the requirements list to allow the final `meme-chip_html_to_tsv` step of `meme-chip` to run without errors. The second change is to modify the `meme-chip` script to execute `dreme-py3`, the python 3 version of `dreme`, if the package is built with python 3.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
