### PR TITLE
kaiju - add python to run requirements

### DIFF
--- a/recipes/kaiju/meta.yaml
+++ b/recipes/kaiju/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 4e2b0eccebc36307d561d713c558adb8f82414a1ea1ecf448c217812b12ef5ad
 
 build:
-  number: 0
+  number: 1
   no_link:
     - bin/makeDB.sh
 
@@ -23,6 +23,7 @@ requirements:
     - perl
     - gnu-wget >=1.16
     - zlib
+    - python
 
 test:
   commands:


### PR DESCRIPTION
:information_source:
Bioconda has finished the [GCC7 migration](https://github.com/bioconda/bioconda-recipes/issues/13578). If you are dealing with C/C++ or Python package it can be that you need to rebuild other dependent packages. [Bioconda utils - update-pinning](https://bioconda.github.io/updating.html#updating-recipes-for-a-pinning-change) will assist you with that. If you have any questions please use [issue 13578](https://github.com/bioconda/bioconda-recipes/issues/13578).

----------------

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).


python is required to run `makeDB.sh` script so I have added it to the run requirements and bumped the build number.  

fixes https://github.com/bioinformatics-centre/kaiju/issues/104