### PR TITLE
Update cd-hit to newest version and fix GCC7 issues

### DIFF
--- a/recipes/cd-hit/build.sh
+++ b/recipes/cd-hit/build.sh
@@ -5,6 +5,7 @@ export CPPFLAGS="-I$PREFIX/include"
 export CXXFLAGS="-I$PREFIX/include"
 export LDFLAGS="-L$PREFIX/lib"
 
+sed -i.bak 's/^CC =$//g' Makefile
 
 #cat > test-openmp.cc <<END
 #include <omp.h>
@@ -17,7 +18,7 @@ else
   OPENMP_SUPPORTED=no
 fi
 
-make -e openmp=$OPENMP_SUPPORTED
+make openmp=$OPENMP_SUPPORTED
 
 mkdir -p $PREFIX/bin
 make install PREFIX=$PREFIX/bin

--- a/recipes/cd-hit/build.sh
+++ b/recipes/cd-hit/build.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 
 export CFLAGS="-I$PREFIX/include"
+export CPPFLAGS="-I$PREFIX/include"
+export CXXFLAGS="-I$PREFIX/include"
 export LDFLAGS="-L$PREFIX/lib"
 
 
@@ -15,7 +17,7 @@ else
   OPENMP_SUPPORTED=no
 fi
 
-make openmp=$OPENMP_SUPPORTED
+make -e openmp=$OPENMP_SUPPORTED
 
 mkdir -p $PREFIX/bin
 make install PREFIX=$PREFIX/bin

--- a/recipes/cd-hit/build.sh
+++ b/recipes/cd-hit/build.sh
@@ -4,9 +4,9 @@ export CFLAGS="-I$PREFIX/include"
 export LDFLAGS="-L$PREFIX/lib"
 
 
-cat > test-openmp.cc <<END
+#cat > test-openmp.cc <<END
 #include <omp.h>
-END
+#END
 
 if g++ -o /dev/null -c test-openmp.cc 2>/dev/null
 then

--- a/recipes/cd-hit/meta.yaml
+++ b/recipes/cd-hit/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "4.6.8" %}
-{% set sha256 = "37d685e4aa849314401805fe4d4db707e1d06070368475e313d6f3cb8fb65949" %}
+{% set version = "4.8.1" %}
+{% set sha256 = "26172dba3040d1ae5c73ff0ac6c3be8c8e60cc49fc7379e434cdf9cb1e7415de" %}
 
 package:
   name: cd-hit
@@ -10,7 +10,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 2
+  number: 0
 
 requirements:
   build:

--- a/recipes/cd-hit/meta.yaml
+++ b/recipes/cd-hit/meta.yaml
@@ -17,7 +17,7 @@ requirements:
     - {{ compiler('cxx') }}
     - {{ compiler('c') }}
   host:
-    
+    - zlib    
   run:
 test:
   commands:

--- a/recipes/cd-hit/meta.yaml
+++ b/recipes/cd-hit/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "4.8.1" %}
-{% set sha256 = "26172dba3040d1ae5c73ff0ac6c3be8c8e60cc49fc7379e434cdf9cb1e7415de" %}
+{% set sha256 = "f8bc3cdd7aebb432fcd35eed0093e7a6413f1e36bbd2a837ebc06e57cdb20b70" %}
 
 package:
   name: cd-hit

--- a/recipes/cd-hit/meta.yaml
+++ b/recipes/cd-hit/meta.yaml
@@ -17,7 +17,6 @@ requirements:
     - {{ compiler('cxx') }}
     - {{ compiler('c') }}
   host:
-    - zlib    
   run:
 test:
   commands:

--- a/recipes/cd-hit/meta.yaml
+++ b/recipes/cd-hit/meta.yaml
@@ -17,6 +17,7 @@ requirements:
     - {{ compiler('cxx') }}
     - {{ compiler('c') }}
   host:
+    - zlib
   run:
 test:
   commands:


### PR DESCRIPTION
:information_source:
Bioconda has finished the [GCC7 migration](https://github.com/bioconda/bioconda-recipes/issues/13578). If you are dealing with C/C++ or Python package it can be that you need to rebuild other dependent packages. [Bioconda utils - update-pinning](https://bioconda.github.io/updating.html#updating-recipes-for-a-pinning-change) will assist you with that. If you have any questions please use [issue 13578](https://github.com/bioconda/bioconda-recipes/issues/13578).

----------------

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
