### PR TITLE
Fix some dependencies

### DIFF
--- a/recipes/frogs/meta.yaml
+++ b/recipes/frogs/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 2
+  number: 3
   skip: true  # [py3k]
 
 source:
@@ -36,9 +36,10 @@ requirements:
     - r-phangorn >=2.2.0
     - pandoc <2.0
     - r-rmarkdown >=1.5
-    - bioconductor-phyloseq >=1.20.0
+    - bioconductor-phyloseq >=1.22.0
     - r-plotly >=4.7.1
     - r-gridextra >=2.2.1
+    - r-vegan <2.5
 
 test:
   commands:


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

With phyloseq 1.20:

```
Quitting from lines 74-113 (r_beta_diversity.Rmd) 
Error in .C(ape:::node_depth_edgelength, PACKAGE = "ape", as.integer(Ntip),  : 
  Incorrect number of arguments (7), expecting 5 for 'node_depth_edgelength'
Calls: <Anonymous> ... UniFrac -> fastUniFrac -> ape_node_depth_edge_length -> .C

Execution halted
```

With vegan 2.5:

```
Quitting from lines 74-113 (r_beta_diversity.Rmd) 
Error in .C("veg_distance", x = as.double(x), nr = N, nc = ncol(x), d = double(N *  : 
  "veg_distance" not available for .C() for package "vegan"
Calls: <Anonymous> ... distance -> do.call -> do.call -> vegdist -> vegdist -> .C

Execution halted
```