### PR TITLE
Announce "@BiocondaBot update" from CI script

### DIFF
--- a/.circleci/setup.sh
+++ b/.circleci/setup.sh
@@ -23,9 +23,21 @@ git fetch $UPSTREAM_REMOTE
 if ! git diff --quiet HEAD...$UPSTREAM_REMOTE/master -- .circleci/; then
     echo 'Your bioconda-recipes CI configuration is out of date.'
     echo 'Please update it to the latest version of the upstream master branch.'
-    echo 'You can do this, e.g., by running:'
+    echo ''
+    echo 'Have @BiocondaBot attempt to fix this by creating a comment on your PR:'
+    echo ''
+    echo '   @BiocondaBot update'
+    echo ''
+    echo 'Once the update commit has been created, update your local copy of'
+    echo 'your branch:'
+    echo ''
+    echo '  git pull'
+    echo ''
+    echo ''
+    echo 'You can also fix this manually, e.g., by running:'
     echo '  git fetch https://github.com/bioconda/bioconda-recipes.git master'
     echo '  git merge FETCH_HEAD'
+    echo ''
     exit 1
 fi
 git remote remove $UPSTREAM_REMOTE


### PR DESCRIPTION
Bioconda requires reviews prior to merging pull-requests (PRs). To facilitate this, once your PR is passing tests and ready to be merged, please add the `please review & merge` label so other members of the bioconda community can have a look at your PR and either make suggestions or merge it. Note that if you are not already a member of the bioconda project (meaning that you can't add this label), please ping `@bioconda/core` so that your PR can be reviewed and merged (please note if you'd like to be added to the bioconda project). Please see https://github.com/bioconda/bioconda-recipes/issues/15332 for more details.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).


We check that `.circleci` is up to date with master before executing the CI builds. Updating the branch is error prone, but @BiocondaBot can fix it. This mentions it in the error message.