### PR TITLE
QUAST Bump to Python3.7

### DIFF
--- a/build-fail-blacklist
+++ b/build-fail-blacklist
@@ -31,7 +31,6 @@ recipes/lcfit
 recipes/musicc
 recipes/treekin/0.4.2
 recipes/blast/2.5.0
-recipes/quast
 recipes/w4mclassfilter
 recipes/tobias
 recipes/tadarida-c

--- a/recipes/quast/meta.yaml
+++ b/recipes/quast/meta.yaml
@@ -7,7 +7,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 1
+  number: 2
 
 source:
   url: http://downloads.sourceforge.net/project/{{ name|lower }}/{{ name|lower }}-{{ version }}.tar.gz


### PR DESCRIPTION
Trying to bump to Python3.7 to get my unicycler bump to be installable with Quast in the same environment. I got warned by @dpryan79 but will nevertheless try my best ;-) 

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

