### PR TITLE
Fix virsorter perl paths

### DIFF
--- a/recipes/virsorter/build.sh
+++ b/recipes/virsorter/build.sh
@@ -29,3 +29,14 @@ chmod 775 *
 cd ../
 mkdir -pv "${PREFIX}"/bin/
 mv wrapper_phage_contigs_sorter_iPlant.pl Scripts/ "${PREFIX}"/bin/
+
+
+### Creating scripts to set env variables during activation/deactivation of env
+mkdir -p "${PREFIX}"/etc/conda/activate.d "${PREFIX}"/etc/conda/deactivate.d
+# Setting perl path when activating
+echo '#!/bin/sh' > "${PREFIX}"/etc/conda/activate.d/env_vars.sh
+echo 'export CONDA_PERL5LIB=$(find "${CONDA_PREFIX}" -type d -path "*/site_perl/*" -prune | paste -s -d":")' >> "${PREFIX}"/etc/conda/activate.d/env_vars.sh
+echo 'export PERL5LIB="${CONDA_PERL5LIB}":"${PERL5LIB}"' >> "${PREFIX}"/etc/conda/activate.d/env_vars.sh
+# Resetting perl path when deactivating
+echo '#!/bin/sh' > "${PREFIX}"/etc/conda/deactivate.d/env_vars.sh
+echo 'export PERL5LIB=${PERL5LIB//"${CONDA_PERL5LIB}":/}' >> "${PREFIX}"/etc/conda/deactivate.d/env_vars.sh

--- a/recipes/virsorter/meta.yaml
+++ b/recipes/virsorter/meta.yaml
@@ -10,14 +10,14 @@ source:
   sha256: {{ virsorterSha256 }}
 
 build:
-  number: 3
+  number: 4
 
 requirements:
   build:
     - {{ compiler('c') }}
   host:
     - perl
-    - perl-bioperl >=1.7.2
+    - perl-bioperl
   run:
     - perl
     - blast
@@ -26,7 +26,7 @@ requirements:
     - mcl =14.137
     - metagene_annotator
     - muscle
-    - perl-bioperl >=1.7.2
+    - perl-bioperl
     - perl-file-which
     - perl-list-moreutils
     - perl-parallel-forkmanager


### PR DESCRIPTION
This fixes issues with the conda v4.7 solver pulling the old build of virsorter package due to the solver preferring older versions of bioperl. It adds the bioperl module paths to the environment during environment activation so the modules can be used.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
