### PR TITLE
Use the extended-base container for eggnog-mapper

### DIFF
--- a/recipes/eggnog-mapper/meta.yaml
+++ b/recipes/eggnog-mapper/meta.yaml
@@ -11,7 +11,7 @@ source:
     - setup.patch
 
 build:
-  number: 1
+  number: 2
   skip: True # [not py27]
 
 requirements:
@@ -34,3 +34,8 @@ about:
   home: https://github.com/jhcepas/eggnog-mapper
   license: GPL
   summary: Fast genome-wide functional annotation through orthology assignment
+
+extra:
+  container:
+    # need wget with more options than the busybox one
+    extended-base: True


### PR DESCRIPTION
When downloading databases the wget flags used conflict with the wget in busybox, thus the extended-base container is needed.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
