### PR TITLE
Updates kmc recipe

### DIFF
--- a/recipes/kmc/meta.yaml
+++ b/recipes/kmc/meta.yaml
@@ -13,7 +13,7 @@ source:
     - shared_library.patch
 
 build:
-  number: 1
+  number: 2
   skip: True  # [osx]
 
 requirements:

--- a/recipes/kmc/shared_library.patch
+++ b/recipes/kmc/shared_library.patch
@@ -20,7 +20,7 @@
 +	$(CC) $(CFLAGS) -fpic -c -o $@ $<
 +
 +kmc_api/libkmc.so: $(KMC_API_PICO)
-+	$(CC) -shared $(LDFLAGS) -o $@ $<
++	$(CC) -shared $(LDFLAGS) -o $@ $^
 +
  $(KMC_OBJS) $(KMC_DUMP_OBJS) $(KMC_API_OBJS): %.o: %.cpp
  	$(CC) $(CFLAGS) -c $< -o $@


### PR DESCRIPTION
:information_source:
Bioconda has finished the [GCC7 migration](https://github.com/bioconda/bioconda-recipes/issues/13578). If you are dealing with C/C++ or Python package it can be that you need to rebuild other dependent packages. [Bioconda utils - update-pinning](https://bioconda.github.io/updating.html#updating-recipes-for-a-pinning-change) will assist you with that. If you have any questions please use [issue 13578](https://github.com/bioconda/bioconda-recipes/issues/13578).

----------------

* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [X] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Fixes KMC Makefile patch to compile all objects (see https://github.com/bioconda/bioconda-recipes/pull/14217#issuecomment-478514829)