### PR TITLE
MicroHapDB: fix build number, add test invocation

### DIFF
--- a/recipes/microhapdb/meta.yaml
+++ b/recipes/microhapdb/meta.yaml
@@ -14,7 +14,7 @@ build:
   entry_points:
     - microhapdb = microhapdb.cli:main
   script: python -m pip install --no-deps --ignore-installed .
-  number: 0
+  number: 1
 
 requirements:
   host:
@@ -22,14 +22,14 @@ requirements:
     - pip
   run:
     - python >=3
-    - pandas
+    - pandas >=0.23.4
 
 test:
   imports:
     - microhapdb
   requires:
-    - pytest
-    - pytest-cov
+    - pytest >=3.10
+    - pytest-cov >=2.6
 
 about:
   home: https://github.com/bioforensics/MicroHapDB/

--- a/recipes/microhapdb/run_test.sh
+++ b/recipes/microhapdb/run_test.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+make test


### PR DESCRIPTION
I updated MicroHapDB from version 0.2 to 0.3 in #15037, but failed to increment the build number. This PR fixes the build number and adds a test invocation.

----------------

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

