### PR TITLE
Update to version 2.1.1

### DIFF
--- a/recipes/motus/meta.yaml
+++ b/recipes/motus/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "2.1.0" %}
-{% set sha256 = "df07ced0cde59a2223d6caa7fd718838809e304ce778ad403d87a6312853d67c" %}
+{% set version = "2.1.1" %}
+{% set sha256 = "acefbfff1ee9b59e5668a3b95ada87ce0fecd2db8961f8d2c0e0ea79e6c21787" %}
 
 package:
   name: motus
@@ -10,7 +10,7 @@ source:
   sha256: '{{ sha256 }}'
 
 build:
-  number: 2
+  number: 1
   # motus requires python3
   skip: True # [not py3k]
 
@@ -18,14 +18,16 @@ requirements:
   host:
     - python
   run:
-    - metasnv
+    - metasnv=1.0.3
     - samtools
     - bwa
     - python
+    # samtools requires openssl=1.0 to run
+    - openssl=1.0
 
 test:
   commands:
-    - motus --version
+    - motus profile --test
 
 about:
   home: http://motu-tool.org/


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

This update does two things:

1.  Update the recepe with a new version
2.  Try to solve the problem with samtools mentioned in https://github.com/bioconda/bioconda-recipes/issues/12100. In the samtools recipe ([link](https://github.com/bioconda/bioconda-recipes/blob/e53d407b6ce688974659b88bdc501f48c260cad8/recipes/samtools/meta.yaml)) it's required `openssl <1.1` for `host`, but not for `run`. As a result, during run `openssl 1.1` is used, and samtools is not working. To solve this we:
- add `openssl=1.0` to our recipe in the `run` section
- change the test section, where we run a script that test if samtools is properly installed.
