### PR TITLE
updated entrez direct to version 11.0

### DIFF
--- a/recipes/entrez-direct/meta.yaml
+++ b/recipes/entrez-direct/meta.yaml
@@ -1,6 +1,6 @@
-{% set version = "10.2" %}
-{% set date = "20181018" %}
-{% set sha256 = "27b2c777c8eab9a9716d167b71e2017edcf98c29d80a040d8c78ddffa2222e24" %}
+{% set version = "11.0" %}
+{% set date = "20190322" %}
+{% set sha256 = "8296ea52598a3589f61eba688ca94251d01166b132bfbb590b8ee2d7a56d6979" %}
 
 package:
   name: entrez-direct


### PR DESCRIPTION
:information_source:

This pull requests updates entrez direct to version 11.0 for reasons noted in https://github.com/bioconda/bioconda-recipes/issues/14197

* [*] This PR updates an existing recipe.

