### PR TITLE
porechop: Use the standard release

### DIFF
--- a/recipes/porechop/build.sh
+++ b/recipes/porechop/build.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-$PYTHON setup.py install --single-version-externally-managed --record=record.txt
-$PYTHON -m unittest

--- a/recipes/porechop/conda_build_config.yaml
+++ b/recipes/porechop/conda_build_config.yaml
@@ -1,0 +1,6 @@
+c_compiler:
+  - gcc      # [linux]
+  - clang    # [osx]
+cxx_compiler:
+  - gxx      # [linux]
+  - clangxx  # [osx]

--- a/recipes/porechop/meta.yaml
+++ b/recipes/porechop/meta.yaml
@@ -1,24 +1,21 @@
-# NOTE: Currently we require a modified version of Porechop with downgraded
-# SeqAn to compile with the latest GCC available in conda (4.8).
-#
-# When GCC 4.9 or later is available on conda, the source metadata should be
-# updated to point to the latest mainstream Porechop release.
-
-{% set version = "0.2.3_seqan2.1.1" %}
+{% set version = "0.2.3" %}
 
 package:
   name: porechop
   version: {{ version }}
 
 source:
-  url: https://github.com/rrwick/Porechop/archive/v0.2.3-C++11.tar.gz
-  sha256: 817371dceed77e583e387e9ca7c10214c0faff7c0a89320d60a66efdc6c0d35a
+  url: https://github.com/rrwick/Porechop/archive/v0.2.3.tar.gz
+  sha256: bfed39f82abc54f44fffd9b13d2121868084da7ac3d158ac9b9aa6fa0257f0f4
 
 build:
-  number: 3
+  number: 4
   skip: True # [py27]
   entry_points:
     - porechop = porechop.porechop:main
+  script: |
+    {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
+    {{ PYTHON }} -m unittest
 
 requirements:
   build:


### PR DESCRIPTION
A special tag of Porechop was made to support older versions of GCC.
Use the standard release with a recent version of GCC.


* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [x] This PR updates an existing recipe.