### PR TITLE
Update: arvados-python-client, arvados-cwl-runner, bcbio-variation-recall

### DIFF
--- a/recipes/arvados-cwl-runner/meta.yaml
+++ b/recipes/arvados-cwl-runner/meta.yaml
@@ -1,15 +1,15 @@
-{% set version="1.3.0.20190206223817" %}
+{% set version="1.3.0.20190221150417" %}
 package:
   name: arvados-cwl-runner
   version: {{ version }}
 
 source:
   url: https://pypi.io/packages/source/a/arvados-cwl-runner/arvados-cwl-runner-{{ version }}.tar.gz
-  sha256: f0ac46a4d43a6fe62950a64a4c23b92392dd6a1a4b68c27dffdb2f20b602caf3
+  sha256: 0c21652bd296885de6fa4b4a1d7e726050860418f5c851a605bed646dcb0e7d9
 
 build:
   skip: true  # [osx or py37]
-  number: 1
+  number: 0
 
 requirements:
   host:

--- a/recipes/arvados-cwl-runner/meta.yaml
+++ b/recipes/arvados-cwl-runner/meta.yaml
@@ -20,14 +20,14 @@ requirements:
     - ruamel.yaml >=0.15.54
     - cwltool >=1.0.20181217162649
     - schema-salad >=3.0.20181129082112
-    - arvados-python-client >=1.2.1.20181130020805  # [not py37]
+    - arvados-python-client >=1.3.0.20190221150417  # [not py37]
 
   run:
     - python <3.7
     - ruamel.yaml >=0.15.54
     - cwltool >=1.0.20181217162649
     - schema-salad >=3.0.20181129082112
-    - arvados-python-client >=1.2.1.20181130020805  # [not py37]
+    - arvados-python-client >=1.3.0.20190221150417  # [not py37]
 
 test:
   imports:

--- a/recipes/arvados-cwl-runner/meta.yaml
+++ b/recipes/arvados-cwl-runner/meta.yaml
@@ -15,7 +15,7 @@ build:
 requirements:
   host:
     # arvados-python-client not yet buildable for 3.7
-    - python < 3.7
+    - python <3.7
     - setuptools
     - ruamel.yaml >=0.15.54
     - cwltool >=1.0.20181217162649
@@ -23,7 +23,7 @@ requirements:
     - arvados-python-client >=1.2.1.20181130020805  # [not py37]
 
   run:
-    - python < 3.7
+    - python <3.7
     - ruamel.yaml >=0.15.54
     - cwltool >=1.0.20181217162649
     - schema-salad >=3.0.20181129082112

--- a/recipes/arvados-cwl-runner/meta.yaml
+++ b/recipes/arvados-cwl-runner/meta.yaml
@@ -8,13 +8,13 @@ source:
   sha256: 0c21652bd296885de6fa4b4a1d7e726050860418f5c851a605bed646dcb0e7d9
 
 build:
-  skip: true  # [osx or py37]
+  skip: true  # [osx]
   number: 0
 
 requirements:
   host:
     # arvados-python-client not yet buildable for 3.7
-    - python <3.7
+    - python
     - setuptools
     - ruamel.yaml >=0.15.54
     - cwltool >=1.0.20181217162649
@@ -22,7 +22,7 @@ requirements:
     - arvados-python-client >=1.2.1.20181130020805  # [not py37]
 
   run:
-    - python <3.7
+    - python
     - ruamel.yaml >=0.15.54
     - cwltool >=1.0.20181217162649
     - schema-salad >=3.0.20181129082112

--- a/recipes/arvados-cwl-runner/meta.yaml
+++ b/recipes/arvados-cwl-runner/meta.yaml
@@ -41,3 +41,7 @@ about:
   home: https://github.com/curoverse/arvados/tree/master/sdk/cwl
   license: Apache 2.0
   summary: 'Arvados Common Workflow Language runner'
+
+  extra:
+  skip-lints:
+    - should_not_be_noarch

--- a/recipes/arvados-cwl-runner/meta.yaml
+++ b/recipes/arvados-cwl-runner/meta.yaml
@@ -10,11 +10,12 @@ source:
 build:
   skip: true  # [osx]
   number: 0
+  noarch: python
 
 requirements:
   host:
     # arvados-python-client not yet buildable for 3.7
-    - python
+    - python < 3.7
     - setuptools
     - ruamel.yaml >=0.15.54
     - cwltool >=1.0.20181217162649
@@ -22,7 +23,7 @@ requirements:
     - arvados-python-client >=1.2.1.20181130020805  # [not py37]
 
   run:
-    - python
+    - python < 3.7
     - ruamel.yaml >=0.15.54
     - cwltool >=1.0.20181217162649
     - schema-salad >=3.0.20181129082112

--- a/recipes/arvados-cwl-runner/meta.yaml
+++ b/recipes/arvados-cwl-runner/meta.yaml
@@ -42,6 +42,6 @@ about:
   license: Apache 2.0
   summary: 'Arvados Common Workflow Language runner'
 
-  extra:
+extra:
   skip-lints:
     - should_not_be_noarch

--- a/recipes/arvados-python-client/meta.yaml
+++ b/recipes/arvados-python-client/meta.yaml
@@ -9,13 +9,13 @@ source:
   sha256: 086429fabb1f933ec454fe3c38fe5cada1df9ead698c7ac1d6532d31a62d59e1
 
 build:
-  skip: true  # [osx or py37]
+  skip: true  # [osx]
   number: 0
 
 requirements:
   host:
     # Supported ciso8601 versions do not have python 3.7 builds
-    - python <3.7
+    - python
     - setuptools
     - ciso8601 >=1.0.6,<2.0.0  # [not py37]
     - future
@@ -27,7 +27,7 @@ requirements:
     - subprocess32  # [py2k]
 
   run:
-    - python <3.7
+    - python
     - setuptools
     - ciso8601 >=1.0.6,<2.0.0  # [not py37]
     - future

--- a/recipes/arvados-python-client/meta.yaml
+++ b/recipes/arvados-python-client/meta.yaml
@@ -16,7 +16,7 @@ build:
 requirements:
   host:
     # Supported ciso8601 versions do not have python 3.7 builds
-    - python < 3.7
+    - python <3.7
     - setuptools
     - ciso8601 >=1.0.6,<2.0.0  # [not py37]
     - future
@@ -28,7 +28,7 @@ requirements:
     - subprocess32  # [py2k]
 
   run:
-    - python < 3.7
+    - python <3.7
     - setuptools
     - ciso8601 >=1.0.6,<2.0.0  # [not py37]
     - future

--- a/recipes/arvados-python-client/meta.yaml
+++ b/recipes/arvados-python-client/meta.yaml
@@ -51,3 +51,4 @@ about:
 extra:
   skip-lints:
     - uses_setuptools
+    - should_not_be_noarch

--- a/recipes/arvados-python-client/meta.yaml
+++ b/recipes/arvados-python-client/meta.yaml
@@ -11,11 +11,12 @@ source:
 build:
   skip: true  # [osx]
   number: 0
+  noarch: python
 
 requirements:
   host:
     # Supported ciso8601 versions do not have python 3.7 builds
-    - python
+    - python < 3.7
     - setuptools
     - ciso8601 >=1.0.6,<2.0.0  # [not py37]
     - future
@@ -27,7 +28,7 @@ requirements:
     - subprocess32  # [py2k]
 
   run:
-    - python
+    - python < 3.7
     - setuptools
     - ciso8601 >=1.0.6,<2.0.0  # [not py37]
     - future

--- a/recipes/arvados-python-client/meta.yaml
+++ b/recipes/arvados-python-client/meta.yaml
@@ -1,4 +1,4 @@
-{% set version="1.3.0.20190205182514" %}
+{% set version="1.3.0.20190221150417" %}
 
 package:
   name: arvados-python-client
@@ -6,11 +6,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/a/arvados-python-client/arvados-python-client-{{ version }}.tar.gz
-  sha256: 0b81ee65973087e99a2aa8ac07aeea50877987faac6bdb254cc110bff9d74cff
+  sha256: 086429fabb1f933ec454fe3c38fe5cada1df9ead698c7ac1d6532d31a62d59e1
 
 build:
   skip: true  # [osx or py37]
-  number: 1
+  number: 0
 
 requirements:
   host:

--- a/recipes/bcbio-variation-recall/meta.yaml
+++ b/recipes/bcbio-variation-recall/meta.yaml
@@ -1,4 +1,4 @@
-{% set version="0.2.3" %}
+{% set version="0.2.4" %}
 
 package:
   name: bcbio-variation-recall
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/chapmanb/bcbio.variation.recall/releases/download/v{{ version }}/bcbio-variation-recall
-  sha256: 13b50c51da5fdeb864504edb15a91265a75c4c317c8d99162402543129e3200c
+  sha256: 6ef9bf1bdbedf8f547709b93848347e0d6634e3cbd7bdcbbb3a9718d1c483318
 
 build:
   number: 0


### PR DESCRIPTION
- arvados: fix py3k support by avoiding subprocess32 on py3k
- bcbio-variation-recall: fix platypus contig header generation.
  Fixes bcbio/bcbio-nextgen#2688

----------------

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
