### PR TITLE
Bumping digestiflow-cli to v0.5.2.

### DIFF
--- a/recipes/digestiflow-cli/meta.yaml
+++ b/recipes/digestiflow-cli/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "0.5.1" %}
-{% set sha256 = "67c74971b9934811002fbb8b7cc73a181bc690290348f66395936ce2010d433d" %}
+{% set version = "0.5.2" %}
+{% set sha256 = "86aed393c347c7452219d5bff3d3e70777bb88adf72a3353a0706385ef0f9f0c" %}
 
 package:
   name: digestiflow-cli


### PR DESCRIPTION
:information_source:
Bioconda has finished the [GCC7 migration](https://github.com/bioconda/bioconda-recipes/issues/13578). If you are dealing with C/C++ or Python package it can be that you need to rebuild other dependent packages. [Bioconda utils - update-pinning](https://bioconda.github.io/updating.html#updating-recipes-for-a-pinning-change) will assist you with that. If you have any questions please use [issue 13578](https://github.com/bioconda/bioconda-recipes/issues/13578).

----------------

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
