### PR TITLE
Update perl-set-intervaltree and fix build requirements

### DIFF
--- a/build-fail-blacklist
+++ b/build-fail-blacklist
@@ -598,7 +598,6 @@ recipes/swiftlink
 recipes/tedna
 recipes/transtermhp
 recipes/perl-dbm-deep
-recipes/perl-set-intervaltree
 recipes/carna
 
 # R packages not in CRAN, please feel free to remove from the blacklist if you actually use any of these!

--- a/recipes/perl-set-intervaltree/build.sh
+++ b/recipes/perl-set-intervaltree/build.sh
@@ -9,7 +9,7 @@ if [ -f Build.PL ]; then
     ./Build install --installdirs site
 elif [ -f Makefile.PL ]; then
     # Make sure this goes in site
-    perl Makefile.PL INSTALLDIRS=site
+    perl Makefile.PL INSTALLDIRS=site CC="$CC"
     make
     make test
     make install

--- a/recipes/perl-set-intervaltree/meta.yaml
+++ b/recipes/perl-set-intervaltree/meta.yaml
@@ -1,18 +1,20 @@
 package:
   name: perl-set-intervaltree
-  version: 0.11
+  version: 0.12
 source:
-  url: https://cpan.metacpan.org/authors/id/S/SL/SLOYD/Set-IntervalTree-0.11.tar.gz
-  sha256: 4cf9cca160ad6c5e006d3bd7f09860e817d0deba44d8418d02e39ce75d9aa274
+  url: https://cpan.metacpan.org/authors/id/S/SL/SLOYD/Set-IntervalTree-0.12.tar.gz
+  sha256: 6fd4000e4022968e2ce5b83c07b189219ef1925ecb72977b52a6f7d76adbc349
 build:
-  number: 1
+  number: 0
 requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
   host:
     - perl
     - perl-extutils-cppguess
   run:
     - perl
-    - perl-extutils-cppguess
 test:
   imports:
     - Set::IntervalTree

--- a/recipes/perl-set-intervaltree/meta.yaml
+++ b/recipes/perl-set-intervaltree/meta.yaml
@@ -1,11 +1,17 @@
+{% set version = "0.12" %}
+{% set name = "Set-IntervalTree" %}
+
 package:
-  name: perl-set-intervaltree
-  version: 0.12
+  name: perl-{{ name|lower }}
+  version: {{ version }}
+
 source:
-  url: https://cpan.metacpan.org/authors/id/S/SL/SLOYD/Set-IntervalTree-0.12.tar.gz
+  url: https://cpan.metacpan.org/authors/id/S/SL/SLOYD/{{ name }}-{{ version }}.tar.gz
   sha256: 6fd4000e4022968e2ce5b83c07b189219ef1925ecb72977b52a6f7d76adbc349
+
 build:
   number: 0
+
 requirements:
   build:
     - {{ compiler('c') }}
@@ -15,9 +21,11 @@ requirements:
     - perl-extutils-cppguess
   run:
     - perl
+
 test:
   imports:
     - Set::IntervalTree
+
 about:
   home: https://metacpan.org/pod/Set::IntervalTree
   license: perl_5


### PR DESCRIPTION
Update to upstream Set-IntervalTree-0.12.

Listing the build compiler requirements fixes the build on macOS, so remove from the blacklist "OSX related errors" section.

ExtUtils::CppGuess is needed only when building Set::IntervalTree; at run-time all that is needed is the libcxx runtime.

----

Bioconda requires reviews prior to merging pull-requests (PRs). To facilitate this, once your PR is passing tests and ready to be merged, please add the `please review & merge` label so other members of the bioconda community can have a look at your PR and either make suggestions or merge it. Note that if you are not already a member of the bioconda project (meaning that you can't add this label), please ping `@bioconda/core` so that your PR can be reviewed and merged (please note if you'd like to be added to the bioconda project). Please see `#15332` for more details.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
