### PR TITLE
Fix cromshell dependency

### DIFF
--- a/recipes/cromshell/meta.yaml
+++ b/recipes/cromshell/meta.yaml
@@ -8,7 +8,7 @@ package:
 
 build:
   noarch: generic
-  number: 0
+  number: 1
 
 source:
   url: https://github.com/broadinstitute/{{ name }}/archive/{{ version }}.tar.gz

--- a/recipes/cromshell/meta.yaml
+++ b/recipes/cromshell/meta.yaml
@@ -16,7 +16,7 @@ source:
 
 requirements:
   run:
-    - cromwell
+    - womtool
     - jq
 
 test:


### PR DESCRIPTION
The cromshell recipe was reporting a dependency on cromwell.  It doesn't actually require cromwell.  It does have an optioanl dependency on womtool though which is published alongside cromwell.

Changed dependency from cromwell -> womtool.

* [ ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
