### PR TITLE
Added building lastz_32 to lastz recipe. 

### DIFF
--- a/recipes/lastz/build.sh
+++ b/recipes/lastz/build.sh
@@ -2,10 +2,13 @@
 
 mkdir -p $PREFIX/bin
 
-make 
+make
+make lastz_32
 
-chmod +x  src/lastz
-chmod +x  src/lastz_D
+chmod +x src/lastz
+chmod +x src/lastz_D
+chmod +x src/lastz_32
 
 mv src/lastz $PREFIX/bin
 mv src/lastz_D $PREFIX/bin
+mv src/lastz_32 $PREFIX/bin

--- a/recipes/lastz/build.sh
+++ b/recipes/lastz/build.sh
@@ -2,7 +2,9 @@
 
 mkdir -p $PREFIX/bin
 
+# Build lastz and lastz_D (lastz_D uses floating-point scores
 make
+# Build lastz_32, which uses 32-bit positions index and can handle genomes larger than 2Gb
 make lastz_32
 
 chmod +x src/lastz

--- a/recipes/lastz/meta.yaml
+++ b/recipes/lastz/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: "1.0.4"
 
 build:
-  number: 2
+  number: 3
 
 source:
   url: http://www.bx.psu.edu/~rsharris/lastz/lastz-1.04.00.tar.gz


### PR DESCRIPTION
Update to lastz recipe to also build the binary 'lastz_32'.
This binary is used to handle genomes bigger than 2Gb.
This is my first recipe @bioconda/core 

:information_source:
Bioconda has finished the [GCC7 migration](https://github.com/bioconda/bioconda-recipes/issues/13578). If you are dealing with C/C++ or Python package it can be that you need to rebuild other dependent packages. [Bioconda utils - update-pinning](https://bioconda.github.io/updating.html#updating-recipes-for-a-pinning-change) will assist you with that. If you have any questions please use [issue 13578](https://github.com/bioconda/bioconda-recipes/issues/13578).

----------------

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
