### PR TITLE
Build maker with mpich instead of openmpi to avoid runtime segfaults

### DIFF
--- a/recipes/maker/build.sh
+++ b/recipes/maker/build.sh
@@ -23,6 +23,6 @@ mv perl/lib/* $PREFIX/perl/lib/
 mv lib/* $PREFIX/lib/
 
 # Run a first time MPI_Init() to pre compile inline C code
-mpirun --allow-run-as-root -n 1 $PREFIX/bin/maker_mpi_init || true
+mpiexec -n 1 $PREFIX/bin/maker_mpi_init || true
 # This is not needed anymore
 rm $PREFIX/bin/maker_mpi_init

--- a/recipes/maker/meta.yaml
+++ b/recipes/maker/meta.yaml
@@ -10,7 +10,7 @@ source:
     - "mpi_init.patch"
 
 build:
-  number: 12
+  number: 13
 
 requirements:
   build:
@@ -36,7 +36,7 @@ requirements:
     - perl-forks
     - perl-list-moreutils
     - perl-perl-unsafe-signals
-    - openmpi
+    - mpich
     - trnascan-se
     - postgresql
   run:
@@ -62,7 +62,7 @@ requirements:
     - perl-forks
     - perl-list-moreutils
     - perl-perl-unsafe-signals
-    - openmpi
+    - mpich
     - trnascan-se ==1.3.1
     - postgresql
     # GeneMarkS, GeneMark-ES and FGENESH are optional requirements but are not free


### PR DESCRIPTION
When run using MPI, maker seems to segfault in various places during execution. However, modifying the maker recipe to switch the MPI implementation from openmpi to mpich seems to resolve the issue---at least in our environment (HPC cluster environments are all bespoke to some extent, and it's difficult to ascertain whether some subtle configuration issue is causing problems).

@abretaud : could you please validate this proposed change? Otherwise, have you had success with this maker recipe using Open-MPI?

----------------

* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
