### PR TITLE
Update bioconductor flowtype flowmerge flowmeans

### DIFF
--- a/build-fail-blacklist
+++ b/build-fail-blacklist
@@ -900,10 +900,7 @@ recipes/bioconductor-debrowser
 recipes/bioconductor-mirlab
 
 # r-feature missing
-recipes/bioconductor-flowmerge
-recipes/bioconductor-flowmeans
 recipes/bioconductor-confess
-recipes/bioconductor-flowtype
 recipes/bioconductor-rchyoptimyx
 
 # system call failed: Cannot allocate memory

--- a/recipes/bioconductor-flowmeans/meta.yaml
+++ b/recipes/bioconductor-flowmeans/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.42.0" %}
+{% set version = "1.42.1" %}
 {% set name = "flowMeans" %}
 {% set bioc = "3.8" %}
 
@@ -10,7 +10,7 @@ source:
     - 'https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/{{ name }}_{{ version }}.tar.gz'
     - 'https://bioarchive.galaxyproject.org/{{ name }}_{{ version }}.tar.gz'
     - 'https://depot.galaxyproject.org/software/bioconductor-{{ name|lower }}/bioconductor-{{ name|lower }}_{{ version }}_src_all.tar.gz'
-  md5: 19389036944c6237feb203f969b5fcc6
+  md5: 0b5ac87aa94096b505c62a49f57a0252
 build:
   number: 0
   rpaths:

--- a/recipes/bioconductor-flowmerge/meta.yaml
+++ b/recipes/bioconductor-flowmerge/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.30.0" %}
+{% set version = "2.30.1" %}
 {% set name = "flowMerge" %}
 {% set bioc = "3.8" %}
 
@@ -10,7 +10,7 @@ source:
     - 'https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/{{ name }}_{{ version }}.tar.gz'
     - 'https://bioarchive.galaxyproject.org/{{ name }}_{{ version }}.tar.gz'
     - 'https://depot.galaxyproject.org/software/bioconductor-{{ name|lower }}/bioconductor-{{ name|lower }}_{{ version }}_src_all.tar.gz'
-  md5: 2d009505f7e93f75d8e01843b63b889d
+  md5: 6594ae374303f35932dca812d021147b
 build:
   number: 0
   rpaths:

--- a/recipes/bioconductor-flowtype/meta.yaml
+++ b/recipes/bioconductor-flowtype/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.20.0" %}
+{% set version = "2.20.1" %}
 {% set name = "flowType" %}
 {% set bioc = "3.8" %}
 
@@ -10,9 +10,9 @@ source:
     - 'https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/{{ name }}_{{ version }}.tar.gz'
     - 'https://bioarchive.galaxyproject.org/{{ name }}_{{ version }}.tar.gz'
     - 'https://depot.galaxyproject.org/software/bioconductor-{{ name|lower }}/bioconductor-{{ name|lower }}_{{ version }}_src_all.tar.gz'
-  md5: 75344927b4bf183166789555a40a2319
+  md5: 49e8b8b49790cb4941b43a831022fc89
 build:
-  number: 1
+  number: 0
   rpaths:
     - lib/R/lib/
     - lib/


### PR DESCRIPTION
:information_source:
Bioconda has finished the [GCC7 migration](https://github.com/bioconda/bioconda-recipes/issues/13578). If you are dealing with C/C++ or Python package it can be that you need to rebuild other dependent packages. [Bioconda utils - update-pinning](https://bioconda.github.io/updating.html#updating-recipes-for-a-pinning-change) will assist you with that. If you have any questions please use [issue 13578](https://github.com/bioconda/bioconda-recipes/issues/13578).

----------------

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

Update recipes and remove from blacklist.