### PR TITLE
HiCMatrix update to version 8. Drop of Python 2 support.

### DIFF
--- a/recipes/hicmatrix/meta.yaml
+++ b/recipes/hicmatrix/meta.yaml
@@ -8,7 +8,7 @@ source:
 
 build:
   number: 0
-  skip: True # [not py3k]
+  noarch: python
 
 requirements:
   host:
@@ -39,5 +39,3 @@ about:
   home: https://github.com/deeptools/HiCMatrix
   license: GPL3
   summary: Library to manage Hi-C matrices for HiCExplorer and pyGenomeTracks
-
-

--- a/recipes/hicmatrix/meta.yaml
+++ b/recipes/hicmatrix/meta.yaml
@@ -8,14 +8,13 @@ source:
 
 build:
   number: 0
-  noarch: python
   skip: True # [not py3k]
 
 requirements:
   host:
     - python >=3
     - setuptools
-    - numpy
+    - numpy >=1.16
     - scipy
     - intervaltree
     - pytables
@@ -24,7 +23,7 @@ requirements:
     - future
   run:
     - python >=3
-    - numpy
+    - numpy >=1.16
     - scipy
     - intervaltree
     - pytables

--- a/recipes/hicmatrix/meta.yaml
+++ b/recipes/hicmatrix/meta.yaml
@@ -1,34 +1,35 @@
 package:
   name: hicmatrix
-  version: 7
+  version: 8
 
 source:
-  url: https://github.com/deeptools/HiCMatrix/archive/7.tar.gz
-  sha256: 30f6837483ea1636e45abe9f432124a6d75c7bf6e767ecef56cefd5fe49e54fa
+  url: https://github.com/deeptools/HiCMatrix/archive/8.tar.gz
+  sha256: ec034da60188544770ddaae704342c8ec9215e6002d549e5dde95f0d4696ac51
 
 build:
   number: 0
   noarch: python
+  skip: True # [not py3k]
 
 requirements:
   host:
-    - python
+    - python >=3
     - setuptools
     - numpy
     - scipy
     - intervaltree
     - pytables
     - pandas
-    - cooler 0.8.2
+    - cooler 0.8.3
     - future
   run:
-    - python
+    - python >=3
     - numpy
     - scipy
     - intervaltree
     - pytables
     - pandas
-    - cooler 0.8.2
+    - cooler 0.8.3
     - future
 
 test:


### PR DESCRIPTION
:information_source:
Bioconda has finished the [GCC7 migration](https://github.com/bioconda/bioconda-recipes/issues/13578). If you are dealing with C/C++ or Python package it can be that you need to rebuild other dependent packages. [Bioconda utils - update-pinning](https://bioconda.github.io/updating.html#updating-recipes-for-a-pinning-change) will assist you with that. If you have any questions please use [issue 13578](https://github.com/bioconda/bioconda-recipes/issues/13578).

----------------

* [ ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
