### PR TITLE
GraphAligner versioning

### DIFF
--- a/recipes/graphaligner/meta.yaml
+++ b/recipes/graphaligner/meta.yaml
@@ -8,7 +8,7 @@ source:
   patches: version.patch
 
 build:
-  number: 0
+  number: 1
   skip: True # [osx]
 
 requirements:

--- a/recipes/graphaligner/version.patch
+++ b/recipes/graphaligner/version.patch
@@ -7,7 +7,7 @@ index 82aaf50..3dec394 100755
  LINKFLAGS = $(CPPFLAGS) -Wl,-Bstatic $(LIBS) -Wl,-Bdynamic -Wl,--as-needed -lpthread -pthread -static-libstdc++ $(JEMALLOCFLAGS) `pkg-config --libs libdivsufsort` `pkg-config --libs libdivsufsort64`
  
 -VERSION := Branch $(shell git rev-parse --abbrev-ref HEAD) commit $(shell git rev-parse HEAD) $(shell git show -s --format=%ci)
-+VERSION := bioconda $(PKG_BUILD_STRING)
++VERSION := bioconda $(PKG_VERSION)-$(PKG_BUILD_NUMBER)
  
  $(shell mkdir -p bin)
  $(shell mkdir -p obj)


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

@bioconda/core I'm using "version.patch" to set the version in my makefile. I previously tried to set the version using the environment variable PKG_BUILD_STRING (https://conda.io/docs/user-guide/tasks/build-packages/environment-variables.html#environment-variables-set-during-the-build-process), but instead of the version number it was getting replaced with the text "placeholder", leading to the version displayed in the program being "bioconda placeholder" instead of "bioconda 1.0.1". I'm now trying to replace this with PKG_VERSION and PKG_BUILD_NUMBER. Is this an appropriate way of inserting the version or is there a best practice way of setting the version during building?