### PR TITLE
Recipe for new package rsidx

### DIFF
--- a/recipes/rsidx/meta.yaml
+++ b/recipes/rsidx/meta.yaml
@@ -1,0 +1,35 @@
+{% set version = "0.1" %}
+{% set sha256 = "efbc2f3ae8179b7a45896be3b8a3dc31cc25263fd0cf26c9c74596eb841d2117" %}
+
+package:
+  name: rsidx
+  version: '{{version}}'
+
+source:
+  url: https://github.com/bioforensics/rsidx/archive/{{ version }}.tar.gz
+  sha256: '{{sha256}}'
+
+build:
+  noarch: python
+  entry_points:
+    - rsidx = rsidx.__main__:main
+  script: python -m pip install --no-deps --ignore-installed .
+  number: 0
+
+requirements:
+  host:
+    - python >=3
+
+test:
+  imports:
+    - rsidx
+  requires:
+    - pytest >=3.10
+    - pytest-cov >=2.6
+
+about:
+  home: https://github.com/bioforensics/rsidx/
+  license: BSD License
+  license_family: BSD
+  summary: Library for indexing VCF files for random access searches by rsID
+  dev_url: https://github.com/bioforensics/rsidx/

--- a/recipes/rsidx/meta.yaml
+++ b/recipes/rsidx/meta.yaml
@@ -19,7 +19,9 @@ build:
 requirements:
   host:
     - python >=3
+    - pip
   run:
+    - python >=3
     - tabix
 
 test:

--- a/recipes/rsidx/meta.yaml
+++ b/recipes/rsidx/meta.yaml
@@ -19,6 +19,8 @@ build:
 requirements:
   host:
     - python >=3
+  run:
+    - tabix
 
 test:
   imports:

--- a/recipes/rsidx/meta.yaml
+++ b/recipes/rsidx/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "0.1" %}
-{% set sha256 = "efbc2f3ae8179b7a45896be3b8a3dc31cc25263fd0cf26c9c74596eb841d2117" %}
+{% set version = "0.1.1" %}
+{% set sha256 = "5bd721086be5dfe3f7dec484a34a340fc294ed6ab3aac19ef8ee90aed00790eb" %}
 
 package:
   name: rsidx

--- a/recipes/rsidx/run_test.sh
+++ b/recipes/rsidx/run_test.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+pytest --cov=rsidx --doctest-modules --pyargs rsidx


### PR DESCRIPTION
This PR contains a recipe for a new package rsidx for indexing VCF files for search by rsID. The index is an sqlite3 db mapping rsIDs to genomic coordinates. The query feature uses the index to retrieve coordinates for each query term and then retrieve the requested variant using tabix.

----------

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [x] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
