### PR TITLE
Compile mccortex for extra kmer sizes

### DIFF
--- a/recipes/mccortex/build.sh
+++ b/recipes/mccortex/build.sh
@@ -13,6 +13,8 @@ done
 # 
 make MAXK=31
 make MAXK=63
+make MAXK=95
+make MAXK=127
 
 sed -i.bak '1 s|^.*$|#!/usr/bin/env bash|g' bin/mccortex && rm bin/mccortex.bak
 

--- a/recipes/mccortex/meta.yaml
+++ b/recipes/mccortex/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 1
+  number: 2
 
 source:
   url: https://github.com/mcveanlab/mccortex/releases/download/mccortex-{{ version }}/mccortex{{ version_uscore }}.tar.gz

--- a/recipes/mccortex/run_test.sh
+++ b/recipes/mccortex/run_test.sh
@@ -10,4 +10,6 @@ mccortex 31 build -k 5 --sample test_sample -1 test.fa test.ctx > /dev/null
 set +o pipefail
 mccortex 31 2>&1 | grep -F 'usage: mccortex31 <command> [options] <args>' > /dev/null
 mccortex 63 2>&1 | grep -F 'usage: mccortex63 <command> [options] <args>' > /dev/null
+mccortex 95 2>&1 | grep -F 'usage: mccortex95 <command> [options] <args>' > /dev/null
+mccortex 127 2>&1 | grep -F 'usage: mccortex127 <command> [options] <args>' > /dev/null
 set -o pipefail


### PR DESCRIPTION
:information_source:
Bioconda has finished the [GCC7 migration](https://github.com/bioconda/bioconda-recipes/issues/13578). If you are dealing with C/C++ or Python package it can be that you need to rebuild other dependent packages. [Bioconda utils - update-pinning](https://bioconda.github.io/updating.html#updating-recipes-for-a-pinning-change) will assist you with that. If you have any questions please use [issue 13578](https://github.com/bioconda/bioconda-recipes/issues/13578).

----------------

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
