### PR TITLE
[seurat-scripts] Adds mscorefonts to avoid plots with no letters

### DIFF
--- a/recipes/seurat-scripts/meta.yaml
+++ b/recipes/seurat-scripts/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: f2f52413c35b73c54978bb70e68531f92fe5fdec6ed75a9b662dc3ffc0d7ad5e
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win32]
   noarch: generic
 
@@ -21,6 +21,7 @@ requirements:
         - r-seurat 2.3.1
         - r-optparse
         - r-workflowscriptscommon
+        - mscorefonts
 
 test:
     commands:

--- a/recipes/seurat-scripts/meta.yaml
+++ b/recipes/seurat-scripts/meta.yaml
@@ -10,7 +10,6 @@ source:
 
 build:
   number: 1
-  skip: true  # [win32]
   noarch: generic
 
 requirements:


### PR DESCRIPTION
Bioconda requires reviews prior to merging pull-requests (PRs). To facilitate this, once your PR is passing tests and ready to be merged, please add the `please review & merge` label so other members of the bioconda community can have a look at your PR and either make suggestions or merge it. Note that if you are not already a member of the bioconda project (meaning that you can't add this label), please ping `@bioconda/core` so that your PR can be reviewed and merged (please note if you'd like to be added to the bioconda project). Please see https://github.com/bioconda/bioconda-recipes/issues/15332 for more details.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Currently the mulled container for seurat-scripts produces plots with squares instead of letters. Based on https://github.com/conda-forge/r-base-feedstock/issues/91 this adds the font to alleviate the problem.