### PR TITLE
Update r-basejump recipe and dependencies

### DIFF
--- a/recipes/r-basejump/meta.yaml
+++ b/recipes/r-basejump/meta.yaml
@@ -1,12 +1,13 @@
-{% set version = "0.9.11" %}
+{% set version = "0.10.9" %}
+{% set github = "https://github.com/acidgenomics/basejump" %}
 
 package:
   name: r-basejump
-  version: {{ version }}
+  version: "{{ version }}"
 
 source:
-  url: https://github.com/steinbaugh/basejump/archive/v{{ version }}.tar.gz
-  sha256: c68790afe6c655ec448b39a3afad07f6a13470a295ed9e06c27f30d2dadbfebe
+  url: "{{ github }}/archive/v{{ version }}.tar.gz"
+  sha256: 2f3735c44df99296c584a1dc4583041a9e5b24b3f8c3146cea1b8c497c05c296
 
 build:
   number: 0
@@ -18,105 +19,81 @@ build:
 requirements:
   host:
     - r-base
-    - bioconductor-annotationhub
+    - r-bioverbs >=0.1.19
+    - r-brio >=0.2.1
+    - r-freerange >=0.1.6
+    - r-goalie >=0.2.16
+    - r-syntactic >=0.1.9
+    - r-transformer >=0.1.11
     - bioconductor-biobase
     - bioconductor-biocgenerics
-    - bioconductor-ensembldb
     - bioconductor-genomeinfodb
+    - bioconductor-genomicranges
+    - bioconductor-iranges
     - bioconductor-s4vectors
-    - r-assertive
-    - r-cowplot >=0.9
-    - r-dendsort
-    - r-matrix.utils >=0.9
-    - r-dplyr >=0.7
-    - r-pbapply
-    - r-devtools
-    - r-ggplot2 >=3.0
-    - r-knitr >=1.2.1
+    - bioconductor-singlecellexperiment
+    - bioconductor-summarizedexperiment
+    - r-dplyr >=0.8
+    - r-knitr >=1.22
     - r-magrittr >=1.5
     - r-matrix >=1.2
-    - r-rio
-    - r-sessioninfo >=1.1
-    - r-pheatmap >=1.0
-    - r-rcolorbrewer
-    - r-rcurl >=1.95
+    - r-matrix.utils >=0.9
+    - r-matrixstats >=0.54
+    - r-purrr >=0.2
     - r-readr >=1.3
-    - r-readxl >=1.0
+    - r-reshape2 >=1.4
     - r-rlang >=0.3
-    - r-r.utils
-    - r-scales
+    - r-sessioninfo >=1.1
     - r-stringr >=1.3
     - r-tibble >=2.0
     - r-tidyr >=0.8
-    - r-viridis
-    - r-yaml
-    - r-bioverbs >=0.1.8
-    - r-brio >=0.1.8
-    - r-goalie >=0.2.9
-    - r-syntactic >=0.1.5
-    - r-transformer >=0.1.6
     - r-tidyselect >=0.2
-    - r-ggrepel >=0.8
-    - r-matrixstats >=0.54
-    - r-purrr >=0.2
-    - r-reshape2 >=1.4    
 
   run:
     - r-base
-    - bioconductor-annotationhub
+    - r-bioverbs >=0.1.19
+    - r-brio >=0.2.1
+    - r-freerange >=0.1.6
+    - r-goalie >=0.2.16
+    - r-syntactic >=0.1.9
+    - r-transformer >=0.1.11
     - bioconductor-biobase
     - bioconductor-biocgenerics
-    - bioconductor-ensembldb
     - bioconductor-genomeinfodb
+    - bioconductor-genomicranges
+    - bioconductor-iranges
     - bioconductor-s4vectors
-    - r-assertive
-    - r-cowplot >=0.9
-    - r-dendsort
-    - r-matrix.utils >=0.9
-    - r-dplyr >=0.7
-    - r-pbapply
-    - r-devtools
-    - r-ggplot2 >=3.0
-    - r-knitr >=1.2.1
+    - bioconductor-singlecellexperiment
+    - bioconductor-summarizedexperiment
+    - r-dplyr >=0.8
+    - r-knitr >=1.22
     - r-magrittr >=1.5
     - r-matrix >=1.2
-    - r-rio
-    - r-sessioninfo >=1.1
-    - r-pheatmap >=1.0
-    - r-rcolorbrewer
-    - r-rcurl >=1.95
+    - r-matrix.utils >=0.9
+    - r-matrixstats >=0.54
+    - r-purrr >=0.2
     - r-readr >=1.3
-    - r-readxl >=1.0
+    - r-reshape2 >=1.4
     - r-rlang >=0.3
-    - r-r.utils
-    - r-scales
+    - r-sessioninfo >=1.1
     - r-stringr >=1.3
     - r-tibble >=2.0
     - r-tidyr >=0.8
-    - r-viridis
-    - r-yaml
-    - r-bioverbs >=0.1.8
-    - r-brio >=0.1.8
-    - r-goalie >=0.2.9
-    - r-syntactic >=0.1.5
-    - r-transformer >=0.1.6
     - r-tidyselect >=0.2
-    - r-ggrepel >=0.8
-    - r-matrixstats >=0.54
-    - r-purrr >=0.2
-    - r-reshape2 >=1.4
 
 test:
   commands:
     - $R -e "library('basejump')"
 
 about:
-  home: https://github.com/steinbaugh/basejump
+  home: https://basejump.acidgenomics.com/
+  dev_url: "{{ github }}"
   license: MIT
   summary: Base functions for bioinformatics and R package development.
 
 extra:
   recipe-maintainers:
+    - mjsteinbaugh
     - MathiasHaudgaard
     - FrodePedersen
     - ArneKr

--- a/recipes/r-bioverbs/meta.yaml
+++ b/recipes/r-bioverbs/meta.yaml
@@ -1,29 +1,36 @@
-{% set version = "0.1.8" %}
+{% set version = "0.1.19" %}
+{% set github = "https://github.com/acidgenomics/bioverbs" %}
 
 package:
   name: r-bioverbs
-  version: {{ version }}
+  version: "{{ version }}"
 
 source:
-  url: https://github.com/steinbaugh/bioverbs/archive/v{{ version }}.tar.gz 
-  sha256: f5059996e43ca77e690ee6d2e47f8fd04afac7c201733f94bd0175f2f446a348
+  url: "{{ github }}/archive/v{{ version }}.tar.gz"
+  sha256: 80dd75330faf4ae2053d23645bc8fddeef14f63051a54657b907c3236373db11
 
 build:
   number: 0
 
 requirements:
-    host:
-        - r-base 
-    run:
-        - r-base
+  host:
+    - r-base 
+  run:
+    - r-base
 
 test:
-    commands:
-        - $R -e "library('bioverbs')"
+  commands:
+    - $R -e "library('bioverbs')"
 
 about:
-  home: https://github.com/steinbaugh/bioverbs 
-  dev_url: https://github.com/steinbaugh/bioverbs
+  home: https://bioverbs.acidgenomics.com/
+  dev_url: "{{ github }}"
   license: MIT
-  summary: S4 generic functions for bioinformatics, part of the basejump toolkit. 
-  license_family: MIT
+  summary: S4 generic functions for bioinformatics.
+
+extra:
+  recipe-maintainers:
+    - mjsteinbaugh
+    - pinin4fjords
+    - chapmanb
+

--- a/recipes/r-brio/meta.yaml
+++ b/recipes/r-brio/meta.yaml
@@ -1,67 +1,66 @@
-{% set version = "0.1.8" %}
+{% set version = "0.2.1" %}
+{% set github = "https://github.com/acidgenomics/brio" %}
 
 package:
   name: r-brio
-  version: {{ version }}
+  version: "{{ version }}"
 
 source:
-  url: https://github.com/steinbaugh/brio/archive/v{{ version }}.tar.gz
-  sha256: 7b1ef773fa9255de969abf320401edf87744cdcbecb8a7b87f48ea8ab597d774
+  url: "{{ github }}/archive/v{{ version }}.tar.gz"
+  sha256: 2c7c3666f9458f069b10e727a6fc6cc9b538cee87edb3355772c489e08328054
 
 build:
   number: 0
 
 requirements:
-    host:
-        - r-base 
-        - r-bioverbs >=0.1.8
-        - r-goalie >=0.2.9
-        - r-transformer >=0.1.6
-        - bioconductor-genomicranges
-        - bioconductor-s4vectors
-        - bioconductor-singlecellexperiment
-        - bioconductor-summarizedexperiment
-        - bioconductor-rtracklayer
-        - r-matrix >=1.2
-        - r-r.utils >=2.7
-        - r-curl >=1.95
-        - r-data.table >=1.11
-        - r-jsonlite >=1.6
-        - r-readr >=1.3
-        - r-rio >=0.5
-        - r-stringr >=1.3
-        - r-tibble >=2.0
-        - r-yaml >=2.2
+  host:
+    - r-base
+    - r-bioverbs >=0.1.18
+    - r-goalie >=0.2.16
+    - r-transformer >=0.1.11
+    - bioconductor-genomicranges
+    - bioconductor-rtracklayer
+    - bioconductor-s4vectors
+    - bioconductor-singlecellexperiment
+    - bioconductor-summarizedexperiment
+    - r-curl >=1.95
+    - r-data.table >=1.12
+    - r-jsonlite >=1.6
+    - r-matrix >=1.2
+    - r-r.utils >=2.8
+    - r-readr >=1.3
+    - r-rio >=0.5
+    - r-stringr >=1.4
+    - r-tibble >=2.1
+    - r-yaml >=2.2
 
-    run:
-        - r-base 
-        - r-bioverbs >=0.1.8
-        - r-goalie >=0.2.9
-        - r-transformer >=0.1.6
-        - bioconductor-genomicranges
-        - bioconductor-s4vectors
-        - bioconductor-singlecellexperiment
-        - bioconductor-summarizedexperiment
-        - bioconductor-rtracklayer
-        - r-matrix >=1.2
-        - r-r.utils >=2.7
-        - r-curl >=1.95
-        - r-data.table >=1.11
-        - r-jsonlite >=1.6
-        - r-readr >=1.3
-        - r-rio >=0.5
-        - r-stringr >=1.3
-        - r-tibble >=2.0
-        - r-yaml >=2.2
+  run:
+    - r-base
+    - r-bioverbs >=0.1.18
+    - r-goalie >=0.2.16
+    - r-transformer >=0.1.11
+    - bioconductor-genomicranges
+    - bioconductor-rtracklayer
+    - bioconductor-s4vectors
+    - bioconductor-singlecellexperiment
+    - bioconductor-summarizedexperiment
+    - r-curl >=1.95
+    - r-data.table >=1.12
+    - r-jsonlite >=1.6
+    - r-matrix >=1.2
+    - r-r.utils >=2.8
+    - r-readr >=1.3
+    - r-rio >=0.5
+    - r-stringr >=1.4
+    - r-tibble >=2.1
+    - r-yaml >=2.2
 
 test:
-    commands:
-        - $R -e "library('brio')"
+  commands:
+    - $R -e "library('brio')"
 
 about:
-  home: https://github.com/steinbaugh/brio
-  dev_url: https://github.com/steinbaugh/brio
+  home: https://brio.acidgenomics.com/
+  dev_url: "{{ github }}"
   license: MIT
-  summary: Biological R input/output. This package is part of the basejump
-    toolkit.
-  license_family: MIT
+  summary: Biological R input/output.

--- a/recipes/r-freerange/build.sh
+++ b/recipes/r-freerange/build.sh
@@ -1,0 +1,1 @@
+$R CMD INSTALL --build .

--- a/recipes/r-freerange/meta.yaml
+++ b/recipes/r-freerange/meta.yaml
@@ -1,0 +1,62 @@
+{% set version = "0.1.6" %}
+{% set github = "https://github.com/acidgenomics/freerange" %}
+
+package:
+  name: r-freerange
+  version: "{{ version }}"
+
+source:
+  url: "{{ github }}/archive/v{{ version }}.tar.gz"
+  sha256: a9161118bc9b82ccc5e3d7556b44d7e654506c3eec20a67a3139c1e5a95b6c62
+
+build:
+  number: 0
+
+requirements:
+  host:
+    - r-base
+    - r-brio >=0.2.0
+    - r-goalie >=0.2.16
+    - r-syntactic >=0.1.9
+    - r-transformer >=0.1.11
+    - bioconductor-annotationhub
+    - bioconductor-biocgenerics
+    - bioconductor-ensembldb
+    - bioconductor-genomeinfodb
+    - bioconductor-genomicfeatures
+    - bioconductor-genomicranges
+    - bioconductor-iranges
+    - bioconductor-s4vectors
+    - r-dplyr >=0.8
+    - r-magrittr >=1.5
+    - r-rlang >=0.3
+    - r-tibble >=2.1
+
+  run:
+    - r-base
+    - r-brio >=0.2.0
+    - r-goalie >=0.2.16
+    - r-syntactic >=0.1.9
+    - r-transformer >=0.1.11
+    - bioconductor-annotationhub
+    - bioconductor-biocgenerics
+    - bioconductor-ensembldb
+    - bioconductor-genomeinfodb
+    - bioconductor-genomicfeatures
+    - bioconductor-genomicranges
+    - bioconductor-iranges
+    - bioconductor-s4vectors
+    - r-dplyr >=0.8
+    - r-magrittr >=1.5
+    - r-rlang >=0.3
+    - r-tibble >=2.1
+
+test:
+  commands:
+    - $R -e "library('freerange')"
+
+about:
+  home: https://freerange.acidgenomics.com/
+  dev_url: "{{ github }}"
+  license: MIT
+  summary: Generate and manipulate genomic ranges.

--- a/recipes/r-goalie/meta.yaml
+++ b/recipes/r-goalie/meta.yaml
@@ -1,39 +1,40 @@
-{% set version = "0.2.9" %}
+{% set version = "0.2.16" %}
+{% set github = "https://github.com/acidgenomics/goalie" %}
 
 package:
   name: r-goalie
-  version: {{ version }}
+  version: "{{ version }}"
 
 source:
-  url: https://github.com/steinbaugh/goalie/archive/v{{ version }}.tar.gz 
-  sha256: 69b76b66415ab9fd8fca78549c936f8561dff4298f555fdebd8f01697103ac45
+  url: "{{ github }}/archive/v{{ version }}.tar.gz"
+  sha256: 0fbe297255077f0d43d5f38f6a5d58d607ec43e040c10849f966d16cbd5b69a3
   
 build:
   number: 0
 
 requirements:
-    host:
-        - r-base 
-        - r-backports
-        - r-curl >=3.2.*
-        
-    run:
-        - r-curl >=3.2.*
-        - r-base
+  host:
+    - r-base
+    - r-backports
+    - r-curl >=3.2
+
+  run:
+    - r-base
+    - r-backports
+    - r-curl >=3.2
 
 test:
-    commands:
-        - $R -e "library('goalie')"
+  commands:
+    - $R -e "library('goalie')"
 
 about:
-  home: https://github.com/steinbaugh/goalie
-  dev_url: https://github.com/steinbaugh/goalie
+  home: https://goalie.acidgenomics.com/
+  dev_url: "{{ github }}"
   license: MIT
-  summary: Assertive check functions for defensive R programming. 
-    goalie is an attempt to incorporate elements of multiple assertive check
-    packages into a single package with as few dependencies as possible. All
-    assertive checks are written in the most basic R code possible, without
-    reliance on compilation (e.g. C++/Rcpp). It is still a work in progress,
-    and feature requests are welcome.
+  summary: Assertive check functions for defensive R programming.
 
-  license_family: MIT
+extra:
+  recipe-maintainers:
+    - mjsteinbaugh
+    - pinin4fjords
+    - chapmanb

--- a/recipes/r-syntactic/meta.yaml
+++ b/recipes/r-syntactic/meta.yaml
@@ -1,47 +1,42 @@
-{% set version = "0.1.5" %}
+{% set version = "0.1.9" %}
+{% set github = "https://github.com/acidgenomics/syntactic" %}
 
 package:
   name: r-syntactic
-  version: {{ version }}
+  version: "{{ version }}"
 
 source:
-  url: https://github.com/steinbaugh/syntactic/archive/v{{ version }}.tar.gz 
-  sha256: 0df38399bbaa8c55a679eeae83720276a859e0764411928495add703001e0a7f
+  url: "{{ github }}/archive/v{{ version }}.tar.gz"
+  sha256: 023ae015d91d7ec6bd33de5ec8e627b7138547abe339872da953cdc1fff9725c
 
 build:
   number: 0
 
 requirements:
-    host:
-        - r-base 
-        - r-bioverbs >=0.1.8
-        - r-goalie >=0.2.9
-        - bioconductor-genomicranges
-        - bioconductor-s4vectors
-        - bioconductor-summarizedexperiment
-        - r-matrix
-        - r-r.utils
-        - r-magrittr
+  host:
+    - r-base
+    - r-bioverbs >=0.1.10
+    - r-goalie >=0.2.12
+    - bioconductor-genomicranges
+    - bioconductor-s4vectors
+    - bioconductor-summarizedexperiment
+    - r-matrix
 
-    run:
-        - r-base 
-        - r-bioverbs >=0.1.8
-        - r-goalie >=0.2.9
-        - bioconductor-genomicranges
-        - bioconductor-s4vectors
-        - bioconductor-summarizedexperiment
-        - r-matrix
-        - r-r.utils
-        - r-magrittr
+  run:
+    - r-base
+    - r-bioverbs >=0.1.10
+    - r-goalie >=0.2.12
+    - bioconductor-genomicranges
+    - bioconductor-s4vectors
+    - bioconductor-summarizedexperiment
+    - r-matrix
 
 test:
-    commands:
-        - $R -e "library('syntactic')"
+  commands:
+    - $R -e "library('syntactic')"
 
 about:
-  home: https://github.com/steinbaugh/syntactic
-  dev_url: https://github.com/steinbaugh/syntactic
+  home: https://syntactic.acidgenomics.com/
+  dev_url: "{{ github }}"
   license: MIT
-  summary: Make syntactically valid names out of character vectors. This
-    package is part of the basejump toolkit.
-  license_family: MIT
+  summary: Make syntactically valid names out of character vectors.

--- a/recipes/r-transformer/meta.yaml
+++ b/recipes/r-transformer/meta.yaml
@@ -1,48 +1,55 @@
-{% set version = "0.1.6" %}
+{% set version = "0.1.11" %}
+{% set github = "https://github.com/acidgenomics/transformer" %}
 
 package:
   name: r-transformer
-  version: {{ version }}
+  version: "{{ version }}"
 
 source:
-  url: https://github.com/steinbaugh/transformer/archive/v{{ version }}.tar.gz
-  sha256: 05edb2c71a15b74b87f56efb7ff6e9bd1bc7ce659eef52e442ed44d19ae45f7f
+  url: "{{ github }}/archive/v{{ version }}.tar.gz"
+  sha256: 2a84e481dc9363097b69e447f6e48ba09e35aff39b85d40bb56a7c5e5430858a
 
 build:
   number: 0
 
 requirements:
-    host:
-        - r-base
-        - r-bioverbs >=0.1.8
-        - r-goalie >=0.2.9
-        - bioconductor-genomicranges
-        - bioconductor-s4vectors
-        - bioconductor-summarizedexperiment
-        - r-data.table >=1.12
-        - r-matrix >=1.2
-        - r-tibble >=2.0.1
+  host:
+    - r-base
+    - r-bioverbs >=0.1.9
+    - r-goalie >=0.2.12
+    - bioconductor-biocgenerics
+    - bioconductor-genomicranges
+    - bioconductor-s4vectors
+    - bioconductor-summarizedexperiment
+    - r-data.table >=1.12
+    - r-matrix >=1.2
+    - r-tibble >=2.1
 
-    run:
-        - r-base
-        - r-bioverbs >=0.1.8
-        - r-goalie >=0.2.9
-        - bioconductor-genomicranges
-        - bioconductor-s4vectors
-        - bioconductor-summarizedexperiment
-        - r-data.table >=1.12
-        - r-matrix >=1.2
-        - r-tibble >=2.0.1
+  run:
+    - r-base
+    - r-bioverbs >=0.1.9
+    - r-goalie >=0.2.12
+    - bioconductor-biocgenerics
+    - bioconductor-genomicranges
+    - bioconductor-s4vectors
+    - bioconductor-summarizedexperiment
+    - r-data.table >=1.12
+    - r-matrix >=1.2
+    - r-tibble >=2.1
 
 test:
-    commands:
-        - $R -e "library('transformer')"
+  commands:
+    - $R -e "library('transformer')"
 
 about:
-  home: https://github.com/steinbaugh/transformer
-  dev_url: https://github.com/steinbaugh/transformer
+  home: https://transformer.acidgenomics.com/
+  dev_url: "{{ github }}"
   license: MIT
   summary: Additional S3 and S4 coercion methods for easy interconversion
-    between Bioconductor and tidyverse data classes. This package is part of
-    the basejump toolkit.
-  license_family: MIT
+    between Bioconductor and tidyverse data classes.
+
+extra:
+  recipe-maintainers:
+    - mjsteinbaugh
+    - pinin4fjords
+    - chapmanb


### PR DESCRIPTION
* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [X] This PR adds a new recipe.
* [X] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

This pull request updates r-basejump to v0.10.9. The r-freerange recipe needs to be added, as this is a new dependency for the basejump package.