### PR TITLE
Added irap-components

### DIFF
--- a/recipes/irap-components/activate.sh
+++ b/recipes/irap-components/activate.sh
@@ -1,5 +1,3 @@
-#!/bin/sh
-  
 # Unset the passed env var <myvar>, backing up its value in BAK_<myvar>.
 backup_env_var() {
     local var_name

--- a/recipes/irap-components/activate.sh
+++ b/recipes/irap-components/activate.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+  
+# Unset the passed env var <myvar>, backing up its value in BAK_<myvar>.
+backup_env_var() {
+    local var_name
+    var_name="$1"
+
+    # Var defined and value given, or defined and NO value given
+    if [ -n "${!var_name}" ] || [ -z "${!var_name-foo}" ]; then
+        export BAK_$var_name="${!var_name}"
+        unset $var_name
+    fi
+}
+
+backup_env_var PATH
+
+export IRAP_DIR="$CONDA_PREFIX/bin/irap"
+export PATH="$CONDA_PREFIX/bin/irap:$CONDA_PREFIX/bin/irap/scripts:$BAK_PATH"

--- a/recipes/irap-components/activate.sh
+++ b/recipes/irap-components/activate.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+  
 # Unset the passed env var <myvar>, backing up its value in BAK_<myvar>.
 backup_env_var() {
     local var_name

--- a/recipes/irap-components/build.sh
+++ b/recipes/irap-components/build.sh
@@ -1,0 +1,22 @@
+mkdir -p $PREFIX/bin
+
+# Deploy activation / deactivation scripts
+mkdir -p "$PREFIX/etc/conda/activate.d"
+cp "$RECIPE_DIR/activate.sh" "$PREFIX/etc/conda/activate.d/$PKG_NAME-setenv.sh"
+mkdir -p "$PREFIX/etc/conda/deactivate.d"
+cp "$RECIPE_DIR/deactivate.sh" "$PREFIX/etc/conda/deactivate.d/$PKG_NAME-restoreenv.sh"
+
+echo "$SRC_DIR/scripts/irap_install.sh -c $PREFIX/bin/irap"
+
+export IRAP_DIR=$PREFIX/bin/irap
+
+# iRAP's install script installs too much stuff, even specifying -c. We'll
+# manage dependencies outside of iRAP for now we just copy the files. 
+#$SRC_DIR/scripts/irap_install.sh -s $SRC_DIR -c $PREFIX/bin/irap
+
+cp -rp $SRC_DIR $PREFIX/bin/irap
+
+# Run tests
+source "$RECIPE_DIR/activate.sh"           
+# make test 
+source "$RECIPE_DIR/deactivate.sh"         

--- a/recipes/irap-components/build.sh
+++ b/recipes/irap-components/build.sh
@@ -16,6 +16,7 @@ export IRAP_DIR=$PREFIX/bin/irap
 
 cp -rp $SRC_DIR $PREFIX/bin/irap
 chmod +x $PREFIX/bin/irap
+ln -s $PREFIX/bin/irap/scripts/irap $PREFIX/bin/irap
 
 # Run tests
 source "$RECIPE_DIR/activate.sh"           

--- a/recipes/irap-components/build.sh
+++ b/recipes/irap-components/build.sh
@@ -15,6 +15,9 @@ export IRAP_DIR=$PREFIX/bin/irap
 #$SRC_DIR/scripts/irap_install.sh -s $SRC_DIR -c $PREFIX/bin/irap
 
 cp -rp $SRC_DIR $PREFIX/bin/irap
+sh_location=$(which sh)
+ln -s $sh_location /bin/sh
+chmod +x $PREFIX/bin/irap
 
 # Run tests
 source "$RECIPE_DIR/activate.sh"           

--- a/recipes/irap-components/build.sh
+++ b/recipes/irap-components/build.sh
@@ -15,8 +15,6 @@ export IRAP_DIR=$PREFIX/bin/irap
 #$SRC_DIR/scripts/irap_install.sh -s $SRC_DIR -c $PREFIX/bin/irap
 
 cp -rp $SRC_DIR $PREFIX/bin/irap
-sh_location=$(which sh)
-ln -s $sh_location /bin/sh
 chmod +x $PREFIX/bin/irap
 
 # Run tests

--- a/recipes/irap-components/deactivate.sh
+++ b/recipes/irap-components/deactivate.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+  
+# Restore the value of passed env var <myvar> from a backup variable
+# BAK_<myvar> and unset the backup variable.
+restore_env_var() {
+    local var_name
+    local bak_var_name
+    var_name="${1}"
+    bak_var_name="BAK_$var_name"
+
+    # Var defined and value given, or defined and NO value given
+    if [ -n "${!bak_var_name}" ] || [ -z "${!bak_var_name-foo}" ]; then
+        export $var_name="${!bak_var_name}"
+        unset $bak_var_name
+    fi
+}
+
+restore_env_var PATH
+unset IRAP_DIR

--- a/recipes/irap-components/deactivate.sh
+++ b/recipes/irap-components/deactivate.sh
@@ -1,5 +1,3 @@
-#!/bin/sh
-  
 # Restore the value of passed env var <myvar> from a backup variable
 # BAK_<myvar> and unset the backup variable.
 restore_env_var() {

--- a/recipes/irap-components/deactivate.sh
+++ b/recipes/irap-components/deactivate.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+  
 # Restore the value of passed env var <myvar> from a backup variable
 # BAK_<myvar> and unset the backup variable.
 restore_env_var() {

--- a/recipes/irap-components/meta.yaml
+++ b/recipes/irap-components/meta.yaml
@@ -8,6 +8,7 @@ source:
   url: https://github.com/ebi-gene-expression-group/irap/archive/conda-test.tar.gz 
   sha256: bf3d0a35ffba3076465da9f6a7dc513ea2110f0708edd1640e659366ed304614 
 
+
 build:
   number: 0
   skip: true  # [win32]

--- a/recipes/irap-components/meta.yaml
+++ b/recipes/irap-components/meta.yaml
@@ -1,0 +1,43 @@
+{% set version = "0.0.1" %}
+
+package:
+  name: irap-components
+  version: {{ version }}
+
+source:
+  url: https://github.com/ebi-gene-expression-group/irap/archive/conda-test.tar.gz 
+  sha256: bf3d0a35ffba3076465da9f6a7dc513ea2110f0708edd1640e659366ed304614 
+
+build:
+  number: 0
+  skip: true  # [win32]
+  noarch: generic
+
+requirements:
+    build:
+    host:
+        - r-base >=3.4.1
+    run:
+        - make
+
+test:
+    commands:
+        - irap --help
+
+about:
+  home: https://github.com/nunofonseca/irap
+  dev_url: https://github.com/ebi-gene-expression-group/r-seurat-scripts
+  license: GPL-3
+  summary: A lightweight distribution of iRAP without binaries. Nuno Fonseca's
+      iRAP tool is an integrated RNA-seq anlaysis pipeline. It's based on Make
+      to link workflow steps and has old-style dependency management whereby a
+      monolithic install process installs binaries distributed with the the
+      tool.  This package installs a fork of the iRAP code where the
+      distributed binaries have been removed. The idea is that individual parts
+      of the iRAP codebase can be utiled outside of iRAP's Make workflow and
+      using Conda's dependency management. THIS IS AN ALPHA PROJECT AND SHOULD
+      NOT BE RELIED UPON.  
+  license_family: GPL
+extra:
+  recipe-maintainers:
+    - pinin4fjords

--- a/recipes/irap-components/meta.yaml
+++ b/recipes/irap-components/meta.yaml
@@ -38,6 +38,7 @@ about:
       using Conda's dependency management. THIS IS AN ALPHA PROJECT AND SHOULD
       NOT BE RELIED UPON.  
   license_family: GPL
+
 extra:
   recipe-maintainers:
     - pinin4fjords

--- a/recipes/irap-components/meta.yaml
+++ b/recipes/irap-components/meta.yaml
@@ -8,7 +8,6 @@ source:
   url: https://github.com/ebi-gene-expression-group/irap/archive/conda-test.tar.gz 
   sha256: bf3d0a35ffba3076465da9f6a7dc513ea2110f0708edd1640e659366ed304614 
 
-
 build:
   number: 0
   skip: true  # [win32]

--- a/recipes/irap-components/meta.yaml
+++ b/recipes/irap-components/meta.yaml
@@ -22,6 +22,7 @@ requirements:
 
 test:
     commands:
+        - echo $PATH
         - irap --help
 
 about:


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [x] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

This PR adds a recipe for providing some of the scripts etc from the iRAP package, without installation. The purpose of this is to allow use of some of those components outside of iRAP's Make-based workflows without a full install - which involves lengthy installation of dependencies. 

The recipe includes activation/ deactivation to set the necessary variables for iRAP to function.

This is based on a branch of a fork of iRAP, from which software packages have been removed, which would otherwise have made iRAP painful to download in this recipe. Future versions of this recipe may provide those dependencies via Conda for a fully-functioning Bioconda iRAP install. 