### PR TITLE
Introduce GATK4 Spark to Bioconda

### DIFF
--- a/recipes/gatk4/build_main.sh
+++ b/recipes/gatk4/build_main.sh
@@ -10,7 +10,6 @@ sed -i.bak 's#!/usr/bin/env python#!/opt/anaconda1anaconda2anaconda3/bin/python#
 chmod +x gatk
 cp gatk ${PACKAGE_HOME}/gatk
 cp gatk-*-local.jar $PACKAGE_HOME
-# Does not yet install spark jar to save space.
-# cp gatk-*-spark.jar $PACKAGE_HOME
+# Does not install the spark jars, this is done in the `build_spark.sh`
 
 ln -s $PACKAGE_HOME/gatk $PREFIX/bin

--- a/recipes/gatk4/build_spark.sh
+++ b/recipes/gatk4/build_spark.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+BINARY_HOME=$PREFIX/bin
+PACKAGE_HOME=$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM
+
+mkdir -p $PREFIX/bin
+mkdir -p $PACKAGE_HOME
+
+#Runtime script will be installed using the `build_main.sh` already, so we don't have to modify this anymore.
+#Only installs the SPARK JARs, everything else is installed using the `build_main.sh` already.
+cp gatk-*-spark.jar $PACKAGE_HOME

--- a/recipes/gatk4/meta.yaml
+++ b/recipes/gatk4/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: generic
-  number: 0
+  number: 1
 
 requirements:
   host:

--- a/recipes/gatk4/meta.yaml
+++ b/recipes/gatk4/meta.yaml
@@ -32,6 +32,11 @@ outputs:
       run:
         - openjdk >=8,<9
         - python
+    test:
+      commands:
+        - gatk -h
+        - gatk --list
+        - gatk HaplotypeCaller --help
   - name: gatk4-spark
     script: build_spark.sh
     requirements:
@@ -39,6 +44,11 @@ outputs:
         - openjdk >=8,<9
         - python
         - {{ pin_subpackage("gatk4", exact=True) }}
+    test:
+      commands:
+        - gatk -h
+        - gatk --list
+        - gatk MarkDuplicatesSpark --help
 
 about:
   home: https://www.broadinstitute.org/gatk/

--- a/recipes/gatk4/meta.yaml
+++ b/recipes/gatk4/meta.yaml
@@ -39,6 +39,8 @@ outputs:
         - gatk HaplotypeCaller --help
   - name: gatk4-spark
     script: build_spark.sh
+    build:
+            noarch: generic
     requirements:
       run:
         - openjdk >=8,<9

--- a/recipes/gatk4/meta.yaml
+++ b/recipes/gatk4/meta.yaml
@@ -25,6 +25,21 @@ test:
     - gatk --list
     - gatk HaplotypeCaller --help
 
+outputs:
+  - name: gatk4
+    script: build_main.sh
+    requirements:
+      run:
+        - openjdk >=8,<9
+        - python
+  - name: gatk4-spark
+    script: build_spark.sh
+    requirements:
+      run:
+        - openjdk >=8,<9
+        - python
+        - {{ pin_subpackage("gatk4", exact=True) }}
+
 about:
   home: https://www.broadinstitute.org/gatk/
   license: BSD-3-Clause


### PR DESCRIPTION
Following up on the [discussion](https://github.com/bioconda/bioconda-recipes/issues/15059) we had here, I put some work into including the spark parts of GATK4 into the recipe, too. 

This now creates two packages: `gatk4` with the local version and `gatk4-spark` with the required spark JARs inside. The latter depends on `gatk4` to be installed in the exact same version in order not to break things. 

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

-- edit: fixes #15059 
