### PR TITLE
Update Prokka to use non-expired version of tbl2asn

### DIFF
--- a/recipes/prokka/1.12/meta.yaml
+++ b/recipes/prokka/1.12/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: '{{ sha256 }}'
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipes/prokka/1.12/meta.yaml
+++ b/recipes/prokka/1.12/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - perl-bioperl  >=1.7.2
     - perl-xml-simple
     - prodigal >=2.6
-    - tbl2asn >=25.6
+    - tbl2asn >=25.7
 
 test:
   commands:

--- a/recipes/prokka/1.12/meta.yaml
+++ b/recipes/prokka/1.12/meta.yaml
@@ -10,7 +10,8 @@ source:
   sha256: '{{ sha256 }}'
 
 build:
-  number: 1
+  number: 2
+  noarch: generic
 
 requirements:
   build:

--- a/recipes/prokka/meta.yaml
+++ b/recipes/prokka/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - perl-bioperl  >=1.7.2
     - perl-xml-simple
     - prodigal >=2.6
-    - tbl2asn >=25.6
+    - tbl2asn >=25.7
 
 test:
   commands:

--- a/recipes/prokka/meta.yaml
+++ b/recipes/prokka/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: '{{ sha256 }}'
 
 build:
-  number: 0
+  number: 1
   noarch: generic
 
 requirements:

--- a/recipes/prokka/meta.yaml
+++ b/recipes/prokka/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: '{{ sha256 }}'
 
 build:
-  number: 1
+  number: 2
   noarch: generic
 
 requirements:


### PR DESCRIPTION
Bioconda requires reviews prior to merging pull-requests (PRs). To facilitate this, once your PR is passing tests and ready to be merged, please add the `please review & merge` label so other members of the bioconda community can have a look at your PR and either make suggestions or merge it. Note that if you are not already a member of the bioconda project (meaning that you can't add this label), please ping `@bioconda/core` so that your PR can be reviewed and merged (please note if you'd like to be added to the bioconda project). Please see https://github.com/bioconda/bioconda-recipes/issues/15332 for more details.

* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
* [ ] This PR adds a new recipe.
* [X] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Current recipe allows for an expired version of tbl2asn to be used. I'm changing the requirements to be >= to the most recent version of tbl2asn. 