### PR TITLE
glimmerHMM bump build to 3; move required perl modules into bin/

### DIFF
--- a/recipes/glimmerHMM/build.sh
+++ b/recipes/glimmerHMM/build.sh
@@ -14,10 +14,11 @@ cd sources && make
 cd ../train && make
 cd ..
 
-#copy the execulatbles	
+#copy the executables and perl modules needed for training
 cp bin/glimmhmm.pl $PREFIX/bin/.
 cp sources/glimmerhmm $PREFIX/bin/.
 cp train/trainGlimmerHMM $PREFIX/bin/.
+cp train/*.pm $PREFIX/bin/.
 
 # copy the training data
 cp -R trained_dir $PREFIX/GlimmerHMM/

--- a/recipes/glimmerHMM/meta.yaml
+++ b/recipes/glimmerHMM/meta.yaml
@@ -7,7 +7,7 @@ source:
   url: ftp://ccb.jhu.edu/pub/software/glimmerhmm/GlimmerHMM-3.0.4.tar.gz
 
 build:
-  number: 2
+  number: 3
 
 requirements:
   build:


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).


GlimmerHMM training script is a perl script that has modules missing in the current build. Updated build.sh to include those perl module files. 