### PR TITLE
bioconductor-mzr: new build for 2.10.0

### DIFF
--- a/build-fail-blacklist
+++ b/build-fail-blacklist
@@ -2265,7 +2265,6 @@ recipes/bioconductor-mwastools
 recipes/bioconductor-mwgcod.db
 recipes/bioconductor-mygene
 recipes/bioconductor-myvariant
-recipes/bioconductor-mzr
 recipes/bioconductor-nadfinder
 recipes/bioconductor-nanostringdiff
 recipes/bioconductor-nanostringqcpro

--- a/recipes/bioconductor-mzr/2.10.0/build.sh
+++ b/recipes/bioconductor-mzr/2.10.0/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+mv DESCRIPTION DESCRIPTION.old
+grep -v '^Priority: ' DESCRIPTION.old > DESCRIPTION
+mkdir -p ~/.R
+echo -e "CC=$CC
+FC=$FC
+CXX=$CXX
+CXX98=$CXX
+CXX11=$CXX
+CXX14=$CXX" > ~/.R/Makevars
+$R CMD INSTALL --build .

--- a/recipes/bioconductor-mzr/2.10.0/meta.yaml
+++ b/recipes/bioconductor-mzr/2.10.0/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - bioconductor-protgenerics
     - bioconductor-zlibbioc
     - libnetcdf
-    - r-base
+    - 'r-base ==3.4.1'
     - r-ncdf4
     - 'r-rcpp >=0.10.1'
     - zlib
@@ -35,7 +35,7 @@ requirements:
     - bioconductor-protgenerics
     - bioconductor-zlibbioc
     - libnetcdf
-    - r-base
+    - 'r-base ==3.4.1'
     - r-ncdf4
     - 'r-rcpp >=0.10.1'
     - zlib

--- a/recipes/bioconductor-mzr/2.10.0/meta.yaml
+++ b/recipes/bioconductor-mzr/2.10.0/meta.yaml
@@ -1,0 +1,68 @@
+{% set version="2.10.0" %}
+{% set name="mzR" %}
+{% set bioc="3.5" %}
+
+package:
+  name: 'bioconductor-{{ name|lower }}'
+  version: '{{ version }}'
+source:
+  url:
+    - 'https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/{{ name }}_{{ version }}.tar.gz'
+    - 'https://bioarchive.galaxyproject.org/{{ name }}_{{ version }}.tar.gz'
+    - 'https://depot.galaxyproject.org/software/{{ name }}/{{ name }}_{{ version }}_src_all.tar.gz'
+  sha256: a776226cac45b19ea622dd6a4765e3c3052128aa031b3ff3dac20231a02139fe
+build:
+  number: 1
+##  string: boost{{CONDA_BOOST}}_{{PKG_BUILDNUM}}
+  rpaths:
+    - lib/R/lib/
+    - lib/
+requirements:
+  host:
+    - bioconductor-biobase
+    - 'bioconductor-biocgenerics >=0.13.6'
+    - bioconductor-protgenerics
+    - bioconductor-zlibbioc
+    - libnetcdf
+    - r-base
+    - r-ncdf4
+    - 'r-rcpp >=0.10.1'
+    - zlib
+    - boost
+  run:
+    - bioconductor-biobase
+    - 'bioconductor-biocgenerics >=0.13.6'
+    - bioconductor-protgenerics
+    - bioconductor-zlibbioc
+    - libnetcdf
+    - r-base
+    - r-ncdf4
+    - 'r-rcpp >=0.10.1'
+    - zlib
+    - boost
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - automake
+    - make
+test:
+  commands:
+    - '$R -e "library(''{{ name }}'')"'
+about:
+  home: 'https://bioconductor.org/packages/{{ bioc }}/bioc/html/{{ name }}.html'
+  license: Artistic-2.0
+  summary: API for handling file formats for mass spectrometry data
+  description: |
+    mzR provides a unified API to the common file formats and parsers available
+    for mass spectrometry data. It comes with a wrapper for the ISB random
+    access parser for mass spectrometry mzXML, mzData and mzML files.
+    The package contains the original code written by the ISB, and a subset of
+    the proteowizard library for mzML and mzIdentML. The netCDF reading code
+    has previously been used in XCMS.
+extra:
+  identifiers:
+    - biotools:mzr
+  parent_recipe:
+    name: bioconductor-mzr
+    path: recipes/bioconductor-mzr
+    version: 2.6.3


### PR DESCRIPTION
Follow up from https://github.com/bioconda/bioconda-recipes/pull/15531 . For the current Galaxy wrapper for profia the 2.10.0 version in needed. Currently mzr-2.10.0-boost1.64_0 is installed (the dependency chain is bioconductor-profia-1.4.0-r3.4.1_0 .. bioconductor-xcms-1.50.1-r3.4.1_0 and the bioconductor-mzr). 

Would be really good to have a working recipe for reproduibility. Currently it fails with 

```
Error: package or namespace load failed for ‘mzR’ in dyn.load(file, DLLpath = DLLpath, ...):
 unable to load shared object '/home/berntm/miniconda3/envs/mulled-v1-0aac71eabd627c852daf922fc2ada2ca25012162d88fa88e2fe10c1f0dc1234a/lib/R/library/mzR/libs/mzR.so':
  libnetcdf.so.11: cannot open shared object file: No such file or directory
```

For this recipe I manual merged version form d3ed749dc0c0b1a3e4e037773b8ce5ed18fe80f1
with the current state in the 2.16.2.

Don't know if we should pin the versions of all bioconductor dependencies as it is the case for the current recipes.

@dpryan79 sorry for the extra work .. somehow I mixed up versions. 

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
