### PR TITLE
Bump build for quasitools to fix sub commands for py3

### DIFF
--- a/recipes/quasitools/meta.yaml
+++ b/recipes/quasitools/meta.yaml
@@ -24,6 +24,7 @@ requirements:
     - scipy
     - samtools >=1.3
     - pysam >=0.8.1
+    - pyaavf
     - click
     - biopython
     - bowtie2

--- a/recipes/quasitools/meta.yaml
+++ b/recipes/quasitools/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 7af1223b4ec7df9ad28f554bcb82e265b2ff8fa9b50092207c2c72a83eaa9b70
 
 build:
-  number: 0
+  number: 1
   entry_points:
     - quasitools = quasitools.cli:cli
 
@@ -32,6 +32,8 @@ test:
   commands:
     # click requires a unicode locale
     - quasitools --help
+    - quasitools call --help
+    - quasitools hydra --help
 
 about:
   home: https://github.com/phac-nml/quasitools/


### PR DESCRIPTION
`quasitools call` and `quasitools hydra` subcommands are broken in py3 for build 0, this pr fixes that issue.

----------------

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
