### PR TITLE
Update blacklist for packages that needed r-fda and r-compquadform

### DIFF
--- a/build-fail-blacklist
+++ b/build-fail-blacklist
@@ -861,22 +861,22 @@ recipes/bioconductor-flowtype
 recipes/bioconductor-rchyoptimyx
 
 # some weird test error in Docker (The following specifications were found to be in conflict)
-recipes/bioconductor-iwtomics
-recipes/bioconductor-narrowpeaks
-recipes/bioconductor-nethet
-recipes/bioconductor-funchip
-recipes/bioconductor-fccac
-recipes/bioconductor-rqt
-recipes/bioconductor-ping
-recipes/bioconductor-fourcseq
-recipes/bioconductor-frgepistasis
-recipes/bioconductor-flowstats
+# recipes/bioconductor-iwtomics
+# recipes/bioconductor-narrowpeaks
+# recipes/bioconductor-nethet
+# recipes/bioconductor-funchip
+# recipes/bioconductor-fccac
+# recipes/bioconductor-rqt
+# recipes/bioconductor-ping
+# recipes/bioconductor-fourcseq
+# recipes/bioconductor-frgepistasis
+# recipes/bioconductor-flowstats
 
 # Depend on bioconductor-flowstats
-recipes/bioconductor-flowvs
-recipes/bioconductor-opencyto
-recipes/bioconductor-cytoml
-recipes/bioconductor-platecore
+# recipes/bioconductor-flowvs
+# recipes/bioconductor-opencyto
+# recipes/bioconductor-cytoml
+# recipes/bioconductor-platecore
 
 # system call failed: Cannot allocate memory
 recipes/bioconductor-conumee
@@ -965,11 +965,6 @@ recipes/bioconductor-ampliqueso
 recipes/bioconductor-icheck
 
 # Compilation errors (and dependencies)
-# recipes/bioconductor-ggtree
-# recipes/bioconductor-sapfinder
-# recipes/bioconductor-shinytandem
-# recipes/bioconductor-pga
-# recipes/bioconductor-proteoqc
 recipes/bioconductor-bgmix
 recipes/bioconductor-singlecelltk
 recipes/bioconductor-philr


### PR DESCRIPTION
* [ ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

This is waiting for r-fda to get a `gcc7` label and for r-compquadform to be rerun on circleci.