### PR TITLE
Update meta.yaml to remove mpi4py

### DIFF
--- a/recipes/ipyrad/meta.yaml
+++ b/recipes/ipyrad/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{sha256}}
 
 build:
-  number: 0
+  number: 1
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv "
   noarch: python  
   entry_points:

--- a/recipes/ipyrad/meta.yaml
+++ b/recipes/ipyrad/meta.yaml
@@ -37,6 +37,7 @@ requirements:
     - muscle
     - vsearch >=2.13
     - bwa
+    - samtools
 
 test:
   imports:

--- a/recipes/ipyrad/meta.yaml
+++ b/recipes/ipyrad/meta.yaml
@@ -33,7 +33,6 @@ requirements:
     - requests
     - cutadapt
     - pysam >=0.15
-    - mpi4py >=3.0
     - bedtools
     - muscle
     - vsearch >=2.13


### PR DESCRIPTION
mpi4py>3.0 is only available for py37, and requires the conda-forge channel. Because it is not a hard dependency and to keep things simple I'll exclude it. Users can install it separate if they want to use it.

Bioconda requires reviews prior to merging pull-requests (PRs). To facilitate this, once your PR is passing tests and ready to be merged, please add the `please review & merge` label so other members of the bioconda community can have a look at your PR and either make suggestions or merge it. Note that if you are not already a member of the bioconda project (meaning that you can't add this label), please ping `@bioconda/core` so that your PR can be reviewed and merged (please note if you'd like to be added to the bioconda project). Please see https://github.com/bioconda/bioconda-recipes/issues/15332 for more details.

* [ ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
