### PR TITLE
Salmon 1.0.0 breaks Trinity

### DIFF
--- a/recipes/trinity/meta.yaml
+++ b/recipes/trinity/meta.yaml
@@ -12,7 +12,7 @@ source:
     - patch
 
 build:
-  number: 3
+  number: 4
   skip: True  # [osx]
 
 requirements:

--- a/recipes/trinity/meta.yaml
+++ b/recipes/trinity/meta.yaml
@@ -33,7 +33,7 @@ requirements:
     - python
     - samtools >=1.3
     - zlib
-    - salmon >=0.9.1
+    - salmon >=0.9.1,<1.0
     - numpy
 
 test:


### PR DESCRIPTION
Bioconda requires reviews prior to merging pull-requests (PRs). To facilitate this, once your PR is passing tests and ready to be merged, please add the `please review & merge` label so other members of the bioconda community can have a look at your PR and either make suggestions or merge it. Note that if you are not already a member of the bioconda project (meaning that you can't add this label), please ping `@bioconda/core` so that your PR can be reviewed and merged (please note if you'd like to be added to the bioconda project). Please see https://github.com/bioconda/bioconda-recipes/issues/15332 for more details.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

The Salmon 1.0.0 version which was just uploaded to anaconda.org can not be used by Trinity. Restricting to an older version until Trinity gets updated