### PR TITLE
pin scipy to >= 1.3.0

### DIFF
--- a/recipes/bcbio-nextgen/meta.yaml
+++ b/recipes/bcbio-nextgen/meta.yaml
@@ -3,12 +3,12 @@ package:
   version: '1.1.6a'
 
 build:
-  number: 0
+  number: 1
   # Currently hitting conda errors on OSX
   # ERROR:conda.core.link:An error occurred while installing package
   # FileNotFoundError(2, "No such file or directory: '_placehold_pl/bin/python3.7'
   # https://circleci.com/gh/bioconda/bioconda-recipes/50729
-  skip: true  # [osx]
+  noarch: python
 
 source:
   #url: https://pypi.io/packages/source/b/bcbio-nextgen/bcbio-nextgen-1.1.5.tar.gz
@@ -17,7 +17,7 @@ source:
 
 requirements:
   host:
-    - python
+    - python >=3.6
     - setuptools
     - pip
   run:
@@ -27,7 +27,6 @@ requirements:
     - bioblend
     - biopython
     - boto
-    - cython
     - cyvcf2
     - dnapi
     - fadapa
@@ -57,7 +56,7 @@ requirements:
     - pyvcf
     - pyyaml
     - requests
-    - scipy
+    - scipy >=1.3.0
     - seaborn
     - seqcluster
     - statsmodels


### PR DESCRIPTION
The unversioned scipy installs a broken version 1.1.0 that is missing
openlibblas.

1. Fixes linting issues with the recipe.
2. Re-enables building on OSX, the code should work at least on OSX.
3. python 3+ is required now, so pin to that

Bioconda requires reviews prior to merging pull-requests (PRs). To facilitate this, once your PR is passing tests and ready to be merged, please add the `please review & merge` label so other members of the bioconda community can have a look at your PR and either make suggestions or merge it. Note that if you are not already a member of the bioconda project (meaning that you can't add this label), please ping `@bioconda/core` so that your PR can be reviewed and merged (please note if you'd like to be added to the bioconda project). Please see https://github.com/bioconda/bioconda-recipes/issues/15332 for more details.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
