### PR TITLE
Rebuild BWA 0.7.3a for GCC7

### DIFF
--- a/recipes/bwa/0.7.3a/Makefile.patch
+++ b/recipes/bwa/0.7.3a/Makefile.patch
@@ -1,0 +1,15 @@
+diff --git a/Makefile b/Makefile
+index 7151435..0b38eae 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,9 +1,7 @@
+-CC=			gcc
+-#CC=			clang --analyze
+ CFLAGS=		-g -Wall -Wno-unused-function -O2
+ WRAP_MALLOC=-DUSE_MALLOC_WRAPPERS
+ AR=			ar
+-DFLAGS=		-DHAVE_PTHREAD $(WRAP_MALLOC)
++DFLAGS=		-DHAVE_PTHREAD $(WRAP_MALLOC) $(LDFLAGS)
+ LOBJS=		utils.o kthread.o kstring.o ksw.o bwt.o bntseq.o bwa.o bwamem.o bwamem_pair.o bwamem_extra.o malloc_wrap.o \
+ 			QSufSort.o bwt_gen.o rope.o rle.o is.o bwtindex.o
+ AOBJS=		bwashm.o bwase.o bwaseqio.o bwtgap.o bwtaln.o bamlite.o \

--- a/recipes/bwa/0.7.3a/Makefile.patch
+++ b/recipes/bwa/0.7.3a/Makefile.patch
@@ -1,15 +1,6 @@
-diff --git a/Makefile b/Makefile
-index 7151435..0b38eae 100644
---- a/Makefile
-+++ b/Makefile
-@@ -1,9 +1,7 @@
--CC=			gcc
--#CC=			clang --analyze
- CFLAGS=		-g -Wall -Wno-unused-function -O2
- WRAP_MALLOC=-DUSE_MALLOC_WRAPPERS
- AR=			ar
--DFLAGS=		-DHAVE_PTHREAD $(WRAP_MALLOC)
-+DFLAGS=		-DHAVE_PTHREAD $(WRAP_MALLOC) $(LDFLAGS)
- LOBJS=		utils.o kthread.o kstring.o ksw.o bwt.o bntseq.o bwa.o bwamem.o bwamem_pair.o bwamem_extra.o malloc_wrap.o \
- 			QSufSort.o bwt_gen.o rope.o rle.o is.o bwtindex.o
- AOBJS=		bwashm.o bwase.o bwaseqio.o bwtgap.o bwtaln.o bamlite.o \
+1d0
+< CC=			gcc
+4c3
+< DFLAGS=		-DHAVE_PTHREAD
+---
+> DFLAGS=		-DHAVE_PTHREAD $(LDFLAGS)

--- a/recipes/bwa/0.7.3a/Makefile.patch
+++ b/recipes/bwa/0.7.3a/Makefile.patch
@@ -1,6 +1,13 @@
-1d0
-< CC=			gcc
-4c3
-< DFLAGS=		-DHAVE_PTHREAD
----
-> DFLAGS=		-DHAVE_PTHREAD $(LDFLAGS)
+diff --git a/Makefile b/Makefile
+index b660557..8891160 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,7 +1,6 @@
+-CC=			gcc
+ CFLAGS=		-g -Wall -O2
+ AR=			ar
+-DFLAGS=		-DHAVE_PTHREAD
++DFLAGS=		-DHAVE_PTHREAD $(LDFLAGS)
+ LOBJS=		utils.o kstring.o ksw.o bwt.o bntseq.o bwa.o bwamem.o bwamem_pair.o
+ AOBJS=		QSufSort.o bwt_gen.o bwase.o bwaseqio.o bwtgap.o bwtaln.o bamlite.o \
+ 			is.o bwtindex.o bwape.o kopen.o pemerge.o \

--- a/recipes/bwa/0.7.3a/meta.yaml
+++ b/recipes/bwa/0.7.3a/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 4
+  number: 4 
 
 source:
   url: http://downloads.sourceforge.net/project/bio-bwa/bwa-{{ version }}.tar.bz2

--- a/recipes/bwa/0.7.3a/meta.yaml
+++ b/recipes/bwa/0.7.3a/meta.yaml
@@ -6,11 +6,13 @@ package:
   version: {{ version }}
 
 build:
-  number: 3
+  number: 4
 
 source:
   url: http://downloads.sourceforge.net/project/bio-bwa/bwa-{{ version }}.tar.bz2
   sha256: {{ sha256 }}
+  patches:
+    - Makefile.patch 
 
 requirements:
   build:


### PR DESCRIPTION
:information_source:
Bioconda has finished the [GCC7 migration](https://github.com/bioconda/bioconda-recipes/issues/13578). If you are dealing with C/C++ or Python package it can be that you need to rebuild other dependent packages. [Bioconda utils - update-pinning](https://bioconda.github.io/updating.html#updating-recipes-for-a-pinning-change) will assist you with that. If you have any questions please use [issue 13578](https://github.com/bioconda/bioconda-recipes/issues/13578).

----------------

* [ ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).


Note: the patch is necessary to avoid hard-coding GCC to the container / OS version.  