### PR TITLE
Downgrade Python dependency from 3.7 to 3.6

### DIFF
--- a/recipes/fusion-report/meta.yaml
+++ b/recipes/fusion-report/meta.yaml
@@ -9,14 +9,14 @@ source:
   sha256: 7eb0b22fca5423ba65f7dde47e9ae30a6221f82458295d099859d14807e65029
 
 build:
-  number: 1
+  number: 2
   noarch: python
   preserve_egg_dir: True
   skip: True  # [not py27]
 
 requirements:
   host:
-    - python >=3.7
+    - python >=3.6
     - setuptools
     - wget
     - sqlite
@@ -24,7 +24,7 @@ requirements:
     - python-rapidjson
     - pyyaml >=5.1
   run:
-    - python >=3.7
+    - python >=3.6
     - setuptools
     - wget
     - sqlite


### PR DESCRIPTION
:information_source:
Bioconda has finished the [GCC7 migration](https://github.com/bioconda/bioconda-recipes/issues/13578). If you are dealing with C/C++ or Python package it can be that you need to rebuild other dependent packages. [Bioconda utils - update-pinning](https://bioconda.github.io/updating.html#updating-recipes-for-a-pinning-change) will assist you with that. If you have any questions please use [issue 13578](https://github.com/bioconda/bioconda-recipes/issues/13578).

----------------

* [ ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

This is a downgrade for python dependency so that there is a small chance of dependency collision.