### PR TITLE
add recipe for chorus2

### DIFF
--- a/recipes/chorus2/meta.yaml
+++ b/recipes/chorus2/meta.yaml
@@ -1,0 +1,43 @@
+{% set version = "2.0" %}
+
+package:
+  name: Chorus2
+  version: {{ version }}
+
+source:
+  url: https://github.com/zhangtaolab/Chorus2/archive/2.0.tar.gz
+  sha256: 4d350d38b4e8d5a04e1ca92d20744a052432d5ff9b269b31c7323155fb5e1cb2
+
+build:
+  number: 0
+  noarch: python
+  script: "{{ PYTHON }} -m pip install . --no-deps -v"
+
+requirements:
+  host:
+    - python >=3
+    - setuptools
+    - pip
+  run:
+    - Cython
+    - python >=3
+    - pyBigWig
+    - numpy
+    - pyfasta
+    - pandas
+    - primer3-py >=0.4.2
+    - jellyfish >=2.2.3
+    - bwa >=0.7.15
+
+test:
+  imports:
+    - Choruslib
+
+  commands:
+    - Chorus2 --version
+
+about:
+  home: https://github.com/zhangtaolab/Chorus2
+  summary: A pipeline to select oligonucleotides for fluorescence in situ hbridization (Oligo-FISH).
+  dev_url: https://github.com/zhangtaolab/Chorus2
+  doc_url: https://chorus2.readthedocs.io/en/dev/

--- a/recipes/chorus2/meta.yaml
+++ b/recipes/chorus2/meta.yaml
@@ -1,7 +1,7 @@
 {% set version = "2.0" %}
 
 package:
-  name: Chorus2
+  name: chorus2
   version: {{ version }}
 
 source:

--- a/recipes/chorus2/meta.yaml
+++ b/recipes/chorus2/meta.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/zhangtaolab/Chorus2/archive/2.0.tar.gz
-  sha256: 4d350d38b4e8d5a04e1ca92d20744a052432d5ff9b269b31c7323155fb5e1cb2
+  sha256: 983ea3d1ae68cd0adc53cfd8b9f644d945e555f2bccff07a57acbde7e7e5fb17
 
 build:
   number: 0
@@ -39,5 +39,10 @@ test:
 about:
   home: https://github.com/zhangtaolab/Chorus2
   summary: A pipeline to select oligonucleotides for fluorescence in situ hbridization (Oligo-FISH).
+  license: MIT license
   dev_url: https://github.com/zhangtaolab/Chorus2
   doc_url: https://chorus2.readthedocs.io/en/dev/
+
+extra:
+  identifiers:
+    - biotools:chorus2


### PR DESCRIPTION
:information_source:
Bioconda has finished the [GCC7 migration](https://github.com/bioconda/bioconda-recipes/issues/13578). If you are dealing with C/C++ or Python package it can be that you need to rebuild other dependent packages. [Bioconda utils - update-pinning](https://bioconda.github.io/updating.html#updating-recipes-for-a-pinning-change) will assist you with that. If you have any questions please use [issue 13578](https://github.com/bioconda/bioconda-recipes/issues/13578).

----------------

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [x] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Chorus2 is a pipeline to select oligonucleotides for fluorescence in situ hybridization (Oligo-FISH). It can genome-widely design and select probes for FISH in plant and animal species. 