### PR TITLE
Updated build number to reflect bugfix in HLA*LA release

### DIFF
--- a/recipes/hla-la/1.0/meta.yaml
+++ b/recipes/hla-la/1.0/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 1
+  number: 2
   skip: true # [osx]
 
 source:

--- a/recipes/hla-la/1.0/meta.yaml
+++ b/recipes/hla-la/1.0/meta.yaml
@@ -10,7 +10,7 @@ build:
 
 source:
   url: https://github.com/DiltheyLab/HLA-LA/archive/v{{ version }}.tar.gz
-  sha256: 68e1398537c09b4ef5ac00eca10343e5a0ede70a29b2cfc9c4feefffa5bde57c
+  sha256: 8f713ee5b806e22ebeb0ae02bc19d28039d01ea7254c8c568fd3754a506f86c1
 
 requirements:
   build:


### PR DESCRIPTION
:information_source:
Bioconda has finished the [GCC7 migration](https://github.com/bioconda/bioconda-recipes/issues/13578). If you are dealing with C/C++ or Python package it can be that you need to rebuild other dependent packages. [Bioconda utils - update-pinning](https://bioconda.github.io/updating.html#updating-recipes-for-a-pinning-change) will assist you with that. If you have any questions please use [issue 13578](https://github.com/bioconda/bioconda-recipes/issues/13578).

----------------

* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [X] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
