### PR TITLE
prosic: unblacklist with prosolo setup, incl. yacrd workarounds for build.sh

### DIFF
--- a/recipes/prosic/build.sh
+++ b/recipes/prosic/build.sh
@@ -1,4 +1,15 @@
 #!/bin/bash -euo
 
+# taken from yacrd recipe, see: https://github.com/bioconda/bioconda-recipes/blob/2b02c3db6400499d910bc5f297d23cb20c9db4f8/recipes/yacrd/build.sh
+if [ "$(uname)" == "Darwin" ]; then
+
+    # apparently the HOME variable isn't set correctly, and circle ci output indicates the following as the home directory
+    export HOME="/Users/distiller"
+
+    # according to https://github.com/rust-lang/cargo/issues/2422#issuecomment-198458960 removing circle ci default configuration solves cargo trouble downloading crates
+    git config --global --unset url.ssh://git@github.com.insteadOf
+
+fi
+
 # build statically linked binary with Rust
-C_INCLUDE_PATH=$PREFIX/include LIBRARY_PATH=$PREFIX/lib cargo install --root $PREFIX
+C_INCLUDE_PATH=$PREFIX/include LIBRARY_PATH=$PREFIX/lib cargo install --path . --root $PREFIX

--- a/recipes/prosic/meta.yaml
+++ b/recipes/prosic/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 3
+  number: 4
 
 source:
   url: https://github.com/PROSIC/prosic2/archive/v{{ version }}.tar.gz
@@ -15,11 +15,15 @@ source:
 requirements:
   build:
     - {{ compiler('c') }}
+    - rust >=1.30
+    - pkg-config #[osx]
   host:
-    - rust >=1.12
     - gsl
     - openblas
     - zlib
+    - bzip2
+    - xz
+    - clangdev
   run:
     - gsl
     - openblas


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

Unblacklisting prosic after the conda-build 3 update.