### PR TITLE
Backport bioperl-live patch to perl-bioperl-core

### DIFF
--- a/recipes/perl-bioperl-core/meta.yaml
+++ b/recipes/perl-bioperl-core/meta.yaml
@@ -5,9 +5,11 @@ package:
 source:
   url: https://cpan.metacpan.org/authors/id/C/CJ/CJFIELDS/BioPerl-1.007002.tar.gz
   sha256: 17aa3aaab2f381bbcaffdc370002eaf28f2c341b538068d6586b2276a76464a1
+  patches:
+    - "pr309.patch"
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   host:

--- a/recipes/perl-bioperl-core/pr309.patch
+++ b/recipes/perl-bioperl-core/pr309.patch
@@ -1,0 +1,96 @@
+diff --git a/Bio/DB/Fasta.pm b/Bio/DB/Fasta.pm
+index e150d20dc..3731b0191 100644
+--- a/Bio/DB/Fasta.pm
++++ b/Bio/DB/Fasta.pm
+@@ -292,7 +292,7 @@ sub subseq {
+     seek($fh, $filestart,0);
+     read($fh, $data, $filestop-$filestart+1);
+ 
+-    $data = Bio::DB::IndexedBase::_strip_crnl($data);
++    $data =~ tr/\n\r//d; #strip control characters
+ 
+     if ($strand == -1) {
+         # Reverse-complement the sequence
+@@ -334,7 +334,7 @@ sub header {
+     read($fh, $data, $headerlen);
+     # On Windows chomp remove '\n' but leaves '\r'
+     # when reading '\r\n' in binary mode
+-    $data = Bio::DB::IndexedBase::_strip_crnl($data);
++    $data =~ tr/\n\r//d; #strip control characters
+     substr($data, 0, 1) = '';
+     return $data;
+ }
+diff --git a/Bio/DB/IndexedBase.pm b/Bio/DB/IndexedBase.pm
+index 88aea4a1e..14f20175d 100644
+--- a/Bio/DB/IndexedBase.pm
++++ b/Bio/DB/IndexedBase.pm
+@@ -267,46 +267,6 @@ use constant PROTEIN   => 3;
+ # You can avoid dying if you want but you may get incorrect results
+ use constant DIE_ON_MISSMATCHED_LINES => 1;
+ 
+-# Remove carriage returns (\r) and newlines (\n) from a string.  When
+-# called from subseq, this can take a signficiant portion of time, in
+-# Variant Effect Prediction. Therefore we compile the match portion.
+-sub _strip_crnl {
+-    eval 'require Inline::C';
+-    if ( $INC{'Inline/C.pm'} ) {
+-        # C can do _strip_crnl much faster. But this requires the
+-        # Inline::C module which we don't require people to have. So we make
+-        # this optional by wrapping the C code in an eval. If the eval works,
+-        # the Perl strip_crnl() function is overwritten.
+-        Inline->bind(
+-            C => q(
+-        /*
+-        Strip all newlines (\n) and carriage returns (\r) from the string
+-        */
+-        char* _strip_crnl(char* str) {
+-          char *s;
+-          char *s2 = str;
+-          for (s = str; *s; *s++) {
+-            if (*s != '\n' && *s != '\r') {
+-              *s2++ = *s;
+-            }
+-          }
+-          *s2 = '\0';
+-          return str;
+-        }
+-        )
+-        );
+-    } else {
+-        # "tr" is much faster than the regex, with "s"
+-        *Bio::DB::IndexedBase::_strip_crnl = sub {
+-            my $str = shift;
+-            $str =~ tr/\n\r//d;
+-            return $str;
+-        };
+-    }
+-
+-    return _strip_crnl(@_);
+-}
+-
+ =head2 new
+ 
+  Title   : new
+diff --git a/Bio/DB/Qual.pm b/Bio/DB/Qual.pm
+index 729d7bc68..adc6abd46 100644
+--- a/Bio/DB/Qual.pm
++++ b/Bio/DB/Qual.pm
+@@ -335,7 +335,7 @@ sub subqual {
+     read($fh, $data, $filestop-$filestart+1);
+ 
+     # Process quality score
+-    Bio::DB::IndexedBase::_strip_crnl($data);
++    $data =~ tr/\n\r//d; #strip control characters
+     my $subqual = 0;
+     $subqual = 1 if ( $start || $stop );
+     my @data;
+@@ -379,8 +379,7 @@ sub header {
+     read($fh, $data, $headerlen);
+     # On Windows chomp remove '\n' but leaves '\r'
+     # when reading '\r\n' in binary mode,
+-    # _strip_crnl removes both
+-    $data = Bio::DB::IndexedBase::_strip_crnl($data);
++    $data =~ tr/\n\r//d; #strip control characters
+     substr($data, 0, 1) = '';
+     return $data;
+ }


### PR DESCRIPTION
This PR backports the commit from the following bioperl-live (post 1.7.5 release) PR to 1.7.2:

https://github.com/bioperl/bioperl-live/pull/309

The aforementioned patch (authored by a MAKER developer) is important for (at least) avoiding odd runtime errors when running MAKER using MPI.

----------------

* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
