### PR TITLE
Restrict bulk to R and bioconductor recipes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,6 +189,7 @@ jobs:
           command: |
             bioconda-utils build recipes config.yml \
               --docker --mulled-test --anaconda-upload --mulled-upload-target biocontainers \
+              --package "bioconductor-*" "r-*" \
               --check-channels conda-forge/label/gcc7 bioconda/label/gcc7 bioconda
 
   # build, test and upload for bulk branch on macos
@@ -206,6 +207,7 @@ jobs:
           command: |
             bioconda-utils build recipes config.yml \
               --anaconda-upload \
+              --package "bioconductor-*" "r-*" \
               --check-channels conda-forge/label/gcc7 bioconda/label/gcc7 bioconda
 
   # nightly build, test and upload of unpublished recipes on linux


### PR DESCRIPTION
* [ ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

@bgruening As discussed, this should restrict `bulk` to only build CRAN/bioconductor packages.