### PR TITLE
remove GCC7 hint

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 :information_source:
-If this is your first pull request to Bioconda please ping @bioconda/core so it can be reviewed and to request being added as a member of the bioconda team.
+If this is your first pull request to Bioconda please ping `@bioconda/core` so it can be reviewed and to request being added as a member of the bioconda team.
 
 ----------------
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,3 @@
-:information_source:
-Bioconda has finished the [GCC7 migration](https://github.com/bioconda/bioconda-recipes/issues/13578). If you are dealing with C/C++ or Python package it can be that you need to rebuild other dependent packages. [Bioconda utils - update-pinning](https://bioconda.github.io/updating.html#updating-recipes-for-a-pinning-change) will assist you with that. If you have any questions please use [issue 13578](https://github.com/bioconda/bioconda-recipes/issues/13578).
-
-----------------
 
 * [ ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
 * [ ] This PR adds a new recipe.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 :information_source:
-If this is your first pull request to Bioconda please ping `@bioconda/core` so it can be reviewed and to request being added as a member of the bioconda team.
+If this is your first pull request to Bioconda please ping `@bioconda/core` so it can be reviewed and to request being added as a member of the Bioconda team. Members of the Bioconda team are able to merge their own pull requests once tests and linting have passed.
 
 ----------------
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,7 @@
+:information_source:
+If this is your first pull request to Bioconda please ping @bioconda/core so it can be reviewed and to request being added as a member of the bioconda team.
+
+----------------
 
 * [ ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
 * [ ] This PR adds a new recipe.


### PR DESCRIPTION
@bioconda/core I think this note can be removed now?

:information_source:
Bioconda has finished the [GCC7 migration](https://github.com/bioconda/bioconda-recipes/issues/13578). If you are dealing with C/C++ or Python package it can be that you need to rebuild other dependent packages. [Bioconda utils - update-pinning](https://bioconda.github.io/updating.html#updating-recipes-for-a-pinning-change) will assist you with that. If you have any questions please use [issue 13578](https://github.com/bioconda/bioconda-recipes/issues/13578).

----------------

* [ ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
