### PR TITLE
update chado-tools to version 0.2.8

### DIFF
--- a/recipes/chado-tools/meta.yaml
+++ b/recipes/chado-tools/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "0.2.5" %}
-{% set sha256 = "ed25a5677b9f93c5e6f0ad9a0a3a561ead4ecd1a2cadd6ae5c7df5e087c96d85" %}
+{% set version = "0.2.8" %}
+{% set sha256 = "e455c89ac18082177e916eef40a1ef508e2c65af9fafd7d0450015e7969fa974" %}
 
 package:
   name: chado-tools


### PR DESCRIPTION
:information_source:
Bioconda has finished the [GCC7 migration](https://github.com/bioconda/bioconda-recipes/issues/13578). If you are dealing with C/C++ or Python package it can be that you need to rebuild other dependent packages. [Bioconda utils - update-pinning](https://bioconda.github.io/updating.html#updating-recipes-for-a-pinning-change) will assist you with that. If you have any questions please use [issue 13578](https://github.com/bioconda/bioconda-recipes/issues/13578).

----------------

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
