### PR TITLE
THAPBI PICT to v0.1.12, new xlsxwriter dependency

### DIFF
--- a/recipes/thapbi-pict/meta.yaml
+++ b/recipes/thapbi-pict/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "thapbi-pict" %}
-{% set version = "0.1.10" %}
+{% set version = "0.1.12" %}
 
 package:
   name: "{{ name|lower }}"
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name | replace("-", "_") }}/{{ name | replace("-", "_") }}-{{ version }}.tar.gz
-  sha256: 33361e0e1bde72cad14e14263a8b86234a28ee5b11c47b1b08e7d67b6e675711
+  sha256: 891313d5b752b4557af90607ece3b324e1d4e72d38e7c775073847119b229068
 
 build:
   noarch: python
@@ -32,6 +32,7 @@ requirements:
     - hmmer
     - swarm
     - trimmomatic
+    - xlsxwriter
 
 test:
   imports:


### PR DESCRIPTION
The main change in the tool of relevance to the packaging is optional Excel output, which needs the ``xlsxwriter`` dependency (another Python package):

https://anaconda.org/conda-forge/xlsxwriter

:information_source:
If this is your first pull request to Bioconda please ping `@bioconda/core` so it can be reviewed and to request being added as a member of the Bioconda team. Members of the Bioconda team are able to merge their own pull requests once tests and linting have passed.

----------------

* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [X] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
