### PR TITLE
pb-assembly: bump build number

### DIFF
--- a/recipes/pb-assembly/meta.yaml
+++ b/recipes/pb-assembly/meta.yaml
@@ -2,14 +2,14 @@ package:
   name: pb-assembly
   version: "0.0.4"
 build:
-  number: 1
+  number: 2
   script: echo noop
   skip: True # [not py27 or osx]
 requirements:
   build:
     - python
   run:
-    - python2
+    - python
     - pb-falcon>=0.2.5
     - pb-dazzler
     - future >=0.16.0 # [not py3k]


### PR DESCRIPTION
Maybe this will cause 0.0.4 to show up. I have not seen
it since merging several hours ago.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
