### PR TITLE
kWIP: Hopefully fix incompatible instruction set

### DIFF
--- a/recipes/kwip/build.sh
+++ b/recipes/kwip/build.sh
@@ -7,6 +7,7 @@ export LDFLAGS="-L$PREFIX/lib"
 export CPATH=${PREFIX}/include
 
 cd $SRC_DIR
+sed -i -e 's/-march=native//' CMakeLists.txt
 mkdir build && cd build
 cmake .. -DCMAKE_INSTALL_PREFIX=${BINARY_HOME}
 make

--- a/recipes/kwip/meta.yaml
+++ b/recipes/kwip/meta.yaml
@@ -12,7 +12,7 @@ about:
   license: 'GNU General Public License version 3'
 
 build:
-  number: 0
+  number: 1
 
 source:
   url: https://github.com/kdmurray91/kWIP/archive/{{ version }}.tar.gz


### PR DESCRIPTION
By default, kWIP is built with -march=native, which will produce
binaries that only work on architectures similar to the TravisCI CPUs.
This defeats the purpose of conda, and should be disabled.

(I am upstream, and the above is deliberate, as most folks install from source, and will get a performance boost with `-march=native`)

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
