### PR TITLE
Fix perl-bioperl-core version pin

### DIFF
--- a/recipes/perl-bioperl/meta.yaml
+++ b/recipes/perl-bioperl/meta.yaml
@@ -3,12 +3,12 @@ package:
   version: "1.7.2"
 
 build:
-  number: 9
+  number: 10
 
 requirements:
   host:
     - perl
-    - perl-bioperl-core ==1.7.2
+    - perl-bioperl-core ==1.007002
     - perl-bioperl-run
     - perl-bio-samtools
     - perl-bio-featureio
@@ -17,7 +17,7 @@ requirements:
 
   run:
     - perl
-    - perl-bioperl-core ==1.7.2
+    - perl-bioperl-core ==1.007002
     - perl-bioperl-run
     - perl-bio-tools-phylo-paml
     - perl-bio-tools-run-alignment-tcoffee  # [linux]


### PR DESCRIPTION
* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Since PR https://github.com/bioconda/bioconda-recipes/pull/12040, perl-bioperl-core changed from version 1.7.2 to 1.007002. Need to update the version pin in perl-bioperl to get newer builds of perl-bioperl-core.