### PR TITLE
Updated STAR to version 2.7.0c (fixed linux segfault issue)

### DIFF
--- a/recipes/star/meta.yaml
+++ b/recipes/star/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "2.7.0b" %}
-{% set sha256 = "23f331c2f719d41d51d46a6ffd49b2784518073bfed587dde080e56b11d72e67" %}
+{% set version = "2.7.0c" %}
+{% set sha256 = "6b44f0d4bd97f5007c6124c39970abd036b28e648cece260b3506b89ff0b20b5" %}
 
 package:
   name: star


### PR DESCRIPTION
Updates STAR from version 2.7.0b -> [2.7.0c](https://github.com/alexdobin/STAR/releases/tag/2.7.0c) -- fixes an issue causing STAR to segfault on 64-bit linux.

----------------

* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [X] This PR updates an existing recipe.

