### PR TITLE
Topic/cutadapt pigz

### DIFF
--- a/recipes/cutadapt/meta.yaml
+++ b/recipes/cutadapt/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: ced79e49b93e922e579d0bb9d21298dcb2d7b7b1ea721feed484277e08b1660b
 
 build:
-  number: 0
+  number: 1
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
   skip: True  # [py27]
 

--- a/recipes/cutadapt/meta.yaml
+++ b/recipes/cutadapt/meta.yaml
@@ -27,7 +27,8 @@ requirements:
     - python
     - xopen >=0.5.0
     - dnaio >=0.3
-    - pigz
+    # remove pigz until https://github.com/marcelm/xopen/pull/20 has found its way into cutadapt
+    #- pigz
 
 test:
   imports:


### PR DESCRIPTION
 cutadapt: remove pigz run requirement

currently cutadapt calls pigz (via xopen) without limiting the number of used CPUs (https://github.com/marcelm/cutadapt/issues/290). hence pigz uses the default = all CPUs which is not acceptable on shared compute ressources.

if pigz is not installed single threaded python libraries are used.

alternatively (would be better) a new xopen version should be used once it is available https://github.com/marcelm/xopen/pull/20

Bioconda requires reviews prior to merging pull-requests (PRs). To facilitate this, once your PR is passing tests and ready to be merged, please add the `please review & merge` label so other members of the bioconda community can have a look at your PR and either make suggestions or merge it. Note that if you are not already a member of the bioconda project (meaning that you can't add this label), please ping `@bioconda/core` so that your PR can be reviewed and merged (please note if you'd like to be added to the bioconda project). Please see https://github.com/bioconda/bioconda-recipes/issues/15332 for more details.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).



