### PR TITLE
Amend build for ataqv

### DIFF
--- a/recipes/ataqv/build.sh
+++ b/recipes/ataqv/build.sh
@@ -15,3 +15,7 @@ mkdir -p $PREFIX/bin
 cp ./build/ataqv $PREFIX/bin/
 cp ./src/scripts/mkarv $PREFIX/bin/
 cp ./src/scripts/srvarv $PREFIX/bin/
+
+## COPY WEB DIRECTORY REQUIRED BY MKARV
+mkdir -p $PREFIX/web
+cp -r ./src/web/* $PREFIX/web/

--- a/recipes/ataqv/meta.yaml
+++ b/recipes/ataqv/meta.yaml
@@ -7,7 +7,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 0
+  number: 1
 
 source:
   url: https://github.com/ParkerLab/ataqv/archive/{{ version }}.tar.gz


### PR DESCRIPTION
:information_source:
Bioconda has finished the [GCC7 migration](https://github.com/bioconda/bioconda-recipes/issues/13578). If you are dealing with C/C++ or Python package it can be that you need to rebuild other dependent packages. [Bioconda utils - update-pinning](https://bioconda.github.io/updating.html#updating-recipes-for-a-pinning-change) will assist you with that. If you have any questions please use [issue 13578](https://github.com/bioconda/bioconda-recipes/issues/13578).

----------------

* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [X] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

This is a rebuild of:
https://github.com/bioconda/bioconda-recipes/pull/13374
https://github.com/bioconda/bioconda-recipes/pull/13160


`ataqv` requires the `web/` directory in `${PREFIX}/` to run one of its commands.
https://github.com/ParkerLab/ataqv/tree/master/src/web

`build.sh` has been updated accordingly.

Im not sure if there will be other tools/packages on bioconda that will require such a directory, and hopefully it doesnt break anything!