### PR TITLE
bioconductor-rhdf5lib: revert to Bioconductor URL

### DIFF
--- a/recipes/bioconductor-rhdf5lib/meta.yaml
+++ b/recipes/bioconductor-rhdf5lib/meta.yaml
@@ -7,13 +7,10 @@ package:
   version: '{{ version }}'
 source:
   url:
-    - 'https://www.huber.embl.de/users/msmith/{{ name }}_{{ version }}.tar.gz'
-#    - 'https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/{{ name }}_{{ version }}.tar.gz'
-#    - 'https://bioarchive.galaxyproject.org/{{ name }}_{{ version }}.tar.gz'
-#    - 'https://depot.galaxyproject.org/software/bioconductor-{{ name|lower }}/bioconductor-{{ name|lower }}_{{ version }}_src_all.tar.gz'
-  md5: d7acd66e1d74ba2b77c6d56cceedeb6f
-#  patches:
-#    - configure.patch
+    - 'https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/{{ name }}_{{ version }}.tar.gz'
+    - 'https://bioarchive.galaxyproject.org/{{ name }}_{{ version }}.tar.gz'
+    - 'https://depot.galaxyproject.org/software/bioconductor-{{ name|lower }}/bioconductor-{{ name|lower }}_{{ version }}_src_all.tar.gz'
+  md5: 79b9c0902ae67edbc6faa63143fc2a9d
 build:
   number: 0
   rpaths:


### PR DESCRIPTION
:information_source:
Bioconda has finished the [GCC7 migration](https://github.com/bioconda/bioconda-recipes/issues/13578). If you are dealing with C/C++ or Python package it can be that you need to rebuild other dependent packages. [Bioconda utils - update-pinning](https://bioconda.github.io/updating.html#updating-recipes-for-a-pinning-change) will assist you with that. If you have any questions please use [issue 13578](https://github.com/bioconda/bioconda-recipes/issues/13578).

----------------

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
