### PR TITLE
Recompile pysam using a newer libcrypto.so

### DIFF
--- a/recipes/pysam/meta.yaml
+++ b/recipes/pysam/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: f553d48d0345404b6b103d0b82bad09c8d78420e1cc6bef33040553fc579e284
 
 build:
-  number: 1
+  number: 2
   binary_relocation: False # [linux]
 
 requirements:


### PR DESCRIPTION
Current build uses libcrypto.so.1.0.0 which is part of a deprecated openssl version.
This would give the error:
    import pysam
     ../../miniconda3/envs/cromwell/lib/python3.6/site-packages/pysam/__init__.py:5: in <module>
         from pysam.libchtslib import *
    E   ImportError: libcrypto.so.1.0.0: cannot open shared object file: No such file or directory

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

Current build uses libcrypto.so.1.0.0 which is part of a deprecated openssh version.
This would give the error:
```
import pysam
../../miniconda3/envs/cromwell/lib/python3.6/site-packages/pysam/__init__.py:5: in <module>
    from pysam.libchtslib import *
E   ImportError: libcrypto.so.1.0.0: cannot open shared object file: No such file or directory
```