### PR TITLE
Build blast without sse4.2

### DIFF
--- a/recipes/blast/build.sh
+++ b/recipes/blast/build.sh
@@ -63,10 +63,10 @@ export AR="${AR} rcs"
     --without-vdb \
     --with-z=$PREFIX \
     --with-bz2=$PREFIX \
-    --with-z=$PREFIX \
     --without-krb5 \
     --without-openssl \
     --without-gnutls \
+    --without-sse42 \
     --without-gcrypt
 
 apps="blastp.exe blastn.exe blastx.exe tblastn.exe tblastx.exe psiblast.exe"

--- a/recipes/blast/meta.yaml
+++ b/recipes/blast/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 3
+  number: 4
 
 requirements:
   build:


### PR DESCRIPTION
The current build of blast has been built with sse4.2.  This causes it to fail on our older nodes with Opteron processors.  The official blast binaries are build without sse4.2 and work fine on the older nodes.

I also removed a duplicate line from build.sh.

Bioconda requires reviews prior to merging pull-requests (PRs). To facilitate this, once your PR is passing tests and ready to be merged, please add the `please review & merge` label so other members of the bioconda community can have a look at your PR and either make suggestions or merge it. Note that if you are not already a member of the bioconda project (meaning that you can't add this label), please ping `@bioconda/core` so that your PR can be reviewed and merged (please note if you'd like to be added to the bioconda project). Please see https://github.com/bioconda/bioconda-recipes/issues/15332 for more details.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
