### PR TITLE
Rebuild nanopolish for openssl 1.1

### DIFF
--- a/recipes/nanopolish/meta.yaml
+++ b/recipes/nanopolish/meta.yaml
@@ -16,7 +16,8 @@ source:
 
 requirements:
   build:
-    - {{ compiler('cxx') }}
+    - {{ compiler('cxx') }}  # [linux64]
+    - gcc                    # [osx]
   host:
     - fast5 ==0.6.5
     - htslib >1.4

--- a/recipes/nanopolish/meta.yaml
+++ b/recipes/nanopolish/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 0
+  number: 1
 
 source:
   url: https://github.com/jts/nanopolish/archive/v{{ version }}.tar.gz

--- a/recipes/nanopolish/meta.yaml
+++ b/recipes/nanopolish/meta.yaml
@@ -19,8 +19,8 @@ requirements:
     - {{ compiler('cxx') }}  # [linux64]
     - gcc                    # [osx]
   host:
-    - fast5 ==0.6.5
-    - htslib >1.4
+    - fast5 0.6.5
+    - htslib
     - hdf5
     - eigen
     - ncurses

--- a/recipes/nanopolish/meta.yaml
+++ b/recipes/nanopolish/meta.yaml
@@ -16,7 +16,7 @@ source:
 
 requirements:
   build:
-    - gcc
+    - {{ compiler('cxx') }}
   host:
     - fast5 ==0.6.5
     - htslib >1.4


### PR DESCRIPTION
:information_source:
Bioconda has finished the [GCC7 migration](https://github.com/bioconda/bioconda-recipes/issues/13578). If you are dealing with C/C++ or Python package it can be that you need to rebuild other dependent packages. [Bioconda utils - update-pinning](https://bioconda.github.io/updating.html#updating-recipes-for-a-pinning-change) will assist you with that. If you have any questions please use [issue 13578](https://github.com/bioconda/bioconda-recipes/issues/13578).

----------------

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

Trigger rebuild for `openssl 1.1` pinning.