### PR TITLE
[Nullarbor 2] Add "make" to the requirements

### DIFF
--- a/recipes/nullarbor/meta.yaml
+++ b/recipes/nullarbor/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 4
+  number: 5
   skip: True # [osx]
 
 source:

--- a/recipes/nullarbor/meta.yaml
+++ b/recipes/nullarbor/meta.yaml
@@ -7,6 +7,7 @@ package:
 
 build:
   number: 5
+  noarch: generic
   skip: True # [osx]
 
 source:
@@ -60,6 +61,7 @@ extra:
   skip-lints:
     - uses_git_url
     - missing_hash
+    - uses_vcs_url
 
 about:
   home: https://github.com/tseemann/nullarbor

--- a/recipes/nullarbor/meta.yaml
+++ b/recipes/nullarbor/meta.yaml
@@ -7,7 +7,6 @@ package:
 
 build:
   number: 5
-  noarch: generic
   skip: True # [osx]
 
 source:
@@ -62,6 +61,7 @@ extra:
     - uses_git_url
     - missing_hash
     - uses_vcs_url
+    - should_be_noarch_generic
 
 about:
   home: https://github.com/tseemann/nullarbor

--- a/recipes/nullarbor/meta.yaml
+++ b/recipes/nullarbor/meta.yaml
@@ -49,6 +49,7 @@ requirements:
     - quicktree >=2.4
     - pigz
     - samtools >=1.8
+    - make
 
 test:
   commands:


### PR DESCRIPTION
Just added `make ` in the requirements list.
When installing in vanilla images, "make" will be missing but is needed to perform the analysis (i.e. `nullarbor.pl --run` requires `make `to be present).

Bioconda requires reviews prior to merging pull-requests (PRs). To facilitate this, once your PR is passing tests and ready to be merged, please add the `please review & merge` label so other members of the bioconda community can have a look at your PR and either make suggestions or merge it. Note that if you are not already a member of the bioconda project (meaning that you can't add this label), please ping `@bioconda/core` so that your PR can be reviewed and merged (please note if you'd like to be added to the bioconda project). Please see https://github.com/bioconda/bioconda-recipes/issues/15332 for more details.

* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
* [ ] This PR adds a new recipe.
* [X] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
