### PR TITLE
Apparently we need openJDK to be below 9, not below 11 as in prev PR

### DIFF
--- a/recipes/msgf_plus/meta.yaml
+++ b/recipes/msgf_plus/meta.yaml
@@ -4,7 +4,7 @@ package:
 
 build:
   noarch: generic
-  number: 2
+  number: 3
 
 source:
   url: https://github.com/sangtaekim/msgfplus/releases/download/v2017.07.21/v20170721.zip
@@ -12,7 +12,7 @@ source:
 
 requirements:
   run:
-    - openjdk<11
+    - openjdk<9
     - python
 
 test:


### PR DESCRIPTION
* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [X] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Because otherwise it picks openJDK 10 from conda-forge (in my tests without forge it apparently picked openJDK 8 from the default channel).