### PR TITLE
WIP: Update NGLess recipe to newer conda world

### DIFF
--- a/recipes/ngless/build.sh
+++ b/recipes/ngless/build.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
 
-export LIBRARY_PATH="${PREFIX}/lib:/usr/lib:/usr/lib64"
-export LD_LIBRARY_PATH="${PREFIX}/lib:/usr/lib:/usr/lib64"
+export LIBRARY_PATH="${CONDA_PREFIX}/lib:/usr/lib:/usr/lib64"
+export LD_LIBRARY_PATH="${CONDA_PREFIX}/lib:/usr/lib:/usr/lib64"
 
-export LDFLAGS="-L${PREFIX}/lib"
-export CPPFLAGS="-I${PREFIX}/include"
-export CFLAGS="-I$PREFIX/include"
-export CPATH=${PREFIX}/include
+export LDFLAGS="-L${CONDA_PREFIX}/lib"
+export CPPFLAGS="-I${CONDA_PREFIX}/include"
+export CFLAGS="-I${CONDA_PREFIX}/include"
+export CPATH=${CONDA_PREFIX}/include
 
 
 # stack relies on $HOME, so fake it:
 mkdir -p fake-home
 export HOME=$PWD/fake-home
 export STACK_ROOT="$HOME/.stack"
-stack setup --local-bin-path ${PREFIX}/bin
-make install WGET="wget --no-check-certificate" prefix=$PREFIX
+stack setup --local-bin-path ${CONDA_PREFIX}/bin
+make install WGET="wget --no-check-certificate" prefix=$CONDA_PREFIX
 
 #cleanup
 rm -r .stack-work

--- a/recipes/ngless/build.sh
+++ b/recipes/ngless/build.sh
@@ -13,7 +13,7 @@ export CPATH=${CONDA_PREFIX}/include
 mkdir -p fake-home
 export HOME=$PWD/fake-home
 export STACK_ROOT="$HOME/.stack"
-stack setup --local-bin-path ${CONDA_PREFIX}/bin
+stack setup --ghc-variant integersimple --local-bin-path ${CONDA_PREFIX}/bin
 make install WGET="wget --no-check-certificate" prefix=$CONDA_PREFIX
 
 #cleanup

--- a/recipes/ngless/build.sh
+++ b/recipes/ngless/build.sh
@@ -1,20 +1,21 @@
 #!/bin/bash
 
-export LIBRARY_PATH="${CONDA_PREFIX}/lib:/usr/lib:/usr/lib64"
-export LD_LIBRARY_PATH="${CONDA_PREFIX}/lib:/usr/lib:/usr/lib64"
+export LIBRARY_PATH="${PREFIX}/lib:/usr/lib:/usr/lib64:${LIBRARY_PATH}"
+export LD_LIBRARY_PATH="${PREFIX}/lib:/usr/lib:/usr/lib64:${LD_LIBRARY_PATH}"
+export LD_RUN_PATH="${PREFIX}/lib:/usr/lib:/usr/lib64:${LD_RUN_PATH}"
 
-export LDFLAGS="-L${CONDA_PREFIX}/lib"
-export CPPFLAGS="-I${CONDA_PREFIX}/include"
-export CFLAGS="-I${CONDA_PREFIX}/include"
-export CPATH=${CONDA_PREFIX}/include
+export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib"
+export CPPFLAGS="${CPPFLAGS} -I${PREFIX}/include"
+export CFLAGS="${CFLAGS} -I${PREFIX}/include"
+export CPATH="${CPATH} ${PREFIX}/include"
 
 
 # stack relies on $HOME, so fake it:
 mkdir -p fake-home
 export HOME=$PWD/fake-home
 export STACK_ROOT="$HOME/.stack"
-stack setup --ghc-variant integersimple --local-bin-path ${CONDA_PREFIX}/bin
-make install WGET="wget --no-check-certificate" prefix=$CONDA_PREFIX
+stack setup --system-ghc --local-bin-path ${PREFIX}/bin
+make install WGET="wget --no-check-certificate" prefix=$PREFIX
 
 #cleanup
 rm -r .stack-work

--- a/recipes/ngless/build.sh
+++ b/recipes/ngless/build.sh
@@ -16,7 +16,7 @@ export HOME=$PWD/fake-home
 export STACK_ROOT="$HOME/.stack"
 export STACKOPTS="--local-bin-path ${PREFIX}/bin --extra-include-dirs ${PREFIX}/include --extra-lib-dirs ${PREFIX}/lib"
 
-stack setup
+stack setup --ghc-build standard
 make install WGET="wget --no-check-certificate" prefix=$PREFIX
 
 #cleanup

--- a/recipes/ngless/build.sh
+++ b/recipes/ngless/build.sh
@@ -14,7 +14,9 @@ export CPATH="${CPATH} ${PREFIX}/include"
 mkdir -p fake-home
 export HOME=$PWD/fake-home
 export STACK_ROOT="$HOME/.stack"
-stack setup --system-ghc --local-bin-path ${PREFIX}/bin
+export STACKOPTS="--local-bin-path ${PREFIX}/bin --extra-include-dirs ${PREFIX}/include --extra-lib-dirs ${PREFIX}/lib"
+
+stack setup
 make install WGET="wget --no-check-certificate" prefix=$PREFIX
 
 #cleanup

--- a/recipes/ngless/meta.yaml
+++ b/recipes/ngless/meta.yaml
@@ -18,6 +18,7 @@ requirements:
   build:
     - {{ compiler('c') }}
   host:
+    - ghc 8.2.2
     - stack >=1.7.1
     - cairo
     - xorg-libxext # [linux]

--- a/recipes/ngless/meta.yaml
+++ b/recipes/ngless/meta.yaml
@@ -11,7 +11,7 @@ source:
   md5: {{ md5 }}
 
 build:
-  number: 0
+  number: 1
   skip: True  #  [osx]
 
 requirements:
@@ -43,6 +43,6 @@ test:
     - ngless --check-install
 
 about:
-  home: http://ngless.embl.de
+  home: https://ngless.embl.de
   license: MIT
   summary: A tool for metagenomics processing with a focus on metagenomics


### PR DESCRIPTION
Some conda changes mean that the recipe is no longer working.

Take the opportunity to update the URL of the tool to HTTPS
(https://ngless.embl.de).

This was reported as https://github.com/ngless-toolkit/ngless/issues/101

:information_source:
Bioconda has finished the [GCC7 migration](https://github.com/bioconda/bioconda-recipes/issues/13578). If you are dealing with C/C++ or Python package it can be that you need to rebuild other dependent packages. [Bioconda utils - update-pinning](https://bioconda.github.io/updating.html#updating-recipes-for-a-pinning-change) will assist you with that. If you have any questions please use [issue 13578](https://github.com/bioconda/bioconda-recipes/issues/13578).

----------------

* [ ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
