### PR TITLE
Added tximport-scripts recipe

### DIFF
--- a/recipes/tximport-scripts/build.sh
+++ b/recipes/tximport-scripts/build.sh
@@ -1,0 +1,2 @@
+mkdir -p $PREFIX/bin
+cp *.R $PREFIX/bin

--- a/recipes/tximport-scripts/meta.yaml
+++ b/recipes/tximport-scripts/meta.yaml
@@ -1,0 +1,42 @@
+{% set version = "0.0.1" %}
+
+package:
+  name: tximport-scripts
+  version: {{ version }}
+
+source:
+  url: https://github.com/ebi-gene-expression-group/tximport-scripts/archive/v{{ version }}.tar.gz 
+  sha256: 7910a7519dd6655d8a2007019639d4204829aeb8d1a9f6a94d0c80055003ea10 
+
+build:
+  number: 0
+  skip: true  # [win32]
+  noarch: generic
+
+requirements:
+    host:
+        - r-base 3.5.1
+    run:
+        - r-base 3.5.1
+        - bioconductor-tximport 1.10.0
+        - r-optparse
+        - r-workflowscriptscommon
+
+test:
+    commands:
+        - tximport.R --help
+
+about:
+  home: https://github.com/ebi-gene-expression-group/tximport-scripts 
+  dev_url: https://github.com/ebi-gene-expression-group/tximport-scripts
+  license: GPL-3
+  summary: A set of wrappers for individual components of the tximport package.
+      Functions R packages are hard to call when building workflows outside of R,
+      so this package adds a set of simple wrappers with robust argument parsing.
+      Intermediate steps are currently mainly serialized R objects, but the
+      ultimate objective is to have language-agnostic intermediate formats allowing
+      composite workflows using a variety of software packages.
+  license_family: GPL
+extra:
+  recipe-maintainers:
+    - pinin4fjords

--- a/recipes/tximport-scripts/meta.yaml
+++ b/recipes/tximport-scripts/meta.yaml
@@ -21,6 +21,7 @@ requirements:
         - bioconductor-tximport 1.10.0
         - r-optparse
         - r-workflowscriptscommon
+        - bioconductor-dropletutilst
 
 test:
     commands:

--- a/recipes/tximport-scripts/meta.yaml
+++ b/recipes/tximport-scripts/meta.yaml
@@ -21,7 +21,7 @@ requirements:
         - bioconductor-tximport 1.10.0
         - r-optparse
         - r-workflowscriptscommon
-        - bioconductor-dropletutilst
+        - bioconductor-dropletutils
 
 test:
     commands:

--- a/recipes/tximport-scripts/meta.yaml
+++ b/recipes/tximport-scripts/meta.yaml
@@ -10,15 +10,12 @@ source:
 
 build:
   number: 0
-  skip: true  # [win32]
   noarch: generic
 
 requirements:
-    host:
-        - r-base 3.5.1
     run:
         - r-base 3.5.1
-        - bioconductor-tximport 1.10.0
+        - bioconductor-tximport 1.10.*
         - r-optparse
         - r-workflowscriptscommon
         - bioconductor-dropletutils
@@ -38,6 +35,3 @@ about:
       ultimate objective is to have language-agnostic intermediate formats allowing
       composite workflows using a variety of software packages.
   license_family: GPL
-extra:
-  recipe-maintainers:
-    - pinin4fjords

--- a/recipes/tximport-scripts/meta.yaml
+++ b/recipes/tximport-scripts/meta.yaml
@@ -14,7 +14,6 @@ build:
 
 requirements:
     run:
-        - r-base 3.5.1
         - bioconductor-tximport 1.10.*
         - r-optparse
         - r-workflowscriptscommon


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [x] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

This is another R package CLI along the lines of e.g. [r-seurat-scripts](https://github.com/bioconda/bioconda-recipes/tree/master/recipes/r-seurat-scripts). This is basically a single rich wrapper script for the central tximport() function of the Bioconductor tximport package. It uses DropletUtils to provide optional sparse matrix output. Source package at https://github.com/ebi-gene-expression-group/tximport-scripts. I've dropped the 'r-' prefix convention to prevent interference with build systems recognising r packages (to be remedied in r-seurat-scripts in the future).