### PR TITLE
Update: arvados-cwl-runner, arvados-python-client; second py3k attempt

### DIFF
--- a/recipes/arvados-cwl-runner/meta.yaml
+++ b/recipes/arvados-cwl-runner/meta.yaml
@@ -8,8 +8,8 @@ source:
   sha256: f0ac46a4d43a6fe62950a64a4c23b92392dd6a1a4b68c27dffdb2f20b602caf3
 
 build:
-  noarch: python
-  number: 0
+  skip: true  # [osx or py37]
+  number: 1
 
 requirements:
   host:
@@ -19,14 +19,14 @@ requirements:
     - ruamel.yaml >=0.15.54
     - cwltool >=1.0.20181217162649
     - schema-salad >=3.0.20181129082112
-    - arvados-python-client >=1.2.1.20181130020805
+    - arvados-python-client >=1.2.1.20181130020805  # [not py37]
 
   run:
     - python <3.7
     - ruamel.yaml >=0.15.54
     - cwltool >=1.0.20181217162649
     - schema-salad >=3.0.20181129082112
-    - arvados-python-client >=1.2.1.20181130020805
+    - arvados-python-client >=1.2.1.20181130020805  # [not py37]
 
 test:
   imports:

--- a/recipes/arvados-python-client/meta.yaml
+++ b/recipes/arvados-python-client/meta.yaml
@@ -9,15 +9,15 @@ source:
   sha256: 0b81ee65973087e99a2aa8ac07aeea50877987faac6bdb254cc110bff9d74cff
 
 build:
-  number: 0
-  noarch: python
+  skip: true  # [osx or py37]
+  number: 1
 
 requirements:
   host:
     # Supported ciso8601 versions do not have python 3.7 builds
     - python <3.7
     - setuptools
-    - ciso8601 >=1.0.6,<2.0.0
+    - ciso8601 >=1.0.6,<2.0.0  # [not py37]
     - future
     - google-api-python-client <1.7,>=1.6.2
     - httplib2
@@ -29,7 +29,7 @@ requirements:
   run:
     - python <3.7
     - setuptools
-    - ciso8601 >=1.0.6,<2.0.0
+    - ciso8601 >=1.0.6,<2.0.0  # [not py37]
     - future
     - google-api-python-client <1.7,>=1.6.2
     - httplib2


### PR DESCRIPTION
Original noarch approach didn't work properly on py3k due to
subprocess32 conditional selector. It doesn't get applied on
noarch so will be a dependency and make it incompatible with py3.
Trying a new approach to restrict to avoid py37 errors.

----------------

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
