### PR TITLE
minimap2 - require libstdc++ for k8 paftools.js

### DIFF
--- a/recipes/minimap2/meta.yaml
+++ b/recipes/minimap2/meta.yaml
@@ -9,10 +9,11 @@ source:
   sha256: 0a3eaa3ef3d9f9e41f48199cc4aac0508366ac644fc3e8fe05e3463acd23d20b
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
+    - {{ compiler('cxx') }}
     - {{ compiler('c') }}
   host:
     - zlib
@@ -22,6 +23,7 @@ requirements:
 test:
   commands:
     - minimap2 2>&1 | grep 'Usage'
+    - paftools.js version | grep {{ version }}
 
 about:
   home: https://github.com/lh3/minimap2


### PR DESCRIPTION
Briefly, [minimap2](https://github.com/lh3/minimap2) has a companion script called [paftools.js](https://github.com/lh3/minimap2/tree/master/misc) but the latest [BioContainer](https://quay.io/repository/biocontainers/minimap2) won't run it because it's missing the C++ standard library - please see https://github.com/lh3/minimap2/issues/492. This PR should fix that.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).