### PR TITLE
Add centrosome recipe from pypi

### DIFF
--- a/recipes/centrosome/meta.yaml
+++ b/recipes/centrosome/meta.yaml
@@ -15,7 +15,6 @@ source:
 build:
   number: 0
   script: $PYTHON setup.py install --single-version-externally-managed --record=record.txt
-  noarch: python
 
 requirements:
   host:

--- a/recipes/centrosome/meta.yaml
+++ b/recipes/centrosome/meta.yaml
@@ -14,12 +14,15 @@ source:
 
 build:
   number: 0
-  script: $PYTHON setup.py install --single-version-externally-managed --record=record.txt
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv "
 
 requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
   host:
     - python
-    - setuptools
+    - pip
     - cython
     - numpy
     - scipy
@@ -42,8 +45,6 @@ requirements:
 test:
   imports:
     - centrosome
-  requires:
-    - pytest
 
 about:
   home: https://github.com/CellProfiler/centrosome

--- a/recipes/centrosome/meta.yaml
+++ b/recipes/centrosome/meta.yaml
@@ -1,0 +1,54 @@
+{% set name = "centrosome" %}
+{% set version = "1.1.5" %}
+{% set file_ext = "tar.gz" %}
+{% set hash_type = "sha256" %}
+{% set hash_value = "b1dfbe45c3755837a350a855f47123ed306fdd306726fd0c69bb0900b38a5b4c" %}
+
+package:
+  name: '{{ name|lower }}'
+  version: '{{ version }}'
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ file_ext }}
+  '{{ hash_type }}': '{{ hash_value }}'
+
+build:
+  number: 0
+  script: $PYTHON setup.py install --single-version-externally-managed --record=record.txt
+  noarch: python
+
+requirements:
+  host:
+    - python
+    - setuptools
+    - cython
+    - numpy
+    - scipy
+    - matplotlib
+    - deprecation
+    - pillow
+    - scikit-image
+    - pytest
+  run:
+    - python
+    - cython
+    - numpy
+    - scipy
+    - matplotlib
+    - deprecation
+    - pillow
+    - scikit-image
+    - pytest
+
+test:
+  imports:
+    - centrosome
+  requires:
+    - pytest
+
+about:
+  home: https://github.com/CellProfiler/centrosome
+  license: BSD
+  license_family: BSD
+  summary: An open source image processing library required by CellProfiler
+  dev_url: https://github.com/CellProfiler/centrosome


### PR DESCRIPTION
:information_source:
Bioconda has finished the [GCC7 migration](https://github.com/bioconda/bioconda-recipes/issues/13578). If you are dealing with C/C++ or Python package it can be that you need to rebuild other dependent packages. [Bioconda utils - update-pinning](https://bioconda.github.io/updating.html#updating-recipes-for-a-pinning-change) will assist you with that. If you have any questions please use [issue 13578](https://github.com/bioconda/bioconda-recipes/issues/13578).

----------------

* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [X] This PR adds a new recipe.
* [X] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Added `centrosome` package required by `CellProfiler`. Recipe file was built using:
```
conda skeleton pypi centrosome
```

Some modifications have been made to accomodate missing packages required for the build.