### PR TITLE
specifies openjdk for Java 8

### DIFF
--- a/recipes/snippy/meta.yaml
+++ b/recipes/snippy/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: '{{ sha256 }}'
 
 build:
-  number: 1
+  number: 2
   noarch: generic
 
 requirements:
@@ -33,7 +33,7 @@ requirements:
     - samclip >=0.2
     - seqtk >=1.2
     - minimap2 >=2.10
-    - openjdk >=8
+    - openjdk =8
 
 test:
   commands:


### PR DESCRIPTION
Hi @bioconda/core, this is a pull request to update the recipe for snippy in response to [this issue](https://github.com/tseemann/snippy/issues/259) and is a correction to PR #16003.  This recipe specifies `openjdk =8` in the `meta.yaml`, ensures that Java 8 is called for snpEff as recommended by @tseemann

- [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/guidelines.html).
- [ ] This PR adds a new recipe.
- [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
- [x] This PR updates an existing recipe.
- [ ] This PR does something else (explain below).

May the SNPs be with you.
