### PR TITLE
bismark v0.21.0

### DIFF
--- a/recipes/bismark/meta.yaml
+++ b/recipes/bismark/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "0.20.0" %}
-{% set sha256 = "4c3f0d9eb75c4bf099505c5a2c1f9a00c35a54cce3074c572f8d69ecb9831337" %}
+{% set version = "0.21.0" %}
+{% set sha256 = "0ae3d3db3968a7c03aeadf85e814664278ed59aef0ab891eacab76d44f7acb98" %}
 
 package:
   name: bismark
@@ -18,6 +18,7 @@ requirements:
     - perl
     - samtools
     - bowtie2
+    - hisat2
 
 about:
   home: https://www.bioinformatics.babraham.ac.uk/projects/bismark/

--- a/recipes/bismark/meta.yaml
+++ b/recipes/bismark/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "0.21.0" %}
-{% set sha256 = "0ae3d3db3968a7c03aeadf85e814664278ed59aef0ab891eacab76d44f7acb98" %}
+{% set sha256 = "edf493676c2c90ac39ec86a2d3fef03b24ed16148b109dec64179a9f084eb261" %}
 
 package:
   name: bismark


### PR DESCRIPTION
This bumps the bismark version to v0.21.0 and adds hisat2 as a new dependency, since bismark now optionally supports alignment using hisat2


:information_source:
Bioconda has finished the [GCC7 migration](https://github.com/bioconda/bioconda-recipes/issues/13578). If you are dealing with C/C++ or Python package it can be that you need to rebuild other dependent packages. [Bioconda utils - update-pinning](https://bioconda.github.io/updating.html#updating-recipes-for-a-pinning-change) will assist you with that. If you have any questions please use [issue 13578](https://github.com/bioconda/bioconda-recipes/issues/13578).

----------------

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
