### PR TITLE
Update seqCAT to version 1.4.1

### DIFF
--- a/recipes/bioconductor-seqcat/meta.yaml
+++ b/recipes/bioconductor-seqcat/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.4.0" %}
+{% set version = "1.4.1" %}
 {% set name = "seqCAT" %}
 {% set bioc = "3.8" %}
 
@@ -10,7 +10,7 @@ source:
     - 'https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/{{ name }}_{{ version }}.tar.gz'
     - 'https://bioarchive.galaxyproject.org/{{ name }}_{{ version }}.tar.gz'
     - 'https://depot.galaxyproject.org/software/bioconductor-{{ name|lower }}/bioconductor-{{ name|lower }}_{{ version }}_src_all.tar.gz'
-  md5: 02c71dd7b83aae90fea8c864a286bea1
+  md5: e2742e15dd741cb9369fbafc2da0b3e4
 build:
   number: 0
   rpaths:
@@ -26,7 +26,7 @@ requirements:
     - 'bioconductor-s4vectors >=0.20.0,<0.21.0'
     - 'bioconductor-summarizedexperiment >=1.12.0,<1.13.0'
     - 'bioconductor-variantannotation >=1.28.0,<1.29.0'
-    - r-base
+    - 'r-base'
     - 'r-dplyr >=0.5.0'
     - 'r-ggplot2 >=2.2.1'
     - 'r-lazyeval >=0.2.0'
@@ -39,7 +39,7 @@ requirements:
     - 'bioconductor-s4vectors >=0.20.0,<0.21.0'
     - 'bioconductor-summarizedexperiment >=1.12.0,<1.13.0'
     - 'bioconductor-variantannotation >=1.28.0,<1.29.0'
-    - r-base
+    - 'r-base'
     - 'r-dplyr >=0.5.0'
     - 'r-ggplot2 >=2.2.1'
     - 'r-lazyeval >=0.2.0'
@@ -50,6 +50,5 @@ test:
     - '$R -e "library(''{{ name }}'')"'
 about:
   home: 'https://bioconductor.org/packages/{{ bioc }}/bioc/html/{{ name }}.html'
-  license: 'MIT + file LICENCE'
+  license: 'MIT'
   summary: 'The seqCAT package uses variant calling data (in the form of VCF files) from high throughput sequencing technologies to authenticate and validate the source, function and characteristics of biological samples used in scientific endeavours.'
-


### PR DESCRIPTION
This is my very first PR to Bioconda, so would appreciate feedback from @bioconda/core. I started to read up on how to add a recipe for my `seqCAT` Bioconductor package, and got to the point of creating a skeleton when I realised it had already been added in a bulk submission some months back. I thus wanted to update the package to the latest version, but it seems Bioconda does not yet use `R 3.6`? At least I thought I could update from `1.4.0` to `1.4.1`. I tried to build it locally, which ran successfully, but please let me know if I did something wrong or if I need to change something. 

----------------

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
