### PR TITLE
Bump IgBLAST to 1.9.0

### DIFF
--- a/build-fail-blacklist
+++ b/build-fail-blacklist
@@ -1886,7 +1886,6 @@ recipes/jali
 recipes/intervalstats
 
 # failing
-recipes/igblast
 recipes/igblast/1.4.0
 
 # missing fortran lib, will fix this upstream

--- a/recipes/igblast/build.sh
+++ b/recipes/igblast/build.sh
@@ -6,34 +6,27 @@ SHARE_DIR=$PREFIX/share/igblast
 
 mkdir -p $PREFIX/bin
 
-# This is going to contain the igblastn and igblastp binaries.
-# Only wrappers are installed into $PREFIX/bin/ .
-mkdir -p $SHARE_DIR/bin
-
 if [ $(uname) == Linux ]; then
-    # If on Linux, compile the tool ourselves because the distributed binaries
-    # link against libbz2.so, and the usual conda bzip2 package does not
-    # provide this. See https://github.com/bioconda/bioconda-recipes/pull/3020
-
-    cd c++
-    ./configure --prefix=$PREFIX --with-sqlite3=$PREFIX
-    make -j2
-    mv ReleaseMT/bin/{igblastn,igblastp} $SHARE_DIR/bin/
-    mv ReleaseMT/bin/makeblastdb $PREFIX/bin/
-else
-    # On macOS, use the prebuilt binaries
-    mv bin/makeblastdb $PREFIX/bin/
-    mv bin/igblastn bin/igblastp $SHARE_DIR/bin/
+  # The binaries want libbz2.so.1, but the correct soname is libbz2.so.1.0
+  for name in makeblastdb igblastn igblastp; do
+    patchelf --replace-needed libbz2.so.1 libbz2.so.1.0 bin/$name
+  done
 fi
 
+# $SHARE_DIR contains the actual igblastn and igblastp binaries and also the
+# required data files. Wrappers will be installed into $PREFIX/bin that set
+# $IGDATA to point to those data files.
+mkdir -p $SHARE_DIR/bin
 
-# Since IgBLAST needs the environment variable IGDATA in order to find its
-# data files (download below), the igblastn and igblastp binaries will be
-# wrappers that set IGDATA to $SCRIPT_DIR/../share/igblast.
-cp -f $RECIPE_DIR/igblastn.sh $PREFIX/bin/igblastn
-sed 's/igblastn/igblastp/g' $PREFIX/bin/igblastn > $PREFIX/bin/igblastp
-chmod +x $PREFIX/bin/igblastn $PREFIX/bin/igblastp
+# Copy binaries and wrappers
+for name in igblastn igblastp; do
+  mv bin/$name $SHARE_DIR/bin/
+  sed "s/igblastn/$name/g" $RECIPE_DIR/igblastn.sh > $PREFIX/bin/$name
+  chmod +x $PREFIX/bin/$name
+done
 
+# No wrapper needed
+mv bin/makeblastdb $PREFIX/bin/
 
 wget $IGBLAST_ADDRESS/edit_imgt_file.pl
 # Replace the hardcoded perl shebang pointing to /opt with `#!/usr/bin/env perl`.

--- a/recipes/igblast/meta.yaml
+++ b/recipes/igblast/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: igblast
-  version: "1.7.0"
+  version: "1.9.0"
 
 about:
   home: http://www.ncbi.nlm.nih.gov/projects/igblast/
@@ -8,31 +8,36 @@ about:
   summary: A tool for analyzing immunoglobulin (IG) and T cell receptor (TR) sequences.
 
 source:
-  # Use sources on Linux, binaries on macOS
-  md5: 238857cff5de770ac3fc93d96526a247  # [linux]
-  md5: a28c6cab4c9706c330e6496f3450da9e  # [osx]
-  url: ftp://ftp.ncbi.nih.gov/blast/executables/igblast/release/1.7.0/ncbi-igblast-1.7.0-src.tar.gz  # [linux]
-  url: ftp://ftp.ncbi.nih.gov/blast/executables/igblast/release/1.7.0/ncbi-igblast-1.7.0-x64-macosx.tar.gz  # [osx]
+  sha256: 83d861853a1a1943bff43f8b5bcd1203e634c3492848e53991503a3e73d275e5  # [linux]
+  sha256: 32a974c944520ffaa8aa4261c9da2d19098cc92056835178d1215edd7539ecee  # [osx]
+  url: ftp://ftp.ncbi.nih.gov/blast/executables/igblast/release/1.9.0/ncbi-igblast-1.9.0-x64-linux.tar.gz  # [linux]
+  url: ftp://ftp.ncbi.nih.gov/blast/executables/igblast/release/1.9.0/ncbi-igblast-1.9.0-x64-macosx.tar.gz  # [osx]
 
 build:
-  number: 1
+  number: 0
 
 requirements:
   build:
     - {{ compiler('c') }}
-  host:
+    - patchelf  # [linux]
     - gnu-wget
-    - sqlite
-    - openssl
-  run:
-    - perl
+  host:
     - zlib
-    - sqlite
-    - openssl
-
+    - bzip2
+    - libidn11
+    - libxml2
+  run:
+    - zlib
+    - bzip2
+    - libidn11
+    - libxml2
+    - perl
+    - gnutls  # [osx]
 test:
   commands:
     - igblastn -h
+    - igblastp -h
+    - makeblastdb -h
 
 extra:
   identifiers:

--- a/recipes/igblast/meta.yaml
+++ b/recipes/igblast/meta.yaml
@@ -14,6 +14,7 @@ source:
   url: ftp://ftp.ncbi.nih.gov/blast/executables/igblast/release/1.9.0/ncbi-igblast-1.9.0-x64-macosx.tar.gz  # [osx]
 
 build:
+  skip: true  # [osx]
   number: 0
 
 requirements:


### PR DESCRIPTION
Re-package the binary version this time. There are problems building the
source version when the configure script reaches this step:
"trying to build the NCBI SRA/VDB Toolkit from GitHub"

The previous problem about the binaries linking against libbz2.so, for
which we had no conda package, is now solved.

Also, this saves about 45 minutes compilation time.

* [X] This PR updates an existing recipe.

