### PR TITLE
Cromwell to use the released jars.

### DIFF
--- a/recipes/cromwell/build.sh
+++ b/recipes/cromwell/build.sh
@@ -6,11 +6,10 @@ mkdir -p $outdir
 mkdir -p $PREFIX/bin
 
 cd $SRC_DIR
-sbt assembly
 
 # cromwell
-cp server/target/scala-*/cromwell-*.jar $outdir/cromwell.jar
+cp cromwell/cromwell-*.jar $outdir/cromwell.jar
 cp $RECIPE_DIR/cromwell.py ${PREFIX}/bin/cromwell
 
-cp womtool/target/scala-*/womtool*.jar $outdir/womtool.jar
+cp womtool/womtool-*.jar $outdir/womtool.jar
 cp $RECIPE_DIR/womtool.py ${PREFIX}/bin/womtool

--- a/recipes/cromwell/cromwell.py
+++ b/recipes/cromwell/cromwell.py
@@ -13,7 +13,7 @@ import os
 from os import access, getenv, path, X_OK
 
 
-# Expected name of the VarScan JAR file.
+# Expected name of the JAR file.
 JAR_NAME = 'cromwell.jar'
 PKG_NAME = 'cromwell'
 

--- a/recipes/cromwell/meta.yaml
+++ b/recipes/cromwell/meta.yaml
@@ -28,7 +28,7 @@ requirements:
 
 test:
   commands:
-    - cromwell --version 2>&1 | grep "cromwell "
+    - cromwell --version 2>&1 | grep "cromwell"
     - womtool --help 2>&1 | grep "Usage"
 
 about:

--- a/recipes/cromwell/meta.yaml
+++ b/recipes/cromwell/meta.yaml
@@ -1,6 +1,7 @@
 {% set version = "40" %}
-#{% set revision = "ec67d65" %}
-{% set sha256 = "16e5de6a98915132ff93193dad6df3c113f2d2625dd977fab294f1322e0b039b" %}
+{% set sha256_cromwell = "8e1f9c8777bb3b860fd1bf6b6dc05a51145889620f0510cb2fa89aa7e1dfd3ec" %}
+{% set sha256_womtool = "1904ebc87c605b4330ddd88770b522104d0bd506be2b9bcfe8424e90d38e4fb9" %}
+
 
 package:
   name: cromwell
@@ -8,26 +9,26 @@ package:
 
 build:
   noarch: python
-  number: 0
+  number: 1
 
 source:
-  url: https://github.com/broadinstitute/cromwell/archive/{{ version }}.tar.gz
-  #url: https://github.com/broadinstitute/cromwell/archive/{{ revision }}.tar.gz
-  sha256: {{ sha256 }}
+  - url: https://github.com/broadinstitute/cromwell/releases/download/{{ version }}/cromwell-{{ version }}.jar
+    sha256: {{ sha256_cromwell }}
+    folder: cromwell
+  - url: https://github.com/broadinstitute/cromwell/releases/download/{{ version }}/womtool-{{ version }}.jar
+    sha256: {{ sha256_womtool }}
+    folder: womtool
 
 requirements:
-  host:
-    - openjdk >=8,<9
-    - sbt
-    - scala
+  host: []
   run:
     - openjdk >=8,<9
     - python
-    - findutils  
+    - findutils
 
 test:
   commands:
-    - cromwell --version 2>&1 | grep "cromwell"
+    - cromwell --version 2>&1 | grep "cromwell "
     - womtool --help 2>&1 | grep "Usage"
 
 about:

--- a/recipes/cromwell/womtool.py
+++ b/recipes/cromwell/womtool.py
@@ -13,7 +13,7 @@ import os
 from os import access, getenv, path, X_OK
 
 
-# Expected name of the VarScan JAR file.
+# Expected name of the JAR file.
 JAR_NAME = 'womtool.jar'
 PKG_NAME = 'cromwell'
 


### PR DESCRIPTION
The original recipe did a lot of compiling and the resulting jar would not match the Jar as released by broadinstitute. 
This downloads those jars directly. It saves a lot of compile time and other hassle.
@micknudsen do you approve of this? Since you last updated cromwell.
@bioconda/core is this an okay way of packaging java packages?


----------------

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
