### PR TITLE
MAKER: add support for running Biocontainers-derived Singularity images using host MPI

### DIFF
--- a/recipes/maker/meta.yaml
+++ b/recipes/maker/meta.yaml
@@ -10,7 +10,7 @@ source:
     - "mpi_init.patch"
 
 build:
-  number: 13
+  number: 14
 
 requirements:
   build:
@@ -23,7 +23,7 @@ requirements:
     - snap
     - snoscan
     - perl
-    - perl-bioperl >=1.7
+    - perl-bioperl-core >=1.007002=pl526_1
     - perl-bit-vector
     - perl-dbd-pg
     - perl-dbd-sqlite
@@ -49,7 +49,7 @@ requirements:
     - snap
     - snoscan
     - perl
-    - perl-bioperl >=1.7
+    - perl-bioperl-core >=1.007002=pl526_1
     - perl-bit-vector
     - perl-dbd-pg
     - perl-dbd-sqlite

--- a/recipes/maker/meta.yaml
+++ b/recipes/maker/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - snap
     - snoscan
     - perl
-    - perl-bioperl-core >=1.007002=pl526_1
+    - perl-bioperl-core >=1.007002
     - perl-bit-vector
     - perl-dbd-pg
     - perl-dbd-sqlite
@@ -49,7 +49,7 @@ requirements:
     - snap
     - snoscan
     - perl
-    - perl-bioperl-core >=1.007002=pl526_1
+    - perl-bioperl-core >=1.007002
     - perl-bit-vector
     - perl-dbd-pg
     - perl-dbd-sqlite

--- a/recipes/maker/meta.yaml
+++ b/recipes/maker/meta.yaml
@@ -77,5 +77,8 @@ test:
     - maker --version
 
 extra:
+  container:
+    # mpich needs /etc/resolv.conf : https://github.com/bioconda/bioconda-recipes/issues/11583
+    extended-base: true
   identifiers:
     - biotools:maker

--- a/recipes/maker/mpi_init.patch
+++ b/recipes/maker/mpi_init.patch
@@ -19,9 +19,42 @@
 +carp "Calling MPI_Init";
 +MPI_Init();
 +
---- src/lib/Parallel/Application/MPI.pm	2014-12-01 23:37:10.000000000 +0100
-+++ src/lib/Parallel/Application/MPI.pm	2018-09-24 15:36:25.167387409 +0200
-@@ -232,7 +232,9 @@
+--- src/bin/maker
++++ src/bin/maker
+@@ -198,6 +198,11 @@ Options:
+      -cpus|c  <integer>  Tells how many cpus to use for BLAST analysis.
+                          Note: this is for BLAST and not for MPI!
+ 
++     -mpi                Forces MAKER to use MPI (overriding MPI autodetection).
++                         Useful if MAKER doesn't correctly detect that it was
++                         launched using an MPI process manager, or if running
++                         in a Singularity container.
++
+      -force|f            Forces MAKER to delete old files before running again.
+ 			 This will require all blast analyses to be rerun.
+ 
+@@ -247,7 +252,8 @@ my %OPT;
+ carp "Calling GetOptions pre-init" if($main::debug);
+ Getopt::Long::Configure(qw(pass_through));
+ GetOptions("MPICC=s" => \$OPT{MPICC}, #hidden
+-	   "MPIDIR=s" => \$OPT{MPIDIR},); #hidden
++	   "MPIDIR=s" => \$OPT{MPIDIR},   #hidden
++	   "mpi" => \$main::mpi);
+ 
+ #--set MPI configuration if specified on the command line
+ if($OPT{MPICC} || $OPT{MPIDIR}){
+--- src/lib/Parallel/Application/MPI.pm
++++ src/lib/Parallel/Application/MPI.pm
+@@ -165,7 +165,7 @@ sub _load {
+     require Proc::Signal;
+ 
+     my $name = Proc::Signal::get_pname_by_id($$);
+-    if($name =~ /(mpiexec|mpirun|mpdrun|mpdexec|mpd|smpd|orted|orterun|pmi_proxy|hydra|mpispawn|exec\d+)$/){
++    if($main::mpi or $name =~ /(mpiexec|mpirun|mpdrun|mpdexec|mpd|smpd|orted|orterun|pmi_proxy|hydra|mpispawn|exec\d+)$/){
+ 	require MAKER::ConfigData;
+ 	my $mpi_support = MAKER::ConfigData->feature('mpi_support');
+ 	if(! $mpi_support){
+@@ -232,7 +232,9 @@ sub _bind {
  
      eval{
  	#this comment is just a way to force Inline::C to recompile on changing MPICC and MPIDIR


### PR DESCRIPTION
* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

This PR implements several minor changes to the maker recipe to allow running maker from a Biocontainers-derived Singularity container on multiple nodes of an HPC cluster using the host MPI.
@abretaud : could you please review?

1. Add `-mpi` option to maker script

The "maker" script tries to detect if its parent process is an MPI process manager, and if so enables MPI support. This autodetection can fail when MAKER is run from a Singularity container.  The patch adds a command-line "-mpi" option to the "maker" script to override MPI autodetection and force MPI on. I have communicated with MAKER maintainer Carson Holt; he may include something similar in the next MAKER release, in which case this patch could be removed. 

2. Use the extended base image

If the host (MPICH-derived) MPI process launcher is used to launch the current Biocontainers MAKER on multiple compute nodes, the MPI processes are unable to wireup in MPI_Init() due to being unable to resolve hostnames. This can be illustrated with a simple example:

```
$ singularity pull maker_2.31.10--pl526_13.sif docker://quay.io/biocontainers/maker:2.31.10--pl526_13
...
$ cat test.c
#include <mpi.h>
#include <stdio.h>

int main(void) {
   int rank, size, rank_sum;
   MPI_Init(NULL, NULL);
   MPI_Comm_size(MPI_COMM_WORLD, &size);
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
   MPI_Allreduce(&rank, &rank_sum, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
   printf("rank: %d size: %d rank_sum: %d\n", rank, size, rank_sum);
   MPI_Finalize();
}
$ singularity exec maker_2.31.10--pl526_13.sif mpicc test.c
$ srun -p test --pty --mem-per-cpu=4G  --nodes=4 --ntasks-per-node=2 -t 00:00:00 bash
[test-node]$ mpiexec -n 8 singularity exec maker_2.31.10--pl526_13.sif ./a.out
...
Fatal error in MPI_Init: Other MPI error, error stack:
MPIR_Init_thread(474)..............:
MPID_Init(190).....................: channel initialization failed
MPIDI_CH3_Init(89).................:
MPID_nem_init(320).................:
MPID_nem_tcp_init(173).............:
MPID_nem_tcp_get_business_card(420):
MPID_nem_tcp_init(379).............: gethostbyname failed, holy7c19302 (errno 2)
...
```

This is because when the Biocontainers BusyBox base image is used, the resulting Singularity containers have a broken /etc/resolv.conf (issue https://github.com/bioconda/bioconda-recipes/issues/11583). Until that issue is resolved, the extended image can be used as a workaround.

An example using a Singularity image created incorporating the maker recipe changes in this PR:

```
$ singularity exec maker_2.31.10--pl526_14-2019-05-16-4d08d97ea398.simg mpicc test.c
$ srun -p test --pty --mem-per-cpu=4G  --nodes=4 --ntasks-per-node=2 -t 00:00:00 bash
[test-node]$ mpiexec -n 8 singularity exec maker_2.31.10--pl526_14-2019-05-16-4d08d97ea398.simg ./a.out
rank: 0 size: 8 rank_sum: 28
rank: 4 size: 8 rank_sum: 28
rank: 1 size: 8 rank_sum: 28
rank: 2 size: 8 rank_sum: 28
rank: 5 size: 8 rank_sum: 28
rank: 3 size: 8 rank_sum: 28
rank: 6 size: 8 rank_sum: 28
rank: 7 size: 8 rank_sum: 28
```

3. Require perl-bioperl-core that includes PR https://github.com/bioconda/bioconda-recipes/pull/15001

That build removes Inline::C code that would otherwise cause a runtime error for a MAKER Singularity container when trying to compile the Inline::C code (in addition to resolving any oddities observed when run under MPI outside of a container that prompted the patch in the first place).

```
"/usr/local/bin/perl" -MExtUtils::Command::MM -e 'cp_nonempty' -- IndexedBase_14e0.bs blib/arch/auto/Bio/DB/IndexedBase_14e0/IndexedBase_14e0.bs 644
./..//bin/x86_64-conda_cos6-linux-gnu-gcc -c  -I"/usr/local/bin" -D_REENTRANT -D_GNU_SOURCE --sysroot=./..//x86_64-conda_cos6-linux-gnu/sysroot -fwrapv -fno-strict-aliasing -pipe -fstack-protector-strong -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -D_FORTIFY_SOURCE=2 -O2   -DVERSION=\"0.00\" -DXS_VERSION=\"0.00\" -fPIC --sysroot=./..//x86_64-conda_cos6-linux-gnu/sysroot "-I/usr/local/lib/5.26.2/x86_64-linux-thread-multi/CORE"   IndexedBase_14e0.c
/bin/sh: ./..//bin/x86_64-conda_cos6-linux-gnu-gcc: not found
make: *** [Makefile:330: IndexedBase_14e0.o] Error 127
```

Also, MAKER apparently needs only Perl modules from perl-bioperl-core, rather than requiring the entire perl-bioperl package.