### PR TITLE
pb-assembly-0.0.4: openssl-1.1.1a

### DIFF
--- a/recipes/pb-assembly/meta.yaml
+++ b/recipes/pb-assembly/meta.yaml
@@ -1,8 +1,8 @@
 package:
   name: pb-assembly
-  version: "0.0.3"
+  version: "0.0.4"
 build:
-  number: 3
+  number: 1
   script: echo noop
   skip: True # [not py27 or osx]
 requirements:
@@ -22,6 +22,7 @@ requirements:
     - pbmm2
     - mummer4
     - samtools
+    - openssl >=1.1.1a
     - bedtools
     - bwa
     - numpy


### PR DESCRIPTION
After I rebuilt samtools, the samtools problem disappeared for me in some cases,
but only because pb-assembly was suddenly using the older openssl again.

Hopefully, this will create a self-consistent tree.

* [ ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
