### PR TITLE
Fix MPI build for raxml-ng

### DIFF
--- a/recipes/raxml-ng/build.sh
+++ b/recipes/raxml-ng/build.sh
@@ -10,10 +10,13 @@ pushd build_pthreads
 popd
 
 # mpi
-mkdir build_mpi
-pushd build_mpi
-   CXX=mpicxx cmake -DUSE_MPI=ON ..
-   make
-   install -d ${PREFIX}/bin
-   install ../bin/raxml-ng-mpi ${PREFIX}/bin
-popd
+if [ ! "$(uname)" = 'Darwin' ]
+then
+  mkdir build_mpi
+  pushd build_mpi
+     CXX=mpicxx cmake -DUSE_MPI=ON ..
+     make
+     install -d ${PREFIX}/bin
+     install ../bin/raxml-ng-mpi ${PREFIX}/bin
+  popd
+fi

--- a/recipes/raxml-ng/build.sh
+++ b/recipes/raxml-ng/build.sh
@@ -12,8 +12,8 @@ popd
 # mpi
 mkdir build_mpi
 pushd build_mpi
-   cmake -DUSE_MPI=ON ..
+   CXX=mpicxx cmake -DUSE_MPI=ON ..
    make
    install -d ${PREFIX}/bin
-   install ../bin/raxml-ng ${PREFIX}/bin/raxml-ng-MPI
+   install ../bin/raxml-ng-mpi ${PREFIX}/bin
 popd

--- a/recipes/raxml-ng/meta.yaml
+++ b/recipes/raxml-ng/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 43b95ee1bddae0daee84644e9ee760a77f28bb16e2071e95cca79a30f39373e5
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -28,7 +28,7 @@ requirements:
 test:
   commands:
     - raxml-ng --version
-    - raxml-ng-MPI --version
+    - raxml-ng-mpi --version
 
 about:
    home: https://github.com/amkozlov/raxml-ng

--- a/recipes/raxml-ng/meta.yaml
+++ b/recipes/raxml-ng/meta.yaml
@@ -28,7 +28,7 @@ requirements:
 test:
   commands:
     - raxml-ng --version
-    - raxml-ng-mpi --version
+    - raxml-ng-mpi --version # [not osx]
 
 about:
    home: https://github.com/amkozlov/raxml-ng

--- a/recipes/raxml-ng/meta.yaml
+++ b/recipes/raxml-ng/meta.yaml
@@ -38,8 +38,10 @@ about:
    summary: "RAxML Next Generation: faster, easier-to-use and more flexible"
 
 extra:
+   container:
+     # openmpi needs ssh client
+     extended-base: true
    skip-lints:
-     - uses_git_url
      - uses_vcs_url
    identifiers:
      - doi:10.1093/bioinformatics/btz305


### PR DESCRIPTION
* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Fix https://github.com/bioconda/bioconda-recipes/issues/17606 . The executable was renamed from `raxml-ng-MPI` to `raxml-ng-mpi`, as that is what the upstream uses. Tested on 2 nodes of an HPC cluster that uses the SLURM workload manager using the https://github.com/amkozlov/ng-tutorial data set, launched with both the SLURM srun:
```
srun --mpi=pmix_v3 --ntasks=${SLURM_NTASKS} --cpus-per-task=${SLURM_CPUS_PER_TASK} raxml-ng-mpi --msa rbcl.phy --model GTR+G --prefix H1 --threads ${SLURM_CPUS_PER_TASK}
```
as well as the `mpiexec` bundled with the conda-installed openmpi package:
```
mpiexec -n ${SLURM_NTASKS} raxml-ng-mpi --msa rbcl.phy --model GTR+G --prefix H1 --threads ${SLURM_CPUS_PER_TASK}
```
In both cases, raxml-ng-mpi appeared to execute on both nodes:
```
Analysis options:
...
  parallelization: hybrid MPI+PTHREADS (2 ranks x 4 threads), thread pinning: ON
```