### PR TITLE
Remove motus from build-fail-blacklist

### DIFF
--- a/build-fail-blacklist
+++ b/build-fail-blacklist
@@ -16,7 +16,6 @@ recipes/gqt
 recipes/diamond_add_taxonomy
 recipes/cgat-core
 recipes/gmtk
-recipes/motus
 recipes/shapemapper
 recipes/biom-format
 recipes/bioconductor-sictools


### PR DESCRIPTION
motus was blacklisted during the openssl transition.
Removing from blacklist now that things are working again.