### PR TITLE
bracken: remove kraken1 dependency

### DIFF
--- a/recipes/bracken/meta.yaml
+++ b/recipes/bracken/meta.yaml
@@ -13,7 +13,7 @@ source:
     - py3.patch
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
@@ -23,7 +23,6 @@ requirements:
     - python
   run:
     - python
-    - kraken
     - kraken2
     - llvm-openmp  # [osx]
 


### PR DESCRIPTION
Bioconda requires reviews prior to merging pull-requests (PRs). To facilitate this, once your PR is passing tests and ready to be merged, please add the `please review & merge` label so other members of the bioconda community can have a look at your PR and either make suggestions or merge it. Note that if you are not already a member of the bioconda project (meaning that you can't add this label), please ping `@bioconda/core` so that your PR can be reviewed and merged (please note if you'd like to be added to the bioconda project). Please see https://github.com/bioconda/bioconda-recipes/issues/15332 for more details.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

Related to #17791. Remove `kraken` as a dependency of `bracken`, as it conflicts with `kraken2` during installation.