### PR TITLE
Bumping varfish-annotator-cli to v0.2

### DIFF
--- a/recipes/varfish-annotator-cli/meta.yaml
+++ b/recipes/varfish-annotator-cli/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "0.1" %}
-{% set sha256 = "9a0964f680d55dff550cbc658d7e488efe2e03c981eadf5cecdb2deb110c51f4" %}
+{% set version = "0.2" %}
+{% set sha256 = "79e7f92cb033f2327f626cd8529f5c1555b4398d8a9e9ce27dd54378a1d4d353" %}
 
 package:
   name: varfish-annotator-cli


### PR DESCRIPTION
:information_source:
Bioconda has finished the [GCC7 migration](https://github.com/bioconda/bioconda-recipes/issues/13578). If you are dealing with C/C++ or Python package it can be that you need to rebuild other dependent packages. [Bioconda utils - update-pinning](https://bioconda.github.io/updating.html#updating-recipes-for-a-pinning-change) will assist you with that. If you have any questions please use [issue 13578](https://github.com/bioconda/bioconda-recipes/issues/13578).

----------------

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
