### PR TITLE
HTSeq - Pin numpy version

### DIFF
--- a/recipes/htseq/meta.yaml
+++ b/recipes/htseq/meta.yaml
@@ -7,12 +7,12 @@ source:
   sha256: 19145fd3359baa4a8dd5c93470aa0a77e16da3ffde8e4e10fa8df4191df5cd29
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
     - {{ compiler('c') }}
-    
+
   host:
     - python
     - setuptools
@@ -23,7 +23,7 @@ requirements:
 
   run:
     - python
-    - numpy
+    - {{ pin_compatible('numpy') }}
     - matplotlib >=1.4
     - pysam >=0.9.0
 


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

I've run into issues when attempting to use HTSeq as a dependency for other packages (specifically DEXSeq).
```
/home/lparsons/miniconda3/envs/test_dexseq/lib/python2.7/site-packages/HTSeq/__init__.py:9: RuntimeWarning: numpy.dtype size changed, may indicate binary incompatibility. Expected 96, got 88
  from _HTSeq import *
```

This is my attempt to resolve this issue, at least for this and future versions of HTSeq. I'm not sure if/how to fix this for prior versions of HTSeq.