### PR TITLE
Add unifrac (strided state unifrac)

### DIFF
--- a/recipes/unifrac/build.sh
+++ b/recipes/unifrac/build.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+export USE_CYTHON=True
+export PERFORMING_CONDA_BUILD=True
+export LIBRARY_PATH="${CONDA_PREFIX}/lib"
+export CPLUS_INCLUDE_PATH="${CONDA_PREFIX}/include"
+
+if [ "$(uname)" == "Darwin" ]; then
+    export MACOSX_DEPLOYMENT_TARGET=10.12
+fi
+
+pushd sucpp
+make api
+popd
+
+$PYTHON -m pip install --no-deps --ignore-installed .

--- a/recipes/unifrac/conda_build_config.yaml
+++ b/recipes/unifrac/conda_build_config.yaml
@@ -1,0 +1,6 @@
+c_compiler:
+  - gcc      # [linux]
+  - clang    # [osx]
+cxx_compiler:
+  - gxx      # [linux]
+  - clangxx  # [osx]

--- a/recipes/unifrac/meta.yaml
+++ b/recipes/unifrac/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   preserve_egg_dir: True
-  number: 1
+  number: 0
   skip: True # [py27]
 
 requirements:

--- a/recipes/unifrac/meta.yaml
+++ b/recipes/unifrac/meta.yaml
@@ -1,0 +1,45 @@
+{% set version = "0.9.3" %}
+
+package:
+  name: unifrac
+  version: {{ version }}
+
+source:
+  url: https://github.com/biocore/unifrac/archive/{{ version }}.tar.gz
+  sha256: 1eb68401cc5c807af1059b611a9e9396c875e074f8a241e3de118fba91a352c4
+
+build:
+  preserve_egg_dir: True
+  number: 1
+  skip: True # [py27]
+
+requirements:
+  build:
+    - {{ compiler('cxx') }}
+
+  host:
+    - python
+    - pip
+    - hdf5
+    - cython
+    - numpy
+
+  run:
+    - python
+    - {{ pin_compatible('numpy') }}
+    - h5py
+    - biom-format
+    - scikit-bio
+
+test:
+  imports:
+    - unifrac
+  commands:
+    - ssu --help
+
+about:
+  home: https://github.com/biocore/unifrac
+  license: BSD-3-Clause
+  license_family: BSD
+  summary: 'High performance UniFrac'
+


### PR DESCRIPTION
This is a recipe for a fast Strided State UniFrac implementation (cc @wasade).

https://github.com/biocore/unifrac

I was able to build locally via:
```
bioconda-utils build recipes config.yml --docker --mulled-test --git-range master
```
so hopefully this works on CircleCI as well.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [x] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
