### PR TITLE
Add pysam pinning for Seroba

### DIFF
--- a/recipes/seroba/meta.yaml
+++ b/recipes/seroba/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256sum }}
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
 
@@ -32,6 +32,7 @@ requirements:
     - biopython >=1.68
     - pyyaml >=3.12
     - pyfastaq >=3.14.0
+    - pysam >=0.15.3 # older versions have wrong openssl pinning
 
 test:
   commands:


### PR DESCRIPTION
This is related to Issue https://github.com/bioconda/bioconda-recipes/issues/17212. 

Using `conda install -c conda-forge -c bioconda seroba` would not pull the correct build of Ariba. Forcing pysam >0.15.3, corrects the problem.

Bioconda requires reviews prior to merging pull-requests (PRs). To facilitate this, once your PR is passing tests and ready to be merged, please add the `please review & merge` label so other members of the bioconda community can have a look at your PR and either make suggestions or merge it. Note that if you are not already a member of the bioconda project (meaning that you can't add this label), please ping `@bioconda/core` so that your PR can be reviewed and merged (please note if you'd like to be added to the bioconda project). Please see https://github.com/bioconda/bioconda-recipes/issues/15332 for more details.

* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
* [ ] This PR adds a new recipe.
* [X] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [X] This PR updates an existing recipe.
* [X] This PR does something else (explain below).

This is related to Issue https://github.com/bioconda/bioconda-recipes/issues/17212. 

Using `conda install -c conda-forge -c bioconda seroba` would not pull the correct build of Ariba. Forcing pysam >0.15.3, corrects the problem.


