### PR TITLE
stacks: fix for @ in exe_path

### DIFF
--- a/recipes/stacks/2.2/build.sh
+++ b/recipes/stacks/2.2/build.sh
@@ -11,8 +11,17 @@ fi
 
 export CXXFLAGS="${CXXFLAGS} -std=c++11"
 
-./configure --prefix=$PREFIX --enable-bam
+./configure --prefix="$PREFIX" --enable-bam
 make
 make install
 # copy missing scripts
-cp -p scripts/{convert_stacks.pl,extract_interpop_chars.pl} $PREFIX/bin/
+cp -p scripts/{convert_stacks.pl,extract_interpop_chars.pl} "$PREFIX/bin/"
+
+# after installation the exe_dir is set to the absolute binary path 
+# this is not necessary and leads to an error if there are characters 
+# like @ included (Galaxy)
+for i in ref_map.pl denovo_map.pl
+do
+	sed -i -e 's/\(my $exe_path\s\+= \).*/\1"";/' $i
+done
+

--- a/recipes/stacks/2.2/build.sh
+++ b/recipes/stacks/2.2/build.sh
@@ -22,6 +22,6 @@ cp -p scripts/{convert_stacks.pl,extract_interpop_chars.pl} "$PREFIX/bin/"
 # like @ included (Galaxy)
 for i in ref_map.pl denovo_map.pl
 do
-	sed -i -e 's/\(my $exe_path\s\+= \).*/\1"";/' $i
+	sed -i -e 's/\(my $exe_path\s\+= \).*/\1"";/' "$PREFIX/bin/$i"
 done
 

--- a/recipes/stacks/2.2/meta.yaml
+++ b/recipes/stacks/2.2/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 0
+  number: 1
 
 source:
   sha256: {{ hash }}


### PR DESCRIPTION
In the perl scripts there could be an `@` in the exe_path variable (Galaxy). Which does not work. 

Alternatively the `@` could be quoted. 


* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
