### PR TITLE
Update ngless to v0.11.1

### DIFF
--- a/recipes/ngless/build.sh
+++ b/recipes/ngless/build.sh
@@ -1,20 +1,7 @@
-#!/bin/bash
-
-export LIBRARY_PATH="${PREFIX}/lib:/usr/lib:/usr/lib64"
-export LD_LIBRARY_PATH="${PREFIX}/lib:/usr/lib:/usr/lib64"
-
-export LDFLAGS="-L${PREFIX}/lib"
-export CPPFLAGS="-I${PREFIX}/include"
-export CFLAGS="-I$PREFIX/include"
-export CPATH=${PREFIX}/include
+#!/usr/bin/env bash
 
 
-# stack relies on $HOME, so fake it:
-mkdir -p fake-home
-export HOME=$PWD/fake-home
-export STACK_ROOT="$HOME/.stack"
-stack setup --local-bin-path ${PREFIX}/bin
-make install WGET="wget --no-check-certificate" prefix=$PREFIX
-
-#cleanup
-rm -r .stack-work
+mkdir -p ${PREFIX}/bin
+mv ngless-0.11.1-static-Linux64 ngless
+chmod +x ngless
+mv ngless ${PREFIX}/bin

--- a/recipes/ngless/meta.yaml
+++ b/recipes/ngless/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "ngless" %}
-{% set version = "0.10.0" %}
-{% set md5 = "8cfdf8c1641f1238ecf187d03c0cd335" %}
+{% set version = "0.11.1" %}
+{% set md5 = "6df5604d9043cfd42de1b1c8816a8cb0" %}
 
 package:
   name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://github.com/ngless-toolkit/ngless/archive/v{{ version }}.tar.gz
+  url: https://github.com/ngless-toolkit/ngless/releases/download/v{{ version }}/ngless-{{ version }}-static-Linux64
   md5: {{ md5 }}
 
 build:
@@ -15,26 +15,8 @@ build:
   skip: True  #  [osx]
 
 requirements:
-  build:
-    - {{ compiler('c') }}
-  host:
-    - stack >=1.7.1
-    - cairo
-    - xorg-libxext # [linux]
-    - bzip2
-    - gmp
-    - zlib
-    - perl
-    - wget
-    - xz
   run:
     - python
-    - cairo
-    - xorg-libxext # [linux]
-    - bzip2
-    - gmp
-    - zlib
-    - xz
 
 
 test:
@@ -43,6 +25,6 @@ test:
     - ngless --check-install
 
 about:
-  home: http://ngless.embl.de
+  home: https://ngless.embl.de
   license: MIT
   summary: A tool for metagenomics processing with a focus on metagenomics


### PR DESCRIPTION
This is redistributing the binary, instead of compiling from scratch.

This is far from the ideal solution, but given that there is no
currently-working method to obtain a working recent-enough GHC on the
bioconda build systems, I do not see how else to package NGLess. I note
that stack is also packaged in this fashion.

----------------

* [x] This PR updates an existing recipe.
