### PR TITLE
BUSCO: Pin BLAST+ version to >= 2.2, < 2.4

### DIFF
--- a/recipes/busco/meta.yaml
+++ b/recipes/busco/meta.yaml
@@ -9,7 +9,7 @@ package:
 build:
   # The R dependencies on OSX needs to be rebuilt with conda-build 3
   skip: True # [osx]
-  number: 8
+  number: 9
 
 source:
   url: https://gitlab.com/ezlab/busco/-/archive/{{ version }}/busco-{{ version }}.tar.gz
@@ -20,7 +20,7 @@ requirements:
     - python
   run:
     - python
-    - blast
+    - blast >=2.2,<2.4
     - hmmer
     - augustus >=3.2.3
     - r-ggplot2 >=2.2.1


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

BUSCO does not parallelise correctly with BLAST+ version >= 2.4 (see [the code](https://gitlab.com/ezlab/busco/blob/master/src/busco/BuscoAnalysis.py#L891)). This update ensures that a suitable BLAST+ version is used.