### PR TITLE
stacks: another try for a fix for @ in exe_path

### DIFF
--- a/recipes/stacks/2.2/at.patch
+++ b/recipes/stacks/2.2/at.patch
@@ -1,7 +1,7 @@
 # this patch sets and ensures that the exe_path (where stacks searches for the binaries)
 # is the empty string, i.e. PATH is used (ie conda takes care).
 diff -ruN stacks-2.2/scripts/denovo_map.pl stacks-2.2/scripts/denovo_map.pl
---- stacks-2.2/scripts/denovo_map.pl	2018-12-01 17:19:52.543672003 +0100
+--- stacks-2.2/scripts/denovo_map.pl	2018-12-01 17:30:58.897731113 +0100
 +++ stacks-2.2/scripts/denovo_map.pl	2018-04-19 18:17:23.000000000 +0200
 @@ -28,7 +28,7 @@
  use constant false => 0;
@@ -12,7 +12,21 @@ diff -ruN stacks-2.2/scripts/denovo_map.pl stacks-2.2/scripts/denovo_map.pl
  my $out_path     = "";
  my $popmap_path  = "";
  my $sample_path  = "";
-@@ -558,6 +558,7 @@
+@@ -50,6 +50,13 @@
+ 
+ parse_command_line();
+ 
++#
++# Check for the existence of the necessary pipeline programs
++#
++foreach my $prog ("ustacks", "cstacks", "sstacks", "tsv2bam", "gstacks", "populations") {
++    die "Unable to find '" . $exe_path . $prog . "'.\n" if (!-e $exe_path . $prog);
++}
++
+ my ($log, $log_fh, $sample);
+ 
+ my (@sample_list, %pop_ids, %pops, %grp_ids, %grps, %sample_ids);
+@@ -551,6 +558,7 @@
          }
      }
  
@@ -21,7 +35,7 @@ diff -ruN stacks-2.2/scripts/denovo_map.pl stacks-2.2/scripts/denovo_map.pl
  
      if (scalar(@parents) > 0 && scalar(@samples) > 0) {
 diff -ruN stacks-2.2/scripts/ref_map.pl stacks-2.2/scripts/ref_map.pl
---- stacks-2.2/scripts/ref_map.pl	2018-12-01 17:19:31.839690592 +0100
+--- stacks-2.2/scripts/ref_map.pl	2018-12-01 17:31:09.209688026 +0100
 +++ stacks-2.2/scripts/ref_map.pl	2018-03-21 15:51:20.000000000 +0100
 @@ -28,7 +28,7 @@
  use constant false => 0;
@@ -32,7 +46,21 @@ diff -ruN stacks-2.2/scripts/ref_map.pl stacks-2.2/scripts/ref_map.pl
  my $out_path     = "";
  my $popmap_path  = "";
  my $sample_path  = "";
-@@ -385,6 +385,7 @@
+@@ -47,6 +47,13 @@
+ 
+ parse_command_line();
+ 
++#
++# Check for the existence of the necessary pipeline programs
++#
++foreach my $prog ("gstacks", "populations") {
++    die "Unable to find '" . $exe_path . $prog . "'.\n" if (!-e $exe_path . $prog);
++}
++
+ my ($log, $log_fh, $sample);
+ 
+ my (@sample_list, %pop_ids, %pops, %grp_ids, %grps, %sample_ids);
+@@ -378,6 +385,7 @@
          }
      }
  

--- a/recipes/stacks/2.2/at.patch
+++ b/recipes/stacks/2.2/at.patch
@@ -1,70 +1,71 @@
-# this patch sets and ensures that the exe_path (where stacks searches for the binaries)
-# is the empty string, i.e. PATH is used (ie conda takes care).
-diff -ruN stacks-2.2/scripts/denovo_map.pl stacks-2.2/scripts/denovo_map.pl
---- stacks-2.2/scripts/denovo_map.pl	2018-12-01 17:30:58.897731113 +0100
-+++ stacks-2.2/scripts/denovo_map.pl	2018-04-19 18:17:23.000000000 +0200
+# the stacks perl scripts don't work if there is an '@' in the exe_path
+# (where stacks searches for the binaries) this patch sets and ensures that the
+# exe_path is the empty string, i.e. PATH is used (ie conda takes care).
+diff -ruN stacks-2.2-old/scripts/denovo_map.pl stacks-2.2-new/scripts/denovo_map.pl
+--- stacks-2.2/scripts/denovo_map.pl	2018-04-19 18:17:23.000000000 +0200
++++ stacks-2.2/scripts/denovo_map.pl	2019-01-03 08:28:27.174444559 +0100
 @@ -28,7 +28,7 @@
  use constant false => 0;
  
  my $dry_run      = false;
--my $exe_path     = "";
-+my $exe_path     = "_BINDIR_";
+-my $exe_path     = "_BINDIR_";
++my $exe_path     = "";
  my $out_path     = "";
  my $popmap_path  = "";
  my $sample_path  = "";
-@@ -50,6 +50,13 @@
+@@ -50,13 +50,6 @@
  
  parse_command_line();
  
-+#
-+# Check for the existence of the necessary pipeline programs
-+#
-+foreach my $prog ("ustacks", "cstacks", "sstacks", "tsv2bam", "gstacks", "populations") {
-+    die "Unable to find '" . $exe_path . $prog . "'.\n" if (!-e $exe_path . $prog);
-+}
-+
+-#
+-# Check for the existence of the necessary pipeline programs
+-#
+-foreach my $prog ("ustacks", "cstacks", "sstacks", "tsv2bam", "gstacks", "populations") {
+-    die "Unable to find '" . $exe_path . $prog . "'.\n" if (!-e $exe_path . $prog);
+-}
+-
  my ($log, $log_fh, $sample);
  
  my (@sample_list, %pop_ids, %pops, %grp_ids, %grps, %sample_ids);
-@@ -551,6 +558,7 @@
+@@ -558,7 +551,6 @@
          }
      }
  
-+    $exe_path = $exe_path . "/"          if (substr($exe_path, -1) ne "/");
+-    $exe_path = $exe_path . "/"          if (substr($exe_path, -1) ne "/");
      $out_path = substr($out_path, 0, -1) if (substr($out_path, -1) eq "/");
  
      if (scalar(@parents) > 0 && scalar(@samples) > 0) {
-diff -ruN stacks-2.2/scripts/ref_map.pl stacks-2.2/scripts/ref_map.pl
---- stacks-2.2/scripts/ref_map.pl	2018-12-01 17:31:09.209688026 +0100
-+++ stacks-2.2/scripts/ref_map.pl	2018-03-21 15:51:20.000000000 +0100
+diff -ruN stacks-2.2-old/scripts/ref_map.pl stacks-2.2-new/scripts/ref_map.pl
+--- stacks-2.2/scripts/ref_map.pl	2018-03-21 15:51:20.000000000 +0100
++++ stacks-2.2/scripts/ref_map.pl	2019-01-03 08:29:17.974257301 +0100
 @@ -28,7 +28,7 @@
  use constant false => 0;
  
  my $dry_run      = false;
--my $exe_path     = "";
-+my $exe_path     = "_BINDIR_";
+-my $exe_path     = "_BINDIR_";
++my $exe_path     = "";
  my $out_path     = "";
  my $popmap_path  = "";
  my $sample_path  = "";
-@@ -47,6 +47,13 @@
+@@ -47,13 +47,6 @@
  
  parse_command_line();
  
-+#
-+# Check for the existence of the necessary pipeline programs
-+#
-+foreach my $prog ("gstacks", "populations") {
-+    die "Unable to find '" . $exe_path . $prog . "'.\n" if (!-e $exe_path . $prog);
-+}
-+
+-#
+-# Check for the existence of the necessary pipeline programs
+-#
+-foreach my $prog ("gstacks", "populations") {
+-    die "Unable to find '" . $exe_path . $prog . "'.\n" if (!-e $exe_path . $prog);
+-}
+-
  my ($log, $log_fh, $sample);
  
  my (@sample_list, %pop_ids, %pops, %grp_ids, %grps, %sample_ids);
-@@ -378,6 +385,7 @@
+@@ -385,7 +378,6 @@
          }
      }
  
-+    $exe_path = $exe_path . "/"          if (substr($exe_path, -1) ne "/");
+-    $exe_path = $exe_path . "/"          if (substr($exe_path, -1) ne "/");
      $out_path = substr($out_path, 0, -1) if (substr($out_path, -1) eq "/");
  
      if (length($popmap_path) == 0) {

--- a/recipes/stacks/2.2/at.patch
+++ b/recipes/stacks/2.2/at.patch
@@ -1,23 +1,42 @@
-# replace @ in the exe_path
+# this patch sets and ensures that the exe_path (where stacks searches for the binaries)
+# is the empty string, i.e. PATH is used (ie conda takes care).
 diff -ruN stacks-2.2/scripts/denovo_map.pl stacks-2.2/scripts/denovo_map.pl
---- stacks-2.2/scripts/denovo_map.pl	2018-12-01 15:15:04.802304555 +0100
-+++ stacks-2.2/scripts/denovo_map.pl	2018-11-29 15:31:16.862582024 +0100
-@@ -29,7 +29,6 @@
+--- stacks-2.2/scripts/denovo_map.pl	2018-12-01 17:19:52.543672003 +0100
++++ stacks-2.2/scripts/denovo_map.pl	2018-04-19 18:17:23.000000000 +0200
+@@ -28,7 +28,7 @@
+ use constant false => 0;
  
  my $dry_run      = false;
- my $exe_path     = "_BINDIR_";
--$exe_path =~ s/@/\\@/g;
+-my $exe_path     = "";
++my $exe_path     = "_BINDIR_";
  my $out_path     = "";
  my $popmap_path  = "";
  my $sample_path  = "";
+@@ -558,6 +558,7 @@
+         }
+     }
+ 
++    $exe_path = $exe_path . "/"          if (substr($exe_path, -1) ne "/");
+     $out_path = substr($out_path, 0, -1) if (substr($out_path, -1) eq "/");
+ 
+     if (scalar(@parents) > 0 && scalar(@samples) > 0) {
 diff -ruN stacks-2.2/scripts/ref_map.pl stacks-2.2/scripts/ref_map.pl
---- stacks-2.2/scripts/ref_map.pl	2018-12-01 15:14:28.746185484 +0100
-+++ stacks-2.2/scripts/ref_map.pl	2018-11-29 15:31:54.698396825 +0100
-@@ -29,7 +29,6 @@
+--- stacks-2.2/scripts/ref_map.pl	2018-12-01 17:19:31.839690592 +0100
++++ stacks-2.2/scripts/ref_map.pl	2018-03-21 15:51:20.000000000 +0100
+@@ -28,7 +28,7 @@
+ use constant false => 0;
  
  my $dry_run      = false;
- my $exe_path     = "_BINDIR_";
--$exe_path =~ s/@/\\@/g;
+-my $exe_path     = "";
++my $exe_path     = "_BINDIR_";
  my $out_path     = "";
  my $popmap_path  = "";
  my $sample_path  = "";
+@@ -385,6 +385,7 @@
+         }
+     }
+ 
++    $exe_path = $exe_path . "/"          if (substr($exe_path, -1) ne "/");
+     $out_path = substr($out_path, 0, -1) if (substr($out_path, -1) eq "/");
+ 
+     if (length($popmap_path) == 0) {

--- a/recipes/stacks/2.2/at.patch
+++ b/recipes/stacks/2.2/at.patch
@@ -1,0 +1,23 @@
+# replace @ in the exe_path
+diff -ruN stacks-2.2/scripts/denovo_map.pl stacks-2.2/scripts/denovo_map.pl
+--- stacks-2.2/scripts/denovo_map.pl	2018-12-01 15:15:04.802304555 +0100
++++ stacks-2.2/scripts/denovo_map.pl	2018-11-29 15:31:16.862582024 +0100
+@@ -29,7 +29,6 @@
+ 
+ my $dry_run      = false;
+ my $exe_path     = "_BINDIR_";
+-$exe_path =~ s/@/\\@/g;
+ my $out_path     = "";
+ my $popmap_path  = "";
+ my $sample_path  = "";
+diff -ruN stacks-2.2/scripts/ref_map.pl stacks-2.2/scripts/ref_map.pl
+--- stacks-2.2/scripts/ref_map.pl	2018-12-01 15:14:28.746185484 +0100
++++ stacks-2.2/scripts/ref_map.pl	2018-11-29 15:31:54.698396825 +0100
+@@ -29,7 +29,6 @@
+ 
+ my $dry_run      = false;
+ my $exe_path     = "_BINDIR_";
+-$exe_path =~ s/@/\\@/g;
+ my $out_path     = "";
+ my $popmap_path  = "";
+ my $sample_path  = "";

--- a/recipes/stacks/2.2/build.sh
+++ b/recipes/stacks/2.2/build.sh
@@ -17,14 +17,6 @@ make install
 # copy missing scripts
 cp -p scripts/{convert_stacks.pl,extract_interpop_chars.pl} "$PREFIX/bin/"
 
-# after installation the exe_dir is set to the absolute binary path 
-# this is not necessary and leads to an error if there are characters 
-# like @ included (Galaxy)
-
-# furthermore a bug in ref_map v2.2 is fixed
-for i in ref_map.pl denovo_map.pl
-do
-    sed -i -e "s/^\(my \$exe_path\s\+=[^@]\+\)/\1\\\\/" "$PREFIX/bin/$i"
-    sed -i -e "s/_alpha/-alpha/" "$PREFIX/bin/$i"
-done
+# fix a bug in ref_map v2.2 is fixed
+sed -i -e "s/_alpha/-alpha/" "$PREFIX"/bin/ref_map.pl
 

--- a/recipes/stacks/2.2/build.sh
+++ b/recipes/stacks/2.2/build.sh
@@ -19,4 +19,3 @@ cp -p scripts/{convert_stacks.pl,extract_interpop_chars.pl} "$PREFIX/bin/"
 
 # fix a bug in ref_map v2.2 is fixed
 sed -i -e "s/_alpha/-alpha/" "$PREFIX"/bin/ref_map.pl
-

--- a/recipes/stacks/2.2/build.sh
+++ b/recipes/stacks/2.2/build.sh
@@ -19,3 +19,4 @@ cp -p scripts/{convert_stacks.pl,extract_interpop_chars.pl} "$PREFIX/bin/"
 
 # fix a bug in ref_map v2.2 is fixed
 sed -i -e "s/_alpha/-alpha/" "$PREFIX"/bin/ref_map.pl
+

--- a/recipes/stacks/2.2/meta.yaml
+++ b/recipes/stacks/2.2/meta.yaml
@@ -6,11 +6,13 @@ package:
   version: {{ version }}
 
 build:
-  number: 2
+  number: 3
 
 source:
   sha256: {{ hash }}
   url: http://catchenlab.life.illinois.edu/stacks/source/stacks-{{ version }}.tar.gz
+  patches:
+    - at.patch
 
 requirements:
   build:


### PR DESCRIPTION
really sorry, but the last fix did not work. I guess that in the constructed package there is no `@`, but only placeholders. Hence I guess this needs to be fixed during runtime.  

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
