### PR TITLE
Fixed missing file PLEK.range for PLEK receipe.

### DIFF
--- a/recipes/plek/build.sh
+++ b/recipes/plek/build.sh
@@ -18,3 +18,4 @@ cp svm-scale ${PREFIX}/bin
 cp svm-train ${PREFIX}/bin
 cp *.py ${PREFIX}/bin
 cp *.R ${PREFIX}/bin
+cp PLEK.range ${PREFIX}/bin


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

PLEK.py throws error because of missing PLEK.range file. This commit fixes it.
