### PR TITLE
samtools: Use same openssl for host and run

### DIFF
--- a/recipes/samtools/meta.yaml
+++ b/recipes/samtools/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 7
+  number: 8
 
 source:
   url: https://github.com/samtools/samtools/releases/download/{{ version }}/samtools-1.9.tar.bz2
@@ -23,7 +23,7 @@ requirements:
     - xz
     - libdeflate
   run:
-    - openssl
+    - openssl <1.1
     - ncurses
     - zlib
     - bzip2


### PR DESCRIPTION
Not pinning openssl for runtime sometimes caused openssl-1.1 to be installed breaking samtools

Related to #12100 and #13903

:information_source: :
Bioconda has finished the [GCC7 migration](https://github.com/bioconda/bioconda-recipes/issues/13578). If you are dealing with C/C++ or Python package it can be that you need to rebuild other dependent packages. [Bioconda utils - update-pinning](https://bioconda.github.io/updating.html#updating-recipes-for-a-pinning-change) will assist you with that. If you have any questions please use [issue 13578](https://github.com/bioconda/bioconda-recipes/issues/13578).

----------------

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
