### PR TITLE
Lumpy-express dependencies added

### DIFF
--- a/recipes/lumpy-sv/meta.yaml
+++ b/recipes/lumpy-sv/meta.yaml
@@ -9,7 +9,7 @@ source:
   #sha256: 1a7a5d18875b297acaa68ee1e864ca048654ebc85348920b518dc689d2b7a3cf
 
 build:
-  number: 3
+  number: 4
 
 requirements:
   build:
@@ -27,6 +27,9 @@ requirements:
     - curl
     - pysam
     - numpy
+    - hexdump #not in the biocontainer 
+    - sambamba #lumpy-express dependency
+    - samblaster #lumpy-express dependency
 
 test:
   commands:


### PR DESCRIPTION
Added hexdump-, sambamba- and samblaster dependencies under run and increased the build number to 4.

:information_source:
Bioconda has finished the [GCC7 migration](https://github.com/bioconda/bioconda-recipes/issues/13578). If you are dealing with C/C++ or Python package it can be that you need to rebuild other dependent packages. [Bioconda utils - update-pinning](https://bioconda.github.io/updating.html#updating-recipes-for-a-pinning-change) will assist you with that. If you have any questions please use [issue 13578](https://github.com/bioconda/bioconda-recipes/issues/13578).

----------------

* [ ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
