### PR TITLE
update mirtop

### DIFF
--- a/recipes/mirtop/meta.yaml
+++ b/recipes/mirtop/meta.yaml
@@ -1,5 +1,5 @@
 {% set version="0.4.18a" %}
-{% set revision="6c42e30" %}
+{% set revision="a61d043" %}
 
 package:
   name: mirtop
@@ -7,11 +7,11 @@ package:
 
 source:
   url: https://github.com/miRTop/mirtop/archive/{{ revision }}.tar.gz
-  sha256: 7a174ff712912605f1b9f36826942848629ea2168ef152531fcbfb527cab0e12
+  sha256: 2f4e91232034b519840da002bb1fedf04b6195e8a865720e606d8b47f974989b
 
 build:
   script: $PYTHON setup.py install --single-version-externally-managed --record=record.txt
-  number: 0
+  number: 1
   entry_points:
     - mirtop=mirtop.command_line:main
 


### PR DESCRIPTION
fix creation of file for memory reporting

:information_source:
Bioconda has finished the [GCC7 migration](https://github.com/bioconda/bioconda-recipes/issues/13578). If you are dealing with C/C++ or Python package it can be that you need to rebuild other dependent packages. [Bioconda utils - update-pinning](https://bioconda.github.io/updating.html#updating-recipes-for-a-pinning-change) will assist you with that. If you have any questions please use [issue 13578](https://github.com/bioconda/bioconda-recipes/issues/13578).

----------------

* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [X] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
