### PR TITLE
Updated python/argparse requirements for mofapy

### DIFF
--- a/recipes/mofapy/meta.yaml
+++ b/recipes/mofapy/meta.yaml
@@ -15,15 +15,15 @@ build:
 
 requirements:
   host:
-    - python
+    - python >=2.7
     - pip
 
   run:
-    - argparse
+    - argparse # [py>27 and py<32]
     - h5py
     - numpy
     - pandas
-    - python
+    - python >=2.7
     - scipy
     - scikit-learn 
 

--- a/recipes/mofapy/meta.yaml
+++ b/recipes/mofapy/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 6a5cef1354a1f25a9b9cdf8506d0ee1f59a4e7e6b98a0a59e26705b149b24f7a 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: python -m pip install --no-deps --ignore-installed . 
 
 requirements:

--- a/recipes/mofapy/meta.yaml
+++ b/recipes/mofapy/meta.yaml
@@ -15,15 +15,13 @@ build:
 
 requirements:
   host:
-    - python >=2.7
+    - python
     - pip
-
   run:
-    - argparse # [py>27 and py<32]
     - h5py
     - numpy
     - pandas
-    - python >=2.7
+    - python
     - scipy
     - scikit-learn 
 


### PR DESCRIPTION
Updated mofapy meta.yaml to indicate that python >= 2.7 is required (see project [setup.py](https://github.com/bioFAM/MOFA/blob/52c430356ba42a1abc8ab1338efbcc931c9d83a6/setup.py#L23)) and that argparse is only needed for python >2.7 and <3.2. Currently, the unconditional argparse requirement results in python <= 3.6 being requested, leading to many conflicts and unneccessary downgrades.

* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
* [ ] This PR adds a new recipe.
* [X] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
