### PR TITLE
MSGFplus does not work with newer Java

### DIFF
--- a/recipes/msgf_plus/meta.yaml
+++ b/recipes/msgf_plus/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 requirements:
   run:
-    - openjdk
+    - openjdk<11
     - python
 
 test:

--- a/recipes/msgf_plus/meta.yaml
+++ b/recipes/msgf_plus/meta.yaml
@@ -4,7 +4,7 @@ package:
 
 build:
   noarch: generic
-  number: 1
+  number: 2
 
 source:
   url: https://github.com/sangtaekim/msgfplus/releases/download/v2017.07.21/v20170721.zip


### PR DESCRIPTION

* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [X] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

This is hardly definite, but the conda-forge openJDK recipe got updated from 1.8 to 11.0 3 or so days ago. This led apparently to it dropping some classes that MSGF needs for XML reading. A later version of MSGF+ works fine apparently (so I will also update the MSGF version in this recipe to a newer version later). The problem is referenced here: https://github.com/MSGFPlus/msgfplus/issues/18.
I tried to use the `--add-modules java.xml.bind` but it hasnt worked (yet).