### PR TITLE
bioconductor-xcms-3.4.3 update from github

### DIFF
--- a/recipes/bioconductor-xcms/meta.yaml
+++ b/recipes/bioconductor-xcms/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.4.2" %}
+{% set version = "3.4.3" %}
 {% set name = "xcms" %}
 {% set bioc = "3.8" %}
 
@@ -7,10 +7,8 @@ package:
   version: '{{ version }}'
 source:
   url:
-    - 'https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/{{ name }}_{{ version }}.tar.gz'
-    - 'https://bioarchive.galaxyproject.org/{{ name }}_{{ version }}.tar.gz'
-    - 'https://depot.galaxyproject.org/software/bioconductor-{{ name }}/bioconductor-{{ name }}_{{ version }}_src_all.tar.gz'
-  md5: 3e16cc634bf6d0a7a8b1254755190663
+    - 'https://github.com/sneumann/xcms/archive/e6b98a1c91f6d04f810e6413440e1eba398df8a0.zip'
+  sha256: c0a20483bbcf241d1f6aae9b0c220e7794a2a0b278ac4eaa8f5d0c3d9815936a
 build:
   number: 0
   rpaths:


### PR DESCRIPTION
* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

@bioconda/r 

This update don't use bioconductor sources but GitHub. The version 3.4.3, I need, isn't release yet.
If you think that it's not the policy of bioconda, I can understand.
In the meanwhile, I have pushed temporary the package in a project conda channel: https://anaconda.org/workflow4metabolomics/bioconductor-xcms. So no pressure :)