### PR TITLE
Update pysam pinning for Ariba

### DIFF
--- a/recipes/ariba/meta.yaml
+++ b/recipes/ariba/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: '{{ sha256 }}'
 
 build:
-  number: 0
+  number: 1
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
@@ -27,7 +27,7 @@ requirements:
     - matplotlib >=3.1.0
     - biopython
     - pyfastaq >=3.12.0
-    - pysam >=0.9.1
+    - pysam >=0.15.3 # older versions have wrong openssl pinning
     - pymummer <=0.10.3
     - bowtie2 >=2.3.1
     - cd-hit >=4.6.5


### PR DESCRIPTION
Bioconda requires reviews prior to merging pull-requests (PRs). To facilitate this, once your PR is passing tests and ready to be merged, please add the `please review & merge` label so other members of the bioconda community can have a look at your PR and either make suggestions or merge it. Note that if you are not already a member of the bioconda project (meaning that you can't add this label), please ping `@bioconda/core` so that your PR can be reviewed and merged (please note if you'd like to be added to the bioconda project). Please see https://github.com/bioconda/bioconda-recipes/issues/15332 for more details.

* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
* [ ] This PR adds a new recipe.
* [X] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [X] This PR updates an existing recipe.
* [X] This PR does something else (explain below).

Seeing the same problem as explained in issue https://github.com/bioconda/bioconda-recipes/issues/17212

```
ariba getref --help
Traceback (most recent call last):
  File "/home/rpetit/miniconda3/envs/ariba/bin/ariba", line 3, in <module>
    import ariba
  File "/home/rpetit/miniconda3/envs/ariba/lib/python3.6/site-packages/ariba/__init__.py", line 57, in <module>
    from ariba import *
  File "/home/rpetit/miniconda3/envs/ariba/lib/python3.6/site-packages/ariba/assembly.py", line 6, in <module>
    from ariba import common, mapping, bam_parse, external_progs, ref_seq_chooser
  File "/home/rpetit/miniconda3/envs/ariba/lib/python3.6/site-packages/ariba/mapping.py", line 4, in <module>
    import pysam
  File "/home/rpetit/miniconda3/envs/ariba/lib/python3.6/site-packages/pysam/__init__.py", line 5, in <module>
    from pysam.libchtslib import *
ImportError: libcrypto.so.1.0.0: cannot open shared object file: No such file or directory
```

After bumping pysam to 0.15.3 (`conda install -c conda-forge -c bioconda pysam=0.15.3`) everything works as expected.

```
ariba getref --help
usage: ariba getref [options] <db> <outprefix>

Download reference data from one of a few supported public resources

positional arguments:
  DB name            Database to download. Must be one of: argannot card
                     megares ncbi plasmidfinder resfinder srst2_argannot
                     vfdb_core vfdb_full virulencefinder
  outprefix          Prefix of output filenames

optional arguments:
  -h, --help         show this help message and exit
  --debug            Do not delete temporary downloaded files
  --version VERSION  Version of reference data to download. If not used, gets
                     the latest version. Applies to: card, megares, ncbi,
                     plasmidfinder, resfinder, srst2_argannot,
                     virulencefinder. For plasmid/res/virulencefinder: default
                     is to get latest from bitbucket - supply git commit hash
                     to get a specific version from bitbucket, or use "old "
                     to get from old website. For srst2_argannot: default is
                     latest version r2, use r1 to get the older version
```