### PR TITLE
Rebuild pysamstats

### DIFF
--- a/recipes/pysamstats/meta.yaml
+++ b/recipes/pysamstats/meta.yaml
@@ -7,7 +7,7 @@ source:
   md5: 050294fe9fe99aae3b07ea28f6cbe449
 
 build:
-  number: 4
+  number: 5
 
 requirements:
   build:


### PR DESCRIPTION
I am suddenly having problems installing latest pysamstats (1.1.2), getting conda conflicts for:

```
CHANNEL_OPTS="--override-channels --channel conda-forge --channel bioconda --channel defaults"
SOLVER_OPTS="--strict-channel-priority"
conda create --yes -v $SOLVER_OPTS $CHANNEL_OPTS --name foo pysamstats==1.1.2
```

...which gives:

```
Collecting package metadata (current_repodata.json): ...working... done
Solving environment: ...working... failed with repodata from current_repodata.json, will retry with next repodata source.
Collecting package metadata (repodata.json): ...working... done
Solving environment: ...working... 
Found conflicts! Looking for incompatible packages.
This can take several minutes.  Press CTRL-C to abort.
failed                                                                                                                                                                       
Traceback (most recent call last):
  File "/home/aliman/malariagen/binder/conda/lib/python3.7/site-packages/conda/exceptions.py", line 1062, in __call__
    return func(*args, **kwargs)
  File "/home/aliman/malariagen/binder/conda/lib/python3.7/site-packages/conda/cli/main.py", line 84, in _main
    exit_code = do_call(args, p)
  File "/home/aliman/malariagen/binder/conda/lib/python3.7/site-packages/conda/cli/conda_argparse.py", line 82, in do_call
    exit_code = getattr(module, func_name)(args, parser)
  File "/home/aliman/malariagen/binder/conda/lib/python3.7/site-packages/conda/cli/main_create.py", line 37, in execute
    install(args, parser, 'create')
  File "/home/aliman/malariagen/binder/conda/lib/python3.7/site-packages/conda/cli/install.py", line 292, in install
    raise e
  File "/home/aliman/malariagen/binder/conda/lib/python3.7/site-packages/conda/cli/install.py", line 265, in install
    should_retry_solve=(_should_retry_unfrozen or repodata_fn != repodata_fns[-1]),
  File "/home/aliman/malariagen/binder/conda/lib/python3.7/site-packages/conda/core/solve.py", line 116, in solve_for_transaction
    should_retry_solve)
  File "/home/aliman/malariagen/binder/conda/lib/python3.7/site-packages/conda/core/solve.py", line 157, in solve_for_diff
    force_remove, should_retry_solve)
  File "/home/aliman/malariagen/binder/conda/lib/python3.7/site-packages/conda/core/solve.py", line 280, in solve_final_state
    ssc = self._run_sat(ssc)
  File "/home/aliman/malariagen/binder/conda/lib/python3.7/site-packages/conda/common/io.py", line 88, in decorated
    return f(*args, **kwds)
  File "/home/aliman/malariagen/binder/conda/lib/python3.7/site-packages/conda/core/solve.py", line 804, in _run_sat
    should_retry_solve=ssc.should_retry_solve
  File "/home/aliman/malariagen/binder/conda/lib/python3.7/site-packages/conda/common/io.py", line 88, in decorated
    return f(*args, **kwds)
  File "/home/aliman/malariagen/binder/conda/lib/python3.7/site-packages/conda/resolve.py", line 1268, in solve
    self.find_conflicts(specs, specs_to_add, history_specs)
  File "/home/aliman/malariagen/binder/conda/lib/python3.7/site-packages/conda/resolve.py", line 340, in find_conflicts
    raise UnsatisfiableError(bad_deps, strict=strict_channel_priority)
conda.exceptions.UnsatisfiableError: The following specifications were found to be incompatible with each other:



Package zlib conflicts for:
pysamstats==1.1.2 -> zlib[version='>=1.2.11,<1.3.0a0']
Package pysam conflicts for:
pysamstats==1.1.2 -> pysam[version='>=0.15.2,<0.16.0a0|>=0.15|>=0.15.2,<0.15.3.0a0|>=0.15.2,<1.0a0']
Package python conflicts for:
pysamstats==1.1.2 -> python[version='>=2.7,<2.8.0a0|>=3.5,<3.6.0a0|>=3.6,<3.7.0a0|>=3.7,<3.8.0a0']
Package numpy conflicts for:
pysamstats==1.1.2 -> numpy
Package libgcc-ng conflicts for:
pysamstats==1.1.2 -> libgcc-ng[version='>=4.9|>=7.3.0']
Package pytables conflicts for:
pysamstats==1.1.2 -> pytables
Note that strict channel priority may have removed packages required for satisfiability.
```

Not sure why this is suddenly happening, it was installing fine a month ago. Trying a rebuild to see if that fixes the problem.