### PR TITLE
Update snpEff meta.yaml to pin java version 8

### DIFF
--- a/recipes/snpeff/meta.yaml
+++ b/recipes/snpeff/meta.yaml
@@ -13,7 +13,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 2
+  number: 3
   noarch: generic
 
 source:
@@ -22,7 +22,7 @@ source:
 
 requirements:
   run:
-    - openjdk
+    - openjdk=8.0.192
     - zlib
 
 test:


### PR DESCRIPTION
:information_source:
Bioconda has finished the [GCC7 migration](https://github.com/bioconda/bioconda-recipes/issues/13578). If you are dealing with C/C++ or Python package it can be that you need to rebuild other dependent packages. [Bioconda utils - update-pinning](https://bioconda.github.io/updating.html#updating-recipes-for-a-pinning-change) will assist you with that. If you have any questions please use [issue 13578](https://github.com/bioconda/bioconda-recipes/issues/13578).

----------------

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
