### PR TITLE
CPAT: Stricter python version requirement

### DIFF
--- a/recipes/cpat/meta.yaml
+++ b/recipes/cpat/meta.yaml
@@ -1,5 +1,3 @@
-
-
 {% set name = "cpat" %}
 {% set version = "1.2.4" %}
 
@@ -9,7 +7,7 @@ package:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv "
 
 source:
@@ -22,14 +20,15 @@ requirements:
     - bx-python
     - pip
     - nose
-    - python <3
+    # CPAT explicitly checks if python's version string starts with 2.7
+    - python >=2.7,<2.8
     - pysam
     - numpy
     - cython
 
   run:
     - bx-python
-    - python <3
+    - python >=2.7,<2.8
     - numpy
     - pysam
     - r-base

--- a/recipes/cpat/meta.yaml
+++ b/recipes/cpat/meta.yaml
@@ -41,5 +41,5 @@ test:
 
 about:
   home: http://rna-cpat.sourceforge.net/
-  license: GNU General Public v2 (GPLv2)
+  license: GNU General Public v2 or later (GPLv2+)
   summary: Coding Potential Assessment Tool


### PR DESCRIPTION
In CPAT's code the version check for a python version that starts with 2.7 is hardcoded.

So I have updated the recipe to reflect this. Only python 2.7 is allowed now in the conda environment.

----------------

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
