### PR TITLE
samtools: pin openssl < 1.1

### DIFF
--- a/recipes/samtools/meta.yaml
+++ b/recipes/samtools/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 6
+  number: 7
 
 source:
   url: https://github.com/samtools/samtools/releases/download/{{ version }}/samtools-1.9.tar.bz2
@@ -15,7 +15,7 @@ requirements:
   build:
     - {{ compiler('c') }}
   host:
-    - openssl
+    - openssl <1.1
     - ncurses
     - zlib
     - bzip2


### PR DESCRIPTION
Another attempt to fix the severe brokenness of bioconda. This is really
driving me crazy.

See 7985452cbb25dc68fdeb033ed53105cc48ae8c0e

and experiments in pb-falcon and pb-assembly

:information_source:
Bioconda has finished the [GCC7 migration](https://github.com/bioconda/bioconda-recipes/issues/13578). If you are dealing with C/C++ or Python package it can be that you need to rebuild other dependent packages. [Bioconda utils - update-pinning](https://bioconda.github.io/updating.html#updating-recipes-for-a-pinning-change) will assist you with that. If you have any questions please use [issue 13578](https://github.com/bioconda/bioconda-recipes/issues/13578).

----------------

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
