### PR TITLE
Remove more rJava packages from the blacklist

### DIFF
--- a/build-fail-blacklist
+++ b/build-fail-blacklist
@@ -813,6 +813,7 @@ recipes/bioconductor-s4vectors/0.8.11
 recipes/r-pcalg
 recipes/bioconductor-epinem
 recipes/bioconductor-debrowser
+recipes/bioconductor-mirlab
 
 # r-xlconnect missing
 recipes/bioconductor-hpaanalyze
@@ -872,6 +873,7 @@ recipes/bioconductor-selex
 recipes/bioconductor-msgfplus
 recipes/bioconductor-msgfgui
 recipes/bioconductor-envisionquery
+recipes/bioconductor-idmappingretrieval
 recipes/bioconductor-rmassbank
 recipes/bioconductor-reqon
 recipes/bioconductor-rcellminer
@@ -880,6 +882,10 @@ recipes/bioconductor-rcpi
 
 # Missing r-fselector
 recipes/bioconductor-damirseq
+recipes/bioconductor-gars
+
+# Missing r-bibitr
+recipes/bioconductor-mirsm
 
 # Missing root dependency
 recipes/bioconductor-xps

--- a/build-fail-blacklist
+++ b/build-fail-blacklist
@@ -868,15 +868,6 @@ recipes/bioconductor-idmappinganalysis
 recipes/r-phytools
 
 # JVM errors (and dependencies)
-recipes/bioconductor-compgo
-recipes/bioconductor-idmappingretrieval
-recipes/bioconductor-mirlab
-recipes/bioconductor-mirsm
-recipes/bioconductor-gars
-recipes/bioconductor-isogenegui
-recipes/bioconductor-bridgedbr
-recipes/bioconductor-paxtoolsr
-recipes/bioconductor-gaggle
 recipes/bioconductor-selex
 recipes/bioconductor-msgfplus
 recipes/bioconductor-msgfgui


### PR DESCRIPTION
:information_source:
Bioconda has finished the [GCC7 migration](https://github.com/bioconda/bioconda-recipes/issues/13578). If you are dealing with C/C++ or Python package it can be that you need to rebuild other dependent packages. [Bioconda utils - update-pinning](https://bioconda.github.io/updating.html#updating-recipes-for-a-pinning-change) will assist you with that. If you have any questions please use [issue 13578](https://github.com/bioconda/bioconda-recipes/issues/13578).

----------------

* [ ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).
