### PR TITLE
Update: CNVkit bump for failed linux build

### DIFF
--- a/recipes/cnvkit/meta.yaml
+++ b/recipes/cnvkit/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 9761c833bbff432b61ad8d035ad0b21714eeebbd965a65de198701400b77d31f
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   host:


### PR DESCRIPTION
Previous build, which fixes CNVkit with recent pandas, failed when
building on CircleCI so doesn't have a new package. Bump build number
and re-build.

https://circleci.com/gh/bioconda/bioconda-recipes/40931

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
