### PR TITLE
Avoid manipulation of LD_LIBRARY_PATH in vmatch

### DIFF
--- a/recipes/vmatch/build.sh
+++ b/recipes/vmatch/build.sh
@@ -26,7 +26,8 @@ fi
 # The SYSTEM variable is not really needed
 # but we set it as should be done.
 # The libs are installed in ${PREFIX}/lib so `vmatch`
-# can find them without the full path.
+# can find them without the full path
+# (thanks to rpath modification by conda).
 pushd SELECT
 SYSTEM=$(uname -s) make
 cp -p *.so ${PREFIX}/lib

--- a/recipes/vmatch/build.sh
+++ b/recipes/vmatch/build.sh
@@ -6,12 +6,10 @@ set -euxo pipefail
 # Those variables are also used in pre and post-link scripts
 BIN_DIR="$PREFIX"/bin
 SHARE_DIR="$PREFIX"/share/${PKG_NAME}-${PKG_VERSION}-${PKG_BUILDNUM}
-PLUGIN_DIR="$SHARE_DIR"/plugin
 DOC_DIR="$SHARE_DIR"/doc
 
 # Create directories
 mkdir -p ${BIN_DIR}
-mkdir -p ${PLUGIN_DIR}
 mkdir -p ${SHARE_DIR}
 mkdir -p ${DOC_DIR}
 mkdir -p ${PREFIX}/lib
@@ -27,9 +25,10 @@ fi
 # Compile selection functions and install them.
 # The SYSTEM variable is not really needed
 # but we set it as should be done.
+# The libs are installed in ${PREFIX}/lib so `vmatch`
+# can find them without the full path.
 pushd SELECT
 SYSTEM=$(uname -s) make
-cp -p *.so ${PLUGIN_DIR}
 cp -p *.so ${PREFIX}/lib
 popd
 

--- a/recipes/vmatch/build.sh
+++ b/recipes/vmatch/build.sh
@@ -24,9 +24,9 @@ else
     find . -maxdepth 1 -type f -executable -exec cp -p \{\} ${BIN_DIR} \;
 fi
 
-# Compile selection functions
+# Compile selection functions and install them.
 # The SYSTEM variable is not really needed
-# but we set it as should be done
+# but we set it as should be done.
 pushd SELECT
 SYSTEM=$(uname -s) make
 cp -p *.so ${PLUGIN_DIR}

--- a/recipes/vmatch/meta.yaml
+++ b/recipes/vmatch/meta.yaml
@@ -17,7 +17,7 @@ source:
 
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipes/vmatch/post-link.sh
+++ b/recipes/vmatch/post-link.sh
@@ -23,12 +23,12 @@ export MKVTREESMAPDIR=${MKVTREESMAPDIR}
 # Create deactivate script
 mkdir -p ${PREFIX}/etc/conda/deactivate.d
 DEACTIVATE_SCRIPT=${PREFIX}/etc/conda/deactivate.d/${PKG_NAME}-${PKG_VERSION}-${PKG_BUILDNUM}.sh
-echo "# Dectivate script for ${PKG_NAME}-${PKG_VERSION}-${PKG_BUILDNUM}
+echo "# Deactivate script for ${PKG_NAME}-${PKG_VERSION}-${PKG_BUILDNUM}
 # Restore LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=\${${SAVE_VARIABLE_NAME}}
 # Remove MKVTREESMAPDIR
 unset MKVTREESMAPDIR
-# Remore ${SAVE_VARIABLE_NAME}
+# Remove ${SAVE_VARIABLE_NAME}
 unset ${SAVE_VARIABLE_NAME}
 " > ${DEACTIVATE_SCRIPT}
 

--- a/recipes/vmatch/post-link.sh
+++ b/recipes/vmatch/post-link.sh
@@ -1,21 +1,11 @@
 #!/bin/bash
 
 SHARE_DIR="$PREFIX"/share/${PKG_NAME}-${PKG_VERSION}-${PKG_BUILDNUM}
-PLUGIN_DIR="$SHARE_DIR"/plugin
 MKVTREESMAPDIR="$SHARE_DIR"/TRANS/
 
 # Create activate script
 mkdir -p ${PREFIX}/etc/conda/activate.d
-ACTIVATE_SCRIPT=${PREFIX}/etc/conda/activate.d/${PKG_NAME}-${PKG_VERSION}-${PKG_BUILDNUM}.sh
-# This variable holds the name of a environement variable
-# that contains the value of LD_LIBRARY_PATH before activating the environment.
-# Its name doesn't include the version (should be enough since there is only one version per env)
-SAVE_VARIABLE_NAME=LD_LIBRARY_PATH_BEFORE_${PKG_NAME}
 echo "# Activate script for ${PKG_NAME}-${PKG_VERSION}-${PKG_BUILDNUM}
-# Save LD_LIBRARY_PATH
-export ${SAVE_VARIABLE_NAME}=\${LD_LIBRARY_PATH}
-# Modify it
-export LD_LIBRARY_PATH=${PLUGIN_DIR}:\${LD_LIBRARY_PATH}
 # Export MKVTREESMAPDIR
 export MKVTREESMAPDIR=${MKVTREESMAPDIR}
 " > ${ACTIVATE_SCRIPT}
@@ -24,18 +14,16 @@ export MKVTREESMAPDIR=${MKVTREESMAPDIR}
 mkdir -p ${PREFIX}/etc/conda/deactivate.d
 DEACTIVATE_SCRIPT=${PREFIX}/etc/conda/deactivate.d/${PKG_NAME}-${PKG_VERSION}-${PKG_BUILDNUM}.sh
 echo "# Deactivate script for ${PKG_NAME}-${PKG_VERSION}-${PKG_BUILDNUM}
-# Restore LD_LIBRARY_PATH
-export LD_LIBRARY_PATH=\${${SAVE_VARIABLE_NAME}}
 # Remove MKVTREESMAPDIR
 unset MKVTREESMAPDIR
-# Remove ${SAVE_VARIABLE_NAME}
-unset ${SAVE_VARIABLE_NAME}
 " > ${DEACTIVATE_SCRIPT}
 
 # Write a message for the user
-echo "Selection functions are installed in ${PLUGIN_DIR}.
+echo "
+vmatch selection functions are installed in ${PREFIX}/lib.
+You can use them without specifying their full path.
 Symbol map files are installed in ${MKVTREESMAPDIR}.
-Activation and deactivation scripts will set LD_LIBRARY_PATH and MKVTREESMAPDIR accordingly
-so you can use selection functions and symbol map files without specifying their full path.
+Activation and deactivation scripts will set MKVTREESMAPDIR accordingly
+so you can use symbol map files without specifying their full path.
 Those scripts are in ${ACTIVATE_SCRIPT} and ${DEACTIVATE_SCRIPT} respectively.
 " > $PREFIX/.messages.txt

--- a/recipes/vmatch/run_test.sh
+++ b/recipes/vmatch/run_test.sh
@@ -14,6 +14,8 @@ mkvtree \
     -db testdatabase.fa -dna -pl 4 -allout -v | \
     grep -q "total length of sequences: 2082 (including 2 separators)"
 echo PASS
+# Note that we use a selection function without its full path.
+# This works thanks to rpath modification by conda.
 echo -n 'Searching Database for Hits... '
 vmatch \
     -v -l 10 -q test.fa -selfun sel392.so 641 testdatabase.fa | \


### PR DESCRIPTION
Bioconda requires reviews prior to merging pull-requests (PRs). To facilitate this, once your PR is passing tests and ready to be merged, please add the `please review & merge` label so other members of the bioconda community can have a look at your PR and either make suggestions or merge it. Note that if you are not already a member of the bioconda project (meaning that you can't add this label), please ping `@bioconda/core` so that your PR can be reviewed and merged (please note if you'd like to be added to the bioconda project). Please see https://github.com/bioconda/bioconda-recipes/issues/15332 for more details.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Following discussion on gitter and conda public ML, we don't want to modify `LD_LIBRARY_PATH` to find plugins. Since the recipe already installs the plugins in `${PREFIX}/lib`, this is indeed not needed. This PR simplifies activation/deactivation scripts and remove the old `PLUGIN_DIR`.