### PR TITLE
ARB: Pin glib

### DIFF
--- a/recipes/arb-bio/meta.yaml
+++ b/recipes/arb-bio/meta.yaml
@@ -25,7 +25,7 @@ source:
     - gsed.patch
 
 build:
-  number: 4
+  number: 5
 
 requirements:
   build:
@@ -55,7 +55,7 @@ requirements:
   run:
     # libs:
     - openmotif
-    - glib
+    - {{ pin_compatible("glib") }}
     - gettext
     - xorg-libxi
     - xorg-libxmu
@@ -94,7 +94,7 @@ outputs:
     script: install_libarbdb.sh
     requirements:
       run:
-        - glib
+        - {{ pin_compatible("glib") }}
         - gettext
   - name: arb-bio-tools
     script: install_tools.sh

--- a/recipes/arb-bio/meta.yaml
+++ b/recipes/arb-bio/meta.yaml
@@ -87,8 +87,6 @@ outputs:
   - name: arb-bio-tools
     script: install_tools.sh
     requirements:
-      build:
-        - {{ compiler('cxx') }}
       host:
         - glib
         - perl >=5.23  # see above
@@ -157,7 +155,6 @@ outputs:
     script: install_devel.sh
     requirements:
       build:
-        - {{ compiler('cxx') }}
         - arb-bio
       run:
         - {{ pin_subpackage('arb-bio', exact=True) }}

--- a/recipes/arb-bio/meta.yaml
+++ b/recipes/arb-bio/meta.yaml
@@ -30,13 +30,17 @@ build:
 requirements:
   build:
     - {{ compiler('cxx') }}
-    - {{ compiler('c') }}
     - pkg-config
     - time
     - lynx
     - xorg-makedepend
     - sed >=4.4
     - tar
+    # Perl is a problem. We must always have a perl version that was compiled with the
+    # same compiler we are using. Otherwise we run into e.g. "-fstack-protector-strong" type
+    # issues. Make-Maker uses the flags from the perl build time for the makefile it generates,
+    # so those flags must work for us as well.
+    - perl >=5.23
   host:
     - openmotif-dev
     - glib
@@ -51,34 +55,8 @@ requirements:
     - libxslt
     - libpng
     - xerces-c
-    - perl >=5.23
-  run:
-    # libs:
-    - openmotif
-    - {{ pin_compatible("glib") }}
-    - gettext
-    - xorg-libxi
-    - xorg-libxmu
-    - xorg-libxp
-    - xorg-libxaw
-    - xorg-libxpm
-    - xorg-libxft
-    - libpng
-    # tools:
-    - gnuplot
-    - muscle
-    - mafft
-    - raxml
-    - mrbayes
-    - phylip
-    - phyml 3.2.0*
-    - fasttree
-    - sed >=4.4
-    - xfig
-    - fig2dev
-    # We build a binary perl module. ABI compatability seems to be maintained
-    # at minor version (5.26.x), so we pin accordingly:
-    - {{ pin_compatible("perl", min_pin="x.x", max_pin="x.x") }}
+
+
 test:
   requires:
     - conda
@@ -93,27 +71,97 @@ outputs:
   - name: libarbdb
     script: install_libarbdb.sh
     requirements:
+      build:
+        - {{ compiler('cxx') }}
       host:
-        - gettext
         - glib
+        # We must have perl in the host sections of all output packages because
+        # `pin_compatible` will fail otherwise. Probably another bug.
+        - perl >=5.23
       run:
         - gettext
-        - {{ pin_compatible("glib") }}
+        - {{ pin_compatible("glib", max_pin="x") }}
+    build:
+      run_exports:
+        - {{ pin_subpackage("libarbdb", exact=True) }}
   - name: arb-bio-tools
     script: install_tools.sh
     requirements:
-      run:
-        - {{ pin_subpackage('libarbdb', exact=True) }}
+      build:
+        - {{ compiler('cxx') }}
+      host:
+        - glib
+        - perl >=5.23  # see above
+        - libarbdb  # will add itself to run dependencies
+
   - name: arb-bio
     script: install_main.sh
     requirements:
+      # We have to restate everything we used above in the top level requirements here.
+      # Lacking proper documentation of anything in conda build 3, all of this is trial
+      # and error. The run dependencies stated at the top level are not applied to the
+      # arb-bio output even though it shares the name with the toplevel.
+      # We also can't use YAML anchors to reference what we wrote above because conda
+      # build breaks YAML by parsing the outputs section again at a later point.
+      # Horrible mess....
+      build:
+        - {{ compiler('cxx') }}
+        - pkg-config
+        - time
+        - lynx
+        - xorg-makedepend
+        - sed >=4.4
+        - tar
+      host:
+        - openmotif-dev
+        - glib
+        - gettext
+        - pthread-stubs
+        - xorg-libxi
+        - xorg-libxp
+        - xorg-libxaw
+        - xorg-libxpm
+        - xorg-libxmu
+        - libtiff
+        - libxslt
+        - libpng
+        - xerces-c
+        - perl >=5.23
       run:
         - {{ pin_subpackage('arb-bio-tools', exact=True) }}
+        # We build a binary perl module. ABI compatability seems to be maintained
+        # at minor version (5.26.x), so we pin accordingly:
+        - {{ pin_compatible("perl", max_pin="x.x") }}
+        - gettext
+        - openmotif
+        - xorg-libxi
+        - xorg-libxmu
+        - xorg-libxp
+        - xorg-libxaw
+        - xorg-libxpm
+        - xorg-libxft
+        - libpng
+        # tools:
+        - gnuplot
+        - muscle
+        - mafft
+        - raxml
+        - mrbayes
+        - phylip
+        - phyml 3.2.0*
+        - fasttree
+        - sed >=4.4
+        - xfig
+        - fig2dev
   - name: arb-bio-devel
     script: install_devel.sh
     requirements:
+      build:
+        - {{ compiler('cxx') }}
+        - arb-bio
       run:
         - {{ pin_subpackage('arb-bio', exact=True) }}
+        - openmotif-dev
 
 about:
   home: http://www.arb-home.de

--- a/recipes/arb-bio/meta.yaml
+++ b/recipes/arb-bio/meta.yaml
@@ -26,7 +26,11 @@ source:
 
 build:
   number: 5
-  skip: True  # [perl <5.23]
+# constraining to perl >= 5.23 does not work via requirements, resulting in a 
+# broken build string. constraining via skip also doesn't work - the suggested
+# approach leads to str < int compare failure during lint. 
+# => let's just hope no one tries building this with an old perl.
+#  skip: True  # [perl <5.23]
 
 requirements:
   build:

--- a/recipes/arb-bio/meta.yaml
+++ b/recipes/arb-bio/meta.yaml
@@ -93,6 +93,9 @@ outputs:
   - name: libarbdb
     script: install_libarbdb.sh
     requirements:
+      build:
+        - gettext
+        - glib
       run:
         - {{ pin_compatible("glib") }}
         - gettext

--- a/recipes/arb-bio/meta.yaml
+++ b/recipes/arb-bio/meta.yaml
@@ -36,11 +36,6 @@ requirements:
     - xorg-makedepend
     - sed >=4.4
     - tar
-    # Perl is a problem. We must always have a perl version that was compiled with the
-    # same compiler we are using. Otherwise we run into e.g. "-fstack-protector-strong" type
-    # issues. Make-Maker uses the flags from the perl build time for the makefile it generates,
-    # so those flags must work for us as well.
-    - perl >=5.23
   host:
     - openmotif-dev
     - glib
@@ -55,6 +50,11 @@ requirements:
     - libxslt
     - libpng
     - xerces-c
+    # Perl is a problem. We must always have a perl version that was compiled with the
+    # same compiler we are using. Otherwise we run into e.g. "-fstack-protector-strong" type
+    # issues. Make-Maker uses the flags from the perl build time for the makefile it generates,
+    # so those flags must work for us as well.
+    - perl >=5.23
 
 
 test:

--- a/recipes/arb-bio/meta.yaml
+++ b/recipes/arb-bio/meta.yaml
@@ -26,6 +26,7 @@ source:
 
 build:
   number: 5
+  skip: True  # [perl <5.23]
 
 requirements:
   build:
@@ -54,7 +55,7 @@ requirements:
     # same compiler we are using. Otherwise we run into e.g. "-fstack-protector-strong" type
     # issues. Make-Maker uses the flags from the perl build time for the makefile it generates,
     # so those flags must work for us as well.
-    - perl >=5.23
+    - perl
 
 
 test:
@@ -77,7 +78,7 @@ outputs:
         - glib
         # We must have perl in the host sections of all output packages because
         # `pin_compatible` will fail otherwise. Probably another bug.
-        - perl >=5.23
+        - perl
       run:
         - gettext
         - {{ pin_compatible("glib", max_pin="x") }}
@@ -91,7 +92,7 @@ outputs:
         - {{ compiler('cxx') }}
       host:
         - glib
-        - perl >=5.23  # see above
+        - perl # see above
       run:
         - {{ pin_subpackage("libarbdb", exact=True) }}
 
@@ -127,7 +128,7 @@ outputs:
         - libxslt
         - libpng
         - xerces-c
-        - perl >=5.23
+        - perl
       run:
         - {{ pin_subpackage('arb-bio-tools', exact=True) }}
         # We build a binary perl module. ABI compatability seems to be maintained

--- a/recipes/arb-bio/meta.yaml
+++ b/recipes/arb-bio/meta.yaml
@@ -87,6 +87,8 @@ outputs:
   - name: arb-bio-tools
     script: install_tools.sh
     requirements:
+      build:
+        - {{ compiler('cxx') }}
       host:
         - glib
         - perl >=5.23  # see above
@@ -138,6 +140,7 @@ outputs:
         - xorg-libxaw
         - xorg-libxpm
         - xorg-libxft
+        - xorg-libxt
         - libpng
         # tools:
         - gnuplot
@@ -155,6 +158,7 @@ outputs:
     script: install_devel.sh
     requirements:
       build:
+        - {{ compiler('cxx') }}
         - arb-bio
       run:
         - {{ pin_subpackage('arb-bio', exact=True) }}
@@ -165,3 +169,9 @@ about:
   license: ARB
   licence_file: arb_LICENSE.txt
   summary: ARB 6 Sequence Analysis Suite
+
+extra:
+  recipe-maintainers:
+    - epruesse
+  skip-lints:
+    - should_not_be_noarch  # false positive, `noarch: False` added by CB3 for outputs

--- a/recipes/arb-bio/meta.yaml
+++ b/recipes/arb-bio/meta.yaml
@@ -92,7 +92,8 @@ outputs:
       host:
         - glib
         - perl >=5.23  # see above
-        - libarbdb  # will add itself to run dependencies
+      run:
+        - {{ pin_subpackage("libarbdb", exact=True) }}
 
   - name: arb-bio
     script: install_main.sh
@@ -159,7 +160,6 @@ outputs:
     requirements:
       build:
         - {{ compiler('cxx') }}
-        - arb-bio
       run:
         - {{ pin_subpackage('arb-bio', exact=True) }}
         - openmotif-dev

--- a/recipes/arb-bio/meta.yaml
+++ b/recipes/arb-bio/meta.yaml
@@ -93,12 +93,12 @@ outputs:
   - name: libarbdb
     script: install_libarbdb.sh
     requirements:
-      build:
+      host:
         - gettext
         - glib
       run:
-        - {{ pin_compatible("glib") }}
         - gettext
+        - {{ pin_compatible("glib") }}
   - name: arb-bio-tools
     script: install_tools.sh
     requirements:


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

@bgruening - I hate to ask, but the previous builds need to be removed from the channel. Otherwise `conda` will install glib `2.55.1` while `2.56.1` is needed (just because it was linked to 2.56, not because of ARB).  It breaks on OSX, Linux is more tolerant I think.

I've created issue conda-forge/glib-feedstock#38 and PR conda-forge/glib-feedstock#37 at CF to add `run_exports` to `glib`. 