### PR TITLE
mzr: try to fix linking error by rebuilding

### DIFF
--- a/build-fail-blacklist
+++ b/build-fail-blacklist
@@ -2266,7 +2266,6 @@ recipes/bioconductor-mwastools
 recipes/bioconductor-mwgcod.db
 recipes/bioconductor-mygene
 recipes/bioconductor-myvariant
-recipes/bioconductor-mzr
 recipes/bioconductor-nadfinder
 recipes/bioconductor-nanostringdiff
 recipes/bioconductor-nanostringqcpro

--- a/recipes/bioconductor-mzr/2.16.2/build.sh
+++ b/recipes/bioconductor-mzr/2.16.2/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+mv DESCRIPTION DESCRIPTION.old
+grep -v '^Priority: ' DESCRIPTION.old > DESCRIPTION
+mkdir -p ~/.R
+echo -e "CC=$CC
+FC=$FC
+CXX=$CXX
+CXX98=$CXX
+CXX11=$CXX
+CXX14=$CXX" > ~/.R/Makevars
+$R CMD INSTALL --build .

--- a/recipes/bioconductor-mzr/2.16.2/meta.yaml
+++ b/recipes/bioconductor-mzr/2.16.2/meta.yaml
@@ -28,6 +28,7 @@ requirements:
     - r-base
     - r-ncdf4
     - 'r-rcpp >=0.10.1'
+    - zlib
   run:
     - 'bioconductor-biobase >=2.42.0,<2.43.0'
     - 'bioconductor-biocgenerics >=0.28.0,<0.29.0'
@@ -37,6 +38,7 @@ requirements:
     - r-base
     - r-ncdf4
     - 'r-rcpp >=0.10.1'
+    - zlib
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}

--- a/recipes/bioconductor-mzr/2.16.2/meta.yaml
+++ b/recipes/bioconductor-mzr/2.16.2/meta.yaml
@@ -1,6 +1,6 @@
-{% set version = "2.18.0" %}
+{% set version = "2.16.2" %}
 {% set name = "mzR" %}
-{% set bioc = "3.9" %}
+{% set bioc = "3.8" %}
 
 package:
   name: 'bioconductor-{{ name|lower }}'
@@ -10,9 +10,9 @@ source:
     - 'https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/{{ name }}_{{ version }}.tar.gz'
     - 'https://bioarchive.galaxyproject.org/{{ name }}_{{ version }}.tar.gz'
     - 'https://depot.galaxyproject.org/software/bioconductor-{{ name|lower }}/bioconductor-{{ name|lower }}_{{ version }}_src_all.tar.gz'
-  md5: 0d04f2321954557784e8080983a7d0e6
+  sha256: 768f559ee349833d26514800a0a9b30785e4cb49de302935046da6423f2ad6a5
 build:
-  number: 0
+  number: 1
   rpaths:
     - lib/R/lib/
     - lib/
@@ -20,20 +20,20 @@ build:
 # SystemRequirements: C++11, GNU make
 requirements:
   host:
-    - 'bioconductor-biobase >=2.44.0,<2.45.0'
-    - 'bioconductor-biocgenerics >=0.30.0,<0.31.0'
-    - 'bioconductor-protgenerics >=1.16.0,<1.17.0'
-    - 'bioconductor-rhdf5lib >=1.6.0,<1.7.0'
-    - 'bioconductor-zlibbioc >=1.30.0,<1.31.0'
+    - 'bioconductor-biobase >=2.42.0,<2.43.0'
+    - 'bioconductor-biocgenerics >=0.28.0,<0.29.0'
+    - 'bioconductor-protgenerics >=1.14.0,<1.15.0'
+    - 'bioconductor-rhdf5lib >=1.4.0,<1.5.0'
+    - 'bioconductor-zlibbioc >=1.28.0,<1.29.0'
     - r-base
     - r-ncdf4
     - 'r-rcpp >=0.10.1'
   run:
-    - 'bioconductor-biobase >=2.44.0,<2.45.0'
-    - 'bioconductor-biocgenerics >=0.30.0,<0.31.0'
-    - 'bioconductor-protgenerics >=1.16.0,<1.17.0'
-    - 'bioconductor-rhdf5lib >=1.6.0,<1.7.0'
-    - 'bioconductor-zlibbioc >=1.30.0,<1.31.0'
+    - 'bioconductor-biobase >=2.42.0,<2.43.0'
+    - 'bioconductor-biocgenerics >=0.28.0,<0.29.0'
+    - 'bioconductor-protgenerics >=1.14.0,<1.15.0'
+    - 'bioconductor-rhdf5lib >=1.4.0,<1.5.0'
+    - 'bioconductor-zlibbioc >=1.28.0,<1.29.0'
     - r-base
     - r-ncdf4
     - 'r-rcpp >=0.10.1'
@@ -56,4 +56,3 @@ extra:
     name: bioconductor-mzr
     path: recipes/bioconductor-mzr
     version: 2.14.0
-

--- a/recipes/bioconductor-mzr/meta.yaml
+++ b/recipes/bioconductor-mzr/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 'https://depot.galaxyproject.org/software/bioconductor-{{ name|lower }}/bioconductor-{{ name|lower }}_{{ version }}_src_all.tar.gz'
   md5: 0d04f2321954557784e8080983a7d0e6
 build:
-  number: 0
+  number: 1
   rpaths:
     - lib/R/lib/
     - lib/

--- a/recipes/bioconductor-mzr/meta.yaml
+++ b/recipes/bioconductor-mzr/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "2.18.0" %}
 {% set name = "mzR" %}
-{% set bioc = "3.9" %}
+{% set bioc = "3.8" %}
 
 package:
   name: 'bioconductor-{{ name|lower }}'

--- a/recipes/bioconductor-mzr/meta.yaml
+++ b/recipes/bioconductor-mzr/meta.yaml
@@ -20,8 +20,8 @@ build:
 # SystemRequirements: C++11, GNU make
 requirements:
   host:
-    - 'bioconductor-biobase >=2.44.0,<2.45.0'
-    - 'bioconductor-biocgenerics >=0.30.0,<0.31.0'
+    - 'bioconductor-biobase'
+    - 'bioconductor-biocgenerics'
     - 'bioconductor-protgenerics >=1.16.0,<1.17.0'
     - 'bioconductor-rhdf5lib >=1.6.0,<1.7.0'
     - 'bioconductor-zlibbioc >=1.30.0,<1.31.0'


### PR DESCRIPTION
the so file currently seems to link wrong:

```ldd CONDA_ENV/lib/R/library/mzR/libs/mzR.so
...
	libnetcdf.so.11 => not found
	libhdf5_hl.so.10 => not found
	libhdf5.so.10 => not found
```

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
