### PR TITLE
Maybe this should depend on openssl explicitly

### DIFF
--- a/recipes/samtools/meta.yaml
+++ b/recipes/samtools/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 5
+  number: 6
 
 source:
   url: https://github.com/samtools/samtools/releases/download/{{ version }}/samtools-1.9.tar.bz2
@@ -15,6 +15,7 @@ requirements:
   build:
     - {{ compiler('c') }}
   host:
+    - openssl
     - ncurses
     - zlib
     - bzip2
@@ -22,6 +23,7 @@ requirements:
     - xz
     - libdeflate
   run:
+    - openssl
     - ncurses
     - zlib
     - bzip2


### PR DESCRIPTION
Maybe the whole problem was that it was being built against
system openssl. I do not see where openssl-1.1.1 is being
specified in Bioconda. In theory, we should be using 1.0.2
everywhere already.

https://github.com/conda-forge/conda-forge.github.io/issues/701

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
