### PR TITLE
DEXSeq - resolve HTSeq/numpy depenency version mismatch

### DIFF
--- a/recipes/bioconductor-dexseq/meta.yaml
+++ b/recipes/bioconductor-dexseq/meta.yaml
@@ -15,7 +15,7 @@ source:
 
 build:
   noarch: python
-  number: 2
+  number: 3
   rpaths:
     - lib/R/lib/
     - lib/
@@ -60,7 +60,8 @@ requirements:
     - r-statmod
     - r-stringr
     - python <3
-    - 'htseq >=0.6.1,<0.10.0'  # dexseq_count.py performes an overly simplistic version check
+    - 'htseq 0.9.1'  # should be >= 0.6.1, but dexseq_count.py performes an overly simplistic version check
+    - numpy 1.9.3    # Not necessary, but older versions of HTSEeq don't have numpy properly pinned
 
 test:
   commands:


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

I've pinned the version of numpy used for HTSeq in https://github.com/bioconda/bioconda-recipes/pull/12467. However, since this requires an older htseq recipe that doesn't have numpy properly pinned, I'm forcing it here. These can be removed when we get various fixes from DEXSeq upstream https://github.com/areyesq89/DEXSeq/pull/1.