### PR TITLE
bump libsequence recipe to 1.9.7

### DIFF
--- a/recipes/libsequence/meta.yaml
+++ b/recipes/libsequence/meta.yaml
@@ -1,14 +1,13 @@
 
 package:
   name: libsequence
-  version: '1.9.6'
+  version: '1.9.7'
 
 source:
-  url: http://github.com/molpopgen/libsequence/archive/1.9.6.tar.gz
-  md5: b497ca4ebf04019a9b9a814d7cb9f3f9
+  url: http://github.com/molpopgen/libsequence/archive/1.9.7.tar.gz
+  md5: 3b3c02514e01e4e5c57cce0956c7d881
 
 build:
-  skip: True  # [osx]
   number: 0
 
 requirements:
@@ -18,7 +17,7 @@ requirements:
 
 test:
   commands:
-    - libsequenceConfig --version | grep 1.9.6 > /dev/null
+    - libsequenceConfig --version | grep 1.9.7 > /dev/null
 
 about:
   home: http://http://molpopgen.github.io/libsequence/


### PR DESCRIPTION
:information_source:
Bioconda has finished the [GCC7 migration](https://github.com/bioconda/bioconda-recipes/issues/13578). If you are dealing with C/C++ or Python package it can be that you need to rebuild other dependent packages. [Bioconda utils - update-pinning](https://bioconda.github.io/updating.html#updating-recipes-for-a-pinning-change) will assist you with that. If you have any questions please use [issue 13578](https://github.com/bioconda/bioconda-recipes/issues/13578).

----------------

* [ ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
