### PR TITLE
updating the recipe for the cromwell workflow manager to version 36.1, which should be used in preference to 37.0 until problems with that version are worked out, according to cromwell developers

### DIFF
--- a/recipes/cromwell/meta.yaml
+++ b/recipes/cromwell/meta.yaml
@@ -1,6 +1,6 @@
-{% set version = "37" %}
+{% set version = "36.1" %}
 #{% set revision = "ec67d65" %}
-{% set sha256 = "c90d2afaa14d2711b42b99d701be2fe332b161f8b3a96372a1bd5a53a87c5743" %}
+{% set sha256 = "3dbdb7cd236169f4d3297a56972082cf718fddb058af300cc3a62950f278b715" %}
 
 package:
   name: cromwell


### PR DESCRIPTION
updating the recipe for the cromwell workflow manager to version 36.1, which should be used in preference to 37.0 until problems with that version are worked out, according to cromwell developers