### PR TITLE
ataqv - Removed Python version dependency

### DIFF
--- a/recipes/ataqv/meta.yaml
+++ b/recipes/ataqv/meta.yaml
@@ -8,7 +8,6 @@ package:
 
 build:
   number: 0
-  skip: True # [py27]
 
 source:
   url: https://github.com/ParkerLab/ataqv/archive/{{ version }}.tar.gz


### PR DESCRIPTION
* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [X] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

`ataqv` should now be built with both Python 2.7 and Python 3.x. 