### PR TITLE
Update IGV to 2.4.16

### DIFF
--- a/recipes/igv/build.sh
+++ b/recipes/igv/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-cp *.jar $PREFIX/bin
+cp lib/*.jar $PREFIX/bin
 cp igv.sh $PREFIX/bin/igv
 chmod +x $PREFIX/bin/igv

--- a/recipes/igv/meta.yaml
+++ b/recipes/igv/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "2.4.9" %}
-{% set sha256 = "e18dd8372e34454ac51cf3fb846fa26f22c34e12e1c6c4aaf9573c01ccc19e29" %}
+{% set version = "2.4.16" %}
+{% set sha256 = "c1d6bc149876cc3e89dbde5ed8c2f2329a661ead30c0a6ba09fce9c33f10542f" %}
 
 package:
   name: igv
@@ -10,12 +10,12 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 0
   noarch: generic
 
 requirements:
   run:
-    - openjdk >=8.0
+    - openjdk >=8.0,<9
 
 test:
   commands:


### PR DESCRIPTION
And pin openjdk to 8 (As mentioned on
https://software.broadinstitute.org/software/igv/download, the 2.4
series is Java 8 compatible only).

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
