### PR TITLE
Adding blasr-mc, fork of blasr to bioconda

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,6 @@ variables:
     run:
       name: Setup bioconda-utils
       command: .circleci/setup.sh
-      command: yum install -y git
   macos: &macos
     macos:
       xcode: "8.3.3"
@@ -69,10 +68,6 @@ jobs:
       - image: bioconda/bioconda-utils-build-env
     steps:
       - checkout
-      - run:
-          command: |
-            yum install -y git tar xargs
-      - run: yum install -y git
       - run:
           name: Setup ssh
           command: |

--- a/recipes/blasr-mc/build.sh
+++ b/recipes/blasr-mc/build.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+export PKG_CONFIG_LIBDIR="${PREFIX}"/lib/pkgconfig
+
+# HDF5 doesn't have pkgconfig files yet
+export CPPFLAGS="-isystem ${PREFIX}/include "
+export CPPOPTS="-std=c++98"
+export LDFLAGS="-L${PREFIX}/lib -lhdf5_cpp -lhdf5"
+export LD_LIBRARY_PATH="${PREFIX}/lib"
+
+make -j 8 HDF5INCLUDEDIR=${PREFIX}/include HDF5LIBDIR=${PREFIX}/lib CPPOPTS="-std=c++11" _GLIBCXX_USE_CXX11_ABI=0
+cp alignment/bin/blasrmc ${PREFIX}/bin
+cp alignment/bin/sawritermc ${PREFIX}/bin
+cp alignment/bin/blDotPlot ${PREFIX}/bin

--- a/recipes/blasr-mc/meta.yaml
+++ b/recipes/blasr-mc/meta.yaml
@@ -3,15 +3,14 @@ package:
   version: "1.MC.rc47"
 
 source:
-  url: https://github.com/mchaisso/blasr/archive/1.MC.rc47.2.tar.gz
-  md5: 55cbc3b299409bd1ff0cf72d1efdc200
-
+  url: https://github.com/mchaisso/blasr/archive/1.MC.rc47.3.tar.gz
+  md5: 95df515bf956a76d85f65c57480fe5bf08ff2529
+	
 build:
   number: 1
 
 requirements:
-  build:
-    - {{ compiler('cxx') }}
+
   host:
     - hdf5 <1.8.19x
 

--- a/recipes/blasr-mc/meta.yaml
+++ b/recipes/blasr-mc/meta.yaml
@@ -13,9 +13,11 @@ requirements:
 
   host:
     - hdf5 <1.8.19x
+    - libstdcxx-ng
 
   run:
     - hdf5 <1.8.19x
+    - libstdcxx-ng
 
 test:
   commands:

--- a/recipes/blasr-mc/meta.yaml
+++ b/recipes/blasr-mc/meta.yaml
@@ -4,6 +4,7 @@ package:
 
 source:
   url: https://github.com/mchaisso/blasr/archive/1.MC.rc47.2.tar.gz
+  md5: 55cbc3b299409bd1ff0cf72d1efdc200
 
 build:
   number: 1

--- a/recipes/blasr-mc/meta.yaml
+++ b/recipes/blasr-mc/meta.yaml
@@ -3,8 +3,8 @@ package:
   version: "1.MC.rc47"
 
 source:
-  url: https://github.com/mchaisso/blasr/archive/1.MC.rc47.2.tar.gz
-  md5: 55cbc3b299409bd1ff0cf72d1efdc200
+  url: https://github.com/mchaisso/blasr/archive/1.MC.rc47.3.tar.gz
+  md5: c2a3a1a4083ca0355c1603fb1fb3be15
 
 build:
   number: 1

--- a/recipes/blasr-mc/meta.yaml
+++ b/recipes/blasr-mc/meta.yaml
@@ -1,0 +1,29 @@
+package:
+  name: blasr-mc
+  version: "1.MC.rc47"
+
+source:
+  url: https://github.com/mchaisso/blasr/archive/1.MC.rc47.2.tar.gz
+
+build:
+  number: 1
+
+requirements:
+  build:
+    - {{ compiler('cxx') }}
+  host:
+    - hdf5 <1.8.19x
+
+  run:
+    - hdf5 <1.8.19x
+
+test:
+  commands:
+    - blasrmc -h
+
+
+about:
+  home: https://github.com/mchaisson/blasr
+  license: GNU General Public License v3 (GPLv3)
+  summary: 'This is a fork of the original PacBio blasr, renamed blasrmc to avoid naming conflicts.'
+


### PR DESCRIPTION
	new file:   blasr-mc/build.sh
	new file:   blasr-mc/meta.yaml

:information_source:
Bioconda has finished the [GCC7 migration](https://github.com/bioconda/bioconda-recipes/issues/13578). If you are dealing with C/C++ or Python package it can be that you need to rebuild other dependent packages. [Bioconda utils - update-pinning](https://bioconda.github.io/updating.html#updating-recipes-for-a-pinning-change) will assist you with that. If you have any questions please use [issue 13578](https://github.com/bioconda/bioconda-recipes/issues/13578).

----------------

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [x] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
