### PR TITLE
New recipe: pytest-workflow

### DIFF
--- a/recipes/pytest-workflow/meta.yaml
+++ b/recipes/pytest-workflow/meta.yaml
@@ -36,11 +36,5 @@ about:
   home: https://github.com/LUMC/pytest-workflow
   license: GNU Affero General Public v3 or later (AGPLv3+)
   license_family: AGPL
-  license_file: 
   summary: A pytest plugin for configuring workflow/pipeline tests using YAML files
   doc_url: https://pytest-workflow.readthedocs.io
-  dev_url: 
-
-extra:
-  recipe-maintainers:
-    - rhpvorderman

--- a/recipes/pytest-workflow/meta.yaml
+++ b/recipes/pytest-workflow/meta.yaml
@@ -1,0 +1,46 @@
+{% set name = "pytest-workflow" %}
+{% set version = "1.1.0" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: c855171d1a68801e6cb61befb91faf1c33f4713c36a3e18e40081b0f85e41cd5
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv "
+
+requirements:
+  host:
+    - jsonschema
+    - pip
+    - pytest >=4
+    - python >=3.5
+    - pyyaml
+    - setuptools
+  run:
+    - jsonschema
+    - pytest >=4
+    - python >=3.5
+    - pyyaml
+
+test:
+  imports:
+    - pytest_workflow
+
+about:
+  home: https://github.com/LUMC/pytest-workflow
+  license: GNU Affero General Public v3 or later (AGPLv3+)
+  license_family: AGPL
+  license_file: 
+  summary: A pytest plugin for configuring workflow/pipeline tests using YAML files
+  doc_url: https://pytest-workflow.readthedocs.io
+  dev_url: 
+
+extra:
+  recipe-maintainers:
+    - rhpvorderman


### PR DESCRIPTION
Pytest-workflow is a pytest add-on that allows a user to configure workflow test in YAML. This package is used at the LUMC to test our Cromwell/WDL pipelines as well as our Snakemake pipelines. Testing of pipelines in other frameworks is also possible, because pytest-workflow is framework agnostic.

https://pytest-workflow.readthedocs.io/en/stable/

----------------

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [x] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
