### PR TITLE
Fix segmentation fault in bioconductor-dada2 1.8.0

### DIFF
--- a/recipes/bioconductor-dada2/1.8.0/build.sh
+++ b/recipes/bioconductor-dada2/1.8.0/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+mv DESCRIPTION DESCRIPTION.old
+grep -v '^Priority: ' DESCRIPTION.old > DESCRIPTION
+mkdir -p ~/.R
+echo -e "CC=$CC
+FC=$FC
+CXX=$CXX
+CXX98=$CXX
+CXX11=$CXX
+CXX14=$CXX" > ~/.R/Makevars
+$R CMD INSTALL --build .

--- a/recipes/bioconductor-dada2/1.8.0/meta.yaml
+++ b/recipes/bioconductor-dada2/1.8.0/meta.yaml
@@ -1,0 +1,59 @@
+{% set version = "1.8.0" %}
+{% set name = "dada2" %}
+{% set bioc = "3.7" %}
+
+package:
+  name: 'bioconductor-{{ name|lower }}'
+  version: '{{ version }}'
+source:
+  url:
+    - 'http://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/{{ name }}_{{ version }}.tar.gz'
+    - 'https://bioarchive.galaxyproject.org/{{ name }}_{{ version }}.tar.gz'
+    - 'https://depot.galaxyproject.org/software/bioconductor-{{ name }}/bioconductor-{{ name }}_{{ version }}_src_all.tar.gz'
+  sha256: 0444f3cbe52037a25d80052f081e2e7c4ad2167faab76d1b3d3f036186e3d824
+build:
+  number: 1
+  rpaths:
+    - lib/R/lib/
+    - lib/
+requirements:
+  host:
+    - 'bioconductor-biocgenerics >=0.26.0,<0.28.0'
+    - 'bioconductor-biostrings >=2.48.0,<2.50.0'
+    - 'bioconductor-iranges >=2.14.12,<2.16.0'
+    - 'bioconductor-shortread >=1.38.0,<1.40.0'
+    - 'bioconductor-xvector >=0.20.0,<0.22.0'
+    - r-base
+    - 'r-data.table >=1.9.4'
+    - 'r-ggplot2 >=2.1.0'
+    - 'r-rcpp >=0.11.2'
+    - 'r-rcppparallel >=4.3.0'
+    - 'r-reshape2 >=1.4.1'
+    - libgcc-ng =7.2.0
+  run:
+    - 'bioconductor-biocgenerics >=0.26.0,<0.28.0'
+    - 'bioconductor-biostrings >=2.48.0,<2.50.0'
+    - 'bioconductor-iranges >=2.14.12,<2.16.0'
+    - 'bioconductor-shortread >=1.38.0,<1.40.0'
+    - 'bioconductor-xvector >=0.20.0,<0.22.0'
+    - r-base
+    - 'r-data.table >=1.9.4'
+    - 'r-ggplot2 >=2.1.0'
+    - 'r-rcpp >=0.11.2'
+    - 'r-rcppparallel >=4.3.0'
+    - 'r-reshape2 >=1.4.1'
+    - libgcc-ng =7.2.0
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - make
+test:
+  commands:
+    - '$R -e "library(''{{ name }}'')"'
+about:
+  home: 'http://bioconductor.org/packages/{{ bioc }}/bioc/html/{{ name }}.html'
+  license: LGPL-3
+  summary: 'The dada2 package infers exact amplicon sequence variants (ASVs) from high-throughput amplicon sequencing data, replacing the coarser and less accurate OTU clustering approach. The dada2 pipeline takes as input demultiplexed fastq files, and outputs the sequence variants and their sample-wise abundances after removing substitution and chimera errors. Taxonomic classification is available via a native implementation of the RDP naive Bayesian classifier, and genus-species assignment by exact matching.'
+extra:
+  identifiers:
+    - biotools:dada2

--- a/recipes/bioconductor-dada2/1.8.0/meta.yaml
+++ b/recipes/bioconductor-dada2/1.8.0/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - 'r-rcpp >=0.11.2'
     - 'r-rcppparallel >=4.3.0'
     - 'r-reshape2 >=1.4.1'
-    - libgcc-ng =7.2.0
+    - libgcc-ng ==7.2.0
   run:
     - 'bioconductor-biocgenerics >=0.26.0,<0.28.0'
     - 'bioconductor-biostrings >=2.48.0,<2.50.0'
@@ -42,7 +42,7 @@ requirements:
     - 'r-rcpp >=0.11.2'
     - 'r-rcppparallel >=4.3.0'
     - 'r-reshape2 >=1.4.1'
-    - libgcc-ng =7.2.0
+    - libgcc-ng ==7.2.0
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

Currently, both the `1.10.0` and `1.8.0` versions of `bioconductor-dada2` bugs that cause a segmentation fault. While there's no *known* simple solution for the `1.10.0` version, `1.8.0` can be fixed installing `libgcc-ng ==7.2.0`.

This PR adds `libgcc-ng` as a dependency for the `1.8.0` version.