### PR TITLE
Add recipe for perl-logger-simple

### DIFF
--- a/recipes/perl-logger-simple/build.sh
+++ b/recipes/perl-logger-simple/build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# If it has Build.PL use that, otherwise use Makefile.PL
+if [ -f Build.PL ]; then
+    perl Build.PL
+    perl ./Build
+    perl ./Build test
+    # Make sure this goes in site
+    perl ./Build install --installdirs site
+elif [ -f Makefile.PL ]; then
+    # Make sure this goes in site
+    perl Makefile.PL INSTALLDIRS=site
+    make
+    make test
+    make install
+else
+    echo 'Unable to find Build.PL or Makefile.PL. You need to modify build.sh.'
+    exit 1
+fi

--- a/recipes/perl-logger-simple/meta.yaml
+++ b/recipes/perl-logger-simple/meta.yaml
@@ -1,0 +1,42 @@
+{% set name = "perl-logger-simple" %}
+{% set version = "2.0" %}
+{% set sha256 = "2e63fd3508775b5902132ba1bfb03b42bee468dfaf35dfe42e1909ff6d291b2d" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://cpan.metacpan.org/authors/id/T/TS/TSTANLEY/Logger-Simple-2.0.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+
+requirements:
+  host:
+    - perl
+    - perl-time-hires
+    - perl-carp
+    - perl-test-pod
+    - perl-test-harness
+    - perl-object-insideout
+  run:
+    - perl
+    - perl-time-hires
+    - perl-test-pod
+    - perl-test-harness
+    - perl-carp
+    - perl-object-insideout
+    #- perl-fcntl
+    #- perl-filehandle
+    #- perl-test-more
+
+test:
+  imports:
+    - Logger::Simple
+
+about:
+  home: http://metacpan.org/pod/Logger::Simple
+  license: perl_5
+  summary: 'Implementation of the Simran-Log-Log and Simran-Error-Error modules'


### PR DESCRIPTION
:information_source:
Bioconda has finished the [GCC7 migration](https://github.com/bioconda/bioconda-recipes/issues/13578). If you are dealing with C/C++ or Python package it can be that you need to rebuild other dependent packages. [Bioconda utils - update-pinning](https://bioconda.github.io/updating.html#updating-recipes-for-a-pinning-change) will assist you with that. If you have any questions please use [issue 13578](https://github.com/bioconda/bioconda-recipes/issues/13578).

----------------

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [x] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).
This package is needed for "braker2", which is bioinformatics tool. "perl-logger-simple" should go to conda-forge; however, all its dependencies are in "bioconda". These dependencies have another dependencies that are in "bioconda" too, so once the perl recipes are moved to conda-forge, I will move this package there. In the meantime, so I can move along with "braker2", I am adding "perl-logger-simple" here.
