### PR TITLE
add fastqsplitter recipe

### DIFF
--- a/recipes/fastqsplitter/meta.yaml
+++ b/recipes/fastqsplitter/meta.yaml
@@ -1,0 +1,44 @@
+{% set name = "fastqsplitter" %}
+{% set version = "1.0.0" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 5d96ce7dd975a0d9a7dee2031a938c26b41d950ee636712c8249f541d96f1c42
+
+build:
+  noarch: python
+  number: 0
+  entry_points:
+    - fastqsplitter=fastqsplitter:main
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv "
+
+requirements:
+  host:
+    - pip
+    - python >=3.5
+    - xopen >=0.6.0
+  run:
+    - pigz  # Pigz is required for optimal speed. 
+    - python >=3.5
+    - xopen >=0.6.0
+
+test:
+  imports:
+    - fastqsplitter
+  commands:
+    - fastqsplitter --help
+
+about:
+  home: https://github.com/LUMC/fastqsplitter
+  license: MIT
+  license_family: MIT
+  summary: Splits FASTQ files evenly.
+  doc_url: https://fastqsplitter.readthedocs.io
+
+extra:
+  recipe-maintainers:
+    - rhpvorderman


### PR DESCRIPTION
A simple tool to split fastq files evenly with no positional bias.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [x] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
