### PR TITLE
Updated Trimmomatic 0.39 (same version) requires new build and SHA256

### DIFF
--- a/recipes/trimmomatic/meta.yaml
+++ b/recipes/trimmomatic/meta.yaml
@@ -5,11 +5,11 @@ package:
   version: '{{ version }}'
 
 build:
-  number: 0
+  number: 1
   noarch: generic
 
 source:
-  sha256: 33c882201cc81cf51e533f2129ccdfdb027f0c799886258cbf5c4815fa0593f7
+  sha256: 2f97e3a237378d55c221abfc38e4b11ea232c8a41d511b8b4871f00c0476abca
   url: http://www.usadellab.org/cms/uploads/supplementary/Trimmomatic/Trimmomatic-{{ version }}.zip
 
 requirements:


### PR DESCRIPTION
Trimmomatic 0.39 was updated due to bug. Same version.

:information_source:
Bioconda has finished the [GCC7 migration](https://github.com/bioconda/bioconda-recipes/issues/13578). If you are dealing with C/C++ or Python package it can be that you need to rebuild other dependent packages. [Bioconda utils - update-pinning](https://bioconda.github.io/updating.html#updating-recipes-for-a-pinning-change) will assist you with that. If you have any questions please use [issue 13578](https://github.com/bioconda/bioconda-recipes/issues/13578).

----------------

* [ ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
