### PR TITLE
Added fusion-report 1.0.0

### DIFF
--- a/recipes/fusion-report/build.sh
+++ b/recipes/fusion-report/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+$PYTHON setup.py install --single-version-externally-managed --record=record.txt
+chmod -R o+r $PREFIX/lib/python*/site-packages/fusion_report*

--- a/recipes/fusion-report/meta.yaml
+++ b/recipes/fusion-report/meta.yaml
@@ -1,0 +1,51 @@
+{% set version = "1.0.0" %}
+
+package:
+  name: fusion-report
+  version: "{{ version }}"
+
+source:
+  url: https://github.com/matq007/fusion-report/archive/{{ version }}.tar.gz
+  sha256: 7eb0b22fca5423ba65f7dde47e9ae30a6221f82458295d099859d14807e65029
+
+build:
+  number: 1
+  noarch: python
+  preserve_egg_dir: True
+  skip: True  # [not py27]
+
+requirements:
+  host:
+    - python >=3.7
+    - setuptools
+    - wget
+    - sqlite
+    - jinja2 >=2.9
+    - python-rapidjson
+    - pyyaml >=5.1
+  run:
+    - python >=3.7
+    - setuptools
+    - wget
+    - sqlite
+    - jinja2 >=2.9
+    - python-rapidjson
+    - pyyaml >=5.1
+
+test:
+  # Python imports
+  imports:
+    - fusion_report
+
+  commands:
+    - fusion_report --help
+
+about:
+  home: https://github.com/matq007/fusion-report
+  license: GNU General Public License v3 (GPLv3)
+  summary: 'Tool for parsing outputs from fusion detection tools. Part of a nf-core/rnafusion pipeline'
+  license_family: GPL3
+
+extra:
+  identifiers:
+    - DOI:10.5281/zenodo.2609024


### PR DESCRIPTION
:information_source:
Bioconda has finished the [GCC7 migration](https://github.com/bioconda/bioconda-recipes/issues/13578). If you are dealing with C/C++ or Python package it can be that you need to rebuild other dependent packages. [Bioconda utils - update-pinning](https://bioconda.github.io/updating.html#updating-recipes-for-a-pinning-change) will assist you with that. If you have any questions please use [issue 13578](https://github.com/bioconda/bioconda-recipes/issues/13578).

----------------

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [x] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

This PR adds fusion-report tool that generates interactive summary report from fusion detection tools. It is part of a bigger pipeline `nf-core/rnafusion`.