### PR TITLE
r-seurat-scripts: Fixed DimPlots() issues, addressed libpng issue for OSX

### DIFF
--- a/recipes/r-seurat-scripts/meta.yaml
+++ b/recipes/r-seurat-scripts/meta.yaml
@@ -6,10 +6,10 @@ package:
 
 source:
   url: https://github.com/ebi-gene-expression-group/r-seurat-scripts/archive/v{{ version }}.tar.gz
-  sha256: 385c4616248b00fee261962f527f39ee85f6b5cbf26e6e8db120bd90f413b00d
+  sha256: 670e7b72c92c0af0a5b812e4ea82ea7997110ecbdb93e528ef63dd1ad0790213
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win32]
   noarch: generic
 

--- a/recipes/r-seurat-scripts/meta.yaml
+++ b/recipes/r-seurat-scripts/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.0.3" %}
+{% set version = "0.0.4" %}
 
 package:
   name: r-seurat-scripts
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/ebi-gene-expression-group/r-seurat-scripts/archive/v{{ version }}.tar.gz
-  sha256: f2dce203cdbec2d1c3e13209925c40318346e9aaa79379901a1017472b841c00 
+  sha256: 385c4616248b00fee261962f527f39ee85f6b5cbf26e6e8db120bd90f413b00d
 
 build:
   number: 0
@@ -21,6 +21,7 @@ requirements:
         - r-seurat 2.3.1
         - r-optparse
         - r-workflowscriptscommon
+        - qt # [osx]
 
 test:
     commands:


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

This PR bumps the referenced source package version. The new package version adds missing arguments and help text to the DimPlots wrapper seurat-dim-plot.R. The updated recipe also adds a dependency on qt for OSX, without which there is an issue with libpng.