### PR TITLE
Update to capture new "usage" help

### DIFF
--- a/recipes/tb-profiler/meta.yaml
+++ b/recipes/tb-profiler/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "tb-profiler" %}
 {% set version = "2.1" %}
-{% set sha256 = "321ecf9fe810a16873b340c6486795e7ceef8bd0a78b5ff32e7a9ad7a5f943a6" %}
+{% set sha256 = "ba2be42fa37ca466766bd591b2f567ac493c8fb2d12813267e74f98ebc7ee955" %}
 
 package:
   name: {{name}}
@@ -13,7 +13,7 @@ source:
 build:
   script: python -m pip install --no-deps --ignore-installed .
   noarch: python
-  number: 1
+  number: 2
 
 requirements:
   host:
@@ -33,4 +33,6 @@ about:
   home: https://github.com/jodyphelan/TBProfiler
   license: GPL3
   license_file: LICENSE
-  summary: TBProfiler tools for Mtb NGS data
+  summary: Profiling tool for Mycobacterium tuberculosis to detect drug resistance and lineage from WGS data
+  identifiers:
+    - doi:10.1186/s13073-015-0164-0


### PR DESCRIPTION
Upstream author has updated 2.1 release with better "usage" method. This captures that update and thus bumps the build number (the upstream release number hasn't changed). Also updates description and adds DOI.

:information_source:
Bioconda has finished the [GCC7 migration](https://github.com/bioconda/bioconda-recipes/issues/13578). If you are dealing with C/C++ or Python package it can be that you need to rebuild other dependent packages. [Bioconda utils - update-pinning](https://bioconda.github.io/updating.html#updating-recipes-for-a-pinning-change) will assist you with that. If you have any questions please use [issue 13578](https://github.com/bioconda/bioconda-recipes/issues/13578).

----------------

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
