### PR TITLE
Increase default max heap size for snpEff

### DIFF
--- a/recipes/snpeff/snpeff.sh
+++ b/recipes/snpeff/snpeff.sh
@@ -29,7 +29,7 @@ fi
 
 # extract memory and system property Java arguments from the list of provided arguments
 # http://java.dzone.com/articles/better-java-shell-script
-default_jvm_mem_opts="-Xms512m -Xmx1g"
+default_jvm_mem_opts="-Xms512m -Xmx2g"
 jvm_mem_opts=""
 jvm_prop_opts=""
 pass_args=""


### PR DESCRIPTION
snpEff documentation specifies at least 2GB is required http://snpeff.sourceforge.net/SnpEff_manual.version_4_0.html

The current 1gb max heap fails at annotating even trivial VCFs

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
