### PR TITLE
Update: mirtop, seqcluster (py3); bcbio-vm (dependencies)

### DIFF
--- a/recipes/bcbio-nextgen-vm/meta.yaml
+++ b/recipes/bcbio-nextgen-vm/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: '0.1.0a'
 
 build:
-  number: 135
+  number: 136
 
 source:
   url: https://github.com/bcbio/bcbio-nextgen-vm/archive/872b995.tar.gz
@@ -22,8 +22,6 @@ requirements:
     - pysam >=0.13.0
     - arvados-cwl-runner >=1.0.20171211211613  # [py2k]
     - cromwell >=0.34
-    - pyhocon
-    - cwl2wdl
     - ruamel.yaml >=0.13.0
     - toil >=3.11.0  # [py2k]
     - rabix-bunny >=1.0.4
@@ -36,6 +34,9 @@ requirements:
     - dx-cwl >=0.1.0a20180820  # [py2k]
     - six
     - google-cloud-sdk
+    # Older dependencies no longer in active use
+    # - pyhocon
+    # - cwl2wdl
     # Deprecate elasticluster and deps to simplify install
     # - elasticluster
 

--- a/recipes/mirtop/meta.yaml
+++ b/recipes/mirtop/meta.yaml
@@ -1,16 +1,17 @@
-{% set version="0.3.17" %}
+{% set version="0.4.15a" %}
+{% set revision="d9ed6c9" %}
 
 package:
   name: mirtop
   version: {{ version }}
 
 source:
-  url: https://github.com/miRTop/mirtop/archive/v{{ version }}.tar.gz
-  sha256: a1a3304a5a879724b02c29f451090bee5bdfd1a8754240100e307c602ffafa79
+  url: https://github.com/miRTop/mirtop/archive/{{ revision }}.tar.gz
+  sha256: a639ed8baeeec0e9a25c36326b7803f3f9fa28c11ccdcefb028f6412d85846e7
 
 build:
   script: $PYTHON setup.py install --single-version-externally-managed --record=record.txt
-  number: 1
+  number: 0
   entry_points:
     - mirtop=mirtop.command_line:main
 

--- a/recipes/seqcluster/meta.yaml
+++ b/recipes/seqcluster/meta.yaml
@@ -1,4 +1,4 @@
-{% set tag="3546d68" %}
+{% set tag="1824d37" %}
 
 about:
   home: https://github.com/lpantano/seqclsuter
@@ -7,13 +7,13 @@ about:
 
 package:
   name: seqcluster
-  version: '1.2.4a12'
+  version: '1.2.4a14'
 
 source:
   url: https://github.com/lpantano/seqcluster/archive/{{ tag  }}.tar.gz
-  sha256: 8eb075ac73e29f7d323841f4c2e79becb624205eb8c5d3d508c68d97d0272cdb
+  sha256: 376bfec8f174a794e3497d28ba42eb041c1495908d37c1bb57a53537d94d031f
 build:
-  number: 1
+  number: 0
 
 requirements:
   host:
@@ -27,15 +27,15 @@ requirements:
     - scipy
     - pandas
     - pybedtools
-    - progressbar # [py2k]
+    - progressbar2
     - biopython
     - mirtop
 
 test:
   commands:
-    - seqcluster cluster -h # [py2k]
+    - seqcluster cluster -h
   imports:
-    - seqcluster # [py2k]
+    - seqcluster
 
 extra:
   identifiers:


### PR DESCRIPTION
- Adds latest development versions of mirtop and seqcluster with
  python 3 support.
- Update bcbio-vm to avoid some dependencies and hopefully prevent
  timeouts on travis tests.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
