### PR TITLE
Attempt rebuild of ismapper

### DIFF
--- a/recipes/ismapper/meta.yaml
+++ b/recipes/ismapper/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 2abcba78ea812139989a573f1e325e1b36231ce00421ea0265fd3b3cb5b77433
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: python -m pip install --no-deps --ignore-installed .
 


### PR DESCRIPTION
:information_source:
Bioconda has finished the [GCC7 migration](https://github.com/bioconda/bioconda-recipes/issues/13578). If you are dealing with C/C++ or Python package it can be that you need to rebuild other dependent packages. [Bioconda utils - update-pinning](https://bioconda.github.io/updating.html#updating-recipes-for-a-pinning-change) will assist you with that. If you have any questions please use [issue 13578](https://github.com/bioconda/bioconda-recipes/issues/13578).

----------------

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

This PR is an attempt to resolve https://github.com/bioconda/bioconda-recipes/issues/14264 (https://github.com/bioconda/bioconda-recipes/pull/14180) in which the first build was never initiated.
