### PR TITLE
Fix ARB run_exports

### DIFF
--- a/recipes/arb-bio/meta.yaml
+++ b/recipes/arb-bio/meta.yaml
@@ -31,7 +31,7 @@ source:
     - typeof.patch
 
 build:
-  number: 7
+  number: 8
 # constraining to perl >= 5.23 does not work via requirements, resulting in a 
 # broken build string. constraining via skip also doesn't work - the suggested
 # approach leads to str < int compare failure during lint. 
@@ -94,9 +94,6 @@ outputs:
       run:
         - gettext
         - {{ pin_compatible("glib", max_pin="x") }}
-    build:
-      run_exports:
-        - {{ pin_subpackage("libarbdb", exact=True) }}
   - name: arb-bio-tools
     script: install_tools.sh
     requirements:
@@ -170,6 +167,9 @@ outputs:
         - fig2dev
   - name: arb-bio-devel
     script: install_devel.sh
+    build:
+      run_exports:
+        - {{ pin_subpackage("libarbdb", exact=True) }}
     requirements:
       build:
         - {{ compiler('cxx') }}


### PR DESCRIPTION
:information_source:
Bioconda has finished the [GCC7 migration](https://github.com/bioconda/bioconda-recipes/issues/13578). If you are dealing with C/C++ or Python package it can be that you need to rebuild other dependent packages. [Bioconda utils - update-pinning](https://bioconda.github.io/updating.html#updating-recipes-for-a-pinning-change) will assist you with that. If you have any questions please use [issue 13578](https://github.com/bioconda/bioconda-recipes/issues/13578).

----------------

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [x] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
