### PR TITLE
Update DEXSeq requirements to force compatible HTSeq version

### DIFF
--- a/recipes/bioconductor-dexseq/meta.yaml
+++ b/recipes/bioconductor-dexseq/meta.yaml
@@ -15,7 +15,7 @@ source:
 
 build:
   noarch: python
-  number: 1
+  number: 2
   rpaths:
     - lib/R/lib/
     - lib/
@@ -60,7 +60,7 @@ requirements:
     - r-statmod
     - r-stringr
     - python <3
-    - 'htseq >=0.9.1'
+    - 'htseq >=0.6.1,<0.10.0'  # dexseq_count.py performes an overly simplistic version check
 
 test:
   commands:


### PR DESCRIPTION
There is a bug in the `dexseq_count.py` that performs an overly simplistic version check of HTSeq. The check fails for versions of `HTSeq >=0.10` since it performs a string comparison. I have [reached out to the DEXSeq author to attempt to get this patched](https://support.bioconductor.org/p/115115/#115638), but that won't happen for this version at least, thus this modification to the requirements to force a compatible HTSeq version be installed.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).