### PR TITLE
do not pin Arriba to specific HTSlib version

### DIFF
--- a/recipes/arriba/meta.yaml
+++ b/recipes/arriba/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   skip: True # [osx]
 
 requirements:
@@ -18,13 +18,13 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
-    - htslib ==1.8 # arriba
+    - htslib >=1.8 # arriba
     - zlib # BAM
     - libdeflate # BAM
     - xz # CRAM
     - bzip2 # CRAM
   run:
-    - htslib ==1.8 # arriba
+    - htslib >=1.8 # arriba
     - zlib # BAM
     - libdeflate # BAM
     - xz # CRAM


### PR DESCRIPTION
Compatibility of Arriba with HTSlib version 1.9 was tested successfully. Therefore, pinning to version 1.8 is not necessary.

----------------

* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [X] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
