### PR TITLE
trying to fix the openjdk java version

### DIFF
--- a/recipes/npinv/meta.yaml
+++ b/recipes/npinv/meta.yaml
@@ -13,7 +13,7 @@ package:
 
 build:
   noarch: generic
-  number: 0
+  number: 1
 
 source:
   url: https://github.com/haojingshao/npInv/releases/download/npInv{{ version }}/npInv{{ version }}.jar
@@ -21,10 +21,10 @@ source:
 
 requirements:
   host:
-    - openjdk >=6
+    - openjdk >=8,<9
     - python
   run:
-    - openjdk >=6
+    - openjdk >=8,<9
     - python
 
 test:


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

This PR changes the dependency to openjdk >=8,<9. Using openjdk11 caused errors, but not in the CI test case.