### PR TITLE
Build kyototycoon with fewer side effects

### DIFF
--- a/recipes/kyototycoon/build.sh
+++ b/recipes/kyototycoon/build.sh
@@ -1,43 +1,14 @@
 #!/bin/bash
 
 
-# using default conda libraries for gcc causes the following error:
+# Remove gcc/g++ -ansi option to avoid the following error:
 #    stdlib.h:513:15: error: expected '=', ',', ';', 'asm' or '__attribute__' before 'void'
 #      static inline void* aligned_alloc (size_t al, size_t sz)
 #
-# This is fixed by downloading glibc from asmeurer channel and adding headers to ${PREFIX}/inlude
 
-mkdir glibc
-cd glibc
-wget https://anaconda.org/asmeurer/glibc/2.19/download/linux-64/glibc-2.19-0.tar.bz2
-tar xfvj glibc-2.19-0.tar.bz2
-rm -r include/bits/string3.h
-cp -r include/* ${PREFIX}/include/
-cd ..
-
+sed -i'' -e 's/-ansi//g' kyototycoon/configure kyotocabinet/configure
 
 # Building Kyotocabinet and Kyototycoon
-export CPATH=${PREFIX}/include/:$CPATH
 export CXXFLAGS="-no-pie"
-make PREFIX=${PREFIX} INCLUDEDIR="${PREFIX}/include/" CMDLIBS="-l kyotocabinet -L${PREFIX}/lib -I${PREFIX}/lib -llzo2 -llua -ldl -lz -I${PREFIX}/include/"
+make PREFIX=${PREFIX} CMDLIBS='-lkyotocabinet -llzo2 -llua -ldl -lz'
 make install
-
-
-# adding activation and deactivation scripts to set LD_LIBRARY_PATH
-mkdir -p ${PREFIX}/etc/conda/activate.d
-mkdir -p ${PREFIX}/etc/conda/deactivate.d
-
-if [ ! -f ${PREFIX}/etc/conda/activate.d/env_vars.sh ]; then
-    echo "#!/bin/bash" > ${PREFIX}/etc/conda/activate.d/env_vars.sh
-fi
-echo "export LD_LIBRARY_PATH=${PREFIX}/lib:$LD_LIBRARY_PATH" >> ${PREFIX}/etc/conda/activate.d/env_vars.sh
-
-if [ ! -f ${PREFIX}/etc/conda/deactivate.d/env_vars.sh ]; then
-    echo "#!/bin/bash" > ${PREFIX}/etc/conda/deactivate.d/env_vars.sh
-fi
-echo "unset LD_LIBRARY_PATH" >> ${PREFIX}/etc/conda/deactivate.d/env_vars.sh
-
-
-
-
-

--- a/recipes/kyototycoon/meta.yaml
+++ b/recipes/kyototycoon/meta.yaml
@@ -11,7 +11,7 @@ source:
     - ktulog.patch
 
 build:
-  number: 1
+  number: 2
   skip: true # [osx]
 
 


### PR DESCRIPTION
Removing "-ansi" from compiler options also works around the noted compiler error involving stdlib.h, (and the previous workaround of copying the contents of a glibc's include directory to ${PREFIX}/include would have unintended side effects).

Setting / unsetting LD_LIBRARY_PATH in conda activate/deactivate scripts has unintended side effects (and is unexpected; no other bioconda recipe appears to do this); remove for safety.

* [ x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
