### PR TITLE
Fix version support for Python2.7

### DIFF
--- a/recipes/deepbgc/meta.yaml
+++ b/recipes/deepbgc/meta.yaml
@@ -19,7 +19,7 @@ build:
 
 requirements:
   host:
-    - python >=3
+    - python>=2.7, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*
     - setuptools
     - biopython>=1.70 # support for structured comments from version 1.70
     - scikit-learn>=0.18.2 # needed for antiSMASH compatibility
@@ -33,7 +33,7 @@ requirements:
     - pytest-mock>=1.10.1
     - appdirs>=1.4.3
   run:
-    - python >=3
+    - python>=2.7, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*
     - biopython>=1.70 # support for structured comments from version 1.70
     - scikit-learn>=0.18.2 # needed for antiSMASH compatibility
     - pandas>=0.24.1


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Fix for #14007

@dpryan79 Can you please take a look at this fix for the DeepBGC module? It turns out the original python version specification was correct, specifying `python >=2.7, >3` will only accept version `>3`. 

Is it possible to fix this for version 0.1.3 or do we have to do a new version? 

Thanks!


