### PR TITLE
Try to use GCC7 for hap.py

### DIFF
--- a/build-fail-blacklist
+++ b/build-fail-blacklist
@@ -328,8 +328,6 @@ recipes/koeken
 recipes/nucleoatac/0.3.1
 
 
-# no clue currently
-recipes/hap.py
 # RuntimeError: Setuptools downloading is disabled in conda build. Be sure to add all dependencies in the meta.yaml  url=https://pypi.org/simple/click/
 recipes/phylotoast
 

--- a/recipes/hap.py/build.sh
+++ b/recipes/hap.py/build.sh
@@ -9,7 +9,14 @@ sed -i.bak 's/make -j4 -C samtools/#make -j4 -C samtools/' external/make_depende
 mkdir -p build
 cd build
 export BOOST_ROOT=${PREFIX}
+
+# Make a symlink to GCC to overcome hard-coded gcc calls in vendored tarballed makefiles
+ln -s $CC $PREFIX/bin/gcc
+
 cmake ../ -DCMAKE_INSTALL_PREFIX=$PREFIX -DBOOST_INCLUDEDIR=$PREFIX/include/boost -DBOOST_LIBRARYDIR=$PREFIX/lib
 make
 rm -f lib/libhts*so
 make install
+
+# Remove gcc symlink
+rm $PREFIX/bin/gcc

--- a/recipes/hap.py/build.sh
+++ b/recipes/hap.py/build.sh
@@ -8,6 +8,7 @@ sed -i.bak -e '/^configure_files.*samtools/s/^/#/' CMakeLists.txt
 sed -i.bak 's/make -j4 -C samtools/#make -j4 -C samtools/' external/make_dependencies.sh
 mkdir -p build
 cd build
+export BOOST_ROOT=${PREFIX}
 cmake ../ -DCMAKE_INSTALL_PREFIX=$PREFIX -DBOOST_INCLUDEDIR=$PREFIX/include/boost -DBOOST_LIBRARYDIR=$PREFIX/lib
 make
 rm -f lib/libhts*so

--- a/recipes/hap.py/conda_build_config.yaml
+++ b/recipes/hap.py/conda_build_config.yaml
@@ -1,0 +1,6 @@
+c_compiler:	
+  - gcc      # [linux]	
+  - clang    # [osx]	
+cxx_compiler:	
+  - gxx      # [linux]	
+  - clangxx  # [osx]	

--- a/recipes/hap.py/meta.yaml
+++ b/recipes/hap.py/meta.yaml
@@ -15,6 +15,7 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
     - cmake
     - autoconf
     - automake

--- a/recipes/hap.py/meta.yaml
+++ b/recipes/hap.py/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: '{{ sha256 }}'
 
 build:
-  number: 2
+  number: 3
   skip: true # [not py27 or osx]
 
 requirements:

--- a/recipes/hap.py/meta.yaml
+++ b/recipes/hap.py/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - autoconf
     - automake
   host:
+    - libboost
     - python
     - setuptools
     - zlib
@@ -32,6 +33,7 @@ requirements:
     - bx-python
 
   run:
+    - libboost     
     - python
     - cython
     - zlib


### PR DESCRIPTION
* [ ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

This tries to overcome https://github.com/Illumina/hap.py/issues/66 by using the latest GCC7 compilers.