### PR TITLE
Store built packages on CI's artifact system after test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ variables:
       command: |
         mkdir -p /tmp/artifacts/packages
         cd miniconda/conda-bld || exit 0
-        for n in rss.xml index.html channeldata.json linux-64 osx-64 noarch; do
+        for n in rss.xml index.html channeldata.json linux-64 osx-64 noarch broken; do
           cp -rv $n /tmp/artifacts/packages || true
         done
   store_artifacts: &store_artifacts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,19 @@ variables:
             echo "Please use a branch other than 'master' or 'bulk' on your fork"
             exit 1
         )
+  store_built_packages: &store_built_packages
+    run:
+      name: Copying packages
+      when: always
+      command: |
+        mkdir -p /tmp/artifacts/packages
+        cd miniconda/conda-bld || exit 0
+        for n in rss.xml index.html channeldata.json linux-64 osx-64 noarch; do
+          cp -rv $n /tmp/artifacts/packages || true
+        done
+  store_artifacts: &store_artifacts
+    store_artifacts:
+      path: /tmp/artifacts
 
 
 jobs:
@@ -108,6 +121,8 @@ jobs:
             bioconda-utils build recipes config.yml \
               --docker --mulled-test \
               --git-range master HEAD
+      - *store_built_packages
+      - *store_artifacts
 
   # build and test on macos
   test-macos:
@@ -123,6 +138,8 @@ jobs:
           command: |
             bioconda-utils build recipes config.yml \
             --git-range master HEAD
+      - *store_built_packages
+      - *store_artifacts
 
   # build, test and upload on linux
   upload-linux:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,7 @@ variables:
       command: |
         mkdir -p /tmp/artifacts/packages
         cd miniconda/conda-bld || exit 0
+        find -name .cache | xargs rm -rf || true
         for n in rss.xml index.html channeldata.json linux-64 osx-64 noarch broken; do
           cp -rv $n /tmp/artifacts/packages || true
         done

--- a/recipes/dnaio/meta.yaml
+++ b/recipes/dnaio/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 47e4449affad0981978fe986684fc0d9c39736f05a157f6cf80e54dae0a92638
 
 build:
-  number: 0
+  number: 1
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
   skip: True  # [py27]
 

--- a/recipes/pywdl/meta.yaml
+++ b/recipes/pywdl/meta.yaml
@@ -9,7 +9,7 @@ source:
 build:
   noarch: python
   script: python -m pip install --no-deps --ignore-installed .
-  number: 1
+  number: 2
 
 requirements:
   host:


### PR DESCRIPTION
:information_source:
Bioconda has finished the [GCC7 migration](https://github.com/bioconda/bioconda-recipes/issues/13578). If you are dealing with C/C++ or Python package it can be that you need to rebuild other dependent packages. [Bioconda utils - update-pinning](https://bioconda.github.io/updating.html#updating-recipes-for-a-pinning-change) will assist you with that. If you have any questions please use [issue 13578](https://github.com/bioconda/bioconda-recipes/issues/13578).

----------------

* [ ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).


Changes (hopefully) the CircleCI config so that the built-packages get uploaded as artifacts after the test. This should make debugging a little easier. Potentially might even allow installing the package locally after successful test, to double check things that cannot be easily tested with the package tests facility. (X11 stuff e.g.)