### PR TITLE
Update unitig-counter to v1.0.5

### DIFF
--- a/recipes/unitig-counter/meta.yaml
+++ b/recipes/unitig-counter/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "unitig-counter" %}
-{% set version = "1.0.4" %}
+{% set version = "1.0.5" %}
 
 package:
   name: {{ name|lower }}
@@ -8,7 +8,7 @@ package:
 source:
   git_url: https://github.com/johnlees/{{ name|lower }}.git
   git_rev: v{{ version }}
-  sha256: 26b964899c341c3236bc7f4a781a772730672951520d7fb0155f03d731c6cb1b
+  sha256: 7ee4344ece2d742c050d6a09a07f2342d812cf9b6d80022bd71a95527b86eb6f
 
 build:
   number: 0


### PR DESCRIPTION
Bioconda requires reviews prior to merging pull-requests (PRs). To facilitate this, once your PR is passing tests and ready to be merged, please add the `please review & merge` label so other members of the bioconda community can have a look at your PR and either make suggestions or merge it. Note that if you are not already a member of the bioconda project (meaning that you can't add this label), please ping `@bioconda/core` so that your PR can be reviewed and merged (please note if you'd like to be added to the bioconda project). Please see https://github.com/bioconda/bioconda-recipes/issues/15332 for more details.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Bump unitig-counter to new release v1.0.5 (fixes error on exit)