### PR TITLE
[WIP] Add makefile patch, bump BWA.

### DIFF
--- a/recipes/bwa/Makefile.patch
+++ b/recipes/bwa/Makefile.patch
@@ -1,0 +1,10 @@
+diff --git a/Makefile b/Makefile
+index 7151435..fdb936f 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,4 +1,4 @@
+-CC=			gcc
++#CC=			gcc
+ #CC=			clang --analyze
+ CFLAGS=		-g -Wall -Wno-unused-function -O2
+ WRAP_MALLOC=-DUSE_MALLOC_WRAPPERS

--- a/recipes/bwa/Makefile.patch
+++ b/recipes/bwa/Makefile.patch
@@ -1,10 +1,16 @@
 diff --git a/Makefile b/Makefile
-index 7151435..fdb936f 100644
+index 7151435..2f0a4fe 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -1,4 +1,4 @@
+@@ -1,9 +1,9 @@
 -CC=			gcc
 +#CC=			gcc
  #CC=			clang --analyze
  CFLAGS=		-g -Wall -Wno-unused-function -O2
  WRAP_MALLOC=-DUSE_MALLOC_WRAPPERS
+ AR=			ar
+-DFLAGS=		-DHAVE_PTHREAD $(WRAP_MALLOC)
++DFLAGS=		-DHAVE_PTHREAD $(WRAP_MALLOC) $(LDFLAGS)
+ LOBJS=		utils.o kthread.o kstring.o ksw.o bwt.o bntseq.o bwa.o bwamem.o bwamem_pair.o bwamem_extra.o malloc_wrap.o \
+ 			QSufSort.o bwt_gen.o rope.o rle.o is.o bwtindex.o
+ AOBJS=		bwashm.o bwase.o bwaseqio.o bwtgap.o bwtaln.o bamlite.o \

--- a/recipes/bwa/meta.yaml
+++ b/recipes/bwa/meta.yaml
@@ -8,9 +8,11 @@ package:
 source:
   url: https://github.com/lh3/bwa/archive/v{{ version }}.tar.gz
   sha256: {{ sha256 }}
+  patches:
+    - Makefile.patch
 
 build:
-  number: 4
+  number: 5
 
 requirements:
   build:


### PR DESCRIPTION
This PR adds makefile flags necessary to force BWA compilation to use the conda GCC compilers, rather than those inherited from the docker image.  

:information_source:
Bioconda has finished the [GCC7 migration](https://github.com/bioconda/bioconda-recipes/issues/13578). If you are dealing with C/C++ or Python package it can be that you need to rebuild other dependent packages. [Bioconda utils - update-pinning](https://bioconda.github.io/updating.html#updating-recipes-for-a-pinning-change) will assist you with that. If you have any questions please use [issue 13578](https://github.com/bioconda/bioconda-recipes/issues/13578).

----------------

* [ ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
