### PR TITLE
Add make to fermi2 runtime dependencies

### DIFF
--- a/recipes/fermi2/meta.yaml
+++ b/recipes/fermi2/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: "r193"
 
 build:
-  number: 2
+  number: 3
 
 source:
   url: https://github.com/lh3/fermi2/archive/580ec8ffd30b73e33c7dda5b13a5bfb4281466ac.tar.gz
@@ -18,7 +18,6 @@ requirements:
     - bfc
     - ropebwt2
     - perl
-    - zlib
     - make
 
 test:

--- a/recipes/fermi2/meta.yaml
+++ b/recipes/fermi2/meta.yaml
@@ -19,6 +19,7 @@ requirements:
     - ropebwt2
     - perl
     - zlib
+    - make
 
 test:
   commands:


### PR DESCRIPTION
fermi2 generates a Makefile, so to run fermi2 we need make.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
