### PR TITLE
minced 0.4.0 - build with older java

### DIFF
--- a/recipes/minced/build.sh
+++ b/recipes/minced/build.sh
@@ -2,8 +2,9 @@
 set -e
 
 make
+make test
 
 OUTDIR=$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM
 mkdir -p "${OUTDIR}" "$PREFIX/bin"
-cp minced minced.jar "${OUTDIR}/"
+cp minced minced.jar LICENSE "${OUTDIR}/"
 ln -s "${OUTDIR}/minced" "${PREFIX}/bin/"

--- a/recipes/minced/meta.yaml
+++ b/recipes/minced/meta.yaml
@@ -1,31 +1,33 @@
 {% set name = "minced" %}
 {% set version = "0.4.0" %}
 {% set hash = "bb0dde26f0dd1f12d0faed68cf269645e0e4f39450cdf0774a1c2bc63889aa9e" %}
+{% set user = "ctSkennerton" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://github.com/ctSkennerton/minced/archive/{{ version }}.tar.gz
+  url: https://github.com/{{ user }}/{{ name }}/archive/{{ version }}.tar.gz
   sha256: {{ hash }}
 
 build:
-  number: 1
+  number: 2
   noarch: generic
 
 requirements:
   build:
-    - openjdk 11.*
+    - openjdk =8
 
   run:
-    - openjdk 11.*
+    - openjdk >=8
 
 test:
   commands:
-    - minced --version | grep MinCED
+    - {{ name }} --version | grep '{{ version }}'
 
 about:
-  home: https://github.com/ctSkennerton/minced
+  home: https://github.com/{{ user }}/{{ name }}
   license: GPL-3.0
+  license_file: LICENSE
   summary: MinCED - Mining CRISPRs in Environmental Datasets


### PR DESCRIPTION
For some reason it was being forced to be built with Java 11, but it can and should be built with Java 8 so it can run across a wider range of Java versions.  This will solve dep issues with `prokka` and `nullarbor`/`bohra` @kristyhoran 

* [x] This PR updates an existing recipe.
