### PR TITLE
Fix detection of python 3 in when building MEME 5.0.2

### DIFF
--- a/recipes/meme/build.sh
+++ b/recipes/meme/build.sh
@@ -23,6 +23,7 @@ ln -s $PREFIX/libexec/meme*/* $PREFIX/bin/
 # if building with python3,
 # modify meme-chip script to use python3 version of DREME
 if [ $PY3K==1 ]; then
-    sed -i '994s/dreme/dreme-py3/' $PREFIX/bin/meme-chip
+    sed -i.bak  '994s/dreme/dreme-py3/' $PREFIX/bin/meme-chip
+    rm $PREFIX/bin/meme-chip.bak
 fi
 

--- a/recipes/meme/build.sh
+++ b/recipes/meme/build.sh
@@ -22,8 +22,7 @@ ln -s $PREFIX/libexec/meme*/* $PREFIX/bin/
 
 # if building with python3,
 # modify meme-chip script to use python3 version of DREME
-if [[ $PGK_BUILDNUM == *"py3"* ]]
-then
-   sed -i '994s/dreme/dreme-py3/' $PREFIX/bin/meme-chip
+if [ $PY3K==1 ]; then
+    sed -i '994s/dreme/dreme-py3/' $PREFIX/bin/meme-chip
 fi
 

--- a/recipes/meme/meta.yaml
+++ b/recipes/meme/meta.yaml
@@ -11,7 +11,7 @@ source:
     - mast.patch
 
 build:
-  number: 4
+  number: 5
   detect_binary_files_with_prefix: True
 
 requirements:
@@ -64,10 +64,19 @@ requirements:
 
 test:
   commands:
-    - meme -version
-    - mast -version
+    - meme -p 1 -version
     - meme-chip -version
+    - glam2 -version
+    - tomtom -version
     - centrimo -version
+    - ame -version
+    - spamo -version
+    - gomo -version
+    - fimo -version
+    - mast -version
+    - mcast -version
+    - glam2scan -version
+    - momo simple -version
 
 about:
   home: http://alternate.meme-suite.org/

--- a/recipes/meme/meta.yaml
+++ b/recipes/meme/meta.yaml
@@ -39,6 +39,7 @@ requirements:
     - perl-math-cdf
     - perl-log-log4perl
     - perl-json
+    - perl-file-which
     - openmpi
   run:
     - yaml
@@ -60,6 +61,7 @@ requirements:
     - perl-math-cdf
     - perl-log-log4perl
     - perl-json
+    - perl-file-which
     - openmpi
 
 test:

--- a/recipes/meme/meta.yaml
+++ b/recipes/meme/meta.yaml
@@ -64,7 +64,7 @@ requirements:
 
 test:
   commands:
-    - meme -p 1 -version
+    - meme -version
     - meme-chip -version
     - glam2 -version
     - tomtom -version


### PR DESCRIPTION
Fix detection of python 3 in MEME build script. Also added additional commands for tests in the meta.yml file.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
