### PR TITLE
Move to ucsc-cell-browser 0.4.38

### DIFF
--- a/recipes/ucsc-cell-browser/build.sh
+++ b/recipes/ucsc-cell-browser/build.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-$PYTHON setup.py install
-mkdir -p $PREFIX/bin
-cp -rp src/cbImportSeurat $PREFIX/bin

--- a/recipes/ucsc-cell-browser/meta.yaml
+++ b/recipes/ucsc-cell-browser/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = '0.4.36' %}
+{% set version = '0.4.38' %}
 
 package:
   name: ucsc-cell-browser
@@ -6,15 +6,17 @@ package:
 
 source:
   url: https://github.com/maximilianh/cellBrowser/archive/v{{ version }}.tar.gz
-  sha256: 93507d1551c4f63c313812e679591a8710619f0a84ddb0d05d80e1354a6b694a 
+  sha256: 6b7604eb07ee0e387e0df633cfcc87e0452b056250fca2980acb60319a5b9199
 
 build:
   number: 0
   noarch: python
+  script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
     host:
         - python >=3.6
+        - pip
     run:
         - python >=3.6
         - numpy
@@ -24,7 +26,6 @@ test:
     commands:
         - which cbBuild
         - which cbGuessGencode
-        - which cbImportSeurat
         - which cbMarkerAnnotate
         - which cbScanpy
         - which cbImportScanpy

--- a/recipes/ucsc-cell-browser/meta.yaml
+++ b/recipes/ucsc-cell-browser/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = '0.4.35' %}
+{% set version = '0.4.36' %}
 
 package:
   name: ucsc-cell-browser
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/maximilianh/cellBrowser/archive/v{{ version }}.tar.gz
-  sha256: 90d580d6a23c847575beba085987bed6d989920aacdc972bc1231f2bf3229baa
+  sha256: 93507d1551c4f63c313812e679591a8710619f0a84ddb0d05d80e1354a6b694a 
 
 build:
   number: 0
@@ -18,10 +18,6 @@ requirements:
     run:
         - python >=3.6
         - numpy
-        - r-data.table
-        - r-argparser
-        - r-matrix
-        - r-reticulate
         - anndata
 
 test:
@@ -33,7 +29,6 @@ test:
         - which cbScanpy
         - which cbImportScanpy
         - which cbImportCellranger
-        - which cbImportSeurat2
         - which cbTool
         - which cbUpgrade
 

--- a/recipes/ucsc-cell-browser/meta.yaml
+++ b/recipes/ucsc-cell-browser/meta.yaml
@@ -11,7 +11,7 @@ source:
 build:
   number: 0
   noarch: python
-  script: python -m pip install --no-deps --ignore-installed .
+  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 
 requirements:
     host:


### PR DESCRIPTION
:information_source:
Bioconda has finished the [GCC7 migration](https://github.com/bioconda/bioconda-recipes/issues/13578). If you are dealing with C/C++ or Python package it can be that you need to rebuild other dependent packages. [Bioconda utils - update-pinning](https://bioconda.github.io/updating.html#updating-recipes-for-a-pinning-change) will assist you with that. If you have any questions please use [issue 13578](https://github.com/bioconda/bioconda-recipes/issues/13578).

----------------

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Switches installation to `python -m pip` mode to avoid egg based installation and move to latest released version.