### PR TITLE
megan: fix jre dir

### DIFF
--- a/recipes/megan/meta.yaml
+++ b/recipes/megan/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
 #  detect_binary_files_with_prefix: true
-  number: 0
+  number: 1
   skip: True  # [osx]
 
 requirements:


### PR DESCRIPTION
problem: in the current package jre_dir is set to jre_dir=/home/berntm/miniconda3/envs/__megan@6.12.3/jre. I guess this happened during building, maybe at build time the jre was there. with the current java package this dir is just empty which makes the subsequent definition java=$jre_dir/bin/java wrong.

I hope that by rebuilding we have an easy fix.

Bioconda requires reviews prior to merging pull-requests (PRs). To facilitate this, once your PR is passing tests and ready to be merged, please add the `please review & merge` label so other members of the bioconda community can have a look at your PR and either make suggestions or merge it. Note that if you are not already a member of the bioconda project (meaning that you can't add this label), please ping `@bioconda/core` so that your PR can be reviewed and merged (please note if you'd like to be added to the bioconda project). Please see https://github.com/bioconda/bioconda-recipes/issues/15332 for more details.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
