### PR TITLE
It looks like rJava has now been rebuilt.

### DIFF
--- a/build-fail-blacklist
+++ b/build-fail-blacklist
@@ -867,33 +867,33 @@ recipes/bioconductor-idmappinganalysis
 recipes/r-phytools
 
 # JVM errors (and dependencies)
-recipes/bioconductor-rgmql
-recipes/bioconductor-camthc
-recipes/bioconductor-onassis
-recipes/bioconductor-cbaf
-recipes/bioconductor-esatac
-recipes/bioconductor-arrayexpresshts
-recipes/bioconductor-rdavidwebservice
-recipes/bioconductor-compgo
-recipes/bioconductor-idmappingretrieval
-recipes/bioconductor-mirlab
-recipes/bioconductor-mirsm
-recipes/bioconductor-damirseq
-recipes/r-rcdk
-recipes/bioconductor-gars
-recipes/bioconductor-isogenegui
-recipes/bioconductor-bridgedbr
-recipes/bioconductor-paxtoolsr
-recipes/bioconductor-gaggle
-recipes/bioconductor-selex
-recipes/bioconductor-msgfplus
-recipes/bioconductor-msgfgui
-recipes/bioconductor-envisionquery
-recipes/bioconductor-rmassbank
-recipes/bioconductor-reqon
-recipes/bioconductor-rcellminer
-recipes/bioconductor-goprofiles
-recipes/bioconductor-rcpi
+# recipes/bioconductor-rgmql
+# recipes/bioconductor-camthc
+# recipes/bioconductor-onassis
+# recipes/bioconductor-cbaf
+# recipes/bioconductor-esatac
+# recipes/bioconductor-arrayexpresshts
+# recipes/bioconductor-rdavidwebservice
+# recipes/bioconductor-compgo
+# recipes/bioconductor-idmappingretrieval
+# recipes/bioconductor-mirlab
+# recipes/bioconductor-mirsm
+# recipes/bioconductor-damirseq
+# recipes/r-rcdk
+# recipes/bioconductor-gars
+# recipes/bioconductor-isogenegui
+# recipes/bioconductor-bridgedbr
+# recipes/bioconductor-paxtoolsr
+# recipes/bioconductor-gaggle
+# recipes/bioconductor-selex
+# recipes/bioconductor-msgfplus
+# recipes/bioconductor-msgfgui
+# recipes/bioconductor-envisionquery
+# recipes/bioconductor-rmassbank
+# recipes/bioconductor-reqon
+# recipes/bioconductor-rcellminer
+# recipes/bioconductor-goprofiles
+# recipes/bioconductor-rcpi
 
 # Missing root dependency
 recipes/bioconductor-xps

--- a/build-fail-blacklist
+++ b/build-fail-blacklist
@@ -137,6 +137,7 @@ recipes/r-purbayes
 recipes/r-qiimer
 recipes/r-qtl
 recipes/r-rbamtools
+recipes/r-rcdk
 recipes/r-rcircos
 recipes/r-readbrukerflexdata
 recipes/r-readmzxmldata
@@ -879,7 +880,6 @@ recipes/r-phytools
 # recipes/bioconductor-mirlab
 # recipes/bioconductor-mirsm
 # recipes/bioconductor-damirseq
-# recipes/r-rcdk
 # recipes/bioconductor-gars
 # recipes/bioconductor-isogenegui
 # recipes/bioconductor-bridgedbr

--- a/build-fail-blacklist
+++ b/build-fail-blacklist
@@ -868,32 +868,27 @@ recipes/bioconductor-idmappinganalysis
 recipes/r-phytools
 
 # JVM errors (and dependencies)
-# recipes/bioconductor-rgmql
-# recipes/bioconductor-camthc
-# recipes/bioconductor-onassis
-# recipes/bioconductor-cbaf
-# recipes/bioconductor-esatac
-# recipes/bioconductor-arrayexpresshts
-# recipes/bioconductor-rdavidwebservice
-# recipes/bioconductor-compgo
-# recipes/bioconductor-idmappingretrieval
-# recipes/bioconductor-mirlab
-# recipes/bioconductor-mirsm
-# recipes/bioconductor-damirseq
-# recipes/bioconductor-gars
-# recipes/bioconductor-isogenegui
-# recipes/bioconductor-bridgedbr
-# recipes/bioconductor-paxtoolsr
-# recipes/bioconductor-gaggle
-# recipes/bioconductor-selex
-# recipes/bioconductor-msgfplus
-# recipes/bioconductor-msgfgui
-# recipes/bioconductor-envisionquery
-# recipes/bioconductor-rmassbank
-# recipes/bioconductor-reqon
-# recipes/bioconductor-rcellminer
-# recipes/bioconductor-goprofiles
-# recipes/bioconductor-rcpi
+recipes/bioconductor-compgo
+recipes/bioconductor-idmappingretrieval
+recipes/bioconductor-mirlab
+recipes/bioconductor-mirsm
+recipes/bioconductor-gars
+recipes/bioconductor-isogenegui
+recipes/bioconductor-bridgedbr
+recipes/bioconductor-paxtoolsr
+recipes/bioconductor-gaggle
+recipes/bioconductor-selex
+recipes/bioconductor-msgfplus
+recipes/bioconductor-msgfgui
+recipes/bioconductor-envisionquery
+recipes/bioconductor-rmassbank
+recipes/bioconductor-reqon
+recipes/bioconductor-rcellminer
+recipes/bioconductor-goprofiles
+recipes/bioconductor-rcpi
+
+# Missing r-fselector
+recipes/bioconductor-damirseq
 
 # Missing root dependency
 recipes/bioconductor-xps

--- a/recipes/bioconductor-arrayexpresshts/meta.yaml
+++ b/recipes/bioconductor-arrayexpresshts/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.32.0" %}
+{% set version = "1.32.1" %}
 {% set name = "ArrayExpressHTS" %}
 {% set bioc = "3.8" %}
 
@@ -10,7 +10,7 @@ source:
     - 'https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/{{ name }}_{{ version }}.tar.gz'
     - 'https://bioarchive.galaxyproject.org/{{ name }}_{{ version }}.tar.gz'
     - 'https://depot.galaxyproject.org/software/bioconductor-{{ name|lower }}/bioconductor-{{ name|lower }}_{{ version }}_src_all.tar.gz'
-  md5: dcb1ef59f60151a8a83f63c2d42ab28a
+  md5: 999bbee605ec5abb2c4328916301e33a
 build:
   number: 0
   rpaths:

--- a/recipes/bioconductor-esatac/meta.yaml
+++ b/recipes/bioconductor-esatac/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.4.0" %}
+{% set version = "1.4.3" %}
 {% set name = "esATAC" %}
 {% set bioc = "3.8" %}
 
@@ -10,7 +10,7 @@ source:
     - 'https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/{{ name }}_{{ version }}.tar.gz'
     - 'https://bioarchive.galaxyproject.org/{{ name }}_{{ version }}.tar.gz'
     - 'https://depot.galaxyproject.org/software/bioconductor-{{ name|lower }}/bioconductor-{{ name|lower }}_{{ version }}_src_all.tar.gz'
-  md5: 1b1bf9585538209631a24a0d6d4c7647
+  md5: e196b9f855c19bbdf03ccf43109417e2
 build:
   number: 0
   rpaths:


### PR DESCRIPTION
:information_source:
Bioconda has finished the [GCC7 migration](https://github.com/bioconda/bioconda-recipes/issues/13578). If you are dealing with C/C++ or Python package it can be that you need to rebuild other dependent packages. [Bioconda utils - update-pinning](https://bioconda.github.io/updating.html#updating-recipes-for-a-pinning-change) will assist you with that. If you have any questions please use [issue 13578](https://github.com/bioconda/bioconda-recipes/issues/13578).

----------------

* [ ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).
