### PR TITLE
[phantompeakqualtools] - add `gawk` as a requirement

### DIFF
--- a/recipes/phantompeakqualtools/meta.yaml
+++ b/recipes/phantompeakqualtools/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   run:

--- a/recipes/phantompeakqualtools/meta.yaml
+++ b/recipes/phantompeakqualtools/meta.yaml
@@ -23,6 +23,7 @@ requirements:
     - bioconductor-rsamtools
     - boost
     - samtools
+    - gawk
 
 test:
   commands:


### PR DESCRIPTION
`run_spp.R` uses the `awk` bitwise operation `and()`. This is unavailable in `mawk` (AFAIK) and so `run_spp.R` failed on my system.
By adding `gawk` to the env in which I ran `phantompeakqualtools` `run_spp.R` script, I could get the latter to work.

:information_source:
If this is your first pull request to Bioconda please ping `@bioconda/core` so it can be reviewed and to request being added as a member of the Bioconda team. Members of the Bioconda team are able to merge their own pull requests once tests and linting have passed.

----------------

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
