### PR TITLE
Add gitpython to snakemake dependencies

### DIFF
--- a/recipes/snakemake-minimal/meta.yaml
+++ b/recipes/snakemake-minimal/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 612a16f2bba580c47183e4f752ed40b034852541ca3e96e480d01fb30ad9570c
 
 build:
-  number: 0
+  number: 1
   skip: True # [py27]
   script: python -m pip install --no-deps --ignore-installed .
   entry_points:
@@ -41,6 +41,7 @@ requirements:
     - configargparse
     - appdirs
     - jsonschema
+    - gitpython
 
 test:
   imports:


### PR DESCRIPTION
gitpython is listed as a dependency in Snakemake’s `setup.py`, but not as a run requirement in this recipe.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
