### PR TITLE
set QUALIMAP_HOME to proper path in qualimap wrapper script

### DIFF
--- a/recipes/qualimap/build.sh
+++ b/recipes/qualimap/build.sh
@@ -10,6 +10,8 @@ cd "${SRC_DIR}"
 if [ "$(uname)" == "Darwin" ]; then
     rm -f libIntel*.so
 fi
+# Set QUALIMAP_HOME to libraries path. This can help qualimap know where scripts/ forlder is.
+sed -i.bak "/-classpath [^ ]*/i\export QUALIMAP_HOME='/opt/anaconda1anaconda2anaconda3/${TGT_BASE}'" qualimap
 # Set classpath to libraries
 sed -i.bak "s#-classpath [^ ]*#-classpath '/opt/anaconda1anaconda2anaconda3/${TGT_BASE}/*'#" qualimap
 # MaxPermSize not supported with Java 8 -- avoid warnings

--- a/recipes/qualimap/meta.yaml
+++ b/recipes/qualimap/meta.yaml
@@ -7,7 +7,7 @@ source:
   sha256: 6b349650c19796ae31023095690425236c1f9b40f43e47303bf3bb26e15461ef
 
 build:
-  number: 0
+  number: 1
   noarch: generic
 
 requirements:


### PR DESCRIPTION

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

@bioconda/core @apeltzer

Hello, I have encountered a problem when running the following command:

```shell
qualimap counts -c -d path/to/samples_data.txt --java-mem-size=8G  -outformat html -outdir path/to/couts_qc
```

It gave the error:

```
Rscript /home/hidden/usr/miniconda3/envs/bioinfo/bin/scripts/countsQC.r --homedir /home/tangwh/usr/miniconda3/envs/bioinfo/bin/scripts --input /tmp/qualimap1560852042263//input.txt -k 5 --compare -o /tmp/qualimap1560852042263/
Fatal error: ??????'/home/hidden/usr/miniconda3/envs/bioinfo/bin/scripts/countsQC.r': ?????????
Failed to run counts
java.lang.RuntimeException: The RScript process finished with error.
 Check log for details.
        at org.bioinfo.ngs.qc.qualimap.process.CountsQcAnalysis.run(CountsQcAnalysis.java:120)
        at org.bioinfo.ngs.qc.qualimap.main.CountsQcTool.execute(CountsQcTool.java:182)
        at org.bioinfo.ngs.qc.qualimap.main.NgsSmartTool.run(NgsSmartTool.java:190)
        at org.bioinfo.ngs.qc.qualimap.main.NgsSmartMain.main(NgsSmartMain.java:113)
```

I think the key point of this problem is that `scripts` folder was not in the location `/home/hidden/usr/miniconda3/envs/bioinfo/bin` 。Actually, the `scripts` and `species` folders were located at `/home/hidden/usr/miniconda3/envs/bioinfo/share/qualimap-2.2.2c-0` 。

In the wrapper script of qualimap `bin/qualimap` , I think that `QUALIMAP_HOME` was used to set home dir. Please see the source code of  `src/main/java/org/bioinfo/ngs/qc/qualimap/main/NgsSmartTool.java` :

```java
    public void init() {

        // log
        logger = new Logger();

        // environment
		homePath = System.getenv("QUALIMAP_HOME");
        if (homePath == null) {
            homePath = new File("").getAbsolutePath() + File.separator;
        }
		if(homePath.endsWith(File.separator)){
			homePath = homePath.substring(0,homePath.length()-1);
		}

		// arguments
		options = new Options();
		parser = new PosixParser();
		outdir = ".";
        reportFileName = "";
        outputType = Constants.REPORT_TYPE_HTML;

		initCommonOptions();

		initOptions();

    }
```

And then, `homePath` was used to find out the real path of `countsQC.r` . Please see the source code of 

`src/main/java/org/bioinfo/ngs/qc/qualimap/process/CountsQcAnalysis.java` :

```java
    private String[] createCommand(String workDir) {

        List<String> argList = new ArrayList<String>();

        String pathToRscript = AppSettings.getGlobalSettings().getPathToRScript();
        argList.add(pathToRscript);

        String commandString = homePath + File.separator + "scripts"+ File.separator + "countsQC.r";
        argList.add(commandString);

        argList.add("--homedir");
        argList.add(homePath + File.separator + "scripts");

        argList.add("--input");
        argList.add(inputFilePath);

        argList.add("-k");
        argList.add(Integer.toString(countsThreshold));
        if (!infoFilePath.isEmpty()) {
            argList.add("--info");
            argList.add(infoFilePath);
        }

        if (compareConditions) {
            argList.add("--compare");
        }
        argList.add("-o");
        argList.add(workDir);

        String[] result = new String[argList.size()];
        result = argList.toArray(result);
        return result;
    }
```

Therefore, the solution of the problem that I have encountered is versy simple. The only thing we need to do is setting correct `QUALIMAP_HOME` at the wrapper script. This is what I have commited at this pull request.