### PR TITLE
Relax version requirement of bioconductor-dropletutils to <1.3

### DIFF
--- a/recipes/dropletutils-scripts/meta.yaml
+++ b/recipes/dropletutils-scripts/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 4c042d559b6371a8f86dc87db7098b9b3a78d747e272cd46ddd9f89aca19ce4e
 
 build:
-  number: 0
+  number: 1
   noarch: generic
 
 requirements:
@@ -17,7 +17,7 @@ requirements:
         - r-base 3.5.1
         - bioconductor-biobase
         - bioconductor-singlecellexperiment
-        - bioconductor-dropletutils 1.0.3
+        - bioconductor-dropletutils >=1.0.3,<1.3
         - r-optparse
         - r-workflowscriptscommon
 


### PR DESCRIPTION
:information_source:
Bioconda has finished the [GCC7 migration](https://github.com/bioconda/bioconda-recipes/issues/13578). If you are dealing with C/C++ or Python package it can be that you need to rebuild other dependent packages. [Bioconda utils - update-pinning](https://bioconda.github.io/updating.html#updating-recipes-for-a-pinning-change) will assist you with that. If you have any questions please use [issue 13578](https://github.com/bioconda/bioconda-recipes/issues/13578).

----------------

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
