### PR TITLE
Added r-brio

### DIFF
--- a/recipes/r-brio/build.sh
+++ b/recipes/r-brio/build.sh
@@ -1,0 +1,1 @@
+$R CMD INSTALL --build .

--- a/recipes/r-brio/meta.yaml
+++ b/recipes/r-brio/meta.yaml
@@ -1,0 +1,67 @@
+{% set version = "0.1.6" %}
+
+package:
+  name: r-brio
+  version: {{ version }}
+
+source:
+  url: https://github.com/steinbaugh/brio/archive/v{{ version }}.tar.gz
+  sha256: e7b0658b33a9b5ecb9b52c78f0a47c70abefc0d068b8eafa17669a0ab3568852 
+
+build:
+  number: 0
+
+requirements:
+    host:
+        - r-base 
+        - r-bioverbs >=0.1.3
+        - r-goalie >=0.2.6
+        - r-transformer >=0.1.3
+        - bioconductor-genomicranges
+        - bioconductor-s4vectors
+        - bioconductor-singlecellexperiment
+        - bioconductor-summarizedexperiment
+        - bioconductor-rtracklayer
+        - r-matrix >=1.2
+        - r-r.utils >=2.7
+        - r-curl >=1.95
+        - r-data.table >=1.11
+        - r-jsonlite >=1.6
+        - r-readr >=1.3
+        - r-rio >=0.5
+        - r-stringr >=1.3
+        - r-tibble >=2.0
+        - r-yaml >=2.2
+
+    run:
+        - r-base 
+        - r-bioverbs >=0.1.3
+        - r-goalie >=0.2.6
+        - r-transformer >=0.1.3
+        - bioconductor-genomicranges
+        - bioconductor-s4vectors
+        - bioconductor-singlecellexperiment
+        - bioconductor-summarizedexperiment
+        - bioconductor-rtracklayer
+        - r-matrix >=1.2
+        - r-r.utils >=2.7
+        - r-curl >=1.95
+        - r-data.table >=1.11
+        - r-jsonlite >=1.6
+        - r-readr >=1.3
+        - r-rio >=0.5
+        - r-stringr >=1.3
+        - r-tibble >=2.0
+        - r-yaml >=2.2
+
+test:
+    commands:
+        - $R -e "library('brio')"
+
+about:
+  home: https://github.com/steinbaugh/brio
+  dev_url: https://github.com/steinbaugh/brio
+  license: MIT
+  summary: Biological R input/output. This package is part of the basejump
+    toolkit.
+  license_family: MIT


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [x] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

As for https://github.com/bioconda/bioconda-recipes/pull/13596, https://github.com/bioconda/bioconda-recipes/pull/13614 and https://github.com/bioconda/bioconda-recipes/pull/13592, this package provides a dependency for updating the r-basejump package. 