### PR TITLE
update kaiju to v1.7.0

### DIFF
--- a/recipes/kaiju/build.sh
+++ b/recipes/kaiju/build.sh
@@ -14,17 +14,17 @@ cd $SRC_DIR/src/
 make
 
 cd $SRC_DIR/bin/
-cp addTaxonNames $PREFIX/bin
-cp convertNR $PREFIX/bin
-cp gbk2faa.pl $PREFIX/bin
+cp kaiju-addTaxonNames $PREFIX/bin
+cp kaiju-convertNR $PREFIX/bin
+cp kaiju-gbk2faa.pl $PREFIX/bin
 cp kaiju $PREFIX/bin
 cp kaiju2krona $PREFIX/bin
+cp kaiju2table $PREFIX/bin
 cp kaijup $PREFIX/bin
-cp kaijuReport $PREFIX/bin
 cp kaijux $PREFIX/bin
-cp makeDB.sh $PREFIX/bin
-cp mergeOutputs $PREFIX/bin
-cp mkbwt $PREFIX/bin
-cp mkfmi $PREFIX/bin
-cp convert_mar_to_kaiju.py $PREFIX/bin
-cp taxonlist.tsv $PREFIX/bin
+cp kaiju-makedb $PREFIX/bin
+cp kaiju-mergeOutputs $PREFIX/bin
+cp kaiju-mkbwt $PREFIX/bin
+cp kaiju-mkfmi $PREFIX/bin
+cp kaiju-convertMAR.py $PREFIX/bin
+cp kaiju-taxonlistEuk.tsv $PREFIX/bin

--- a/recipes/kaiju/build.sh
+++ b/recipes/kaiju/build.sh
@@ -11,7 +11,7 @@ mkdir -p $PREFIX/bin
 
 cd $SRC_DIR/src/
 
-make
+make CC=${CC} CXX=${CXX}
 
 cd $SRC_DIR/bin/
 cp kaiju-addTaxonNames $PREFIX/bin

--- a/recipes/kaiju/meta.yaml
+++ b/recipes/kaiju/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.6.3" %}
+{% set version = "1.7.0" %}
 
 package:
   name: kaiju
@@ -6,12 +6,12 @@ package:
 
 source:
   url: https://github.com/bioinformatics-centre/kaiju/archive/v{{ version }}.tar.gz
-  sha256: 4e2b0eccebc36307d561d713c558adb8f82414a1ea1ecf448c217812b12ef5ad
+  sha256: 96ecc84634f2a5f1440ac6d40896fdb207b1931b78629b56853ab0391e31c105
 
 build:
   number: 2
   no_link:
-    - bin/makeDB.sh
+    - bin/kaiju-makedb.sh
 
 requirements:
   build:


### PR DESCRIPTION
I have updated the kaiju files for the new version 1.7.0. Please review.
I don't understand the meaning of the lines 
```
build:
  number: 2
  no_link:
    - bin/kaiju-makedb.sh  
```
I just replace makeDB.sh by kaiju-makedb (which is also a bash script and supercedes makeDB.sh).


----------------

* [ x ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ x ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

@charlesreid1 @bioconda/core

