### PR TITLE
Pin compatible numpy for older HTSEQ versions

### DIFF
--- a/recipes/htseq/0.6.1.post1/meta.yaml
+++ b/recipes/htseq/0.6.1.post1/meta.yaml
@@ -8,7 +8,7 @@ source:
 
 build:
   preserve_egg_dir: True
-  number: 2
+  number: 3
   skip: True # [not py27]
 
 requirements:
@@ -19,7 +19,7 @@ requirements:
 
   run:
     - python
-    - numpy
+    - {{ pin_compatible('numpy') }}
     - matplotlib
     - pysam
 

--- a/recipes/htseq/0.6.1.post1/meta.yaml
+++ b/recipes/htseq/0.6.1.post1/meta.yaml
@@ -12,6 +12,9 @@ build:
   skip: True # [not py27]
 
 requirements:
+  build:
+    - {{ compiler('c') }}
+
   host:
     - python
     - setuptools

--- a/recipes/htseq/0.6.1/meta.yaml
+++ b/recipes/htseq/0.6.1/meta.yaml
@@ -12,6 +12,8 @@ package:
   version: 0.6.1
 
 requirements:
+  build:
+  - {{ compiler('c') }}
   host:
   - python
   - cython

--- a/recipes/htseq/0.6.1/meta.yaml
+++ b/recipes/htseq/0.6.1/meta.yaml
@@ -4,7 +4,7 @@ about:
   summary: 'A framework to process and analyze data from high-throughput sequencing (HTS) assays'
 
 build:
-  number: 1
+  number: 2
   skip: True # [py3k or osx]
 
 package:

--- a/recipes/htseq/0.7.2/meta.yaml
+++ b/recipes/htseq/0.7.2/meta.yaml
@@ -10,6 +10,9 @@ build:
   number: 2
 
 requirements:
+  build:
+    - {{ compiler('c') }}
+
   host:
     - python
     - setuptools

--- a/recipes/htseq/0.7.2/meta.yaml
+++ b/recipes/htseq/0.7.2/meta.yaml
@@ -7,7 +7,7 @@ source:
   sha256: b9da6d6a9004e8e05a40ecf08f74f765ec0e0be0e835e82205a117aba2ce375b
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   host:
@@ -19,7 +19,7 @@ requirements:
 
   run:
     - python
-    - numpy
+    - {{ pin_compatible('numpy') }}
     - matplotlib
     - pysam >=0.9.0
 

--- a/recipes/htseq/0.9.1/build.sh
+++ b/recipes/htseq/0.9.1/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$PYTHON setup.py build install

--- a/recipes/htseq/0.9.1/meta.yaml
+++ b/recipes/htseq/0.9.1/meta.yaml
@@ -1,0 +1,44 @@
+package:
+  name: htseq
+  version: "0.9.1"
+
+source:
+  fn: HTSeq-0.9.1.tar.gz
+  url: https://pypi.python.org/packages/fd/94/b7c8c1dcb7a3c3dcbde66b8d29583df4fa0059d88cc3592f62d15ef539a2/HTSeq-0.9.1.tar.gz
+  md5: fc71e021bf284a68f5ac7533a57641ac
+
+build:
+  number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - cython
+    - numpy
+    - pysam >=0.9.0
+    - swig >=3.0.8
+
+  run:
+    - python
+    - {{ pin_compatible('numpy') }}
+    - matplotlib >=1.4
+    - pysam >=0.9.0
+
+test:
+  # Python imports
+  imports:
+    - HTSeq._HTSeq_internal
+    - HTSeq.StepVector
+    - HTSeq._version
+    - HTSeq.scripts.count
+    - HTSeq.scripts.qa
+
+  commands:
+    - htseq-count -h
+    - htseq-qa -h
+
+about:
+  home: https://github.com/simon-anders/htseq
+  license: GPL-3.0
+  summary: 'HTSeq is a Python library to facilitate processing and analysis of data from high-throughput sequencing (HTS) experiments.'

--- a/recipes/htseq/0.9.1/meta.yaml
+++ b/recipes/htseq/0.9.1/meta.yaml
@@ -3,15 +3,17 @@ package:
   version: "0.9.1"
 
 source:
-  fn: HTSeq-0.9.1.tar.gz
   url: https://pypi.python.org/packages/fd/94/b7c8c1dcb7a3c3dcbde66b8d29583df4fa0059d88cc3592f62d15ef539a2/HTSeq-0.9.1.tar.gz
   md5: fc71e021bf284a68f5ac7533a57641ac
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
+    - {{ compiler('c') }}
+
+  host:
     - python
     - setuptools
     - cython


### PR DESCRIPTION
This is required to keep older versions of HTSEQ functional

* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [X] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
