### PR TITLE
Retry motus 2.1.0 due to CI failure after merge

### DIFF
--- a/recipes/motus/meta.yaml
+++ b/recipes/motus/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: '{{ sha256 }}'
 
 build:
-  number: 1
+  number: 2
   # motus requires python3
   skip: True # [not py3k]
 


### PR DESCRIPTION
Original pull request is #13885 and there's doesn't seem to be a reason for this failure.

Retrying by increasing the build number.

----------------

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
