### PR TITLE
Fix perl-threaded on OSX

### DIFF
--- a/recipes/perl-threaded/meta.yaml
+++ b/recipes/perl-threaded/meta.yaml
@@ -13,7 +13,7 @@ requirements:
 
 test:
   commands:
-    - perl --help | grep 5.26
+    - perl -v | grep 5.26
 
 about:
   home: http://www.perl.org/

--- a/recipes/perl-threaded/meta.yaml
+++ b/recipes/perl-threaded/meta.yaml
@@ -2,10 +2,10 @@
 
 package:
   name: perl-threaded
-  version: 5.22.0
+  version: 5.26.0
 
 build:
-  number: 13
+  number: 0
 
 requirements:
   run:
@@ -13,7 +13,7 @@ requirements:
 
 test:
   commands:
-    - perl --help > /dev/null
+    - perl --help | grep 5.26
 
 about:
   home: http://www.perl.org/


### PR DESCRIPTION
Xref: https://github.com/bioconda/bioconda-recipes/issues/13415

It looks like in the mass rebuild last summer perl-threaded got uploaded in a broken version for OSX but then in a fixed version for Linux a few weeks later. This should fix the OSX build while also bringing the version information more in line with the version of perl actually used.

:information_source:
Bioconda has finished the [GCC7 migration](https://github.com/bioconda/bioconda-recipes/issues/13578). If you are dealing with C/C++ or Python package it can be that you need to rebuild other dependent packages. [Bioconda utils - update-pinning](https://bioconda.github.io/updating.html#updating-recipes-for-a-pinning-change) will assist you with that. If you have any questions please use [issue 13578](https://github.com/bioconda/bioconda-recipes/issues/13578).

----------------

* [ ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
