### PR TITLE
Revert "update source (#14248)"

### DIFF
--- a/recipes/mtsv/meta.yaml
+++ b/recipes/mtsv/meta.yaml
@@ -1,5 +1,5 @@
 {% set version="1.0.2" %}
-{% set sha256="1d67fc50da8c27c30f74ff15f6fea7693250dc3f48bcfc426d6dd47edc8f16dc" %}
+{% set sha256="0bf611fe8da69f09d5e0ab57910f5ea49f076991259fd06db0c07368531916d5" %}
 
 package:
   name: 'mtsv'


### PR DESCRIPTION
This reverts commit 2698489c9177386841b84e29e45b0916c2470a74 from #14248 

:information_source:
Bioconda has finished the [GCC7 migration](https://github.com/bioconda/bioconda-recipes/issues/13578). If you are dealing with C/C++ or Python package it can be that you need to rebuild other dependent packages. [Bioconda utils - update-pinning](https://bioconda.github.io/updating.html#updating-recipes-for-a-pinning-change) will assist you with that. If you have any questions please use [issue 13578](https://github.com/bioconda/bioconda-recipes/issues/13578).

----------------

* [ ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
