### PR TITLE
Bump motus build again

### DIFF
--- a/recipes/motus/meta.yaml
+++ b/recipes/motus/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: '{{ sha256 }}'
 
 build:
-  number: 2
+  number: 3
   # motus requires python3
   skip: True # [not py3k]
 


### PR DESCRIPTION
The previous build finished successfully but linting got stuck [in a weird state](https://github.com/bioconda/bioconda-recipes/runs/81038702)
And as consequence we don't yet have motus-2.1.1 in bioconda. 
