### PR TITLE
Disabling Haswell instructions in mantis

### DIFF
--- a/recipes/mantis/build.sh
+++ b/recipes/mantis/build.sh
@@ -12,6 +12,6 @@ popd
 # build mantis
 mkdir build && pushd build
 # pass -DNH=1 to disable Haswell instructions
-cmake -DCMAKE_BUILD_TYPE=Release -DSDSL_INSTALL_PATH=$SRC_DIR/sdsl-build -DCMAKE_INSTALL_PREFIX=$PREFIX ..
+cmake -DCMAKE_BUILD_TYPE=Release -DNH=1 -DSDSL_INSTALL_PATH=$SRC_DIR/sdsl-build -DCMAKE_INSTALL_PREFIX=$PREFIX ..
 make install VERBOSE=1
 popd

--- a/recipes/mantis/meta.yaml
+++ b/recipes/mantis/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 0001-Static-libc.patch
 
 build:
-  number: 0
+  number: 1
   skip: True #  [osx]
 
 requirements:


### PR DESCRIPTION
:information_source:
If this is your first pull request to Bioconda please ping `@bioconda/core` so it can be reviewed and to request being added as a member of the Bioconda team. Members of the Bioconda team are able to merge their own pull requests once tests and linting have passed.

----------------

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

This disables the use of Haswell instructions for greater portability