### PR TITLE
bump to use athena version 1.3, and fix to use flye 2.3.1

### DIFF
--- a/recipes/athena_meta/build.sh
+++ b/recipes/athena_meta/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-$PYTHON setup.py install --single-version-externally-managed --record=record.txt
+$PYTHON setup.py install  --single-version-externally-managed --record=record.txt

--- a/recipes/athena_meta/meta.yaml
+++ b/recipes/athena_meta/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.2" %}
+{% set version = "1.3" %}
 
 package:
     name: athena_meta
@@ -6,34 +6,31 @@ package:
 
 source:
     url: https://github.com/abishara/athena_meta/archive/{{ version }}.tar.gz
-    sha256: 43ac63af4a4ca507f376742699a0473a5d0d9b753762c4ed0479a3c11e1a8b0f
+    sha256: 3ae0ef982c52412d5954b6da4b8a3387b1f30eeb96902654d22188d4c536a784
 
 build:
     number: 0
     skip: True  # [osx]
 
 requirements:
-    #build:
-    #    - python 2.7
     host:
         - python 2.7
     run:
         - python 2.7
         - bwa 0.7.*
-        - flye 2.4
-        #- samtools 1.3
-        #- htslib 1.3
-        #- pysam 0.9
-        - samtools 1.9
-        - htslib 1.9
+        - flye 2.3.1
         - pysam 0.15
         - bx-python 0.8
         - numpy 1.11
         - ipython-cluster-helper 0.6
         - idba_subasm 1.1.3a1
+        - htslib 1.9
+        - samtools 1.9
 test:
     commands: 
         - athena-meta -h | grep 'athena-meta'
+        - athena-meta --check_prereqs
+        - athena-meta --test
 
 about:
     home: https://github.com/abishara/athena_meta/


### PR DESCRIPTION
:information_source:
Bioconda has finished the [GCC7 migration](https://github.com/bioconda/bioconda-recipes/issues/13578). If you are dealing with C/C++ or Python package it can be that you need to rebuild other dependent packages. [Bioconda utils - update-pinning](https://bioconda.github.io/updating.html#updating-recipes-for-a-pinning-change) will assist you with that. If you have any questions please use [issue 13578](https://github.com/bioconda/bioconda-recipes/issues/13578).

----------------

* [ ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
