### PR TITLE
MultiQC: Don't force matplotlib <3.0.0 if using py3k

### DIFF
--- a/recipes/multiqc/meta.yaml
+++ b/recipes/multiqc/meta.yaml
@@ -7,7 +7,7 @@ source:
   sha256: 1a6bea211ab584164a6c7513812ede57b28712bc528bd34cc5f1a581e7410644
 
 build:
-  number: 1
+  number: 2
   noarch: python
   preserve_egg_dir: True
 
@@ -23,7 +23,8 @@ requirements:
     - jinja2 >=2.9
     - lzstring
     - markdown
-    - matplotlib >=2.1.1,<3.0.0
+    - matplotlib >=2.1.1 # [py3k]
+    - matplotlib >=2.1.1,<3.0.0 # [py2k]
     - numpy
     - pyyaml
     - requests

--- a/recipes/multiqc/meta.yaml
+++ b/recipes/multiqc/meta.yaml
@@ -8,7 +8,8 @@ source:
 
 build:
   number: 2
-  noarch: python
+  # Disabled noarch to allow varying matplotlib dependencies based on python version. See #12893
+  # noarch: python
   preserve_egg_dir: True
 
 requirements:


### PR DESCRIPTION
x-ref https://github.com/ewels/MultiQC/issues/865

Updates the MultiQC recipe so that the matplotlib `<3.0.0` restriction is only applied if installing with Python 2. This requirement is because matplotlib 3+ is py3k only and was breaking installations for py2k users.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
