### PR TITLE
[BULK] Many R 3.5 only packages

### DIFF
--- a/recipes/bioconductor-affy/meta.yaml
+++ b/recipes/bioconductor-affy/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - 'bioconductor-biocinstaller >=1.30.0,<1.32.0'
     - 'bioconductor-preprocesscore >=1.42.0,<1.44.0'
     - 'bioconductor-zlibbioc >=1.26.0,<1.28.0'
-    - r-base
+    - r-base >=3.5
   run:
     - 'bioconductor-affyio >=1.50.0,<1.52.0'
     - 'bioconductor-biobase >=2.40.0,<2.42.0'
@@ -32,7 +32,7 @@ requirements:
     - 'bioconductor-biocinstaller >=1.30.0,<1.32.0'
     - 'bioconductor-preprocesscore >=1.42.0,<1.44.0'
     - 'bioconductor-zlibbioc >=1.26.0,<1.28.0'
-    - r-base
+    - r-base >=3.5
   build:
     - {{ compiler('c') }}
     - automake

--- a/recipes/bioconductor-affycontam/meta.yaml
+++ b/recipes/bioconductor-affycontam/meta.yaml
@@ -21,12 +21,12 @@ requirements:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
     - 'bioconductor-affydata >=1.28.0,<1.30.0'
     - 'bioconductor-biobase >=2.40.0,<2.42.0'
-    - r-base
+    - r-base >=3.5
   run:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
     - 'bioconductor-affydata >=1.28.0,<1.30.0'
     - 'bioconductor-biobase >=2.40.0,<2.42.0'
-    - r-base
+    - r-base >=3.5
 test:
   commands:
     - '$R -e "library(''{{ name }}'')"'

--- a/recipes/bioconductor-affycoretools/meta.yaml
+++ b/recipes/bioconductor-affycoretools/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - 'bioconductor-oligoclasses >=1.42.0,<1.44.0'
     - 'bioconductor-reportingtools >=2.20.0,<2.22.0'
     - 'bioconductor-s4vectors >=0.18.3,<0.20.0'
-    - r-base
+    - r-base >=3.5
     - r-dbi
     - r-ggplot2
     - r-gplots
@@ -49,7 +49,7 @@ requirements:
     - 'bioconductor-oligoclasses >=1.42.0,<1.44.0'
     - 'bioconductor-reportingtools >=2.20.0,<2.22.0'
     - 'bioconductor-s4vectors >=0.18.3,<0.20.0'
-    - r-base
+    - r-base >=3.5
     - r-dbi
     - r-ggplot2
     - r-gplots

--- a/recipes/bioconductor-affydata/meta.yaml
+++ b/recipes/bioconductor-affydata/meta.yaml
@@ -19,10 +19,10 @@ build:
 requirements:
   host:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
-    - r-base
+    - r-base >=3.5
   run:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
-    - r-base
+    - r-base >=3.5
     - wget
 test:
   commands:

--- a/recipes/bioconductor-affyexpress/meta.yaml
+++ b/recipes/bioconductor-affyexpress/meta.yaml
@@ -20,11 +20,11 @@ requirements:
   host:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
     - 'bioconductor-limma >=3.36.5,<3.38.0'
-    - r-base
+    - r-base >=3.5
   run:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
     - 'bioconductor-limma >=3.36.5,<3.38.0'
-    - r-base
+    - r-base >=3.5
 test:
   commands:
     - '$R -e "library(''{{ name }}'')"'

--- a/recipes/bioconductor-affyilm/meta.yaml
+++ b/recipes/bioconductor-affyilm/meta.yaml
@@ -22,13 +22,13 @@ requirements:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
     - 'bioconductor-biobase >=2.40.0,<2.42.0'
     - 'bioconductor-gcrma >=2.52.0,<2.54.0'
-    - r-base
+    - r-base >=3.5
   run:
     - 'bioconductor-affxparser >=1.52.0,<1.54.0'
     - 'bioconductor-affy >=1.58.0,<1.60.0'
     - 'bioconductor-biobase >=2.40.0,<2.42.0'
     - 'bioconductor-gcrma >=2.52.0,<2.54.0'
-    - r-base
+    - r-base >=3.5
 test:
   commands:
     - '$R -e "library(''{{ name }}'')"'

--- a/recipes/bioconductor-affypdnn/meta.yaml
+++ b/recipes/bioconductor-affypdnn/meta.yaml
@@ -19,10 +19,10 @@ build:
 requirements:
   host:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
-    - r-base
+    - r-base >=3.5
   run:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
-    - r-base
+    - r-base >=3.5
 test:
   commands:
     - '$R -e "library(''{{ name }}'')"'

--- a/recipes/bioconductor-affyplm/meta.yaml
+++ b/recipes/bioconductor-affyplm/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - 'bioconductor-gcrma >=2.52.0,<2.54.0'
     - 'bioconductor-preprocesscore >=1.42.0,<1.44.0'
     - 'bioconductor-zlibbioc >=1.26.0,<1.28.0'
-    - r-base
+    - r-base >=3.5
   run:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
     - 'bioconductor-biobase >=2.40.0,<2.42.0'
@@ -32,7 +32,7 @@ requirements:
     - 'bioconductor-gcrma >=2.52.0,<2.54.0'
     - 'bioconductor-preprocesscore >=1.42.0,<1.44.0'
     - 'bioconductor-zlibbioc >=1.26.0,<1.28.0'
-    - r-base
+    - r-base >=3.5
   build:
     - {{ compiler('c') }}
     - make

--- a/recipes/bioconductor-affyrnadegradation/meta.yaml
+++ b/recipes/bioconductor-affyrnadegradation/meta.yaml
@@ -19,10 +19,10 @@ build:
 requirements:
   host:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
-    - r-base
+    - r-base >=3.5
   run:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
-    - r-base
+    - r-base >=3.5
 test:
   commands:
     - '$R -e "library(''{{ name }}'')"'

--- a/recipes/bioconductor-altcdfenvs/meta.yaml
+++ b/recipes/bioconductor-altcdfenvs/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - 'bioconductor-hypergraph >=1.52.0,<1.54.0'
     - 'bioconductor-makecdfenv >=1.56.0,<1.58.0'
     - 'bioconductor-s4vectors >=0.18.3,<0.20.0'
-    - r-base
+    - r-base >=3.5
   run:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
     - 'bioconductor-biobase >=2.40.0,<2.42.0'
@@ -34,7 +34,7 @@ requirements:
     - 'bioconductor-hypergraph >=1.52.0,<1.54.0'
     - 'bioconductor-makecdfenv >=1.56.0,<1.58.0'
     - 'bioconductor-s4vectors >=0.18.3,<0.20.0'
-    - r-base
+    - r-base >=3.5
 test:
   commands:
     - '$R -e "library(''{{ name }}'')"'

--- a/recipes/bioconductor-annotationhub/meta.yaml
+++ b/recipes/bioconductor-annotationhub/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - 'bioconductor-biocinstaller >=1.30.0,<1.32.0'
     - 'bioconductor-interactivedisplaybase >=1.18.0,<1.20.0'
     - 'bioconductor-s4vectors >=0.18.3,<0.20.0'
-    - r-base
+    - r-base >=3.5
     - r-curl
     - r-httr
     - r-rsqlite
@@ -34,7 +34,7 @@ requirements:
     - 'bioconductor-biocinstaller >=1.30.0,<1.32.0'
     - 'bioconductor-interactivedisplaybase >=1.18.0,<1.20.0'
     - 'bioconductor-s4vectors >=0.18.3,<0.20.0'
-    - r-base
+    - r-base >=3.5
     - r-curl
     - r-httr
     - r-rsqlite

--- a/recipes/bioconductor-annotationhubdata/meta.yaml
+++ b/recipes/bioconductor-annotationhubdata/meta.yaml
@@ -36,7 +36,7 @@ requirements:
     - 'bioconductor-rsamtools >=1.32.3,<1.34.0'
     - 'bioconductor-rtracklayer >=1.40.6,<1.42.0'
     - 'bioconductor-s4vectors >=0.18.3,<0.20.0'
-    - r-base
+    - r-base >=3.5
     - r-dbi
     - 'r-futile.logger >=1.3.0'
     - r-jsonlite
@@ -62,7 +62,7 @@ requirements:
     - 'bioconductor-rsamtools >=1.32.3,<1.34.0'
     - 'bioconductor-rtracklayer >=1.40.6,<1.42.0'
     - 'bioconductor-s4vectors >=0.18.3,<0.20.0'
-    - r-base
+    - r-base >=3.5
     - r-dbi
     - 'r-futile.logger >=1.3.0'
     - r-jsonlite

--- a/recipes/bioconductor-arrayqualitymetrics/meta.yaml
+++ b/recipes/bioconductor-arrayqualitymetrics/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - 'bioconductor-genefilter >=1.62.0,<1.64.0'
     - 'bioconductor-limma >=3.36.5,<3.38.0'
     - 'bioconductor-vsn >=3.48.1,<3.50.0'
-    - r-base
+    - r-base >=3.5
     - 'r-cairo >=1.4-6'
     - 'r-gridsvg >=1.4-3'
     - r-hmisc
@@ -43,7 +43,7 @@ requirements:
     - 'bioconductor-genefilter >=1.62.0,<1.64.0'
     - 'bioconductor-limma >=3.36.5,<3.38.0'
     - 'bioconductor-vsn >=3.48.1,<3.50.0'
-    - r-base
+    - r-base >=3.5
     - 'r-cairo >=1.4-6'
     - 'r-gridsvg >=1.4-3'
     - r-hmisc

--- a/recipes/bioconductor-arraytools/meta.yaml
+++ b/recipes/bioconductor-arraytools/meta.yaml
@@ -21,13 +21,13 @@ requirements:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
     - 'bioconductor-biobase >=2.40.0,<2.42.0'
     - 'bioconductor-limma >=3.36.5,<3.38.0'
-    - r-base
+    - r-base >=3.5
     - r-xtable
   run:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
     - 'bioconductor-biobase >=2.40.0,<2.42.0'
     - 'bioconductor-limma >=3.36.5,<3.38.0'
-    - r-base
+    - r-base >=3.5
     - r-xtable
 test:
   commands:

--- a/recipes/bioconductor-atacseqqc/meta.yaml
+++ b/recipes/bioconductor-atacseqqc/meta.yaml
@@ -32,7 +32,7 @@ requirements:
     - 'bioconductor-rsamtools >=1.32.3,<1.34.0'
     - 'bioconductor-rtracklayer >=1.40.6,<1.42.0'
     - 'bioconductor-s4vectors >=0.18.3,<0.20.0'
-    - r-base
+    - r-base >=3.5
     - r-kernsmooth
     - r-preseqr
     - r-randomforest
@@ -51,7 +51,7 @@ requirements:
     - 'bioconductor-rsamtools >=1.32.3,<1.34.0'
     - 'bioconductor-rtracklayer >=1.40.6,<1.42.0'
     - 'bioconductor-s4vectors >=0.18.3,<0.20.0'
-    - r-base
+    - r-base >=3.5
     - r-kernsmooth
     - r-preseqr
     - r-randomforest

--- a/recipes/bioconductor-cellhts2/meta.yaml
+++ b/recipes/bioconductor-cellhts2/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - 'bioconductor-prada >=1.56.0,<1.58.0'
     - 'bioconductor-splots >=1.46.0,<1.48.0'
     - 'bioconductor-vsn >=3.48.1,<3.50.0'
-    - r-base
+    - r-base >=3.5
     - r-hwriter
     - r-locfit
     - r-rcolorbrewer
@@ -39,7 +39,7 @@ requirements:
     - 'bioconductor-prada >=1.56.0,<1.58.0'
     - 'bioconductor-splots >=1.46.0,<1.48.0'
     - 'bioconductor-vsn >=3.48.1,<3.50.0'
-    - r-base
+    - r-base >=3.5
     - r-hwriter
     - r-locfit
     - r-rcolorbrewer

--- a/recipes/bioconductor-chippeakanno/meta.yaml
+++ b/recipes/bioconductor-chippeakanno/meta.yaml
@@ -41,7 +41,7 @@ requirements:
     - 'bioconductor-rsamtools >=1.32.3,<1.34.0'
     - 'bioconductor-s4vectors >=0.18.3,<0.20.0'
     - 'bioconductor-summarizedexperiment >=1.10.1,<1.12.0'
-    - r-base
+    - r-base >=3.5
     - r-dbi
     - r-idr
     - r-matrixstats
@@ -71,7 +71,7 @@ requirements:
     - 'bioconductor-rsamtools >=1.32.3,<1.34.0'
     - 'bioconductor-s4vectors >=0.18.3,<0.20.0'
     - 'bioconductor-summarizedexperiment >=1.10.1,<1.12.0'
-    - r-base
+    - r-base >=3.5
     - r-dbi
     - r-idr
     - r-matrixstats

--- a/recipes/bioconductor-chipxpress/meta.yaml
+++ b/recipes/bioconductor-chipxpress/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - 'bioconductor-chipxpressdata >=1.18.0,<1.20.0'
     - 'bioconductor-frma >=1.32.0,<1.34.0'
     - 'bioconductor-geoquery >=2.48.0,<2.50.0'
-    - r-base
+    - r-base >=3.5
     - r-biganalytics
     - r-bigmemory
   run:
@@ -32,7 +32,7 @@ requirements:
     - 'bioconductor-chipxpressdata >=1.18.0,<1.20.0'
     - 'bioconductor-frma >=1.32.0,<1.34.0'
     - 'bioconductor-geoquery >=2.48.0,<2.50.0'
-    - r-base
+    - r-base >=3.5
     - r-biganalytics
     - r-bigmemory
 test:

--- a/recipes/bioconductor-cn.farms/meta.yaml
+++ b/recipes/bioconductor-cn.farms/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - 'bioconductor-oligo >=1.44.0,<1.46.0'
     - 'bioconductor-oligoclasses >=1.42.0,<1.44.0'
     - 'bioconductor-preprocesscore >=1.42.0,<1.44.0'
-    - r-base
+    - r-base >=3.5
     - r-dbi
     - r-ff
     - r-lattice
@@ -36,7 +36,7 @@ requirements:
     - 'bioconductor-oligo >=1.44.0,<1.46.0'
     - 'bioconductor-oligoclasses >=1.42.0,<1.44.0'
     - 'bioconductor-preprocesscore >=1.42.0,<1.44.0'
-    - r-base
+    - r-base >=3.5
     - r-dbi
     - r-ff
     - r-lattice

--- a/recipes/bioconductor-cormotif/meta.yaml
+++ b/recipes/bioconductor-cormotif/meta.yaml
@@ -20,11 +20,11 @@ requirements:
   host:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
     - 'bioconductor-limma >=3.36.5,<3.38.0'
-    - r-base
+    - r-base >=3.5
   run:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
     - 'bioconductor-limma >=3.36.5,<3.38.0'
-    - r-base
+    - r-base >=3.5
 test:
   commands:
     - '$R -e "library(''{{ name }}'')"'

--- a/recipes/bioconductor-crisprseekplus/meta.yaml
+++ b/recipes/bioconductor-crisprseekplus/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - 'bioconductor-genomicfeatures >=1.32.2,<1.34.0'
     - 'bioconductor-genomicranges >=1.32.7,<1.34.0'
     - 'bioconductor-guideseq >=1.10.0,<1.12.0'
-    - r-base
+    - r-base >=3.5
     - r-dt
     - r-hash
     - r-shiny
@@ -38,7 +38,7 @@ requirements:
     - 'bioconductor-genomicfeatures >=1.32.2,<1.34.0'
     - 'bioconductor-genomicranges >=1.32.7,<1.34.0'
     - 'bioconductor-guideseq >=1.10.0,<1.12.0'
-    - r-base
+    - r-base >=3.5
     - r-dt
     - r-hash
     - r-shiny

--- a/recipes/bioconductor-crlmm/meta.yaml
+++ b/recipes/bioconductor-crlmm/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - 'bioconductor-oligoclasses >=1.42.0,<1.44.0'
     - 'bioconductor-preprocesscore >=1.42.0,<1.44.0'
     - 'bioconductor-snpchip >=2.26.0,<2.28.0'
-    - r-base
+    - r-base >=3.5
     - r-beanplot
     - r-ellipse
     - r-ff
@@ -45,7 +45,7 @@ requirements:
     - 'bioconductor-oligoclasses >=1.42.0,<1.44.0'
     - 'bioconductor-preprocesscore >=1.42.0,<1.44.0'
     - 'bioconductor-snpchip >=2.26.0,<2.28.0'
-    - r-base
+    - r-base >=3.5
     - r-beanplot
     - r-ellipse
     - r-ff

--- a/recipes/bioconductor-curatedmetagenomicdata/meta.yaml
+++ b/recipes/bioconductor-curatedmetagenomicdata/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - 'bioconductor-biobase >=2.40.0,<2.42.0'
     - 'bioconductor-experimenthub >=1.6.1,<1.8.0'
     - 'bioconductor-s4vectors >=0.18.3,<0.20.0'
-    - r-base
+    - r-base >=3.5
     - 'r-dplyr >=0.5.0'
     - r-magrittr
     - r-tidyr
@@ -31,7 +31,7 @@ requirements:
     - 'bioconductor-biobase >=2.40.0,<2.42.0'
     - 'bioconductor-experimenthub >=1.6.1,<1.8.0'
     - 'bioconductor-s4vectors >=0.18.3,<0.20.0'
-    - r-base
+    - r-base >=3.5
     - 'r-dplyr >=0.5.0'
     - r-magrittr
     - r-tidyr

--- a/recipes/bioconductor-curatedovariandata/meta.yaml
+++ b/recipes/bioconductor-curatedovariandata/meta.yaml
@@ -20,11 +20,11 @@ requirements:
   host:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
     - 'bioconductor-biocgenerics >=0.26.0,<0.28.0'
-    - r-base
+    - r-base >=3.5
   run:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
     - 'bioconductor-biocgenerics >=0.26.0,<0.28.0'
-    - r-base
+    - r-base >=3.5
     - wget
 test:
   commands:

--- a/recipes/bioconductor-dchiprep/meta.yaml
+++ b/recipes/bioconductor-dchiprep/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - 'bioconductor-soggi >=1.12.0,<1.14.0'
     - 'bioconductor-summarizedexperiment >=1.10.1,<1.12.0'
     - r-assertthat
-    - r-base
+    - r-base >=3.5
     - r-fdrtool
     - r-ggplot2
     - r-plyr
@@ -41,7 +41,7 @@ requirements:
     - 'bioconductor-soggi >=1.12.0,<1.14.0'
     - 'bioconductor-summarizedexperiment >=1.10.1,<1.12.0'
     - r-assertthat
-    - r-base
+    - r-base >=3.5
     - r-fdrtool
     - r-ggplot2
     - r-plyr

--- a/recipes/bioconductor-drugvsdisease/meta.yaml
+++ b/recipes/bioconductor-drugvsdisease/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - 'bioconductor-hgu133plus2.db >=3.2.3,<3.4.0'
     - 'bioconductor-limma >=3.36.5,<3.38.0'
     - 'bioconductor-qvalue >=2.12.0,<2.14.0'
-    - r-base
+    - r-base >=3.5
     - r-runit
     - r-xtable
   run:
@@ -48,7 +48,7 @@ requirements:
     - 'bioconductor-hgu133plus2.db >=3.2.3,<3.4.0'
     - 'bioconductor-limma >=3.36.5,<3.38.0'
     - 'bioconductor-qvalue >=2.12.0,<2.14.0'
-    - r-base
+    - r-base >=3.5
     - r-runit
     - r-xtable
 test:

--- a/recipes/bioconductor-epivizrdata/meta.yaml
+++ b/recipes/bioconductor-epivizrdata/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - 'bioconductor-organismdbi >=1.22.0,<1.24.0'
     - 'bioconductor-s4vectors >=0.18.3,<0.20.0'
     - 'bioconductor-summarizedexperiment >=1.10.1,<1.12.0'
-    - r-base
+    - r-base >=3.5
   run:
     - 'bioconductor-biobase >=2.40.0,<2.42.0'
     - 'bioconductor-ensembldb >=2.4.1,<2.6.0'
@@ -40,7 +40,7 @@ requirements:
     - 'bioconductor-organismdbi >=1.22.0,<1.24.0'
     - 'bioconductor-s4vectors >=0.18.3,<0.20.0'
     - 'bioconductor-summarizedexperiment >=1.10.1,<1.12.0'
-    - r-base
+    - r-base >=3.5
 test:
   commands:
     - '$R -e "library(''{{ name }}'')"'

--- a/recipes/bioconductor-eximir/meta.yaml
+++ b/recipes/bioconductor-eximir/meta.yaml
@@ -23,14 +23,14 @@ requirements:
     - 'bioconductor-biobase >=2.40.0,<2.42.0'
     - 'bioconductor-limma >=3.36.5,<3.38.0'
     - 'bioconductor-preprocesscore >=1.42.0,<1.44.0'
-    - r-base
+    - r-base >=3.5
   run:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
     - 'bioconductor-affyio >=1.50.0,<1.52.0'
     - 'bioconductor-biobase >=2.40.0,<2.42.0'
     - 'bioconductor-limma >=3.36.5,<3.38.0'
     - 'bioconductor-preprocesscore >=1.42.0,<1.44.0'
-    - r-base
+    - r-base >=3.5
 test:
   commands:
     - '$R -e "library(''{{ name }}'')"'

--- a/recipes/bioconductor-experimenthub/meta.yaml
+++ b/recipes/bioconductor-experimenthub/meta.yaml
@@ -22,14 +22,14 @@ requirements:
     - 'bioconductor-biocgenerics >=0.26.0,<0.28.0'
     - 'bioconductor-biocinstaller >=1.30.0,<1.32.0'
     - 'bioconductor-s4vectors >=0.18.3,<0.20.0'
-    - r-base
+    - r-base >=3.5
     - r-curl
   run:
     - 'bioconductor-annotationhub >=2.12.1,<2.14.0'
     - 'bioconductor-biocgenerics >=0.26.0,<0.28.0'
     - 'bioconductor-biocinstaller >=1.30.0,<1.32.0'
     - 'bioconductor-s4vectors >=0.18.3,<0.20.0'
-    - r-base
+    - r-base >=3.5
     - r-curl
 test:
   commands:

--- a/recipes/bioconductor-farms/meta.yaml
+++ b/recipes/bioconductor-farms/meta.yaml
@@ -20,12 +20,12 @@ requirements:
   host:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
     - 'bioconductor-biobase >=2.40.0,<2.42.0'
-    - r-base
+    - r-base >=3.5
     - r-mass
   run:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
     - 'bioconductor-biobase >=2.40.0,<2.42.0'
-    - r-base
+    - r-base >=3.5
     - r-mass
 test:
   commands:

--- a/recipes/bioconductor-ffpe/meta.yaml
+++ b/recipes/bioconductor-ffpe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - 'bioconductor-biocgenerics >=0.26.0,<0.28.0'
     - 'bioconductor-lumi >=2.32.0,<2.34.0'
     - 'bioconductor-methylumi >=2.26.0,<2.28.0'
-    - r-base
+    - r-base >=3.5
     - r-sfsmisc
     - r-ttr
   run:
@@ -32,7 +32,7 @@ requirements:
     - 'bioconductor-biocgenerics >=0.26.0,<0.28.0'
     - 'bioconductor-lumi >=2.32.0,<2.34.0'
     - 'bioconductor-methylumi >=2.26.0,<2.28.0'
-    - r-base
+    - r-base >=3.5
     - r-sfsmisc
     - r-ttr
 test:

--- a/recipes/bioconductor-frma/meta.yaml
+++ b/recipes/bioconductor-frma/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - 'bioconductor-oligo >=1.44.0,<1.46.0'
     - 'bioconductor-oligoclasses >=1.42.0,<1.44.0'
     - 'bioconductor-preprocesscore >=1.42.0,<1.44.0'
-    - r-base
+    - r-base >=3.5
     - r-dbi
     - r-mass
   run:
@@ -34,7 +34,7 @@ requirements:
     - 'bioconductor-oligo >=1.44.0,<1.46.0'
     - 'bioconductor-oligoclasses >=1.42.0,<1.44.0'
     - 'bioconductor-preprocesscore >=1.42.0,<1.44.0'
-    - r-base
+    - r-base >=3.5
     - r-dbi
     - r-mass
 test:

--- a/recipes/bioconductor-frmatools/meta.yaml
+++ b/recipes/bioconductor-frmatools/meta.yaml
@@ -21,13 +21,13 @@ requirements:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
     - 'bioconductor-biobase >=2.40.0,<2.42.0'
     - 'bioconductor-preprocesscore >=1.42.0,<1.44.0'
-    - r-base
+    - r-base >=3.5
     - r-dbi
   run:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
     - 'bioconductor-biobase >=2.40.0,<2.42.0'
     - 'bioconductor-preprocesscore >=1.42.0,<1.44.0'
-    - r-base
+    - r-base >=3.5
     - r-dbi
 test:
   commands:

--- a/recipes/bioconductor-gcrma/meta.yaml
+++ b/recipes/bioconductor-gcrma/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - 'bioconductor-biocinstaller >=1.30.0,<1.32.0'
     - 'bioconductor-biostrings >=2.48.0,<2.50.0'
     - 'bioconductor-xvector >=0.20.0,<0.22.0'
-    - r-base
+    - r-base >=3.5
   run:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
     - 'bioconductor-affyio >=1.50.0,<1.52.0'
@@ -32,7 +32,7 @@ requirements:
     - 'bioconductor-biocinstaller >=1.30.0,<1.32.0'
     - 'bioconductor-biostrings >=2.48.0,<2.50.0'
     - 'bioconductor-xvector >=0.20.0,<0.22.0'
-    - r-base
+    - r-base >=3.5
   build:
     - {{ compiler('c') }}
     - make

--- a/recipes/bioconductor-genomicfeatures/meta.yaml
+++ b/recipes/bioconductor-genomicfeatures/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.32.2" %}
+{% set version = "1.32.3" %}
 {% set name = "GenomicFeatures" %}
 {% set bioc = "3.7" %}
 
@@ -10,7 +10,7 @@ source:
     - 'http://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/{{ name }}_{{ version }}.tar.gz'
     - 'https://bioarchive.galaxyproject.org/{{ name }}_{{ version }}.tar.gz'
     - 'https://depot.galaxyproject.org/software/bioconductor-{{ name|lower }}/bioconductor-{{ name|lower }}_{{ version }}_src_all.tar.gz'
-  sha256: ae6041a881ab060b3de153b7171d7a79f4453e0854a9dca1c0d3a115c3f3de4d
+  sha256: 081592aee639cbc730fc10e309d41012b97193a0ee5100f0d3dc0f186391f91a
 build:
   number: 0
   rpaths:

--- a/recipes/bioconductor-genomicscores/meta.yaml
+++ b/recipes/bioconductor-genomicscores/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - 'bioconductor-genomicranges >=1.32.7,<1.34.0'
     - 'bioconductor-iranges >=2.14.12,<2.16.0'
     - 'bioconductor-s4vectors >=0.18.3,<0.20.0'
-    - r-base
+    - r-base >=3.5
     - r-xml
   run:
     - 'bioconductor-annotationhub >=2.12.1,<2.14.0'
@@ -39,7 +39,7 @@ requirements:
     - 'bioconductor-genomicranges >=1.32.7,<1.34.0'
     - 'bioconductor-iranges >=2.14.12,<2.16.0'
     - 'bioconductor-s4vectors >=0.18.3,<0.20.0'
-    - r-base
+    - r-base >=3.5
     - r-xml
 test:
   commands:

--- a/recipes/bioconductor-geosubmission/meta.yaml
+++ b/recipes/bioconductor-geosubmission/meta.yaml
@@ -20,11 +20,11 @@ requirements:
   host:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
     - 'bioconductor-biobase >=2.40.0,<2.42.0'
-    - r-base
+    - r-base >=3.5
   run:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
     - 'bioconductor-biobase >=2.40.0,<2.42.0'
-    - r-base
+    - r-base >=3.5
 test:
   commands:
     - '$R -e "library(''{{ name }}'')"'

--- a/recipes/bioconductor-ggbio/meta.yaml
+++ b/recipes/bioconductor-ggbio/meta.yaml
@@ -37,7 +37,7 @@ requirements:
     - 'bioconductor-s4vectors >=0.18.3,<0.20.0'
     - 'bioconductor-summarizedexperiment >=1.10.1,<1.12.0'
     - 'bioconductor-variantannotation >=1.26.1,<1.28.0'
-    - r-base
+    - r-base >=3.5
     - r-ggally
     - 'r-ggplot2 >=1.0.0'
     - r-gridextra
@@ -66,7 +66,7 @@ requirements:
     - 'bioconductor-s4vectors >=0.18.3,<0.20.0'
     - 'bioconductor-summarizedexperiment >=1.10.1,<1.12.0'
     - 'bioconductor-variantannotation >=1.26.1,<1.28.0'
-    - r-base
+    - r-base >=3.5
     - r-ggally
     - 'r-ggplot2 >=1.0.0'
     - r-gridextra

--- a/recipes/bioconductor-guideseq/meta.yaml
+++ b/recipes/bioconductor-guideseq/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - 'bioconductor-limma >=3.36.5,<3.38.0'
     - 'bioconductor-rsamtools >=1.32.3,<1.34.0'
     - 'bioconductor-s4vectors >=0.18.3,<0.20.0'
-    - r-base
+    - r-base >=3.5
     - r-data.table
     - r-hash
     - r-matrixstats
@@ -49,7 +49,7 @@ requirements:
     - 'bioconductor-limma >=3.36.5,<3.38.0'
     - 'bioconductor-rsamtools >=1.32.3,<1.34.0'
     - 'bioconductor-s4vectors >=0.18.3,<0.20.0'
-    - r-base
+    - r-base >=3.5
     - r-data.table
     - r-hash
     - r-matrixstats

--- a/recipes/bioconductor-harshlight/meta.yaml
+++ b/recipes/bioconductor-harshlight/meta.yaml
@@ -21,12 +21,12 @@ requirements:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
     - 'bioconductor-altcdfenvs >=2.42.0,<2.44.0'
     - 'bioconductor-biobase >=2.40.0,<2.42.0'
-    - r-base
+    - r-base >=3.5
   run:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
     - 'bioconductor-altcdfenvs >=2.42.0,<2.44.0'
     - 'bioconductor-biobase >=2.40.0,<2.42.0'
-    - r-base
+    - r-base >=3.5
   build:
     - {{ compiler('c') }}
     - make

--- a/recipes/bioconductor-homo.sapiens/meta.yaml
+++ b/recipes/bioconductor-homo.sapiens/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - 'bioconductor-org.hs.eg.db >=3.6.0,<3.8.0'
     - 'bioconductor-organismdbi >=1.22.0,<1.24.0'
     - 'bioconductor-txdb.hsapiens.ucsc.hg19.knowngene >=3.2.2,<3.4.0'
-    - r-base
+    - r-base >=3.5
   run:
     - 'bioconductor-annotationdbi >=1.42.1,<1.44.0'
     - 'bioconductor-genomicfeatures >=1.32.2,<1.34.0'
@@ -32,7 +32,7 @@ requirements:
     - 'bioconductor-org.hs.eg.db >=3.6.0,<3.8.0'
     - 'bioconductor-organismdbi >=1.22.0,<1.24.0'
     - 'bioconductor-txdb.hsapiens.ucsc.hg19.knowngene >=3.2.2,<3.4.0'
-    - r-base
+    - r-base >=3.5
     - wget
 test:
   commands:

--- a/recipes/bioconductor-htqpcr/meta.yaml
+++ b/recipes/bioconductor-htqpcr/meta.yaml
@@ -21,14 +21,14 @@ requirements:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
     - 'bioconductor-biobase >=2.40.0,<2.42.0'
     - 'bioconductor-limma >=3.36.5,<3.38.0'
-    - r-base
+    - r-base >=3.5
     - r-gplots
     - r-rcolorbrewer
   run:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
     - 'bioconductor-biobase >=2.40.0,<2.42.0'
     - 'bioconductor-limma >=3.36.5,<3.38.0'
-    - r-base
+    - r-base >=3.5
     - r-gplots
     - r-rcolorbrewer
 test:

--- a/recipes/bioconductor-imagehts/meta.yaml
+++ b/recipes/bioconductor-imagehts/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - 'bioconductor-cellhts2 >=2.44.0,<2.46.0'
     - 'bioconductor-ebimage >=4.22.1,<4.24.0'
     - 'bioconductor-vsn >=3.48.1,<3.50.0'
-    - r-base
+    - r-base >=3.5
     - r-e1071
     - r-hwriter
   run:
@@ -30,7 +30,7 @@ requirements:
     - 'bioconductor-cellhts2 >=2.44.0,<2.46.0'
     - 'bioconductor-ebimage >=4.22.1,<4.24.0'
     - 'bioconductor-vsn >=3.48.1,<3.50.0'
-    - r-base
+    - r-base >=3.5
     - r-e1071
     - r-hwriter
 test:

--- a/recipes/bioconductor-lmgene/meta.yaml
+++ b/recipes/bioconductor-lmgene/meta.yaml
@@ -21,13 +21,13 @@ requirements:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
     - 'bioconductor-biobase >=2.40.0,<2.42.0'
     - 'bioconductor-multtest >=2.36.0,<2.38.0'
-    - r-base
+    - r-base >=3.5
     - r-survival
   run:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
     - 'bioconductor-biobase >=2.40.0,<2.42.0'
     - 'bioconductor-multtest >=2.36.0,<2.38.0'
-    - r-base
+    - r-base >=3.5
     - r-survival
 test:
   commands:

--- a/recipes/bioconductor-logitt/meta.yaml
+++ b/recipes/bioconductor-logitt/meta.yaml
@@ -19,10 +19,10 @@ build:
 requirements:
   host:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
-    - r-base
+    - r-base >=3.5
   run:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
-    - r-base
+    - r-base >=3.5
   build:
     - {{ compiler('c') }}
     - make

--- a/recipes/bioconductor-lumi/meta.yaml
+++ b/recipes/bioconductor-lumi/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - 'bioconductor-genomicranges >=1.32.7,<1.34.0'
     - 'bioconductor-methylumi >=2.26.0,<2.28.0'
     - 'bioconductor-preprocesscore >=1.42.0,<1.44.0'
-    - r-base
+    - r-base >=3.5
     - r-dbi
     - r-kernsmooth
     - r-lattice
@@ -43,7 +43,7 @@ requirements:
     - 'bioconductor-genomicranges >=1.32.7,<1.34.0'
     - 'bioconductor-methylumi >=2.26.0,<2.28.0'
     - 'bioconductor-preprocesscore >=1.42.0,<1.44.0'
-    - r-base
+    - r-base >=3.5
     - r-dbi
     - r-kernsmooth
     - r-lattice

--- a/recipes/bioconductor-lvsmirna/meta.yaml
+++ b/recipes/bioconductor-lvsmirna/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - 'bioconductor-limma >=3.36.5,<3.38.0'
     - 'bioconductor-vsn >=3.48.1,<3.50.0'
     - 'bioconductor-zlibbioc >=1.26.0,<1.28.0'
-    - r-base
+    - r-base >=3.5
     - r-mass
     - r-quantreg
     - r-sparsem
@@ -35,7 +35,7 @@ requirements:
     - 'bioconductor-limma >=3.36.5,<3.38.0'
     - 'bioconductor-vsn >=3.48.1,<3.50.0'
     - 'bioconductor-zlibbioc >=1.26.0,<1.28.0'
-    - r-base
+    - r-base >=3.5
     - r-mass
     - r-quantreg
     - r-sparsem

--- a/recipes/bioconductor-makecdfenv/meta.yaml
+++ b/recipes/bioconductor-makecdfenv/meta.yaml
@@ -22,13 +22,13 @@ requirements:
     - 'bioconductor-affyio >=1.50.0,<1.52.0'
     - 'bioconductor-biobase >=2.40.0,<2.42.0'
     - 'bioconductor-zlibbioc >=1.26.0,<1.28.0'
-    - r-base
+    - r-base >=3.5
   run:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
     - 'bioconductor-affyio >=1.50.0,<1.52.0'
     - 'bioconductor-biobase >=2.40.0,<2.42.0'
     - 'bioconductor-zlibbioc >=1.26.0,<1.28.0'
-    - r-base
+    - r-base >=3.5
   build:
     - {{ compiler('c') }}
     - automake

--- a/recipes/bioconductor-mapredictdsc/meta.yaml
+++ b/recipes/bioconductor-mapredictdsc/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - 'bioconductor-limma >=3.36.5,<3.38.0'
     - 'bioconductor-lungcanceracvssccgeo >=1.16.0,<1.18.0'
     - 'bioconductor-roc >=1.56.0,<1.58.0'
-    - r-base
+    - r-base >=3.5
     - r-caret
     - r-class
     - r-e1071
@@ -39,7 +39,7 @@ requirements:
     - 'bioconductor-limma >=3.36.5,<3.38.0'
     - 'bioconductor-lungcanceracvssccgeo >=1.16.0,<1.18.0'
     - 'bioconductor-roc >=1.56.0,<1.58.0'
-    - r-base
+    - r-base >=3.5
     - r-caret
     - r-class
     - r-e1071

--- a/recipes/bioconductor-maskbad/meta.yaml
+++ b/recipes/bioconductor-maskbad/meta.yaml
@@ -20,11 +20,11 @@ requirements:
   host:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
     - 'bioconductor-gcrma >=2.52.0,<2.54.0'
-    - r-base
+    - r-base >=3.5
   run:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
     - 'bioconductor-gcrma >=2.52.0,<2.54.0'
-    - r-base
+    - r-base >=3.5
 test:
   commands:
     - '$R -e "library(''{{ name }}'')"'

--- a/recipes/bioconductor-minimumdistance/meta.yaml
+++ b/recipes/bioconductor-minimumdistance/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - 'bioconductor-s4vectors >=0.18.3,<0.20.0'
     - 'bioconductor-summarizedexperiment >=1.10.1,<1.12.0'
     - 'bioconductor-vanillaice >=1.42.4,<1.44.0'
-    - r-base
+    - r-base >=3.5
     - r-data.table
     - r-ff
     - r-foreach
@@ -45,7 +45,7 @@ requirements:
     - 'bioconductor-s4vectors >=0.18.3,<0.20.0'
     - 'bioconductor-summarizedexperiment >=1.10.1,<1.12.0'
     - 'bioconductor-vanillaice >=1.42.4,<1.44.0'
-    - r-base
+    - r-base >=3.5
     - r-data.table
     - r-ff
     - r-foreach

--- a/recipes/bioconductor-mlp/meta.yaml
+++ b/recipes/bioconductor-mlp/meta.yaml
@@ -20,7 +20,7 @@ requirements:
   host:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
     - 'bioconductor-annotationdbi >=1.42.1,<1.44.0'
-    - r-base
+    - r-base >=3.5
     - r-gdata
     - r-gmodels
     - r-gplots
@@ -29,7 +29,7 @@ requirements:
   run:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
     - 'bioconductor-annotationdbi >=1.42.1,<1.44.0'
-    - r-base
+    - r-base >=3.5
     - r-gdata
     - r-gmodels
     - r-gplots

--- a/recipes/bioconductor-msnbase/meta.yaml
+++ b/recipes/bioconductor-msnbase/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - 'bioconductor-protgenerics >=1.12.0,<1.14.0'
     - 'bioconductor-s4vectors >=0.18.3,<0.20.0'
     - 'bioconductor-vsn >=3.48.1,<3.50.0'
-    - r-base
+    - r-base >=3.5
     - r-digest
     - r-ggplot2
     - r-lattice
@@ -55,7 +55,7 @@ requirements:
     - 'bioconductor-protgenerics >=1.12.0,<1.14.0'
     - 'bioconductor-s4vectors >=0.18.3,<0.20.0'
     - 'bioconductor-vsn >=3.48.1,<3.50.0'
-    - r-base
+    - r-base >=3.5
     - r-digest
     - r-ggplot2
     - r-lattice

--- a/recipes/bioconductor-oligo/meta.yaml
+++ b/recipes/bioconductor-oligo/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - 'bioconductor-oligoclasses >=1.42.0,<1.44.0'
     - 'bioconductor-preprocesscore >=1.42.0,<1.44.0'
     - 'bioconductor-zlibbioc >=1.26.0,<1.28.0'
-    - r-base
+    - r-base >=3.5
     - 'r-dbi >=0.3.1'
     - r-ff
     - 'r-rsqlite >=1.0.0'
@@ -39,7 +39,7 @@ requirements:
     - 'bioconductor-oligoclasses >=1.42.0,<1.44.0'
     - 'bioconductor-preprocesscore >=1.42.0,<1.44.0'
     - 'bioconductor-zlibbioc >=1.26.0,<1.28.0'
-    - r-base
+    - r-base >=3.5
     - 'r-dbi >=0.3.1'
     - r-ff
     - 'r-rsqlite >=1.0.0'

--- a/recipes/bioconductor-oligoclasses/meta.yaml
+++ b/recipes/bioconductor-oligoclasses/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - 'bioconductor-iranges >=2.14.12,<2.16.0'
     - 'bioconductor-s4vectors >=0.18.3,<0.20.0'
     - 'bioconductor-summarizedexperiment >=1.10.1,<1.12.0'
-    - r-base
+    - r-base >=3.5
     - r-dbi
     - r-ff
     - r-foreach
@@ -42,7 +42,7 @@ requirements:
     - 'bioconductor-iranges >=2.14.12,<2.16.0'
     - 'bioconductor-s4vectors >=0.18.3,<0.20.0'
     - 'bioconductor-summarizedexperiment >=1.10.1,<1.12.0'
-    - r-base
+    - r-base >=3.5
     - r-dbi
     - r-ff
     - r-foreach

--- a/recipes/bioconductor-organismdbi/meta.yaml
+++ b/recipes/bioconductor-organismdbi/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - 'bioconductor-iranges >=2.14.12,<2.16.0'
     - 'bioconductor-rbgl >=1.56.0,<1.58.0'
     - 'bioconductor-s4vectors >=0.18.3,<0.20.0'
-    - r-base
+    - r-base >=3.5
     - r-dbi
   run:
     - 'bioconductor-annotationdbi >=1.42.1,<1.44.0'
@@ -41,7 +41,7 @@ requirements:
     - 'bioconductor-iranges >=2.14.12,<2.16.0'
     - 'bioconductor-rbgl >=1.56.0,<1.58.0'
     - 'bioconductor-s4vectors >=0.18.3,<0.20.0'
-    - r-base
+    - r-base >=3.5
     - r-dbi
 test:
   commands:

--- a/recipes/bioconductor-panp/meta.yaml
+++ b/recipes/bioconductor-panp/meta.yaml
@@ -20,11 +20,11 @@ requirements:
   host:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
     - 'bioconductor-biobase >=2.40.0,<2.42.0'
-    - r-base
+    - r-base >=3.5
   run:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
     - 'bioconductor-biobase >=2.40.0,<2.42.0'
-    - r-base
+    - r-base >=3.5
 test:
   commands:
     - '$R -e "library(''{{ name }}'')"'

--- a/recipes/bioconductor-pdinfobuilder/meta.yaml
+++ b/recipes/bioconductor-pdinfobuilder/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - 'bioconductor-oligo >=1.44.0,<1.46.0'
     - 'bioconductor-oligoclasses >=1.42.0,<1.44.0'
     - 'bioconductor-s4vectors >=0.18.3,<0.20.0'
-    - r-base
+    - r-base >=3.5
     - 'r-dbi >=0.3.1'
     - 'r-rsqlite >=1.0.0'
   run:
@@ -38,7 +38,7 @@ requirements:
     - 'bioconductor-oligo >=1.44.0,<1.46.0'
     - 'bioconductor-oligoclasses >=1.42.0,<1.44.0'
     - 'bioconductor-s4vectors >=0.18.3,<0.20.0'
-    - r-base
+    - r-base >=3.5
     - 'r-dbi >=0.3.1'
     - 'r-rsqlite >=1.0.0'
   build:

--- a/recipes/bioconductor-peca/meta.yaml
+++ b/recipes/bioconductor-peca/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - 'bioconductor-rots >=1.8.0,<1.10.0'
     - r-aroma.affymetrix
     - r-aroma.core
-    - r-base
+    - r-base >=3.5
   run:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
     - 'bioconductor-genefilter >=1.62.0,<1.64.0'
@@ -34,7 +34,7 @@ requirements:
     - 'bioconductor-rots >=1.8.0,<1.10.0'
     - r-aroma.affymetrix
     - r-aroma.core
-    - r-base
+    - r-base >=3.5
 test:
   commands:
     - '$R -e "library(''{{ name }}'')"'

--- a/recipes/bioconductor-plier/meta.yaml
+++ b/recipes/bioconductor-plier/meta.yaml
@@ -20,11 +20,11 @@ requirements:
   host:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
     - 'bioconductor-biobase >=2.40.0,<2.42.0'
-    - r-base
+    - r-base >=3.5
   run:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
     - 'bioconductor-biobase >=2.40.0,<2.42.0'
-    - r-base
+    - r-base >=3.5
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}

--- a/recipes/bioconductor-plw/meta.yaml
+++ b/recipes/bioconductor-plw/meta.yaml
@@ -19,11 +19,11 @@ build:
 requirements:
   host:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
-    - r-base
+    - r-base >=3.5
     - r-mass
   run:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
-    - r-base
+    - r-base >=3.5
     - r-mass
   build:
     - {{ compiler('c') }}

--- a/recipes/bioconductor-prebs/meta.yaml
+++ b/recipes/bioconductor-prebs/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - 'bioconductor-iranges >=2.14.12,<2.16.0'
     - 'bioconductor-rpa >=1.36.0,<1.38.0'
     - 'bioconductor-s4vectors >=0.18.3,<0.20.0'
-    - r-base
+    - r-base >=3.5
   run:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
     - 'bioconductor-biobase >=2.40.0,<2.42.0'
@@ -36,7 +36,7 @@ requirements:
     - 'bioconductor-iranges >=2.14.12,<2.16.0'
     - 'bioconductor-rpa >=1.36.0,<1.38.0'
     - 'bioconductor-s4vectors >=0.18.3,<0.20.0'
-    - r-base
+    - r-base >=3.5
 test:
   commands:
     - '$R -e "library(''{{ name }}'')"'

--- a/recipes/bioconductor-proteomicsannotationhubdata/meta.yaml
+++ b/recipes/bioconductor-proteomicsannotationhubdata/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - 'bioconductor-genomeinfodb >=1.16.0,<1.18.0'
     - 'bioconductor-msnbase >=2.6.4,<2.8.0'
     - 'bioconductor-mzr >=2.17.0,<2.19.0'
-    - r-base
+    - r-base >=3.5
     - r-rcurl
   run:
     - 'bioconductor-annotationhub >=2.12.1,<2.14.0'
@@ -37,7 +37,7 @@ requirements:
     - 'bioconductor-genomeinfodb >=1.16.0,<1.18.0'
     - 'bioconductor-msnbase >=2.6.4,<2.8.0'
     - 'bioconductor-mzr >=2.17.0,<2.19.0'
-    - r-base
+    - r-base >=3.5
     - r-rcurl
 test:
   commands:

--- a/recipes/bioconductor-psygenet2r/meta.yaml
+++ b/recipes/bioconductor-psygenet2r/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - 'bioconductor-biomart >=2.36.1,<2.38.0'
     - 'bioconductor-go.db >=3.6.0,<3.8.0'
     - 'bioconductor-topgo >=2.32.0,<2.34.0'
-    - r-base
+    - r-base >=3.5
     - r-ggplot2
     - r-igraph
     - r-labeling
@@ -38,7 +38,7 @@ requirements:
     - 'bioconductor-biomart >=2.36.1,<2.38.0'
     - 'bioconductor-go.db >=3.6.0,<3.8.0'
     - 'bioconductor-topgo >=2.32.0,<2.34.0'
-    - r-base
+    - r-base >=3.5
     - r-ggplot2
     - r-igraph
     - r-labeling

--- a/recipes/bioconductor-puma/meta.yaml
+++ b/recipes/bioconductor-puma/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - 'bioconductor-biobase >=2.40.0,<2.42.0'
     - 'bioconductor-oligo >=1.44.0,<1.46.0'
     - 'bioconductor-oligoclasses >=1.42.0,<1.44.0'
-    - r-base
+    - r-base >=3.5
     - r-mclust
   run:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
@@ -31,7 +31,7 @@ requirements:
     - 'bioconductor-biobase >=2.40.0,<2.42.0'
     - 'bioconductor-oligo >=1.44.0,<1.46.0'
     - 'bioconductor-oligoclasses >=1.42.0,<1.44.0'
-    - r-base
+    - r-base >=3.5
     - r-mclust
   build:
     - {{ compiler('c') }}

--- a/recipes/bioconductor-pvac/meta.yaml
+++ b/recipes/bioconductor-pvac/meta.yaml
@@ -20,11 +20,11 @@ requirements:
   host:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
     - 'bioconductor-biobase >=2.40.0,<2.42.0'
-    - r-base
+    - r-base >=3.5
   run:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
     - 'bioconductor-biobase >=2.40.0,<2.42.0'
-    - r-base
+    - r-base >=3.5
 test:
   commands:
     - '$R -e "library(''{{ name }}'')"'

--- a/recipes/bioconductor-pvca/meta.yaml
+++ b/recipes/bioconductor-pvca/meta.yaml
@@ -20,13 +20,13 @@ requirements:
   host:
     - 'bioconductor-biobase >=2.40.0,<2.42.0'
     - 'bioconductor-vsn >=3.48.1,<3.50.0'
-    - r-base
+    - r-base >=3.5
     - r-lme4
     - r-matrix
   run:
     - 'bioconductor-biobase >=2.40.0,<2.42.0'
     - 'bioconductor-vsn >=3.48.1,<3.50.0'
-    - r-base
+    - r-base >=3.5
     - r-lme4
     - r-matrix
 test:

--- a/recipes/bioconductor-pwomics/meta.yaml
+++ b/recipes/bioconductor-pwomics/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - 'bioconductor-graph >=1.58.0,<1.60.0'
     - 'bioconductor-rbiopaxparser >=2.20.0,<2.22.0'
     - 'bioconductor-stringdb >=1.20.0,<1.22.0'
-    - r-base
+    - r-base >=3.5
     - r-data.table
     - r-gplots
     - r-igraph
@@ -41,7 +41,7 @@ requirements:
     - 'bioconductor-graph >=1.58.0,<1.60.0'
     - 'bioconductor-rbiopaxparser >=2.20.0,<2.22.0'
     - 'bioconductor-stringdb >=1.20.0,<1.22.0'
-    - r-base
+    - r-base >=3.5
     - r-data.table
     - r-gplots
     - r-igraph

--- a/recipes/bioconductor-qpcrnorm/meta.yaml
+++ b/recipes/bioconductor-qpcrnorm/meta.yaml
@@ -21,12 +21,12 @@ requirements:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
     - 'bioconductor-biobase >=2.40.0,<2.42.0'
     - 'bioconductor-limma >=3.36.5,<3.38.0'
-    - r-base
+    - r-base >=3.5
   run:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
     - 'bioconductor-biobase >=2.40.0,<2.42.0'
     - 'bioconductor-limma >=3.36.5,<3.38.0'
-    - r-base
+    - r-base >=3.5
 test:
   commands:
     - '$R -e "library(''{{ name }}'')"'

--- a/recipes/bioconductor-quasr/meta.yaml
+++ b/recipes/bioconductor-quasr/meta.yaml
@@ -36,7 +36,7 @@ requirements:
     - 'bioconductor-s4vectors >=0.18.3,<0.20.0'
     - 'bioconductor-shortread >=1.38.0,<1.40.0'
     - 'bioconductor-zlibbioc >=1.26.0,<1.28.0'
-    - r-base
+    - r-base >=3.5
   run:
     - 'bioconductor-biobase >=2.40.0,<2.42.0'
     - 'bioconductor-biocgenerics >=0.26.0,<0.28.0'
@@ -56,7 +56,7 @@ requirements:
     - 'bioconductor-s4vectors >=0.18.3,<0.20.0'
     - 'bioconductor-shortread >=1.38.0,<1.40.0'
     - 'bioconductor-zlibbioc >=1.26.0,<1.28.0'
-    - r-base
+    - r-base >=3.5
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}

--- a/recipes/bioconductor-rcgh/meta.yaml
+++ b/recipes/bioconductor-rcgh/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - 'bioconductor-txdb.hsapiens.ucsc.hg18.knowngene >=3.2.2,<3.4.0'
     - 'bioconductor-txdb.hsapiens.ucsc.hg19.knowngene >=3.2.2,<3.4.0'
     - 'bioconductor-txdb.hsapiens.ucsc.hg38.knowngene >=3.4.0,<3.6.0'
-    - r-base
+    - r-base >=3.5
     - r-ggplot2
     - r-lattice
     - r-mclust
@@ -51,7 +51,7 @@ requirements:
     - 'bioconductor-txdb.hsapiens.ucsc.hg18.knowngene >=3.2.2,<3.4.0'
     - 'bioconductor-txdb.hsapiens.ucsc.hg19.knowngene >=3.2.2,<3.4.0'
     - 'bioconductor-txdb.hsapiens.ucsc.hg38.knowngene >=3.4.0,<3.6.0'
-    - r-base
+    - r-base >=3.5
     - r-ggplot2
     - r-lattice
     - r-mclust

--- a/recipes/bioconductor-readqpcr/meta.yaml
+++ b/recipes/bioconductor-readqpcr/meta.yaml
@@ -20,11 +20,11 @@ requirements:
   host:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
     - 'bioconductor-biobase >=2.40.0,<2.42.0'
-    - r-base
+    - r-base >=3.5
   run:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
     - 'bioconductor-biobase >=2.40.0,<2.42.0'
-    - r-base
+    - r-base >=3.5
 test:
   commands:
     - '$R -e "library(''{{ name }}'')"'

--- a/recipes/bioconductor-refnet/meta.yaml
+++ b/recipes/bioconductor-refnet/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - 'bioconductor-biocgenerics >=0.26.0,<0.28.0'
     - 'bioconductor-iranges >=2.14.12,<2.16.0'
     - 'bioconductor-psicquic >=1.18.1,<1.20.0'
-    - r-base
+    - r-base >=3.5
     - r-rcurl
     - r-shiny
   run:
@@ -30,7 +30,7 @@ requirements:
     - 'bioconductor-biocgenerics >=0.26.0,<0.28.0'
     - 'bioconductor-iranges >=2.14.12,<2.16.0'
     - 'bioconductor-psicquic >=1.18.1,<1.20.0'
-    - r-base
+    - r-base >=3.5
     - r-rcurl
     - r-shiny
 test:

--- a/recipes/bioconductor-refplus/meta.yaml
+++ b/recipes/bioconductor-refplus/meta.yaml
@@ -22,13 +22,13 @@ requirements:
     - 'bioconductor-affyplm >=1.56.0,<1.58.0'
     - 'bioconductor-biobase >=2.40.0,<2.42.0'
     - 'bioconductor-preprocesscore >=1.42.0,<1.44.0'
-    - r-base
+    - r-base >=3.5
   run:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
     - 'bioconductor-affyplm >=1.56.0,<1.58.0'
     - 'bioconductor-biobase >=2.40.0,<2.42.0'
     - 'bioconductor-preprocesscore >=1.42.0,<1.44.0'
-    - r-base
+    - r-base >=3.5
 test:
   commands:
     - '$R -e "library(''{{ name }}'')"'

--- a/recipes/bioconductor-ringo/meta.yaml
+++ b/recipes/bioconductor-ringo/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - 'bioconductor-genefilter >=1.62.0,<1.64.0'
     - 'bioconductor-limma >=3.36.5,<3.38.0'
     - 'bioconductor-vsn >=3.48.1,<3.50.0'
-    - r-base
+    - r-base >=3.5
     - r-lattice
     - r-matrix
     - r-rcolorbrewer
@@ -33,7 +33,7 @@ requirements:
     - 'bioconductor-genefilter >=1.62.0,<1.64.0'
     - 'bioconductor-limma >=3.36.5,<3.38.0'
     - 'bioconductor-vsn >=3.48.1,<3.50.0'
-    - r-base
+    - r-base >=3.5
     - r-lattice
     - r-matrix
     - r-rcolorbrewer

--- a/recipes/bioconductor-risa/meta.yaml
+++ b/recipes/bioconductor-risa/meta.yaml
@@ -22,14 +22,14 @@ requirements:
     - 'bioconductor-biobase >=2.40.0,<2.42.0'
     - 'bioconductor-biocviews >=1.48.3,<1.50.0'
     - 'bioconductor-xcms >=3.2.0,<3.4.0'
-    - r-base
+    - r-base >=3.5
     - 'r-rcpp >=0.9.13'
   run:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
     - 'bioconductor-biobase >=2.40.0,<2.42.0'
     - 'bioconductor-biocviews >=1.48.3,<1.50.0'
     - 'bioconductor-xcms >=3.2.0,<3.4.0'
-    - r-base
+    - r-base >=3.5
     - 'r-rcpp >=0.9.13'
   build:
     - {{ compiler('c') }}

--- a/recipes/bioconductor-rnits/meta.yaml
+++ b/recipes/bioconductor-rnits/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - 'bioconductor-impute >=1.54.0,<1.56.0'
     - 'bioconductor-limma >=3.36.5,<3.38.0'
     - 'bioconductor-qvalue >=2.12.0,<2.14.0'
-    - r-base
+    - r-base >=3.5
     - r-boot
     - r-ggplot2
     - r-reshape2
@@ -33,7 +33,7 @@ requirements:
     - 'bioconductor-impute >=1.54.0,<1.56.0'
     - 'bioconductor-limma >=3.36.5,<3.38.0'
     - 'bioconductor-qvalue >=2.12.0,<2.14.0'
-    - r-base
+    - r-base >=3.5
     - r-boot
     - r-ggplot2
     - r-reshape2

--- a/recipes/bioconductor-rpa/meta.yaml
+++ b/recipes/bioconductor-rpa/meta.yaml
@@ -21,12 +21,12 @@ requirements:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
     - 'bioconductor-biocgenerics >=0.26.0,<0.28.0'
     - 'bioconductor-phyloseq >=1.24.2,<1.26.0'
-    - r-base
+    - r-base >=3.5
   run:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
     - 'bioconductor-biocgenerics >=0.26.0,<0.28.0'
     - 'bioconductor-phyloseq >=1.24.2,<1.26.0'
-    - r-base
+    - r-base >=3.5
 test:
   commands:
     - '$R -e "library(''{{ name }}'')"'

--- a/recipes/bioconductor-scan.upc/meta.yaml
+++ b/recipes/bioconductor-scan.upc/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - 'bioconductor-iranges >=2.14.12,<2.16.0'
     - 'bioconductor-oligo >=1.44.0,<1.46.0'
     - 'bioconductor-sva >=3.28.0,<3.30.0'
-    - r-base
+    - r-base >=3.5
     - r-foreach
     - r-mass
   run:
@@ -38,7 +38,7 @@ requirements:
     - 'bioconductor-iranges >=2.14.12,<2.16.0'
     - 'bioconductor-oligo >=1.44.0,<1.46.0'
     - 'bioconductor-sva >=3.28.0,<3.30.0'
-    - r-base
+    - r-base >=3.5
     - r-foreach
     - r-mass
 test:

--- a/recipes/bioconductor-simpleaffy/meta.yaml
+++ b/recipes/bioconductor-simpleaffy/meta.yaml
@@ -23,14 +23,14 @@ requirements:
     - 'bioconductor-biocgenerics >=0.26.0,<0.28.0'
     - 'bioconductor-gcrma >=2.52.0,<2.54.0'
     - 'bioconductor-genefilter >=1.62.0,<1.64.0'
-    - r-base
+    - r-base >=3.5
   run:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
     - 'bioconductor-biobase >=2.40.0,<2.42.0'
     - 'bioconductor-biocgenerics >=0.26.0,<0.28.0'
     - 'bioconductor-gcrma >=2.52.0,<2.54.0'
     - 'bioconductor-genefilter >=1.62.0,<1.64.0'
-    - r-base
+    - r-base >=3.5
   build:
     - {{ compiler('c') }}
     - make

--- a/recipes/bioconductor-snpchip/meta.yaml
+++ b/recipes/bioconductor-snpchip/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - 'bioconductor-oligoclasses >=1.42.0,<1.44.0'
     - 'bioconductor-s4vectors >=0.18.3,<0.20.0'
     - 'bioconductor-summarizedexperiment >=1.10.1,<1.12.0'
-    - r-base
+    - r-base >=3.5
     - r-foreach
     - r-lattice
   run:
@@ -36,7 +36,7 @@ requirements:
     - 'bioconductor-oligoclasses >=1.42.0,<1.44.0'
     - 'bioconductor-s4vectors >=0.18.3,<0.20.0'
     - 'bioconductor-summarizedexperiment >=1.10.1,<1.12.0'
-    - r-base
+    - r-base >=3.5
     - r-foreach
     - r-lattice
 test:

--- a/recipes/bioconductor-sscore/meta.yaml
+++ b/recipes/bioconductor-sscore/meta.yaml
@@ -20,11 +20,11 @@ requirements:
   host:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
     - 'bioconductor-affyio >=1.50.0,<1.52.0'
-    - r-base
+    - r-base >=3.5
   run:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
     - 'bioconductor-affyio >=1.50.0,<1.52.0'
-    - r-base
+    - r-base >=3.5
 test:
   commands:
     - '$R -e "library(''{{ name }}'')"'

--- a/recipes/bioconductor-starr/meta.yaml
+++ b/recipes/bioconductor-starr/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
     - 'bioconductor-ringo >=1.44.0,<1.46.0'
     - 'bioconductor-zlibbioc >=1.26.0,<1.28.0'
-    - r-base
+    - r-base >=3.5
     - r-mass
     - r-pspline
   run:
@@ -30,7 +30,7 @@ requirements:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
     - 'bioconductor-ringo >=1.44.0,<1.46.0'
     - 'bioconductor-zlibbioc >=1.26.0,<1.28.0'
-    - r-base
+    - r-base >=3.5
     - r-mass
     - r-pspline
   build:

--- a/recipes/bioconductor-stategra/meta.yaml
+++ b/recipes/bioconductor-stategra/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - 'bioconductor-biobase >=2.40.0,<2.42.0'
     - 'bioconductor-edger >=3.22.4,<3.24.0'
     - 'bioconductor-limma >=3.36.5,<3.38.0'
-    - r-base
+    - r-base >=3.5
     - r-calibrate
     - r-foreach
     - r-ggplot2
@@ -34,7 +34,7 @@ requirements:
     - 'bioconductor-biobase >=2.40.0,<2.42.0'
     - 'bioconductor-edger >=3.22.4,<3.24.0'
     - 'bioconductor-limma >=3.36.5,<3.38.0'
-    - r-base
+    - r-base >=3.5
     - r-calibrate
     - r-foreach
     - r-ggplot2

--- a/recipes/bioconductor-turbonorm/meta.yaml
+++ b/recipes/bioconductor-turbonorm/meta.yaml
@@ -22,14 +22,14 @@ requirements:
     - 'bioconductor-convert >=1.56.0,<1.58.0'
     - 'bioconductor-limma >=3.36.5,<3.38.0'
     - 'bioconductor-marray >=1.58.0,<1.60.0'
-    - r-base
+    - r-base >=3.5
     - r-lattice
   run:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
     - 'bioconductor-convert >=1.56.0,<1.58.0'
     - 'bioconductor-limma >=3.36.5,<3.38.0'
     - 'bioconductor-marray >=1.58.0,<1.60.0'
-    - r-base
+    - r-base >=3.5
     - r-lattice
   build:
     - {{ compiler('c') }}

--- a/recipes/bioconductor-vanillaice/meta.yaml
+++ b/recipes/bioconductor-vanillaice/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - 'bioconductor-oligoclasses >=1.42.0,<1.44.0'
     - 'bioconductor-s4vectors >=0.18.3,<0.20.0'
     - 'bioconductor-summarizedexperiment >=1.10.1,<1.12.0'
-    - r-base
+    - r-base >=3.5
     - r-data.table
     - r-foreach
     - r-lattice
@@ -44,7 +44,7 @@ requirements:
     - 'bioconductor-oligoclasses >=1.42.0,<1.44.0'
     - 'bioconductor-s4vectors >=0.18.3,<0.20.0'
     - 'bioconductor-summarizedexperiment >=1.10.1,<1.12.0'
-    - r-base
+    - r-base >=3.5
     - r-data.table
     - r-foreach
     - r-lattice

--- a/recipes/bioconductor-vsn/meta.yaml
+++ b/recipes/bioconductor-vsn/meta.yaml
@@ -21,14 +21,14 @@ requirements:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
     - 'bioconductor-biobase >=2.40.0,<2.42.0'
     - 'bioconductor-limma >=3.36.5,<3.38.0'
-    - r-base
+    - r-base >=3.5
     - r-ggplot2
     - r-lattice
   run:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
     - 'bioconductor-biobase >=2.40.0,<2.42.0'
     - 'bioconductor-limma >=3.36.5,<3.38.0'
-    - r-base
+    - r-base >=3.5
     - r-ggplot2
     - r-lattice
   build:

--- a/recipes/bioconductor-wavetiling/meta.yaml
+++ b/recipes/bioconductor-wavetiling/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - 'bioconductor-oligo >=1.44.0,<1.46.0'
     - 'bioconductor-oligoclasses >=1.42.0,<1.44.0'
     - 'bioconductor-preprocesscore >=1.42.0,<1.44.0'
-    - r-base
+    - r-base >=3.5
     - r-waveslim
   run:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
@@ -39,7 +39,7 @@ requirements:
     - 'bioconductor-oligo >=1.44.0,<1.46.0'
     - 'bioconductor-oligoclasses >=1.42.0,<1.44.0'
     - 'bioconductor-preprocesscore >=1.42.0,<1.44.0'
-    - r-base
+    - r-base >=3.5
     - r-waveslim
   build:
     - {{ compiler('c') }}

--- a/recipes/bioconductor-webbioc/meta.yaml
+++ b/recipes/bioconductor-webbioc/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - 'bioconductor-multtest >=2.36.0,<2.38.0'
     - 'bioconductor-qvalue >=2.12.0,<2.14.0'
     - 'bioconductor-vsn >=3.48.1,<3.50.0'
-    - r-base
+    - r-base >=3.5
   run:
     - 'bioconductor-affy >=1.58.0,<1.60.0'
     - 'bioconductor-annaffy >=1.52.0,<1.54.0'
@@ -36,7 +36,7 @@ requirements:
     - 'bioconductor-multtest >=2.36.0,<2.38.0'
     - 'bioconductor-qvalue >=2.12.0,<2.14.0'
     - 'bioconductor-vsn >=3.48.1,<3.50.0'
-    - r-base
+    - r-base >=3.5
 test:
   commands:
     - '$R -e "library(''{{ name }}'')"'


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

There are a bunch of additional packages that will need to be made R 3.5 only, due to dependencies that are only built for 3.5. Next time we should probably just do this with all bioconductor packages just to make life easier.

Follow up to #11406 from @nsoranzo 