### PR TITLE
Adding recipe for fit_nbinom

### DIFF
--- a/recipes/fit_nbinom/meta.yaml
+++ b/recipes/fit_nbinom/meta.yaml
@@ -1,9 +1,10 @@
+{% set version = "1.0" %}
 package:
   name: fit_nbinom
-  version: '1.0'
+  version: '{{ version }}'
 
 source:
-  url: https://github.com/joachimwolff/fit_nbinom/archive/{{ version }}.tar.gz
+  url: 'https://github.com/joachimwolff/fit_nbinom/archive/{{ version }}.tar.gz'
   sha256: b6090d1ee2bc8a63f273572655c65ca6e5e11e94580a990b007885b4f0371dea
 
 build:

--- a/recipes/fit_nbinom/meta.yaml
+++ b/recipes/fit_nbinom/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: '1.0'
 
 source:
-  url: hhttps://github.com/joachimwolff/fit_nbinom/archive/{{ version }}.tar.gz
+  url: https://github.com/joachimwolff/fit_nbinom/archive/{{ version }}.tar.gz
   sha256: b6090d1ee2bc8a63f273572655c65ca6e5e11e94580a990b007885b4f0371dea
 
 build:

--- a/recipes/fit_nbinom/meta.yaml
+++ b/recipes/fit_nbinom/meta.yaml
@@ -3,12 +3,12 @@ package:
   version: '1.0'
 
 source:
-  url: hhttps://github.com/joachimwolff/fit_nbinom/archive/1.0.tar.gz
+  url: hhttps://github.com/joachimwolff/fit_nbinom/archive/{{ version }}.tar.gz
   sha256: b6090d1ee2bc8a63f273572655c65ca6e5e11e94580a990b007885b4f0371dea
 
 build:
   number: 0
-  script: "python setup.py install"
+  script: "python -m pip install --no-deps --ignore-installed ."
   noarch: python
 
 requirements:

--- a/recipes/fit_nbinom/meta.yaml
+++ b/recipes/fit_nbinom/meta.yaml
@@ -1,0 +1,31 @@
+package:
+  name: fit_nbinom
+  version: '1.0'
+
+source:
+  url: hhttps://github.com/joachimwolff/fit_nbinom/archive/1.0.tar.gz
+  sha256: b6090d1ee2bc8a63f273572655c65ca6e5e11e94580a990b007885b4f0371dea
+
+build:
+  number: 0
+  script: "python setup.py install"
+  noarch: python
+
+requirements:
+  host:
+    - python <3.7
+  run:
+    - python <3.7
+    - numpy >=1.15
+    - scipy
+
+test:
+  imports:
+    - fit_nbinom
+
+about:
+  home: https://github.com/joachimwolff/fit_nbinom/
+  license: GPL3
+  summary: Script to fit negative binomial distributions via maximum likelihood estimation.
+
+


### PR DESCRIPTION
:information_source:
Bioconda has finished the [GCC7 migration](https://github.com/bioconda/bioconda-recipes/issues/13578). If you are dealing with C/C++ or Python package it can be that you need to rebuild other dependent packages. [Bioconda utils - update-pinning](https://bioconda.github.io/updating.html#updating-recipes-for-a-pinning-change) will assist you with that. If you have any questions please use [issue 13578](https://github.com/bioconda/bioconda-recipes/issues/13578).

----------------

* [ ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

This PR adds a conda package to enable the fitting of negative binomial distributions via a maximum likelihood estimator. This feature is missing in scipy.