### PR TITLE
metawrap: fix perl and mkl dependencies

### DIFF
--- a/recipes/metawrap/meta.yaml
+++ b/recipes/metawrap/meta.yaml
@@ -1,4 +1,4 @@
-{% set name = "metawrap" %}
+{% set name = "metaWRAP" %}
 {% set version = "1.2" %}
 
 package:
@@ -10,12 +10,10 @@ source:
   md5: 9018a30354fe066b3e936ae625c6f1b7
 
 build:
-  number: 0
-  skip: True # [osx]
+  number: 1
+  skip: True  # [osx]
 
 requirements:
-  build: 
-
   run:
     - biopython 1.68
     - blas 2.5
@@ -32,7 +30,9 @@ requirements:
     - maxbin2 2.2.6
     - megahit 1.1.3
     - metabat2 2.12.1
+    - mkl
     - pandas 0.24.2
+    - perl-lwp-simple
     - pplacer 1.1.alpha19
     - prokka 1.13
     - quast 5.0.2
@@ -53,6 +53,10 @@ test:
 about:
   home: https://github.com/bxlab/metaWRAP
   license: MIT
+  license_family: MIT
+  license_file: LICENSE
   summary: "MetaWRAP is a pipeline for genome-resolved metagenomic data analysis"
 
-
+extra:
+  identifiers:
+    - doi:10.1186/s40168-018-0541-1

--- a/recipes/metawrap/meta.yaml
+++ b/recipes/metawrap/meta.yaml
@@ -60,3 +60,5 @@ about:
 extra:
   identifiers:
     - doi:10.1186/s40168-018-0541-1
+  skip-lints:
+    - should_be_noarch_generic


### PR DESCRIPTION
Bioconda requires reviews prior to merging pull-requests (PRs). To facilitate this, once your PR is passing tests and ready to be merged, please add the `please review & merge` label so other members of the bioconda community can have a look at your PR and either make suggestions or merge it. Note that if you are not already a member of the bioconda project (meaning that you can't add this label), please ping `@bioconda/core` so that your PR can be reviewed and merged (please note if you'd like to be added to the bioconda project). Please see https://github.com/bioconda/bioconda-recipes/issues/15332 for more details.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

- "metawrap binning" is requiring "perl-lwp-simple"
- metaWRAP=1.2 gives CONCOCT endless warning messages, https://github.com/bxlab/metaWRAP#basic-installation, that are removed by adding "mkl"