### PR TITLE
Bump khmer to 3.0.0a3

### DIFF
--- a/recipes/khmer/meta.yaml
+++ b/recipes/khmer/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "3.0.0a2" %}
-{% set sha256 = "34b0b27f7a36a71862e80a34a7fecfad18d217a64f5e4aeb4297064a98e59bf8" %}
+{% set version = "3.0.0a3" %}
+{% set sha256 = "9ec987442b153d45034755629d702252c3412fa8e3baf7489107a2929d195979" %}
 
 package:
   name: khmer
@@ -10,7 +10,7 @@ source:
   sha256: '{{sha256}}'
 
 build:
-  number: 1
+  number: 0
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 
 requirements:
@@ -20,7 +20,6 @@ requirements:
   host:
     - python >=3
     - pip
-    - pytest-runner >=2.0,<3dev
     - setuptools >=18.0
     - Cython >=0.25.2
   run:


### PR DESCRIPTION
:information_source:
Bioconda has finished the [GCC7 migration](https://github.com/bioconda/bioconda-recipes/issues/13578). If you are dealing with C/C++ or Python package it can be that you need to rebuild other dependent packages. [Bioconda utils - update-pinning](https://bioconda.github.io/updating.html#updating-recipes-for-a-pinning-change) will assist you with that. If you have any questions please use [issue 13578](https://github.com/bioconda/bioconda-recipes/issues/13578).

----------------

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

Removes dependency on pytest-runner