### PR TITLE
Store docker images as artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ variables:
         if command -V docker >/dev/null; then
           mkdir -p /tmp/artifacts/images
           cd /tmp/artifacts/images
-          docker image ls --format '{{.Repository}}:{{.Tag}} {{.ID}}' | grep biocontainers > containers.txt
+          docker image ls --format '{{.Repository}}:{{.Tag}} {{.ID}}' | grep biocontainers > containers.txt || true
           cat containers.txt | xargs -n2 -P4 bash -c 'docker save $2 | gzip -c > "${1##*/}.tar.gz"' --
         fi
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,13 @@ variables:
         for n in rss.xml index.html channeldata.json linux-64 osx-64 noarch broken; do
           cp -rv $n /tmp/artifacts/packages || true
         done
+        if command -V docker 2>; then
+          mkdir -p /tmp/artifacts/images
+          cd /tmp/artifacts/images
+          docker image ls --format '{{.Repository}}:{{.Tag}} {{.ID}}' | grep biocontainers > containers.txt
+          cat containers.txt | xargs -n2 -P4 bash -c 'docker save $2 | gzip -c > "${1##*/}.tar.gz"' --
+        fi
+
   store_artifacts: &store_artifacts
     store_artifacts:
       path: /tmp/artifacts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ variables:
         for n in rss.xml index.html channeldata.json linux-64 osx-64 noarch broken; do
           cp -rv $n /tmp/artifacts/packages || true
         done
-        if command -V docker 2>; then
+        if command -V docker >/dev/null; then
           mkdir -p /tmp/artifacts/images
           cd /tmp/artifacts/images
           docker image ls --format '{{.Repository}}:{{.Tag}} {{.ID}}' | grep biocontainers > containers.txt

--- a/recipes/sina/meta.yaml
+++ b/recipes/sina/meta.yaml
@@ -11,7 +11,7 @@ source:
   url: https://github.com/epruesse/SINA/releases/download/v{{version}}/sina-{{version}}.tar.gz
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipes/sina/meta.yaml
+++ b/recipes/sina/meta.yaml
@@ -11,7 +11,7 @@ source:
   url: https://github.com/epruesse/SINA/releases/download/v{{version}}/sina-{{version}}.tar.gz
 
 build:
-  number: 1
+  number: 0
 
 requirements:
   build:


### PR DESCRIPTION
* [x] This PR does something else (explain below).

Store mulled docker images as artifacts. See https://github.com/bioconda/bioconda-utils/issues/508