### PR TITLE
Recipe for rust-ncbitaxonomy / taxonomy_filter_refseq

### DIFF
--- a/recipes/rust-ncbitaxonomy/build.sh
+++ b/recipes/rust-ncbitaxonomy/build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -euo
+
+if [ "$(uname)" == "Darwin" ]; then
+    # Apparently the Home variable isn't set correctly
+    export HOME="/Users/distiller"
+
+    # According to https://github.com/rust-lang/cargo/issues/2422#issuecomment-198458960 remove circle ci default configuration solve cargo trouble
+    git config --global --unset url.ssh://git@github.com.insteadOf 
+fi
+
+# build statically linked binary with Rust
+RUST_BACKTRACE=1 C_INCLUDE_PATH=$PREFIX/include LIBRARY_PATH=$PREFIX/lib cargo install --verbose --root $PREFIX --path .

--- a/recipes/rust-ncbitaxonomy/meta.yaml
+++ b/recipes/rust-ncbitaxonomy/meta.yaml
@@ -8,7 +8,7 @@ package:
 
 build:
   number: 0
-  script: C_INCLUDE_PATH=$PREFIX/include LIBRARY_PATH=$PREFIX/lib cargo install --root $PREFIX
+  script: C_INCLUDE_PATH=$PREFIX/include LIBRARY_PATH=$PREFIX/lib cargo install --root $PREFIX --path .
 
 source:
   url: "https://github.com/pvanheus/ncbitaxonomy/archive/{{ version }}.tar.gz"

--- a/recipes/rust-ncbitaxonomy/meta.yaml
+++ b/recipes/rust-ncbitaxonomy/meta.yaml
@@ -8,7 +8,6 @@ package:
 
 build:
   number: 0
-  script: C_INCLUDE_PATH=$PREFIX/include LIBRARY_PATH=$PREFIX/lib cargo install --root $PREFIX --path .
 
 source:
   url: "https://github.com/pvanheus/ncbitaxonomy/archive/{{ version }}.tar.gz"

--- a/recipes/rust-ncbitaxonomy/meta.yaml
+++ b/recipes/rust-ncbitaxonomy/meta.yaml
@@ -1,6 +1,6 @@
-{% set version = "0.1.2" %}
+{% set version = "0.1.3" %}
 {% set name = "rust-ncbitaxonomy" %}
-{% set sha256 = "7a776c5ac25861eb2810f329adb78f161e7a8349c632a697b3d6f71acb4eb8d3" %}
+{% set sha256 = "1a259ea52f8576b770f3cb8699bee4f3f34c5d57ff16ec6418d985f54949f7c7" %}
 
 package:
   name: "{{ name }}"
@@ -26,4 +26,4 @@ about:
   home: https://github.com/pvanheus/ncbitaxonomy
   license: MIT
   summary: |
-    a Rust crate for working with a local copy of the NCBI Taxonomy database, which provides the taxonomy_filter_refseq commmand
+    A Rust crate for working with a local copy of the NCBI Taxonomy database, which provides the taxonomy_filter_refseq commmand

--- a/recipes/rust-ncbitaxonomy/meta.yaml
+++ b/recipes/rust-ncbitaxonomy/meta.yaml
@@ -24,6 +24,7 @@ test:
 
 about:
   home: https://github.com/pvanheus/ncbitaxonomy
+  doc_url: "https://docs.rs/crate/ncbitaxonomy/{{ version }}"
   license: MIT
   summary: |
     A Rust crate for working with a local copy of the NCBI Taxonomy database, which provides the taxonomy_filter_refseq commmand

--- a/recipes/rust-ncbitaxonomy/meta.yaml
+++ b/recipes/rust-ncbitaxonomy/meta.yaml
@@ -1,0 +1,30 @@
+{% set version = "0.1.2" %}
+{% set name = "rust-ncbitaxonomy" %}
+{% set sha256 = "7a776c5ac25861eb2810f329adb78f161e7a8349c632a697b3d6f71acb4eb8d3" %}
+
+package:
+  name: "{{ name }}"
+  version: "{{ version }}"
+
+build:
+  number: 0
+  script: C_INCLUDE_PATH=$PREFIX/include LIBRARY_PATH=$PREFIX/lib cargo install --root $PREFIX
+
+source:
+  url: "https://github.com/pvanheus/ncbitaxonomy/archive/{{ version }}.tar.gz"
+  sha256: "{{ sha256 }}"
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - rust >=1.31.1
+
+test:
+  commands:
+    - taxonomy_filter_refseq --help | grep NCBI
+
+about:
+  home: https://github.com/pvanheus/ncbitaxonomy
+  license: MIT
+  summary: |
+    a Rust crate for working with a local copy of the NCBI Taxonomy database, which provides the taxonomy_filter_refseq commmand


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [x] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

This recipe builds the binaries from the ncbitaxonomy Rust crate - at the moment that only means `taxonomy_filter_refseq` but it might be more tools in the future.