### PR TITLE
Limit to hpy 2.9.0 as 2.10 breaks UMAP

### DIFF
--- a/recipes/scanpy-scripts/meta.yaml
+++ b/recipes/scanpy-scripts/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: def6a4ef2d0899df5063f6ee5b3d84007a634ba80411ab5e000de31451c9cd15
 
 build:
-  number: 2
+  number: 3
   noarch: python
   entry_points:
     - scanpy-cli=scanpy_scripts.cli:cli
@@ -44,6 +44,7 @@ requirements:
     - python >=3
     - scanpy >=1.4.2,<1.4.4
     - scipy >=1.2.0,<1.3.0
+    - h5py <2.10.0
 
 test:
   imports:


### PR DESCRIPTION
Bioconda requires reviews prior to merging pull-requests (PRs). To facilitate this, once your PR is passing tests and ready to be merged, please add the `please review & merge` label so other members of the bioconda community can have a look at your PR and either make suggestions or merge it. Note that if you are not already a member of the bioconda project (meaning that you can't add this label), please ping `@bioconda/core` so that your PR can be reviewed and merged (please note if you'd like to be added to the bioconda project). Please see https://github.com/bioconda/bioconda-recipes/issues/15332 for more details.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Currently scanpy-scripts umap part fails as described in https://github.com/ebi-gene-expression-group/scanpy-scripts/issues/58. We have nailed it down to being h5py version 2.10.0 introducing the issue, and working well on h5py version 2.9.0