### PR TITLE
fasta-splitter update to version 0.2.6

### DIFF
--- a/recipes/fasta-splitter/build.sh
+++ b/recipes/fasta-splitter/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+outdir=$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM
+mkdir -p $outdir
+ln -s $PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM $PREFIX/share/$PKG_NAME
+
+cp ./fasta-splitter.pl $outdir/
+chmod +x $outdir/fasta-splitter.pl
+
+mkdir -p $PREFIX/bin
+ln -s $outdir/fasta-splitter.pl $PREFIX/bin/fasta-splitter

--- a/recipes/fasta-splitter/meta.yaml
+++ b/recipes/fasta-splitter/meta.yaml
@@ -1,0 +1,28 @@
+{% set version = "0.2.6" %}
+
+package:
+  name: fasta-splitter
+  version: '{{ version }}'
+
+source:
+  fn: fasta-splitter-{{ version }}.zip
+  sha256: fe0d551d23c540163e66c225e0fbe17656694174046a2bc2631daa41b1fd0068
+  url: http://kirill-kryukov.com/study/tools/fasta-splitter/files/fasta-splitter-{{ version }}.zip
+
+build:
+  number: 1
+  skip: False
+
+requirements:
+  run:
+      - perl
+      - perl-file-util
+
+test:
+    commands:
+      - fasta-splitter --help
+
+about:
+  home: http://kirill-kryukov.com/study/tools/fasta-splitter/
+  license: zlib/libpng
+  summary: 'Divides a large FASTA file into a set of smaller, approximately equally sized files'

--- a/recipes/fasta-splitter/meta.yaml
+++ b/recipes/fasta-splitter/meta.yaml
@@ -5,12 +5,12 @@ package:
   version: '{{ version }}'
 
 source:
-  fn: fasta-splitter-{{ version }}.zip
   sha256: fe0d551d23c540163e66c225e0fbe17656694174046a2bc2631daa41b1fd0068
   url: http://kirill-kryukov.com/study/tools/fasta-splitter/files/fasta-splitter-{{ version }}.zip
 
 build:
-  number: 1
+  number: 0
+  noarch: generic
   skip: False
 
 requirements:


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Adds `meta.yaml` and `build.sh` files for `fasta-splitter` to build the latest version (0.2.6).
