### PR TITLE
Add fontconfig / ttf-dejavu to fastqc recipe

### DIFF
--- a/recipes/fastqc/meta.yaml
+++ b/recipes/fastqc/meta.yaml
@@ -14,7 +14,7 @@ source:
 
 build:
   detect_binary_files_with_prefix: true
-  number: 0
+  number: 1
 
 requirements:
   run:
@@ -24,6 +24,8 @@ requirements:
     # Version number reference: https://github.com/conda/conda/issues/6948#issuecomment-369360906
     - openjdk >=8.0.144
     - perl
+    - fontconfig
+    - font-ttf-dejavu-sans-mono
 
 test:
   commands:


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

For x-ref:

https://github.com/bioconda/bioconda-recipes/issues/5026


This adds `fontconfig` and a ttf font to the recipe, to make sure that it doesn't randomly fail on systems lacking these packages in the host environment. We had several issues with this:

https://github.com/nf-core/ampliseq/issues/44

https://github.com/SciLifeLab/Sarek/issues/701


Either the recipe failed when doing local testing with pipelines and/or the CI builds of our pipelines broke by stalling forever due to an error causing the JAR file to hang in and endless loop.

