### PR TITLE
Use quotes when extending PATH.

### DIFF
--- a/.circleci/setup.sh
+++ b/.circleci/setup.sh
@@ -12,7 +12,7 @@ set -u
 source .circleci/common.sh
 
 # Set path
-echo "export PATH=$WORKSPACE/miniconda/bin:$PATH" >> $BASH_ENV
+echo "export PATH=\"$WORKSPACE/miniconda/bin:$PATH\"" >> $BASH_ENV
 source $BASH_ENV
 
 # Make sure the CircleCI config is up to date.

--- a/recipes/r-biodb/meta.yaml
+++ b/recipes/r-biodb/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 709b941fb1bb738400228aaab31876d255df32bb634139023f7984624880c318
 
 build:
-  number: 0
+  number: 1
   rpaths:
     - lib/R/lib/
     - lib/


### PR DESCRIPTION
* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [X] This PR does something else (explain below).

Correct PATH definition, when extending it for miniconda.
When extending PATH env var, use quotes in order to handle potential space characters in PATH.