### PR TITLE
libssw: add a patch for mengyao/Complete-Striped-Smith-Waterman-Library#65

### DIFF
--- a/recipes/libssw/meta.yaml
+++ b/recipes/libssw/meta.yaml
@@ -7,12 +7,14 @@ package:
   version: {{ version }}
 
 build:
-  number: 1
+  number: 2
   skip: True # [py3k or osx]
 
 source:
   url: https://github.com/mengyao/Complete-Striped-Smith-Waterman-Library/archive/v{{ version }}.tar.gz
   md5: {{ md5 }}
+  patches:
+    - ssw_lib.py.patch
 
 requirements:
   build:

--- a/recipes/libssw/ssw_lib.py.patch
+++ b/recipes/libssw/ssw_lib.py.patch
@@ -1,0 +1,13 @@
+--- src/ssw_lib.py	2019-06-10 13:10:39.667611674 +0200
++++ src/ssw_lib.py	2019-06-10 13:11:08.451687753 +0200
+@@ -101,8 +101,8 @@
+         """
+ # load libssw
+         sLibName = 'libssw.so'
+-        if not sLibPath:
+-# user doesn't give the path explicitly
++        if sLibPath:
++# user does give the path explicitly
+             if not op.exists(op.join(sLibPath, sLibName)):
+                 print >> sys.stderr, 'libssw.so does not exist in the input path'
+                 sys.exit()


### PR DESCRIPTION
Bioconda requires reviews prior to merging pull-requests (PRs). To facilitate this, once your PR is passing tests and ready to be merged, please add the `please review & merge` label so other members of the bioconda community can have a look at your PR and either make suggestions or merge it. Note that if you are not already a member of the bioconda project (meaning that you can't add this label), please ping `@bioconda/core` so that your PR can be reviewed and merged (please note if you'd like to be added to the bioconda project). Please see https://github.com/bioconda/bioconda-recipes/issues/15332 for more details.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

This patch fixes the case where the user provides the Python wrapper with an explicit path to the libssw.so library (see mengyao/Complete-Striped-Smith-Waterman-Library#65).
