### PR TITLE
Remove openssl=1.0 pinning in motus

### DIFF
--- a/recipes/motus/meta.yaml
+++ b/recipes/motus/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: '{{ sha256 }}'
 
 build:
-  number: 1
+  number: 2
   # motus requires python3
   skip: True # [not py3k]
 
@@ -22,8 +22,6 @@ requirements:
     - samtools
     - bwa
     - python
-    # samtools requires openssl=1.0 to run
-    - openssl=1.0
 
 test:
   commands:

--- a/recipes/motus/post-link.sh
+++ b/recipes/motus/post-link.sh
@@ -1,12 +1,11 @@
 #!/usr/bin/env bash
 
-echo "Downloading mOTUs-v2 database"
+echo ">>> post-link: Downloading mOTUs-v2 database"
 
 # In build.sh we keep the tool files in a custom location
 pkgdir=$PREFIX/share/motus-${PKG_VERSION}/
 
+echo ">>> post-link: Running motus setup.py"
+
 # mOTUs-v2 requires a ~1GB download which is performed by the setup.py script
 python "$pkgdir/setup.py"
-
-# After install check that everything is available and working as expected
-python "$pkgdir/test.py"


### PR DESCRIPTION
This is unnecessary now that samtools was updated to build against openssl-1.1

:information_source:
Bioconda has finished the [GCC7 migration](https://github.com/bioconda/bioconda-recipes/issues/13578). If you are dealing with C/C++ or Python package it can be that you need to rebuild other dependent packages. [Bioconda utils - update-pinning](https://bioconda.github.io/updating.html#updating-recipes-for-a-pinning-change) will assist you with that. If you have any questions please use [issue 13578](https://github.com/bioconda/bioconda-recipes/issues/13578).

----------------

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
