### PR TITLE
tardis update to 1.0.19 (fix paired fastq sampling)

### DIFF
--- a/recipes/tardis/meta.yaml
+++ b/recipes/tardis/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "tardis" %}
-{% set version = "0.5.17" %}
-{% set sha256 = "3442823498cfa3d5106a9f37188240777c9b00a550191b16796e290be36b8ef6" %}
+{% set version = "1.0.19" %}
+{% set sha256 = "d77e88b89db7ea66eaca1de606aca7cf5497e26714f5d446159d5287cf67bf8f" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
* [ ] This PR updates an existing recipe.