### PR TITLE
Require python to be version 2

### DIFF
--- a/recipes/gat/meta.yaml
+++ b/recipes/gat/meta.yaml
@@ -9,13 +9,13 @@ source:
   md5: c0271d7235eddfdc912afa1ee4b7d278
 
 build:
-  number: 2
+  number: 3
 
 requirements:
   build:
     - {{ compiler('c') }}
   host:
-    - python
+    - python =2
     - zlib
     - setuptools >=1.1
     - cython >=0.19
@@ -24,7 +24,7 @@ requirements:
     - matplotlib >=1.3.0
 
   run:
-    - python
+    - python =2
     - zlib
     - cython >=0.19
     - numpy >=1.7


### PR DESCRIPTION
Previous recipe(s) required python without specifying the version. This
resulted in python3 to be used. However, GAT requires python2 making the
current recipe faulty. Previous tests passed because `gat-run.py -h`
doesn't hit any incompatibility.

:information_source:
Bioconda has finished the [GCC7 migration](https://github.com/bioconda/bioconda-recipes/issues/13578). If you are dealing with C/C++ or Python package it can be that you need to rebuild other dependent packages. [Bioconda utils - update-pinning](https://bioconda.github.io/updating.html#updating-recipes-for-a-pinning-change) will assist you with that. If you have any questions please use [issue 13578](https://github.com/bioconda/bioconda-recipes/issues/13578).

----------------

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
