### PR TITLE
MultiQC: Remove upper matplotlib version pin

### DIFF
--- a/recipes/multiqc/meta.yaml
+++ b/recipes/multiqc/meta.yaml
@@ -7,7 +7,7 @@ source:
   sha256: 1a6bea211ab584164a6c7513812ede57b28712bc528bd34cc5f1a581e7410644
 
 build:
-  number: 3
+  number: 4
   noarch: python
   preserve_egg_dir: True
 
@@ -23,7 +23,7 @@ requirements:
     - jinja2 >=2.9
     - lzstring
     - markdown
-    - matplotlib >=2.1.1,<3.0.0
+    - matplotlib >=2.1.1
     - numpy
     - pyyaml
     - requests


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

x-ref https://github.com/ewels/MultiQC/issues/958

Had an upper matplotlib version pin as recent mpl is not compatible with python2. However, conda should be able to figure this out by itself, so removing this upper limit.

'cc @dpryan79 @grzadr