### PR TITLE
Bumped version for r-annotables to trigger build for R 3.6

### DIFF
--- a/recipes/r-annotables/meta.yaml
+++ b/recipes/r-annotables/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: a2a0e929cc2682c72032337aac3775733a68163ed7a6d72c25cc316f9f9c5c47
 
 build:
-  number: 2
+  number: 3
   noarch: generic
   rpaths:
     - lib/R/lib/


### PR DESCRIPTION
Bumped version to (hopefully) trigger a build for R 3.6.

It's my understanding that this process should happen automatically, but it's been several weeks now and no such build has been generated, preventing this package from being used in an R 3.6 environment.

* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
* [ ] This PR adds a new recipe.
* [X] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
