### PR TITLE
Missing deps for ucsc-cell-browser 0.4.23

### DIFF
--- a/recipes/ucsc-cell-browser/meta.yaml
+++ b/recipes/ucsc-cell-browser/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: e2a019f8bb150f8d115b0dd1f75a76831c9e96898c42d70b42f37ff61f01641e
 
 build:
-  number: 0
+  number: 1
   noarch: python
 
 requirements:

--- a/recipes/ucsc-cell-browser/meta.yaml
+++ b/recipes/ucsc-cell-browser/meta.yaml
@@ -19,6 +19,8 @@ requirements:
         - python >=3.6
         - numpy
         - r-data.table
+        - r-argparser
+        - r-matrix
         - anndata
 
 test:


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

UCSC Cell Browser 0.4.23 was missing some dependencies for reading Seurat objects.