### PR TITLE
Add the EGA v2 client

### DIFF
--- a/recipes/ega2/build.sh
+++ b/recipes/ega2/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -eu -o pipefail
+
+outdir=$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM
+mkdir -p $outdir
+cp EgaDemoClient.jar $outdir
+
+mkdir -p $PREFIX/bin
+cp $RECIPE_DIR/ega2.py $outdir/ega2
+ln -s $outdir/ega2 $PREFIX/bin
+chmod 0755 "${PREFIX}/bin/ega2"

--- a/recipes/ega2/build.sh
+++ b/recipes/ega2/build.sh
@@ -3,7 +3,7 @@ set -eu -o pipefail
 
 outdir=$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM
 mkdir -p $outdir
-cp EgaDemoClient.jar $outdir
+cp EGA_download_client_*/EgaDemoClient.jar $outdir
 
 mkdir -p $PREFIX/bin
 cp $RECIPE_DIR/ega2.py $outdir/ega2

--- a/recipes/ega2/ega2.py
+++ b/recipes/ega2/ega2.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+#
+# Wrapper script for Java Conda packages that ensures that the java runtime
+# is invoked with the right options. Adapted from the bash script (http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in/246128#246128).
+
+#
+# Program Parameters
+#
+import os
+import subprocess
+import sys
+import shutil
+from os import access
+from os import getenv
+from os import X_OK
+
+jar_file = 'EgaDemoClient.jar'
+
+
+default_jvm_mem_opts = ['-Xms512m', '-Xmx1g']
+
+# !!! End of parameter section. No user-serviceable code below this line !!!
+
+
+def real_dirname(path):
+    """Return the symlink-resolved, canonicalized directory-portion of path."""
+    return os.path.dirname(os.path.realpath(path))
+
+
+def java_executable():
+    """Return the executable name of the Java interpreter."""
+    java_home = getenv('JAVA_HOME')
+    java_bin = os.path.join('bin', 'java')
+
+    if java_home and access(os.path.join(java_home, java_bin), X_OK):
+        return os.path.join(java_home, java_bin)
+    else:
+        return 'java'
+
+
+def jvm_opts(argv):
+    """Construct list of Java arguments based on our argument list.
+
+    The argument list passed in argv must not include the script name.
+    The return value is a 3-tuple lists of strings of the form:
+      (memory_options, prop_options, passthrough_options)
+    """
+    mem_opts = []
+    prop_opts = []
+    pass_args = []
+    exec_dir = None
+
+    for arg in argv:
+        if arg.startswith('-D'):
+            prop_opts.append(arg)
+        elif arg.startswith('-XX'):
+            prop_opts.append(arg)
+        elif arg.startswith('-Xm'):
+            mem_opts.append(arg)
+        elif arg.startswith('--exec_dir='):
+            exec_dir = arg.split('=')[1].strip('"').strip("'")
+            if not os.path.exists(exec_dir):
+                shutil.copytree(real_dirname(sys.argv[0]), exec_dir, symlinks=False, ignore=None)
+        else:
+            pass_args.append(arg)
+
+    # In the original shell script the test coded below read:
+    #   if [ "$jvm_mem_opts" == "" ] && [ -z ${_JAVA_OPTIONS+x} ]
+    # To reproduce the behaviour of the above shell code fragment
+    # it is important to explictly check for equality with None
+    # in the second condition, so a null envar value counts as True!
+
+    if mem_opts == [] and getenv('_JAVA_OPTIONS') is None:
+        mem_opts = default_jvm_mem_opts
+
+    return (mem_opts, prop_opts, pass_args, exec_dir)
+
+
+def main():
+    java = java_executable()
+    """
+    PeptideShaker updates files relative to the path of the jar file.
+    In a multiuser setting, the option --exec_dir="exec_dir"
+    can be used as the location for the peptide-shaker distribution.
+    If the exec_dir dies not exist,
+    we copy the jar file, lib, and resources to the exec_dir directory.
+    """
+    (mem_opts, prop_opts, pass_args, exec_dir) = jvm_opts(sys.argv[1:])
+    jar_dir = exec_dir if exec_dir else real_dirname(sys.argv[0])
+
+    if pass_args != [] and pass_args[0].startswith('eu'):
+        jar_arg = '-cp'
+    else:
+        jar_arg = '-jar'
+
+    jar_path = os.path.join(jar_dir, jar_file)
+
+    java_args = [java] + mem_opts + prop_opts + [jar_arg] + [jar_path] + pass_args
+
+    sys.exit(subprocess.call(java_args))
+
+
+if __name__ == '__main__':
+    main()

--- a/recipes/ega2/meta.yaml
+++ b/recipes/ega2/meta.yaml
@@ -20,7 +20,6 @@ requirements:
 test:
   commands:
     - which ega2
-    - ega2 -p foo@bar.com -help 2>&1 | grep {{ version }}
 
 about:
   home: https://ega-archive.org/download/downloader-quickguide-v2 

--- a/recipes/ega2/meta.yaml
+++ b/recipes/ega2/meta.yaml
@@ -1,0 +1,34 @@
+{% set version = "2.2.2" %}
+
+package:
+  name: ega2
+  version: {{ version }}
+
+build:
+  number: 0
+
+source:
+  url: https://ega-archive.org/files/EGA_download_client_2.2.2.zip
+  sha256: 3b7ee5a4bd134c855b5271dd7eb1f5a0971e5939e31c3cf6c6b92d53110fa570
+  
+requirements:
+  host:
+  build:
+    - {{ compiler('c') }}
+  run:
+    - openjdk >=8
+    - python
+
+test:
+  commands:
+    - which ega2
+
+about:
+  home: https://ega-archive.org/download/downloader-quickguide-v2 
+  summary: EGA download client v2 
+  description: |
+    The most up-to-date download client for EGA can be found in the pyega3
+    package. However, that tool does not download a fairly large chunk of EGA
+    files (those ending in .gpg rather than .cip), which limits its generic
+    usefulness. This package attempts to provide the v2 Java client in a more
+    useful manner than a simple .jar.

--- a/recipes/ega2/meta.yaml
+++ b/recipes/ega2/meta.yaml
@@ -5,6 +5,7 @@ package:
   version: {{ version }}
 
 build:
+  noarch: generic
   number: 0
 
 source:
@@ -12,9 +13,6 @@ source:
   sha256: 3b7ee5a4bd134c855b5271dd7eb1f5a0971e5939e31c3cf6c6b92d53110fa570
   
 requirements:
-  host:
-  build:
-    - {{ compiler('c') }}
   run:
     - openjdk >=8
     - python

--- a/recipes/ega2/meta.yaml
+++ b/recipes/ega2/meta.yaml
@@ -9,7 +9,7 @@ build:
   number: 0
 
 source:
-  url: https://ega-archive.org/files/EGA_download_client_2.2.2.zip
+  url: https://ega-archive.org/files/EGA_download_client_{{ version }}.zip
   sha256: 3b7ee5a4bd134c855b5271dd7eb1f5a0971e5939e31c3cf6c6b92d53110fa570
   
 requirements:

--- a/recipes/ega2/meta.yaml
+++ b/recipes/ega2/meta.yaml
@@ -20,6 +20,7 @@ requirements:
 test:
   commands:
     - which ega2
+    - ega2 -p foo@bar.com -help 2>&1 | grep {{ version }}
 
 about:
   home: https://ega-archive.org/download/downloader-quickguide-v2 

--- a/recipes/ega2/meta.yaml
+++ b/recipes/ega2/meta.yaml
@@ -23,7 +23,8 @@ test:
 
 about:
   home: https://ega-archive.org/download/downloader-quickguide-v2 
-  summary: EGA download client v2 
+  summary: EGA download client v2
+  license: unknown
   description: |
     The most up-to-date download client for EGA can be found in the pyega3
     package. However, that tool does not download a fairly large chunk of EGA


### PR DESCRIPTION
Bioconda requires reviews prior to merging pull-requests (PRs). To facilitate this, once your PR is passing tests and ready to be merged, please add the `please review & merge` label so other members of the bioconda community can have a look at your PR and either make suggestions or merge it. Note that if you are not already a member of the bioconda project (meaning that you can't add this label), please ping `@bioconda/core` so that your PR can be reviewed and merged (please note if you'd like to be added to the bioconda project). Please see https://github.com/bioconda/bioconda-recipes/issues/15332 for more details.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
* [x] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

The European Genome/ Phenome archive seems to have two clients right now, the v3 (available via @AlexanderVi 's pyega3 recipe), and the v2, which is a less friendly .jar. The v2 is still required for downloading files in some datasets which the v3 client does not, but the jar file makes things fiddly. and difficult to integrate into workflows. This package just provides the .jar and adds a wrapper script to make command-line usage easier. It borrows heavily from the peptideshaker recipe in way it wraps the .jar. Seem sensible to you @AlexanderVi ?

Issues:

-  absence of proper tests. I haven't been able to identify a good test command that can be run without providing credentials and logging in. 
- licensing: I haven't been able to find a license associated with the v2 client download