### PR TITLE
Update: r-deconstructsigs with fixes for hg38

### DIFF
--- a/build-fail-blacklist
+++ b/build-fail-blacklist
@@ -195,7 +195,7 @@ recipes/r-coloc
 recipes/r-dartr
 recipes/r-data.table
 recipes/r-dbchip
-recipes/r-deconstructsigs
+#recipes/r-deconstructsigs
 recipes/r-deoptimr
 recipes/r-diptest
 recipes/r-dpeak

--- a/recipes/r-deconstructsigs/build.sh
+++ b/recipes/r-deconstructsigs/build.sh
@@ -5,9 +5,3 @@ mv DESCRIPTION DESCRIPTION.old
 grep -v '^Priority: ' DESCRIPTION.old > DESCRIPTION
 
 $R CMD INSTALL --build .
-
-# Add more build steps here, if they are necessary.
-
-# See
-# http://docs.continuum.io/conda/build.html
-# for a list of environment variables that are set during the build process.

--- a/recipes/r-deconstructsigs/meta.yaml
+++ b/recipes/r-deconstructsigs/meta.yaml
@@ -1,34 +1,35 @@
-{% set version = '1.8.0' %}
+{% set version = '1.8.0.1' %}
 
 package:
   name: r-deconstructsigs
   version: {{ version|replace("-", "_") }}
 
 source:
-  url:
-    - https://cran.r-project.org/src/contrib/deconstructSigs_{{ version }}.tar.gz
-    - https://cran.r-project.org/src/contrib/Archive/deconstructSigs/deconstructSigs_{{ version }}.tar.gz
-  sha256: 2ab8f6c0fd674bd270035ba2112f1a79d63de1155ba9698c4169c92196059d04
+  # Last release version is missing fixes for hg38, pull from GitHub
+  # https://github.com/raerose01/deconstructSigs/issues/27
+  url: https://github.com/raerose01/deconstructSigs/archive/ca3c2f9.tar.gz
+  #  - https://cran.r-project.org/src/contrib/deconstructSigs_{{ version }}.tar.gz
+  #  - https://cran.r-project.org/src/contrib/Archive/deconstructSigs/deconstructSigs_{{ version }}.tar.gz
+  sha256: 0e31aed3e4428e0026b33e663deee71d9bba81db56a1306e0a81666aa4a0e39d
 
 build:
-  number: 1
+  number: 0
   rpaths:
     - lib/R/lib/
     - lib/
 
 requirements:
   host:
+    - r-base
     - bioconductor-bsgenome
     - bioconductor-bsgenome.hsapiens.ucsc.hg19
     - bioconductor-genomeinfodb
-    - r-base
     - r-reshape2
-
   run:
+    - r-base
     - bioconductor-bsgenome
     - bioconductor-bsgenome.hsapiens.ucsc.hg19
     - bioconductor-genomeinfodb
-    - r-base
     - r-reshape2
 
 test:


### PR DESCRIPTION
The 1.8.0 release, from 2016, has some issues with hg38 and other
custom genomes that are fixed in development (raerose01/deconstructSigs#27).
There hasn't been a new release pushed so this rolls these into a new
sub-version and makes them available.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
