### PR TITLE
pb-assembly: Do not specify openssl version (#13464)

### DIFF
--- a/recipes/pb-assembly/meta.yaml
+++ b/recipes/pb-assembly/meta.yaml
@@ -2,7 +2,7 @@ package:
   name: pb-assembly
   version: "0.0.4"
 build:
-  number: 2
+  number: 3
   script: echo noop
   skip: True # [not py27 or osx]
 requirements:
@@ -22,7 +22,6 @@ requirements:
     - pbmm2
     - mummer4
     - samtools
-    - openssl >=1.1.1a
     - bedtools
     - bwa
     - numpy


### PR DESCRIPTION
This does not solve our problem in all cases, and it may
hinder bioconda-wide changes to the openssl version.

See https://github.com/bioconda/bioconda-recipes/pull/13448

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
