### PR TITLE
Remove the remainder of the rJava bioc packages from the blacklist

### DIFF
--- a/build-fail-blacklist
+++ b/build-fail-blacklist
@@ -868,18 +868,6 @@ recipes/bioconductor-idmappinganalysis
 # Missing r-animation
 recipes/r-phytools
 
-# JVM errors (and dependencies)
-recipes/bioconductor-selex
-recipes/bioconductor-msgfplus
-recipes/bioconductor-msgfgui
-recipes/bioconductor-envisionquery
-recipes/bioconductor-idmappingretrieval
-recipes/bioconductor-rmassbank
-recipes/bioconductor-reqon
-recipes/bioconductor-rcellminer
-recipes/bioconductor-goprofiles
-recipes/bioconductor-rcpi
-
 # Missing r-fselector
 recipes/bioconductor-damirseq
 recipes/bioconductor-gars

--- a/build-fail-blacklist
+++ b/build-fail-blacklist
@@ -910,3 +910,4 @@ recipes/bioconductor-biggr
 
 # Unknown java error
 recipes/bioconductor-msgfplus
+recipes/bioconductor-msgfgui

--- a/build-fail-blacklist
+++ b/build-fail-blacklist
@@ -907,3 +907,6 @@ recipes/bioconductor-adacgh2
 recipes/bioconductor-snapcgh
 recipes/bioconductor-italics
 recipes/bioconductor-biggr
+
+# Unknown java error
+recipes/bioconductor-msgfplus

--- a/recipes/bioconductor-rmassbank/meta.yaml
+++ b/recipes/bioconductor-rmassbank/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.10.0" %}
+{% set version = "2.10.1" %}
 {% set name = "RMassBank" %}
 {% set bioc = "3.8" %}
 
@@ -10,7 +10,7 @@ source:
     - 'https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/{{ name }}_{{ version }}.tar.gz'
     - 'https://bioarchive.galaxyproject.org/{{ name }}_{{ version }}.tar.gz'
     - 'https://depot.galaxyproject.org/software/bioconductor-{{ name|lower }}/bioconductor-{{ name|lower }}_{{ version }}_src_all.tar.gz'
-  md5: be820644e8da8f88c16de86381fd518c
+  md5: 47a3192d7b020db8dc92f01e42ecf0fa
 build:
   number: 0
   rpaths:
@@ -33,6 +33,7 @@ requirements:
     - r-rjson
     - r-xml
     - r-yaml
+    - openbabel
   run:
     - 'bioconductor-biobase >=2.42.0,<2.43.0'
     - 'bioconductor-msnbase >=2.8.0,<2.9.0'
@@ -47,6 +48,7 @@ requirements:
     - r-rjson
     - r-xml
     - r-yaml
+    - openbabel
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}


### PR DESCRIPTION
:information_source:
Bioconda has finished the [GCC7 migration](https://github.com/bioconda/bioconda-recipes/issues/13578). If you are dealing with C/C++ or Python package it can be that you need to rebuild other dependent packages. [Bioconda utils - update-pinning](https://bioconda.github.io/updating.html#updating-recipes-for-a-pinning-change) will assist you with that. If you have any questions please use [issue 13578](https://github.com/bioconda/bioconda-recipes/issues/13578).

----------------

* [ ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).
