### PR TITLE
Add LoomExperiment as dependency for SCMap

### DIFF
--- a/recipes/scmap-cli/meta.yaml
+++ b/recipes/scmap-cli/meta.yaml
@@ -9,13 +9,14 @@ source:
   sha256: bd08fd65c6e44671f5c788bbe8b3548fc202518b5a9f0fc9f06ce11a390d9ba4
 
 build:
-  number: 0
+  number: 1
   noarch: generic
 
 requirements:
     run:
         - bioconductor-biobase
         - bioconductor-singlecellexperiment
+        - bioconductor-loomexperiment
         - bioconductor-scmap >=1.6.0,<1.7
         - r-optparse
         - r-workflowscriptscommon


### PR DESCRIPTION
Bioconda requires reviews prior to merging pull-requests (PRs). To facilitate this, once your PR is passing tests and ready to be merged, please add the `please review & merge` label so other members of the bioconda community can have a look at your PR and either make suggestions or merge it. Note that if you are not already a member of the bioconda project (meaning that you can't add this label), please ping `@bioconda/core` so that your PR can be reviewed and merged (please note if you'd like to be added to the bioconda project). Please see https://github.com/bioconda/bioconda-recipes/issues/15332 for more details.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

For reading SingleCellLoomExperiment, SCMap requires bioconductor-loomexperiment as dependency. This aims to address https://github.com/ebi-gene-expression-group/scmap-cli/issues/6