### PR TITLE
Fix smhasher

### DIFF
--- a/recipes/smhasher/meta.yaml
+++ b/recipes/smhasher/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: "0.150.1"
 
 build:
-  number: 1
+  number: 2
 
 source:
   url: https://pypi.python.org/packages/5f/b2/421c060300f1449646787273ecd7df558f6f8e4caee3d6fbe8b193cd60d4/smhasher-0.150.1.tar.gz
@@ -11,7 +11,7 @@ source:
 
 requirements:
   build:
-    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
   host:
     - python
   run:


### PR DESCRIPTION
Otherwise it fails in a container with:
```
Traceback (most recent call last):
  File "/data/users/mvandenb/gx124/data/shed_tools/toolshed.g2.bx.psu.edu/repos/mvdbeek/dedup_hash/f33e9e6a6c88/dedup_hash/dedup_hash/dedup_hash.py", line 161, in <module>
    main()
  File "/data/users/mvandenb/gx124/data/shed_tools/toolshed.g2.bx.psu.edu/repos/mvdbeek/dedup_hash/f33e9e6a6c88/dedup_hash/dedup_hash/dedup_hash.py", line 157, in main
    hash_module=args.algo)
  File "/data/users/mvandenb/gx124/data/shed_tools/toolshed.g2.bx.psu.edu/repos/mvdbeek/dedup_hash/f33e9e6a6c88/dedup_hash/dedup_hash/dedup_hash.py", line 26, in __init__
    self.hash_module = self.import_hash_module(hash_module)
  File "/data/users/mvandenb/gx124/data/shed_tools/toolshed.g2.bx.psu.edu/repos/mvdbeek/dedup_hash/f33e9e6a6c88/dedup_hash/dedup_hash/dedup_hash.py", line 38, in import_hash_module
    from smhasher import murmur3_x64_64
ImportError: libstdc++.so.6: cannot open shared object file: No such file or directory
```

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
