### PR TITLE
trinity: change quoting in perl script

### DIFF
--- a/recipes/trinity/build.sh
+++ b/recipes/trinity/build.sh
@@ -56,6 +56,9 @@ find $TRINITY_HOME -type f -print0 | xargs -0 sed -i.bak 's/FindBin::Bin/FindBin
 # Replace hard coded path to deps
 find $TRINITY_HOME -type f -print0 | xargs -0 sed -i.bak 's/$JELLYFISH_DIR\/bin\/jellyfish/jellyfish/g'
 sed -i.bak "s/\$ROOTDIR\/trinity-plugins\/Trimmomatic/\/opt\/anaconda1anaconda2anaconda3\/share\/trimmomatic/g" $TRINITY_HOME/Trinity
+sed -i 's/my $TRIMMOMATIC = "\([^"]\+\)";/my $TRIMMOMATIC = '"'"'\1'"'"'/' $TRINITY_HOME/Trinity
+sed -i 's/my $TRIMMOMATIC_DIR = "\([^"]\+\)";/my $TRIMMOMATIC_DIR = '"'"'\1'"'"'/' $TRINITY_HOME/Trinity
+
 
 find $TRINITY_HOME -type f -name "*.bak" -print0 | xargs -0 rm -f
 

--- a/recipes/trinity/meta.yaml
+++ b/recipes/trinity/meta.yaml
@@ -12,7 +12,7 @@ source:
     - patch
 
 build:
-  number: 0
+  number: 1
   skip: True  # [osx]
 
 requirements:


### PR DESCRIPTION
since the path can contain an '@' character (galaxy) single quotes are necessary.

note that trinity actually ships with trimmomatic 0.36 in `opt/trinity-2.8.5/trinity-plugins/Trimmomatic/` and `/home/berntm/miniconda3/envs/__trinity@2.8.5/opt/trinity-2.8.5/trinity-plugins/Trimmomatic-0.36` each containing seemingly identical files `trimmomatic-0.36.jar`  `trimmomatic.jar` .. what a mess.

Currently the bioconda recipe requires trimmomatic>=0.36 (introduced here https://github.com/bioconda/bioconda-recipes/pull/10581) which installs 0.39 currently. 

I don't like this and would prefer to use trimmomatic as shipped with trinity or pin version 0.36. 

Would be good to know why the conda package has the requirement anyway. ping @abretaud 

supersedes https://github.com/bioconda/bioconda-recipes/issues/14466


Bioconda requires reviews prior to merging pull-requests (PRs). To facilitate this, once your PR is passing tests and ready to be merged, please add the `please review & merge` label so other members of the bioconda community can have a look at your PR and either make suggestions or merge it. Note that if you are not already a member of the bioconda project (meaning that you can't add this label), please ping `@bioconda/core` so that your PR can be reviewed and merged (please note if you'd like to be added to the bioconda project). Please see https://github.com/bioconda/bioconda-recipes/issues/15332 for more details.

* [ ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
