### PR TITLE
fix bootstrap.py with proxy

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -106,7 +106,7 @@ use_docker = "true"
 if args.no_docker:
     use_docker = "false"
 
-env = {'WORKSPACE': args.bootstrap, 'BOOTSTRAP': "true", 'USE_DOCKER': use_docker, 'PATH': os.environ['PATH']}
+env = {'WORKSPACE': args.bootstrap, 'BOOTSTRAP': "true", 'USE_DOCKER': use_docker, 'PATH': os.environ['PATH'], 'https_proxy': os.environ['https_proxy']}
 sp.check_call(['.circleci/setup.sh'], env=env)
 _write_custom_activate(args.bootstrap)
 

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -106,7 +106,15 @@ use_docker = "true"
 if args.no_docker:
     use_docker = "false"
 
-env = {'WORKSPACE': args.bootstrap, 'BOOTSTRAP': "true", 'USE_DOCKER': use_docker, 'PATH': os.environ['PATH'], 'https_proxy': os.environ['https_proxy']}
+env = {
+    'WORKSPACE': args.bootstrap, 
+    'BOOTSTRAP': "true", 
+    'USE_DOCKER': use_docker, 
+    'PATH': os.environ['PATH'], 
+    'HTTPS_PROXY': os.environ['HTTPS_PROXY'],
+    'https_proxy': os.environ['https_proxy']
+}
+
 sp.check_call(['.circleci/setup.sh'], env=env)
 _write_custom_activate(args.bootstrap)
 


### PR DESCRIPTION
Bioconda requires reviews prior to merging pull-requests (PRs). To facilitate this, once your PR is passing tests and ready to be merged, please add the `please review & merge` label so other members of the bioconda community can have a look at your PR and either make suggestions or merge it. Note that if you are not already a member of the bioconda project (meaning that you can't add this label), please ping `@bioconda/core` so that your PR can be reviewed and merged (please note if you'd like to be added to the bioconda project). Please see https://github.com/bioconda/bioconda-recipes/issues/15332 for more details.

* [ ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

Under a machine with a proxy configured the script bootstrap.py was failing with the following error:

```
$ ./bootstrap.py /tmp/miniconda
fatal: unable to access 'https://github.com/bioconda/bioconda-recipes.git/': Failed to connect to github.com port 443: Connection refused
Traceback (most recent call last):
  File "bootstrap.py", line 110, in <module>
    sp.check_call(['.circleci/setup.sh'], env=env)
  File "/usr/lib/python3.5/subprocess.py", line 271, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['.circleci/setup.sh']' returned non-zero exit status 128
```

This PR should fix it by passing the https_proxy variable to the .circleci/setup.sh call.

@bioconda/core please check