### PR TITLE
Releasing digestiflow-cli v0.5.1

### DIFF
--- a/recipes/digestiflow-cli/meta.yaml
+++ b/recipes/digestiflow-cli/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "0.5.0" %}
-{% set sha256 = "747ee3c2eb6b812637b693950b60b28b2b64260690c6157973898b445017c850" %}
+{% set version = "0.5.1" %}
+{% set sha256 = "67c74971b9934811002fbb8b7cc73a181bc690290348f66395936ce2010d433d" %}
 
 package:
   name: digestiflow-cli


### PR DESCRIPTION
:information_source:
Bioconda has finished the [GCC7 migration](https://github.com/bioconda/bioconda-recipes/issues/13578). If you are dealing with C/C++ or Python package it can be that you need to rebuild other dependent packages. [Bioconda utils - update-pinning](https://bioconda.github.io/updating.html#updating-recipes-for-a-pinning-change) will assist you with that. If you have any questions please use [issue 13578](https://github.com/bioconda/bioconda-recipes/issues/13578).

----------------

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
