### PR TITLE
Added recipe for pydemult: Streamed and parallel demultiplexing of fastq files

### DIFF
--- a/recipes/pydemult/meta.yaml
+++ b/recipes/pydemult/meta.yaml
@@ -1,0 +1,47 @@
+{% set name = "pydemult" %}
+{% set version = "0.4" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: fe902ac1614f572ec0c4aefc950ef97fda0c9a3575667f1e6aa2c9fc33856ab3
+
+build:
+  number: 0
+  skip: True  # [py27]
+  entry_points:
+    - pydemult = pydemult.pydemult:demultiplex
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv "
+
+requirements:
+  host:
+    - mputil
+    - pandas
+    - pip
+    - python
+  run:
+    - mputil
+    - pandas
+    - python
+
+test:
+  imports:
+    - pydemult
+  commands:
+    - pydemult --help
+
+about:
+  home: https://github.com/jenzopr/pydemult
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: Streamed and parallel demultiplexing of fastq files in python
+  doc_url: https://github.com/jenzopr/pydemult
+  dev_url: https://github.com/jenzopr/pydemult
+
+extra:
+  recipe-maintainers:
+    - jenzopr

--- a/recipes/pydemult/meta.yaml
+++ b/recipes/pydemult/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pydemult" %}
-{% set version = "0.4" %}
+{% set version = "0.4.1" %}
 
 package:
   name: "{{ name|lower }}"
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: fe902ac1614f572ec0c4aefc950ef97fda0c9a3575667f1e6aa2c9fc33856ab3
+  sha256: 5a44dc6c819fd4394b282d6aeff4b571b61654486ce6e4b782d3cc0731c3a0e2
 
 build:
   number: 0


### PR DESCRIPTION
* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [X] This PR adds a new recipe.
* [X] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

I added a small tool from PyPI, pydemult, to demultiplex fastq files (e.g. from single-cell RNA-seq) in parallel. It utilizes the mputil package *sloppily* stream the input file and distribute the demultiplexing work onto many cores. Hope this is useful for others as well 😊 