### PR TITLE
Update openssl dependency

### DIFF
--- a/recipes/hyphy/2.3.11/meta.yaml
+++ b/recipes/hyphy/2.3.11/meta.yaml
@@ -25,7 +25,7 @@ requirements:
   run:
     - openmpi
     - curl
-    - openssl=1.0.*
+    - openssl
 
 test:
   commands:

--- a/recipes/hyphy/2.3.11/meta.yaml
+++ b/recipes/hyphy/2.3.11/meta.yaml
@@ -12,7 +12,7 @@ source:
     - CMakeLists.txt.patch
 
 build:
-  number: 0
+  number: 1
   skip: true # [osx]
 
 requirements:


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [x] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).

I'm not positive why it changed, but now `$PREFIX/bin/HYPHYMPI` gets dynamically linked against `libcrypto.so.1.1`, which is found in `openssl=1.1.1`

