### PR TITLE
Update r-basejump to v0.9.9 with additional package dependencies

### DIFF
--- a/recipes/r-basejump/meta.yaml
+++ b/recipes/r-basejump/meta.yaml
@@ -1,15 +1,15 @@
+{% set version = "0.9.9" %}
+
 package:
   name: r-basejump
-
-  version: "0.7.2"
+  version: {{ version }}
 
 source:
-  url: https://github.com/steinbaugh/basejump/archive/685a16c.tar.gz
-  sha256: 86b7f8f0f452276c12e38ab8ee0da506fdfdb7ed9b2fe95ff1a92b70285a45dd
+  url: https://github.com/steinbaugh/basejump/archive/v{{ version }}.tar.gz
+  sha256: 6b34141663c0d4b20a383c2a76b7df39f79c2d799890a556e389d987700025bd 
 
 build:
-  number: 1
-  skip: true  # [win32]
+  number: 0
 
   rpaths:
     - lib/R/lib/
@@ -17,7 +17,7 @@ build:
 
 requirements:
   host:
-    - 'r-base >=3.4.0'
+    - r-base
     - bioconductor-annotationhub
     - bioconductor-biobase
     - bioconductor-biocgenerics
@@ -25,34 +25,44 @@ requirements:
     - bioconductor-genomeinfodb
     - bioconductor-s4vectors
     - r-assertive
-    - 'r-cowplot >=0.9'
+    - r-cowplot >=0.9
     - r-dendsort
-    - 'r-matrix.utils >=0.9'
-    - 'r-dplyr >=0.7'
+    - r-matrix.utils >=0.9
+    - r-dplyr >=0.7
     - r-pbapply
     - r-devtools
-    - 'r-ggplot2 >=2.2.1'
-    - 'r-knitr >=1.2.0'
-    - 'r-magrittr >=1.5'
-    - 'r-matrix >=1.2'
+    - r-ggplot2 >=3.0
+    - r-knitr >=1.2.1
+    - r-magrittr >=1.5
+    - r-matrix >=1.2
     - r-rio
-    - r-sessioninfo
-    - r-pheatmap
+    - r-sessioninfo >=1.1
+    - r-pheatmap >=1.0
     - r-rcolorbrewer
-    - 'r-rcurl >=1.95'
-    - 'r-readr >=1.1'
-    - 'r-readxl >=1.0'
-    - 'r-rlang >=0.2'
+    - r-rcurl >=1.95
+    - r-readr >=1.3
+    - r-readxl >=1.0
+    - r-rlang >=0.3
     - r-r.utils
     - r-scales
-    - 'r-stringr >=1.3'
-    - 'r-tibble >=1.4'
-    - 'r-tidyr >=0.8'
+    - r-stringr >=1.3
+    - r-tibble >=2.0
+    - r-tidyr >=0.8
     - r-viridis
     - r-yaml
+    - r-bioverbs >=0.1.6
+    - r-brio >=0.1.5
+    - r-goalie >=0.2.8
+    - r-syntactic >=0.1.4
+    - r-transformer >=0.1.4
+    - r-tidyselect >=0.2
+    - r-ggrepel >=0.8
+    - r-matrixstats >=0.54
+    - r-purrr >=0.2
+    - r-reshape2 >=1.4    
 
   run:
-    - 'r-base >=3.4.0'
+    - r-base
     - bioconductor-annotationhub
     - bioconductor-biobase
     - bioconductor-biocgenerics
@@ -60,31 +70,41 @@ requirements:
     - bioconductor-genomeinfodb
     - bioconductor-s4vectors
     - r-assertive
-    - 'r-cowplot >=0.9'
+    - r-cowplot >=0.9
     - r-dendsort
-    - 'r-matrix.utils >=0.9'
-    - 'r-dplyr >=0.7'
+    - r-matrix.utils >=0.9
+    - r-dplyr >=0.7
     - r-pbapply
     - r-devtools
-    - 'r-ggplot2 >=2.2.1'
-    - 'r-knitr >=1.2.0'
-    - 'r-magrittr >=1.5'
-    - 'r-matrix >=1.2'
+    - r-ggplot2 >=3.0
+    - r-knitr >=1.2.1
+    - r-magrittr >=1.5
+    - r-matrix >=1.2
     - r-rio
-    - r-sessioninfo
-    - r-pheatmap
+    - r-sessioninfo >=1.1
+    - r-pheatmap >=1.0
     - r-rcolorbrewer
-    - 'r-rcurl >=1.95'
-    - 'r-readr >=1.1'
-    - 'r-readxl >=1.0'
-    - 'r-rlang >=0.2'
+    - r-rcurl >=1.95
+    - r-readr >=1.3
+    - r-readxl >=1.0
+    - r-rlang >=0.3
     - r-r.utils
     - r-scales
-    - 'r-stringr >=1.3'
-    - 'r-tibble >=1.4'
-    - 'r-tidyr >=0.8'
+    - r-stringr >=1.3
+    - r-tibble >=2.0
+    - r-tidyr >=0.8
     - r-viridis
     - r-yaml
+    - r-bioverbs >=0.1.6
+    - r-brio >=0.1.5
+    - r-goalie >=0.2.8
+    - r-syntactic >=0.1.4
+    - r-transformer >=0.1.4
+    - r-tidyselect >=0.2
+    - r-ggrepel >=0.8
+    - r-matrixstats >=0.54
+    - r-purrr >=0.2
+    - r-reshape2 >=1.4
 
 test:
   commands:
@@ -94,6 +114,7 @@ about:
   home: https://github.com/steinbaugh/basejump
   license: MIT
   summary: Base functions for bioinformatics and R package development.
+
 extra:
   recipe-maintainers:
     - MathiasHaudgaard


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

This is an update to the basejump package, having added newly factored-out dependencies. WIP until @mjsteinbaugh has sorted pinning for downstream dependents.