### PR TITLE
New recipe for ecTyper v0.9.0 with improved serotyping sensitivity

### DIFF
--- a/recipes/ectyper/meta.yaml
+++ b/recipes/ectyper/meta.yaml
@@ -13,9 +13,7 @@ package:
 
 source:
     url: https://github.com/phac-nml/ecoli_serotyping/archive/{{ version }}.tar.gz
-    sha256sum: 7b5f58c515da00cc026c6e8d051ef9921637e6e486410fb93931764727ebfd39   
-    #git_url: https://github.com/kbessonov1984/ecoli_serotyping.git
-    #git_rev: master
+    sha256: 7b5f58c515da00cc026c6e8d051ef9921637e6e486410fb93931764727ebfd39   
 
 build:
     number: 0

--- a/recipes/ectyper/meta.yaml
+++ b/recipes/ectyper/meta.yaml
@@ -34,18 +34,8 @@ requirements:
 test:
     import:
         - ectyper
-    source_files:
-        - test/*.py
-        - test/Data/*
-        - test/Data/test_dir/*
-        - test/Data/test_dir/subfolder1/*
-        - test/Data/test_dir/subfolder2/*
-    requires:
-        - pytest
     commands:
         - "ectyper --help"
-        - "pytest -s ./test/test_O_serotyping.py"
-        - "pytest -s ./test/test_ectyper_integration.py"
 
 
 about:

--- a/recipes/ectyper/meta.yaml
+++ b/recipes/ectyper/meta.yaml
@@ -44,7 +44,6 @@ test:
         - pytest
     commands:
         - "ectyper --help"
-        - "pwd && ls ./test/Data/*"
         - "pytest -s ./test/test_O_serotyping.py"
         - "pytest -s ./test/test_ectyper_integration.py"
 

--- a/recipes/ectyper/meta.yaml
+++ b/recipes/ectyper/meta.yaml
@@ -17,6 +17,7 @@ source:
 
 build:
     number: 0
+    noarch: python
     script: python -m pip install --no-deps --ignore-installed .
 
 requirements:

--- a/recipes/ectyper/meta.yaml
+++ b/recipes/ectyper/meta.yaml
@@ -1,43 +1,50 @@
-{% set version = "0.8.1" %}
-
-package:
-  name: ectyper
-  version: {{ version }}
-
-source:
-  url: https://github.com/phac-nml/ecoli_serotyping/archive/v{{ version }}.tar.gz
-  sha256: 7328c3c5e9c92c3626e762e87232358af2433f675b8c8ca4a75868f388e37750
-
-build:   
-  number: 0
-  script: python -m pip install --no-deps --ignore-installed .
-  noarch: python
-
-requirements:
-  build:
-    - python
-    - pip
-       
-  run:
-    - python >=3.5
-    - pytest >=3.5
-    - pandas >=0.23.1
-    - samtools >=1.8
-    - bowtie2 >=2.3.4.1
-    - mash >=2.0
-    - bcftools >=1.8
-    - biopython >=1.7.1
-    - blast >=2.7.1
-    - seqtk >=1.2
-
-test:
-  imports:
-     - ectyper
-  commands:
-     - ectyper --help
+{% set version = data.get('version') %}
 
 about:
     license: Apache 2
-    summary: ECTyper is a python program for serotyping E. coli genomes
-    author: Chad Laing, Camille La Rose, Sam Sung
+    summary: ECtyper is a python program for serotyping E. coli genomes
+    author: Chad Laing, Kyrylo Bessonov, Camille La Rose, Sam Sung
     home: https://github.com/phac-nml/ecoli_serotyping
+
+package:
+    name: ectyper
+    version: {{ version }}
+
+source:
+    url: https://github.com/phac-nml/ecoli_serotyping/archive/v{{ version }}.tar.gz
+
+build:
+    number: 1
+    script: python setup.py install
+
+requirements:
+    build:
+        - python >=3.5
+
+    run:
+        - python >=3.5
+        - pytest >=3.5
+        - pandas 0.23.1.*
+        - samtools 1.8.*
+        - bowtie2 2.3.4.1.*
+        - mash 2.0.*
+        - bcftools 1.8.*
+        - biopython 1.70.*
+        - blast 2.7.1.*
+        - seqtk 1.2.*
+        - requests 2.22.*
+        - portalocker 1.5.*
+test:
+    import:
+        - ectyper
+    source_files:
+        - test/
+    requires:
+         - pytest
+    commands:
+        - "ectyper --help"
+        - "pytest -s ectyper/test/test_ectyper_intergration.py"
+        - "pytest -s ectyper/test/test_O_serotyping.py"
+
+
+

--- a/recipes/ectyper/meta.yaml
+++ b/recipes/ectyper/meta.yaml
@@ -1,3 +1,4 @@
+{% set data = load_setup_py_data(setup_file='../setup.py', from_recipe_dir=True) %}
 {% set version = data.get('version') %}
 
 about:
@@ -11,40 +12,50 @@ package:
     version: {{ version }}
 
 source:
-    url: https://github.com/phac-nml/ecoli_serotyping/archive/v{{ version }}.tar.gz
+    url: https://github.com/phac-nml/ecoli_serotyping/archive/{{ version }}.tar.gz
+    sha256sum: 7b5f58c515da00cc026c6e8d051ef9921637e6e486410fb93931764727ebfd39   
+    #git_url: https://github.com/kbessonov1984/ecoli_serotyping.git
+    #git_rev: master
 
 build:
-    number: 1
-    script: python setup.py install
+    number: 0
+    script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
     build:
         - python >=3.5
+        - pip
 
     run:
         - python >=3.5
         - pytest >=3.5
-        - pandas 0.23.1.*
-        - samtools 1.8.*
-        - bowtie2 2.3.4.1.*
-        - mash 2.0.*
-        - bcftools 1.8.*
-        - biopython 1.70.*
-        - blast 2.7.1.*
-        - seqtk 1.2.*
-        - requests 2.22.*
-        - portalocker 1.5.*
+        - pandas >=0.23.1.*
+        - samtools >=1.8.*
+        - bowtie2 >=2.3.*
+        - mash >=2.0.*
+        - bcftools >=1.8.*
+        - biopython >=1.70.*
+        - blast >=2.7.1.*
+        - seqtk >=1.2.*
+        - requests >=2.*.*
+        - portalocker >=1.5.*
 test:
     import:
         - ectyper
     source_files:
-        - test/
+        - test/*.py
+        - test/Data/*
+        - test/Data/test_dir/*
+        - test/Data/test_dir/subfolder1/*
+        - test/Data/test_dir/subfolder2/*
     requires:
-         - pytest
+        - pytest
     commands:
         - "ectyper --help"
-        - "pytest -s ectyper/test/test_ectyper_intergration.py"
-        - "pytest -s ectyper/test/test_O_serotyping.py"
+        - "pwd && ls ./test/Data/*"
+        - "pytest -s ./test/test_O_serotyping.py"
+        - "pytest -s ./test/test_ectyper_integration.py"
+
 
 
 

--- a/recipes/ectyper/meta.yaml
+++ b/recipes/ectyper/meta.yaml
@@ -1,11 +1,4 @@
-{% set data = load_setup_py_data(setup_file='../setup.py', from_recipe_dir=True) %}
-{% set version = data.get('version') %}
-
-about:
-    license: Apache 2
-    summary: ECtyper is a python program for serotyping E. coli genomes
-    author: Chad Laing, Kyrylo Bessonov, Camille La Rose, Sam Sung
-    home: https://github.com/phac-nml/ecoli_serotyping
+{% set version = "0.9.0" %}
 
 package:
     name: ectyper
@@ -56,5 +49,9 @@ test:
         - "pytest -s ./test/test_ectyper_integration.py"
 
 
-
+about:
+    license: Apache 2
+    summary: ECtyper is a python program for serotyping E. coli genomes
+    author: Chad Laing, Kyrylo Bessonov, Camille La Rose, Sam Sung
+    home: https://github.com/phac-nml/ecoli_serotyping
 


### PR DESCRIPTION
* improved O-antigen serotyping coverage of complex samples that lack some O-antigen signatures. 
* fall back to single O-antigen signature detection when both signature pairs are not found and species is E.coli
* improved O-antigen identification favoring presence of both alleles (e.g. wzx and wzy) to support the final call. 
The sum of scores for both alleles of the same antigen is used in ranking now
* verification for E.albertii species against RefSeq genomes
* addition of Quality Control flags in the output (as an extra column in the `results.tsv`) for ease of results interpretation
* species reporting to better resolve E.coli vs Shigella vs E.albertii cases and contamination
* serotype prediction for all Escherichia genus to ease classification of cryptic spqeices
* automatic download of the RefSeq sketch and associated meta data every 6 months for improved species identification
* improved species identification for the FASTQ files. All raw reads are used for species identification
* better complex cases handling and error recovery in cases of poor reference allele coverage. 
* serotype reporting based on multiple evidences including reference allele database and closest reference genome
* query length coverage default threshold lowered from 50% to 10% for truncated alleles. This greatly improved sensitivity.
Did not found any noticeable negative effect on specificity and accuracy based on EnteroBase, PNC2018-2019 and internal datasets
* users is warned about potential false postive result in case of non-E.coli species or assembly errors
* wrote additional unit tests

