### PR TITLE
update seqcluster

### DIFF
--- a/recipes/seqcluster/meta.yaml
+++ b/recipes/seqcluster/meta.yaml
@@ -1,4 +1,4 @@
-{% set tag="fa804cb" %}
+{% set tag="fd0a6c6" %}
 
 about:
   home: https://github.com/lpantano/seqclsuter
@@ -7,13 +7,13 @@ about:
 
 package:
   name: seqcluster
-  version: '1.2.4a14'
+  version: '1.2.4a15'
 
 source:
   url: https://github.com/lpantano/seqcluster/archive/{{ tag  }}.tar.gz
-  sha256: 6d265ad44e341c662021a58f691f2dafc62550c79d212ef8bc677ec9c84d13f3
+  sha256: 7703f13d5df7b3e96d479acf53415b22259b23ef956cc41e976831f7f6296c7a
 build:
-  number: 2
+  number: 0
 
 requirements:
   host:


### PR DESCRIPTION
more workaround to get it working on py3. Issues with map function no longer returning a list in py3.

:information_source:
Bioconda has finished the [GCC7 migration](https://github.com/bioconda/bioconda-recipes/issues/13578). If you are dealing with C/C++ or Python package it can be that you need to rebuild other dependent packages. [Bioconda utils - update-pinning](https://bioconda.github.io/updating.html#updating-recipes-for-a-pinning-change) will assist you with that. If you have any questions please use [issue 13578](https://github.com/bioconda/bioconda-recipes/issues/13578).

----------------

* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [X] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
