### PR TITLE
add biowdl-input-converter recipe

### DIFF
--- a/recipes/biowdl-input-converter/meta.yaml
+++ b/recipes/biowdl-input-converter/meta.yaml
@@ -20,7 +20,6 @@ requirements:
   host:
     - pip
     - python>=3.7
-    - pyyaml
   run:
     - python>=3.7
     - pyyaml
@@ -34,6 +33,7 @@ test:
 about:
   home: "https://github.com/biowdl/biowdl-input-converter"
   license: "MIT"
+  license_file: "LICENSE"
   license_family: "MIT"
   summary: "Converting various input formats into WDL structs for BioWDL pipelines."
   doc_url: "https://biowdl-input-converter.readthedocs.io"

--- a/recipes/biowdl-input-converter/meta.yaml
+++ b/recipes/biowdl-input-converter/meta.yaml
@@ -1,0 +1,44 @@
+{% set name = "biowdl-input-converter" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  sha256: 81a34261f1a4552538335dada5bcf381020156d5954daaceff62954522d5587e
+
+build:
+  number: 0
+  entry_points:
+    - biowdl-input-converter = biowdl_input_converter:main
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv "
+
+requirements:
+  host:
+    - pip
+    - python>=3.7
+    - pyyaml
+  run:
+    - python>=3.7
+    - pyyaml
+
+test:
+  imports:
+    - biowdl_input_converter
+  commands:
+    - biowdl-input-converter --help
+
+about:
+  home: "https://github.com/biowdl/biowdl-input-converter"
+  license: "MIT"
+  license_family: "MIT"
+  summary: "Converting various input formats into WDL structs for BioWDL pipelines."
+  doc_url: "https://biowdl-input-converter.readthedocs.io"
+  dev_url: "https://github.com/biowdl/biowdl-input-converter"
+
+extra:
+  recipe-maintainers:
+    - rhpvorderman
+    - DavyCats

--- a/recipes/biowdl-input-converter/meta.yaml
+++ b/recipes/biowdl-input-converter/meta.yaml
@@ -10,6 +10,7 @@ source:
   sha256: 81a34261f1a4552538335dada5bcf381020156d5954daaceff62954522d5587e
 
 build:
+  noarch: python
   number: 0
   entry_points:
     - biowdl-input-converter = biowdl_input_converter:main


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
* [x] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Biowdl-input-converter is directly relevant to the biological sciences beause:
- [BioWDL pipelines](https://github.com/biowdl) are bioinformatics pipelines written in WDL. They are free and open source and are built to be shared with the scientific community.
- biowdl-input-converter exists to convert formats that can be easily edited by researchers in spreadsheet programs to formats that can be read by cromwell to be used in BioWDL pipelines. As such it can also be used by other people who write bioinformatics pipelines in WDL.
- Due to the structure of the input and output formats, it makes no sense outside of bioinformatics.

@bioconda/core I hope this motivation is sufficient to accept this package in the bioconda channel. Thanks!
