### PR TITLE
Try rebuilding 0.6.6 to see if ldc is causing segfaults

### DIFF
--- a/recipes/sambamba/0.6.6/build.sh
+++ b/recipes/sambamba/0.6.6/build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -eu
+
+export C_INCLUDE_PATH=${PREFIX}/include
+export LIBRARY_PATH=${PREFIX}/lib
+
+if [ $(uname) == "Darwin" ]; then
+    export LDFLAGS="-headerpad_max_install_names $LDFLAGS"
+fi
+sed -i.bak 's/ gcc / $(CC) /g' Makefile
+cd htslib && make CC=$CC LDFLAGS="-L$PREFIX/lib" && cd ..
+make CC=$CC LIBRARY_PATH=$PREFIX/lib
+make test
+mkdir -p ${PREFIX}/bin
+cp bin/sambamba ${PREFIX}/bin/sambamba

--- a/recipes/sambamba/0.6.6/meta.yaml
+++ b/recipes/sambamba/0.6.6/meta.yaml
@@ -17,6 +17,7 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
+    - dmd
   host:
     - ldc 1.13.*
     - bzip2

--- a/recipes/sambamba/0.6.6/meta.yaml
+++ b/recipes/sambamba/0.6.6/meta.yaml
@@ -1,0 +1,43 @@
+{% set version='0.6.6' %}
+package:
+  name: sambamba
+  version: {{ version }}
+
+# There are no OSX binaries yet, so just build on both platforms
+source:
+  git_url: https://github.com/biod/sambamba
+  git_tag: v0.6.6
+  md5: unused
+
+build:
+  number: 3
+
+# ldc provides run time libraries as well as a compiler.
+# The version needs to be pinned
+requirements:
+  build:
+    - {{ compiler('c') }}
+  host:
+    - ldc 1.13.*
+    - bzip2
+    - htslib
+    - zlib
+    - xz
+  run:
+    - ldc 1.13.*
+    - bzip2
+    - zlib
+    - xz
+
+test:
+  commands:
+    - sambamba view
+
+about:
+  home: https://github.com/biod/sambamba
+  license: GPLv2
+  summary: Tools for working with SAM/BAM data
+
+extra:
+  skip-lints:
+    - uses_git_url

--- a/recipes/sambamba/0.6.6/meta.yaml
+++ b/recipes/sambamba/0.6.6/meta.yaml
@@ -23,6 +23,7 @@ requirements:
     - htslib
     - zlib
     - xz
+    - python 2
   run:
     - ldc 1.13.*
     - bzip2


### PR DESCRIPTION
:information_source:
Bioconda has finished the [GCC7 migration](https://github.com/bioconda/bioconda-recipes/issues/13578). If you are dealing with C/C++ or Python package it can be that you need to rebuild other dependent packages. [Bioconda utils - update-pinning](https://bioconda.github.io/updating.html#updating-recipes-for-a-pinning-change) will assist you with that. If you have any questions please use [issue 13578](https://github.com/bioconda/bioconda-recipes/issues/13578).

----------------

* [ ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
