### PR TITLE
Add new recipe for ataqv

### DIFF
--- a/recipes/ataqv/build.sh
+++ b/recipes/ataqv/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+## BUILD WITH APPROPRIATE ENVIRONMENT VARIABLES
+export LIBRARY_PATH="${PREFIX}/lib"
+export LD_LIBRARY_PATH="${PREFIX}/lib"
+make CPPFLAGS="-I$PREFIX/include" LDFLAGS="-L$PREFIX/lib"
+
+## MAKE EXECUTABLES EXECUTABLE!
+chmod a+x ./build/ataqv
+chmod a+x ./src/scripts/mkarv
+chmod a+x ./src/scripts/srvarv
+
+## COPY BINARIES TO ENVIRONMENT INSTALLATION BIN DIRECTORY
+mkdir -p $PREFIX/bin
+cp ./build/ataqv $PREFIX/bin/
+cp ./src/scripts/mkarv $PREFIX/bin/
+cp ./src/scripts/srvarv $PREFIX/bin/

--- a/recipes/ataqv/conda_build_config.yaml
+++ b/recipes/ataqv/conda_build_config.yaml
@@ -1,0 +1,2 @@
+cxx_compiler:
+  - gxx # [linux]

--- a/recipes/ataqv/meta.yaml
+++ b/recipes/ataqv/meta.yaml
@@ -1,0 +1,45 @@
+{% set name = "ataqv" %}
+{% set version = "1.0.0" %}
+{% set sha256  = "4226336dd0caf22df4c1393920f7dbe50c8f6a400b56b97527b51f24fd090760" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+build:
+  number: 0
+
+source:
+  url: https://github.com/ParkerLab/ataqv/archive/{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+requirements:
+  build:
+    - {{ compiler('cxx') }}
+  host:
+    - boost
+    - htslib
+    - ncurses
+    - zlib
+    - python <3
+  run:
+    - boost
+    - htslib
+    - ncurses
+    - zlib
+    - python <3
+
+test:
+  commands:
+    - ataqv --version 2>&1 | grep "{{ version }}"
+    - ataqv --help 2>&1 | grep "metrics"
+    - mkarv --help 2>&1 | grep "DESCRIPTION"
+    - srvarv --help 2>&1 | grep "instance"
+
+about:
+  home: https://parkerlab.github.io/ataqv/
+  license: GPL3
+  license_file: LICENSE
+  summary: ataqv is a toolkit for measuring and comparing ATAC-seq results. It was written to help understand how well ATAC-seq assays have worked, and to make it easier to spot differences that might be caused by library prep or sequencing.
+  dev_url: https://github.com/ParkerLab/ataqv
+  doc_url: https://github.com/ParkerLab/ataqv/blob/master/README.rst


### PR DESCRIPTION
* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [X] This PR adds a new recipe.
* [X] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

New recipe for `ataqv` package (https://github.com/ParkerLab/ataqv). This is the first time Im submitting a bioconda recipe so Im hoping Ive done things right!

Local tests with `bioconda-utils build` are passing:
```
22:27:37 BIOCONDA INFO BUILD SUCCESS ataqv-1.0.0-py27heba63b0_0.tar.bz2
22:27:44 BIOCONDA INFO BUILD SUMMARY: successfully built 1 of 1 recipes
```

`conda build` also completed successfully, however, I did get some warnings regarding `boost`:
```
WARNING (ataqv,bin/ataqv): Needed DSO lib/libboost_iostreams.so.1.69.0 found in ['boost-cpp']
WARNING (ataqv,bin/ataqv): .. but ['boost-cpp'] not in reqs/run, i.e. it is overlinked (likely) or a missing dependency (less likely)
```