### PR TITLE
Update: arvados-cwl-runner, arvados-python-client

### DIFF
--- a/recipes/arvados-cwl-runner/meta.yaml
+++ b/recipes/arvados-cwl-runner/meta.yaml
@@ -1,31 +1,31 @@
-{% set version="1.0.20180216164101" %}
+{% set version="1.3.0.20181218191458" %}
 package:
   name: arvados-cwl-runner
   version: {{ version }}
 
 source:
   url: https://pypi.io/packages/source/a/arvados-cwl-runner/arvados-cwl-runner-{{ version }}.tar.gz
-  md5: 056b92bcd9934b7a914ecceac52e42ad
+  sha256: f7fdb3a357ccac03e5a55fc99290f7f2297eaaac6a91e35b8fb0270ef9de3767
 
 build:
-  number: 1
+  number: 0
   skip: True # [not py27]
 
 requirements:
   host:
     - python
     - setuptools
-    - ruamel.yaml >=0.13.7,<0.15
-    - cwltool >=1.0.20180130110340
-    - schema-salad >=2.6.20171201034858
-    - arvados-python-client >=0.1.20171211211613
+    - ruamel.yaml >=0.15.54
+    - cwltool >=1.0.20181217162649
+    - schema-salad >=3.0.20181129082112
+    - arvados-python-client >=1.2.1.20181130020805
 
   run:
     - python
-    - ruamel.yaml >=0.13.7,<0.15
-    - cwltool >=1.0.20180130110340
-    - schema-salad >=2.6.20171201034858
-    - arvados-python-client >=0.1.20171211211613
+    - ruamel.yaml >=0.15.54
+    - cwltool >=1.0.20181217162649
+    - schema-salad >=3.0.20181129082112
+    - arvados-python-client >=1.2.1.20181130020805
 
 test:
   imports:

--- a/recipes/arvados-cwl-runner/meta.yaml
+++ b/recipes/arvados-cwl-runner/meta.yaml
@@ -9,7 +9,7 @@ source:
 
 build:
   number: 0
-  skip: True # [not py27]
+  skip: True # [osx or not py27]
 
 requirements:
   host:

--- a/recipes/arvados-python-client/meta.yaml
+++ b/recipes/arvados-python-client/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   number: 0
-  skip: True # [not py27]
+  skip: True # [osx or not py27]
 
 requirements:
   host:

--- a/recipes/arvados-python-client/meta.yaml
+++ b/recipes/arvados-python-client/meta.yaml
@@ -1,4 +1,4 @@
-{% set version="1.2.1" %}
+{% set version="1.3.0.20181130020805" %}
 
 package:
   name: arvados-python-client
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/a/arvados-python-client/arvados-python-client-{{ version }}.tar.gz
-  sha256: ab4b19a5c76538cc882ef600625540e7ce7059415f9c8a2bb6613f32f8f70469
+  sha256: a6ed50d638e4a3b0da78f57b0ada0532655704c89cec2bd2248a1809260f3aa2
 
 build:
   number: 0
@@ -16,31 +16,26 @@ requirements:
   host:
     - python
     - setuptools
-    - ciso8601 <=1.0.4,>=1.0.0
+    - ciso8601 >=1.0.6,<2.0.0
     - future
     - google-api-python-client <1.7,>=1.6.2
     - httplib2
-    - oauth2client <2,>=1.4.6
-    - pycurl <7.21.5,>=7.19.5.1
-    - python-gflags
-    - requests
-    - rsa
-    - urllib3 >1.12
-    - ws4py <0.4,>=0.3.5
+    - pycurl >=7.19.5.1
+    - ruamel.yaml >=0.15.54
+    - ws4py >=0.4.2
+    - subprocess32
 
   run:
     - python
-    - ciso8601 <=1.0.4,>=1.0.0
+    - setuptools
+    - ciso8601 >=1.0.6,<2.0.0
     - future
     - google-api-python-client <1.7,>=1.6.2
     - httplib2
-    - oauth2client <2,>=1.4.6
-    - pycurl <7.21.5,>=7.19.5.1
-    - python-gflags
-    - requests
-    - rsa
-    - urllib3 >1.12
-    - ws4py <0.4,>=0.3.5
+    - pycurl >=7.19.5.1
+    - ruamel.yaml >=0.15.54
+    - ws4py >=0.4.2
+    - subprocess32
 
 test:
   imports:


### PR DESCRIPTION
Bring Arvados CWL integration up to date with latest cwltool and
dependencies. Fixed pycurl/curl incompatibilities with 1.8+
htslib/bcftools/samtools

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
