### PR TITLE
bootstrap fix call to env. variables when they are not set

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -110,9 +110,9 @@ env = {
     'WORKSPACE': args.bootstrap, 
     'BOOTSTRAP': "true", 
     'USE_DOCKER': use_docker, 
-    'PATH': os.environ['PATH'], 
-    'HTTPS_PROXY': os.environ['HTTPS_PROXY'],
-    'https_proxy': os.environ['https_proxy']
+    'PATH': os.environ.get('PATH', ""),
+    'HTTPS_PROXY': os.environ.get('HTTPS_PROXY', ""),
+    'https_proxy': os.environ.get('https_proxy', "")
 }
 
 sp.check_call(['.circleci/setup.sh'], env=env)


### PR DESCRIPTION
Bioconda requires reviews prior to merging pull-requests (PRs). To facilitate this, once your PR is passing tests and ready to be merged, please add the `please review & merge` label so other members of the bioconda community can have a look at your PR and either make suggestions or merge it. Note that if you are not already a member of the bioconda project (meaning that you can't add this label), please ping `@bioconda/core` so that your PR can be reviewed and merged (please note if you'd like to be added to the bioconda project). Please see https://github.com/bioconda/bioconda-recipes/issues/15332 for more details.

* [ ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Fixing the PR #15834 when variables are not set in the environment. 
