### PR TITLE
Update requirements to match scanpy 1.4.4.post1

### DIFF
--- a/recipes/scanpy/meta.yaml
+++ b/recipes/scanpy/meta.yaml
@@ -20,24 +20,24 @@ requirements:
     - python >=3.6
     - pip
   run:
-    - python >=3.6
-    - seaborn
-    - scikit-learn
-    - statsmodels
-    - importlib-metadata
-    - numba
-    - python-igraph
-    - louvain
-    - 'anndata >=0.6.10'
-    - 'matplotlib >=2.2'
-    - 'pandas >=0.21'
-    - scipy
-    - h5py
-    - pytables
-    - networkx
+    - anndata>=0.6.22rc1
+    - h5py!=2.10.0
+    - importlib_metadata>=0.7
+    - joblib
+    - matplotlib==3.0.*
     - natsort
+    - networkx
+    - numba>=0.41.0
+    - pandas>=0.21
+    - patsy
+    - python >=3.6
+    - scikit-learn>=0.21.2
+    - scipy>=1.3
+    - seaborn
+    - statsmodels>=0.10.0rc2
+    - tables
     - tqdm
-    - umap-learn
+    - umap-learn>=0.3.0
 
 test:
   imports:

--- a/recipes/scanpy/meta.yaml
+++ b/recipes/scanpy/meta.yaml
@@ -30,12 +30,12 @@ requirements:
     - numba >=0.41.0
     - pandas >=0.21
     - patsy
+    - pytables
     - python >=3.6
     - scikit-learn >=0.21.2
     - scipy >=1.3
     - seaborn
     - statsmodels >=0.10.0rc2
-    - tables
     - tqdm
     - umap-learn >=0.3.0
 

--- a/recipes/scanpy/meta.yaml
+++ b/recipes/scanpy/meta.yaml
@@ -20,24 +20,24 @@ requirements:
     - python >=3.6
     - pip
   run:
-    - anndata>=0.6.22rc1
-    - h5py!=2.10.0
-    - importlib_metadata>=0.7
+    - anndata >=0.6.22rc1
+    - h5py !=2.10.0
+    - importlib_metadata >=0.7
     - joblib
-    - matplotlib==3.0.*
+    - matplotlib ==3.0.*
     - natsort
     - networkx
-    - numba>=0.41.0
-    - pandas>=0.21
+    - numba >=0.41.0
+    - pandas >=0.21
     - patsy
     - python >=3.6
-    - scikit-learn>=0.21.2
-    - scipy>=1.3
+    - scikit-learn >=0.21.2
+    - scipy >=1.3
     - seaborn
-    - statsmodels>=0.10.0rc2
+    - statsmodels >=0.10.0rc2
     - tables
     - tqdm
-    - umap-learn>=0.3.0
+    - umap-learn >=0.3.0
 
 test:
   imports:

--- a/recipes/scanpy/meta.yaml
+++ b/recipes/scanpy/meta.yaml
@@ -5,7 +5,7 @@ package:
   name: {{ name|lower }}
   version: {{ version }}
 build:
-  number: 0
+  number: 1
   noarch: python
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 


### PR DESCRIPTION
Match requirements from here: https://github.com/theislab/scanpy/blob/master/requirements.txt

It seems liek the requirements of scanpy haven't been updatet a long time. And currentyl matplotlib 3.1 and h5py 2.10.0 brake some functionality. @BiocondaBot 

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
