### PR TITLE
Update Subread from 1.6.2 to 1.6.3.

### DIFF
--- a/recipes/subread/meta.yaml
+++ b/recipes/subread/meta.yaml
@@ -32,7 +32,6 @@ test:
     - txUnique || [[ $? == 1 ]]
     - qualityScores
     - subread-fullscan || [[ $? == 255 ]]
-    - coverageCount
 
 extra:
   identifiers:

--- a/recipes/subread/meta.yaml
+++ b/recipes/subread/meta.yaml
@@ -4,14 +4,14 @@ about:
   summary: High-performance read alignment, quantification, and mutation discovery
 package:
   name: subread
-  version: 1.6.2
+  version: 1.6.3
 
 build:
   number: 0
 
 source:
-  url: https://downloads.sourceforge.net/project/subread/subread-1.6.2/subread-1.6.2-source.tar.gz
-  sha256: 77b4896c1c242967c5883a06c0a5576a5ff220008a12aa60af9669d2f9a87d7a
+  url: https://downloads.sourceforge.net/project/subread/subread-1.6.3/subread-1.6.3-source.tar.gz
+  sha256: 2d9f3ae072e32ec64095fc6b211c287d0f3496cbe6ac72b255c42cbd41778e1a
 
 requirements:
   build:


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Updated package requested on [Subread mailing list](https://groups.google.com/d/msg/subread/TkXD0N3vLG8/7_uwRgDDAwAJ). From the [changelog](http://subread.sourceforge.net/):

**Release 1.6.3, 9 Oct 2018**
* Fixed a bug in subread-align and subjunc that may cause incorrect reporting of mapping result when a read is mapped out of chromosome boundary.
* Fixed a bug in featureCounts that may cause incorrect counting of reads when '--byReadGroup' is specified and unmapped reads are not included in the BAM input.
* Limit on the size of header in the SAM input is removed from featureCounts.
