### PR TITLE
remove fwdpy11 from blacklist

### DIFF
--- a/build-fail-blacklist
+++ b/build-fail-blacklist
@@ -536,9 +536,6 @@ recipes/flexbar/3.3.0
 # Error: Could not find or load main class edu.duke.igsp.gkde.Main
 recipes/fseq
 
-# compiler error
-recipes/fwdpy11
-
 # node error
 recipes/azure-cli
 recipes/arvados-cli

--- a/recipes/fwdpy11/build.sh
+++ b/recipes/fwdpy11/build.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 
-$PYTHON setup.py install --gcc
+# cmake's "find GSL macro" can barf when conda
+# envs are involved, so we use GSL_ROOT_DIR to 
+# fix that:
+GSL_ROOT_DIR=$PREFIX $PYTHON setup.py install 

--- a/recipes/fwdpy11/build.sh
+++ b/recipes/fwdpy11/build.sh
@@ -3,4 +3,4 @@
 # cmake's "find GSL macro" can barf when conda
 # envs are involved, so we use GSL_ROOT_DIR to 
 # fix that:
-GSL_ROOT_DIR=$PREFIX $PYTHON setup.py install 
+GSL_ROOT_DIR=$PREFIX $PYTHON -m pip install . --no-deps --ignore-installed -vv

--- a/recipes/fwdpy11/meta.yaml
+++ b/recipes/fwdpy11/meta.yaml
@@ -7,29 +7,26 @@ source:
   sha256: 85ea4f233dbb0ca273242b018e3e804fa5f017372a799ade937d12522b379eec
 
 build:
-  skip: True # [not py36]
+  skip: True # [py27 or py==37]
   number: 0
 
 requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - cmak
   host:
+    - pkgconfig
     - python
-    - numpy
-    - pybind11 >=2.2.2
+    - numpy >=1.10
+    - pybind11 >=2.2.4
     - gsl
     - openblas
-    - cmake
-    - msprime >=0.7.0
-    - svgwrite
   run:
     - python
-    - numpy
+    - numpy >= 1.10
     - gsl
     - openblas
-    - svgwrite
-    - tskit >=0.1.4
 
 test:
   # Python imports

--- a/recipes/fwdpy11/meta.yaml
+++ b/recipes/fwdpy11/meta.yaml
@@ -8,7 +8,7 @@ source:
 
 build:
   skip: True # [py27]
-  number: 3
+  number: 1
 
 requirements:
   build:
@@ -20,11 +20,13 @@ requirements:
     - pybind11 >=2.2.2
     - gsl
     - openblas
+    - cmake
   run:
     - python
     - numpy >=1.10
     - gsl
     - openblas
+    - tskit >=0.1.4
 
 test:
   # Python imports

--- a/recipes/fwdpy11/meta.yaml
+++ b/recipes/fwdpy11/meta.yaml
@@ -14,7 +14,7 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - cmak
+    - cmake
   host:
     - pkgconfig
     - python

--- a/recipes/fwdpy11/meta.yaml
+++ b/recipes/fwdpy11/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - openblas
   run:
     - python
-    - numpy >= 1.10
+    - numpy >=1.10
     - gsl
     - openblas
 

--- a/recipes/fwdpy11/meta.yaml
+++ b/recipes/fwdpy11/meta.yaml
@@ -16,7 +16,7 @@ requirements:
     - {{ compiler('cxx') }}
   host:
     - python
-    - numpy >=1.16
+    - numpy
     - pybind11 >=2.2.2
     - gsl
     - openblas
@@ -25,7 +25,7 @@ requirements:
     - svgwrite
   run:
     - python
-    - numpy >=1.16
+    - numpy
     - gsl
     - openblas
     - tskit >=0.1.4

--- a/recipes/fwdpy11/meta.yaml
+++ b/recipes/fwdpy11/meta.yaml
@@ -7,8 +7,8 @@ source:
   sha256: 85ea4f233dbb0ca273242b018e3e804fa5f017372a799ade937d12522b379eec
 
 build:
-  skip: True # [py27]
-  number: 1
+  skip: True # [not py36]
+  number: 0
 
 requirements:
   build:

--- a/recipes/fwdpy11/meta.yaml
+++ b/recipes/fwdpy11/meta.yaml
@@ -16,14 +16,15 @@ requirements:
     - {{ compiler('cxx') }}
   host:
     - python
-    - numpy >=1.10
+    - numpy >=1.16
     - pybind11 >=2.2.2
     - gsl
     - openblas
     - cmake
+    - msprime >=0.7.0
   run:
     - python
-    - numpy >=1.10
+    - numpy >=1.16
     - gsl
     - openblas
     - tskit >=0.1.4

--- a/recipes/fwdpy11/meta.yaml
+++ b/recipes/fwdpy11/meta.yaml
@@ -8,7 +8,7 @@ source:
 
 build:
   skip: True # [py27 or py==37]
-  number: 0
+  number: 3
 
 requirements:
   build:

--- a/recipes/fwdpy11/meta.yaml
+++ b/recipes/fwdpy11/meta.yaml
@@ -22,6 +22,7 @@ requirements:
     - openblas
     - cmake
     - msprime >=0.7.0
+    - svgwrite
   run:
     - python
     - numpy >=1.16

--- a/recipes/fwdpy11/meta.yaml
+++ b/recipes/fwdpy11/meta.yaml
@@ -28,6 +28,7 @@ requirements:
     - numpy
     - gsl
     - openblas
+    - svgwrite
     - tskit >=0.1.4
 
 test:

--- a/recipes/fwdpy11/meta.yaml
+++ b/recipes/fwdpy11/meta.yaml
@@ -8,7 +8,7 @@ source:
 
 build:
   skip: True # [py27 or py==37]
-  number: 3
+  number: 0
 
 requirements:
   build:


### PR DESCRIPTION
:information_source:
Bioconda has finished the [GCC7 migration](https://github.com/bioconda/bioconda-recipes/issues/13578). If you are dealing with C/C++ or Python package it can be that you need to rebuild other dependent packages. [Bioconda utils - update-pinning](https://bioconda.github.io/updating.html#updating-recipes-for-a-pinning-change) will assist you with that. If you have any questions please use [issue 13578](https://github.com/bioconda/bioconda-recipes/issues/13578).

----------------

* [ ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [X] This PR does something else (explain below).

I am removing fwdpy11 from the blacklist.  I recently update the recipe to 0.2.1, but noticed that it never became available for download b/c it was blacklisted.

Related: should the linting be checking for updates to blacklisted packages and issuing a warning?
