### PR TITLE
ensembl-vep: remove perl-cgi dependency (not required anymore to run ensembl-vep)

### DIFF
--- a/recipes/ensembl-vep/meta.yaml
+++ b/recipes/ensembl-vep/meta.yaml
@@ -25,7 +25,6 @@ requirements:
     - htslib
     - perl-bioperl >=1.7.2
     - perl-bio-db-hts >=2.7
-    - perl-cgi
     - perl-dbi
     - perl-dbd-mysql
     - perl-io-compress


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
