### PR TITLE
make quasitools noarch: python, try fixing the container

### DIFF
--- a/recipes/quasitools/meta.yaml
+++ b/recipes/quasitools/meta.yaml
@@ -9,7 +9,8 @@ source:
   sha256: 7af1223b4ec7df9ad28f554bcb82e265b2ff8fa9b50092207c2c72a83eaa9b70
 
 build:
-  number: 1
+  noarch: python
+  number: 2
   entry_points:
     - quasitools = quasitools.cli:cli
 
@@ -45,4 +46,4 @@ extra:
   container:
     # click requires a unicode locale when used with Python 3
     # extended-base generates en_US.UTF-8 locale and sets LC_ALL, LANG properly
-    extended-base: true  # [py3k]
+    extended-base: true


### PR DESCRIPTION
:information_source:
Bioconda has finished the [GCC7 migration](https://github.com/bioconda/bioconda-recipes/issues/13578). If you are dealing with C/C++ or Python package it can be that you need to rebuild other dependent packages. [Bioconda utils - update-pinning](https://bioconda.github.io/updating.html#updating-recipes-for-a-pinning-change) will assist you with that. If you have any questions please use [issue 13578](https://github.com/bioconda/bioconda-recipes/issues/13578).

----------------

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
