### PR TITLE
Bump shmlast build num and remove pytest version restriction

### DIFF
--- a/recipes/shmlast/meta.yaml
+++ b/recipes/shmlast/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 916005206da93afc4ffdf96082cd76d33cfca3fc9ba867d63deaa452af9aa881
 
 build:
-  number: 1
+  number: 2
   noarch: python
   script: python -m pip install --no-deps --ignore-installed .
 
@@ -28,7 +28,7 @@ requirements:
     - scipy >=0.16.0
     - screed >=0.9
     - seaborn >=0.6.0
-    - pytest <4
+    - pytest
     - pytest-benchmark
     - pytest-runner
     - filelock >=2.0.6


### PR DESCRIPTION
:information_source:
Bioconda has finished the [GCC7 migration](https://github.com/bioconda/bioconda-recipes/issues/13578). If you are dealing with C/C++ or Python package it can be that you need to rebuild other dependent packages. [Bioconda utils - update-pinning](https://bioconda.github.io/updating.html#updating-recipes-for-a-pinning-change) will assist you with that. If you have any questions please use [issue 13578](https://github.com/bioconda/bioconda-recipes/issues/13578).

----------------

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
