### PR TITLE
Let NextGenMap depend on bintuils, because it's OpenCL implementation uses 'as'

### DIFF
--- a/recipes/nextgenmap/meta.yaml
+++ b/recipes/nextgenmap/meta.yaml
@@ -10,13 +10,14 @@ source:
   sha256: '{{sha256}}'
 
 build:
-  number: 2
+  number: 3
 
 requirements:
   build:
     - {{ compiler('cxx') }}
     - cmake
   run:
+    - binutils
 
 test:
   commands:


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Without an assembler installed, NGM fails with a 'program build error' when
JIT compiling the OpenCL code. Discovered when trying to run NextGenMap in
a miniconda docker container which does not have the binutils installed.