### PR TITLE
kraken2: Use conda-forge::wget instead of bioconda::gnu-wget

### DIFF
--- a/recipes/kraken2/meta.yaml
+++ b/recipes/kraken2/meta.yaml
@@ -13,7 +13,7 @@ source:
     - Makefile.patch
 
 build:
-  number: 2
+  number: 3
   has_prefix_files:
     - libexec/kraken2
     - libexec/kraken2-build
@@ -33,7 +33,7 @@ requirements:
     - libcxx >=4.0  # [osx]
     - llvm-openmp  # [osx]
     - rsync
-    - gnu-wget
+    - wget
 test:
   commands:
     - kraken2 --version


### PR DESCRIPTION
:information_source:
Bioconda has finished the [GCC7 migration](https://github.com/bioconda/bioconda-recipes/issues/13578). If you are dealing with C/C++ or Python package it can be that you need to rebuild other dependent packages. [Bioconda utils - update-pinning](https://bioconda.github.io/updating.html#updating-recipes-for-a-pinning-change) will assist you with that. If you have any questions please use [issue 13578](https://github.com/bioconda/bioconda-recipes/issues/13578).

----------------

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Fixes #14288 