### PR TITLE
For VarDict-Java, install utility scripts.

### DIFF
--- a/recipes/vardict-java/build.sh
+++ b/recipes/vardict-java/build.sh
@@ -7,5 +7,8 @@ mkdir -p $PREFIX/bin
 
 cp lib/*.jar $outdir/lib
 cp bin/VarDict $outdir/bin/vardict-java
-chmod +x $outdir/bin/vardict-java
-ln -s $outdir/bin/vardict-java $PREFIX/bin
+cp bin/*.{R,pl} $outdir/bin
+for binary in vardict-java testsomatic.R teststrandbias.R var2vcf_paired.pl var2vcf_valid.pl; do
+  chmod +x $outdir/bin/$binary
+  ln -s $outdir/bin/$binary $PREFIX/bin
+done

--- a/recipes/vardict-java/meta.yaml
+++ b/recipes/vardict-java/meta.yaml
@@ -15,10 +15,13 @@ build:
 requirements:
   run:
     - openjdk
+    - perl
+    - r-base
 
 test:
   commands:
     - vardict-java -h
+    - var2vcf_paired.pl -h
 
 about:
   home: https://github.com/AstraZeneca-NGS/VarDictJava


### PR DESCRIPTION
Utility script that were previously only shipped with VarDict are not
part of VarDict-Java as well, making installation of both packages
unnecessary.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).
