### PR TITLE
GenMap: fixed recipe

### DIFF
--- a/recipes/genmap/build.sh
+++ b/recipes/genmap/build.sh
@@ -3,6 +3,6 @@
 git submodule update --init --recursive
 mkdir build
 cd build
-cmake .. -DCMAKE_INSTALL_PREFIX="${PREFIX}" -DCMAKE_BUILD_TYPE=Release
+cmake .. -DCMAKE_INSTALL_PREFIX="${PREFIX}" -DCMAKE_BUILD_TYPE=Release -DGENMAP_NATIVE_BUILD=OFF
 make
 make install

--- a/recipes/genmap/meta.yaml
+++ b/recipes/genmap/meta.yaml
@@ -9,7 +9,7 @@ source:
   git_rev: 7e61d9b7 # for next releases use: genmap-v{{ version }}
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
Recipe was previous built with `-march=native` which lets genmap crash when executed on older processors.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
