### PR TITLE
Restore linking of PureCN analysis scripts.

### DIFF
--- a/build-fail-blacklist
+++ b/build-fail-blacklist
@@ -2636,7 +2636,6 @@ recipes/bioconductor-psygenet2r
 recipes/bioconductor-pth2o2lipids
 recipes/bioconductor-puma
 recipes/bioconductor-pumadata
-recipes/bioconductor-purecn
 recipes/bioconductor-pvac
 recipes/bioconductor-pvca
 recipes/bioconductor-pviz

--- a/recipes/bioconductor-purecn/build.sh
+++ b/recipes/bioconductor-purecn/build.sh
@@ -9,3 +9,15 @@ CXX98=$CXX
 CXX11=$CXX
 CXX14=$CXX" > ~/.R/Makevars
 $R CMD INSTALL --build .
+
+extdata=$PREFIX/lib/R/library/PureCN/extdata
+mkdir -p $PREFIX/bin
+
+for S in Coverage.R Dx.R FilterCallableLoci.R IntervalFile.R NormalDB.R
+do
+	perl -pi -e 'print "#!/opt/anaconda1anaconda2anaconda3/bin/Rscript\n" if $. == 1' $extdata/$S
+	ln -s $extdata/$S $PREFIX/bin/PureCN_${S}
+done
+
+perl -pi -e 'print "#!/opt/anaconda1anaconda2anaconda3/bin/Rscript\n" if $. == 1' $extdata/PureCN.R
+ln -s $extdata/PureCN.R $PREFIX/bin/PureCN.R

--- a/recipes/bioconductor-purecn/meta.yaml
+++ b/recipes/bioconductor-purecn/meta.yaml
@@ -20,19 +20,19 @@ build:
 # Suggests: PSCBS, copynumber, BiocStyle, BiocParallel, knitr, optparse, TxDb.Hsapiens.UCSC.hg19.knownGene, org.Hs.eg.db, covr, testthat
 requirements:
   host:
-    - 'bioconductor-biocgenerics >=0.30.0,<0.31.0'
-    - 'bioconductor-biostrings >=2.52.0,<2.53.0'
+    - bioconductor-biocgenerics
+    - bioconductor-biostrings
     - 'bioconductor-dnacopy >=1.58.0,<1.59.0'
-    - 'bioconductor-genomeinfodb >=1.20.0,<1.21.0'
-    - 'bioconductor-genomicfeatures >=1.36.0,<1.37.0'
-    - 'bioconductor-genomicranges >=1.36.0,<1.37.0'
-    - 'bioconductor-iranges >=2.18.0,<2.19.0'
+    - bioconductor-genomeinfodb
+    - bioconductor-genomicfeatures
+    - bioconductor-genomicranges
+    - bioconductor-iranges
     - 'bioconductor-rhdf5 >=2.28.0,<2.29.0'
-    - 'bioconductor-rsamtools >=2.0.0,<2.1.0'
-    - 'bioconductor-rtracklayer >=1.44.0,<1.45.0'
-    - 'bioconductor-s4vectors >=0.22.0,<0.23.0'
-    - 'bioconductor-summarizedexperiment >=1.14.0,<1.15.0'
-    - 'bioconductor-variantannotation >=1.30.0,<1.31.0'
+    - bioconductor-rsamtools
+    - bioconductor-rtracklayer
+    - bioconductor-s4vectors
+    - bioconductor-summarizedexperiment
+    - bioconductor-variantannotation
     - r-base
     - r-data.table
     - r-futile.logger
@@ -42,19 +42,19 @@ requirements:
     - r-rcolorbrewer
     - r-vgam
   run:
-    - 'bioconductor-biocgenerics >=0.30.0,<0.31.0'
-    - 'bioconductor-biostrings >=2.52.0,<2.53.0'
+    - bioconductor-biocgenerics
+    - bioconductor-biostrings
     - 'bioconductor-dnacopy >=1.58.0,<1.59.0'
-    - 'bioconductor-genomeinfodb >=1.20.0,<1.21.0'
-    - 'bioconductor-genomicfeatures >=1.36.0,<1.37.0'
-    - 'bioconductor-genomicranges >=1.36.0,<1.37.0'
-    - 'bioconductor-iranges >=2.18.0,<2.19.0'
+    - bioconductor-genomeinfodb
+    - bioconductor-genomicfeatures
+    - bioconductor-genomicranges
+    - bioconductor-iranges
     - 'bioconductor-rhdf5 >=2.28.0,<2.29.0'
-    - 'bioconductor-rsamtools >=2.0.0,<2.1.0'
-    - 'bioconductor-rtracklayer >=1.44.0,<1.45.0'
-    - 'bioconductor-s4vectors >=0.22.0,<0.23.0'
-    - 'bioconductor-summarizedexperiment >=1.14.0,<1.15.0'
-    - 'bioconductor-variantannotation >=1.30.0,<1.31.0'
+    - bioconductor-rsamtools
+    - bioconductor-rtracklayer
+    - bioconductor-s4vectors
+    - bioconductor-summarizedexperiment
+    - bioconductor-variantannotation
     - r-base
     - r-data.table
     - r-futile.logger
@@ -66,10 +66,16 @@ requirements:
 test:
   commands:
     - '$R -e "library(''{{ name }}'')"'
+    - 'command -v PureCN.R >/dev/null 2>&1 || { echo >&2 "PureCN.R is not installed.  Aborting."; exit 1; }'
+    - 'command -v PureCN_Coverage.R >/dev/null 2>&1 || { echo >&2 "PureCN_Coverage.R is not installed.  Aborting."; exit 1; }'
+    - 'command -v PureCN_Dx.R >/dev/null 2>&1 || { echo >&2 "PureCN_Dx.R is not installed.  Aborting."; exit 1; }'
+    - 'command -v PureCN_FilterCallableLoci.R >/dev/null 2>&1 || { echo >&2 "PureCN_FilterCallableLoci.R is not installed.  Aborting."; exit 1; }'
+    - 'command -v PureCN_IntervalFile.R >/dev/null 2>&1 || { echo >&2 "PureCN_IntervalFile.R is not installed.  Aborting."; exit 1; }'
+    - 'command -v PureCN_NormalDB.R >/dev/null 2>&1 || { echo >&2 "PureCN_NormalDB.R is not installed.  Aborting."; exit 1; }'
 about:
   home: 'https://bioconductor.org/packages/{{ bioc }}/bioc/html/{{ name }}.html'
   license: Artistic-2.0
-  summary: 'This package estimates tumor purity, copy number, and loss of heterozygosity (LOH), and classifies single nucleotide variants (SNVs) by somatic status and clonality. PureCN is designed for targeted short read sequencing data, integrates well with standard somatic variant detection and copy number pipelines, and has support for tumor samples without matching normal samples.'
+  summary: Copy number calling and SNV classification using targeted short read sequencing
 extra:
   identifiers:
     - biotools:purecn
@@ -77,4 +83,5 @@ extra:
     name: bioconductor-purecn
     path: recipes/bioconductor-purecn
     version: 1.13.1
-
+  recipe_maintainers:
+    - roryk


### PR DESCRIPTION
The automatic updates removed the linking of the scripts. The dependencies were
pinned too hard for this formula and needed to be build on R 3.6 depite the
PureCN recipe not needing versions that were that new, so I removed the pinning
on those formulas.

I also added in checks to make sure the scripts are properly linked and
available.

Bioconda requires reviews prior to merging pull-requests (PRs). To facilitate this, once your PR is passing tests and ready to be merged, please add the `please review & merge` label so other members of the bioconda community can have a look at your PR and either make suggestions or merge it. Note that if you are not already a member of the bioconda project (meaning that you can't add this label), please ping `@bioconda/core` so that your PR can be reviewed and merged (please note if you'd like to be added to the bioconda project). Please see https://github.com/bioconda/bioconda-recipes/issues/15332 for more details.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
