### PR TITLE
Update MicroHapulator recipe to release 0.2

### DIFF
--- a/recipes/microhapulator/meta.yaml
+++ b/recipes/microhapulator/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "0.1.3" %}
-{% set sha256 = "d613d1c4ec977feab1f3ec7a53835b6b2bde9d48af2036c2b910a4d1d943641a" %}
+{% set version = "0.2" %}
+{% set sha256 = "7a2b91a1906a286ac781bb2a6f6cc1fcc382f797a584bb9ebad309ca4fd92395" %}
 
 package:
   name: microhapulator

--- a/recipes/microhapulator/meta.yaml
+++ b/recipes/microhapulator/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - numpy >=1.15.4
     - python >=3
     - pyfaidx >=0.5.5.2
-    - pysam >=0.15.2,<0.16
+    - pysam >=0.15.2,<0.16.0a0
 
 test:
   imports:

--- a/recipes/microhapulator/meta.yaml
+++ b/recipes/microhapulator/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - numpy >=1.15.4
     - python >=3
     - pyfaidx >=0.5.5.2
-    - pysam >=0.15.2
+    - pysam >=0.15.2,<0.16
 
 test:
   imports:

--- a/recipes/microhapulator/run_test.sh
+++ b/recipes/microhapulator/run_test.sh
@@ -1,10 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-wget -O hg38.fasta.gz http://hgdownload.soe.ucsc.edu/goldenPath/hg38/bigZips/hg38.fa.gz
-gunzip hg38.fasta.gz
-faidx hg38.fasta chr1:100-150 > /dev/null
-
+mhpl8r getrefr
 pytest -m 'not known_failing' --cov=microhapulator --pyargs microhapulator
-
-rm -f hg38.fasta
+rm $(mhpl8r getrefr --path)


### PR DESCRIPTION
This PR updates the MicroHapulator package to version 0.2. The test build is simplified, and based on the review for version 0.1.3 I've also [restricted pysam version to < 0.16](https://github.com/bioconda/bioconda-recipes/pull/15040#discussion_r283975028).

---------

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
