### PR TITLE
Link kmer2read_distr to bin/src

### DIFF
--- a/recipes/bracken/build.sh
+++ b/recipes/bracken/build.sh
@@ -10,4 +10,5 @@ cp src/generate_kmer_distribution.py "${PREFIX}"/bin/src && chmod +x "${PREFIX}"
 ln -s "${PREFIX}"/bin/src/generate_kmer_distribution.py "${PREFIX}"/bin/generate_kmer_distribution.py
 cp src/kreport2mpa.py "${PREFIX}"/bin && chmod +x "${PREFIX}"/bin/kreport2mpa.py
 cp src/kmer2read_distr "${PREFIX}"/bin
+ln -s "${PREFIX}"/bin/kmer2read_distr "${PREFIX}"/bin/src/
 cp analysis_scripts/combine_bracken_outputs.py "${PREFIX}"/bin && chmod +x "${PREFIX}"/bin/combine_bracken_outputs.py


### PR DESCRIPTION
Fix `ERROR: kmer2read_distr program not found` error, see issue jenniferlu717/Bracken#58.

Bioconda requires reviews prior to merging pull-requests (PRs). To facilitate this, once your PR is passing tests and ready to be merged, please add the `please review & merge` label so other members of the bioconda community can have a look at your PR and either make suggestions or merge it. Note that if you are not already a member of the bioconda project (meaning that you can't add this label), please ping `@bioconda/core` so that your PR can be reviewed and merged (please note if you'd like to be added to the bioconda project). Please see https://github.com/bioconda/bioconda-recipes/issues/15332 for more details.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
