### PR TITLE
Add legacy recipe for scanpy-scripts to deal with h5py issue

### DIFF
--- a/recipes/scanpy-scripts/0.0.5/build.sh
+++ b/recipes/scanpy-scripts/0.0.5/build.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+mkdir -p $PREFIX/bin
+cp *.py $PREFIX/bin
+cp *.sh $PREFIX/bin

--- a/recipes/scanpy-scripts/0.0.5/meta.yaml
+++ b/recipes/scanpy-scripts/0.0.5/meta.yaml
@@ -1,0 +1,51 @@
+{% set version = '0.0.5' %}
+
+package:
+  name: scanpy-scripts
+  version: {{ version }}
+
+source:
+  url: https://github.com/ebi-gene-expression-group/scanpy-scripts/archive/v{{ version }}.tar.gz
+  sha256: 21cd088e17e6f0179ae5e6bc6903bf2feb73ddf4f5752fb6fc8a8682353921d2
+
+build:
+  number: 3
+  noarch: generic
+
+requirements:
+    host:
+        - python>=3.6
+    run:
+        - python>=3.6
+        - pandas>=0.21,<0.24
+        - matplotlib>=3.0.0
+        - scanpy==1.3.2
+        - loompy
+        - multicore-tsne==0.1_d4ff4aab
+        - h5py <2.10
+
+test:
+    commands:
+        - scanpy-read-10x.py --help
+        - scanpy-filter-cells.py --help
+        - scanpy-filter-genes.py --help
+        - scanpy-normalise-data.py --help
+        - scanpy-find-variable-genes.py --help
+        - scanpy-scale-data.py --help
+        - scanpy-run-pca.py --help
+        - scanpy-neighbours.py --help
+        - scanpy-run-umap.py --help
+        - scanpy-run-tsne.py --help
+        - scanpy-find-cluster.py --help
+        - scanpy-find-markers.py --help
+        - which scanpy-scripts-post-install-tests.sh
+
+about:
+    home: https://github.com/ebi-gene-expression-group/scanpy-scripts
+    dev_url: https://github.com/ebi-gene-expression-group/scanpy-scripts
+    license: GPL-3
+    summary: A set of wrappers for individual components of the scanpy package.
+             Functions in python packages are hard to call when building workflows
+             outside of python, so this package adds a set of simple wrappers with
+             robust argument parsing.
+    license_family: GPL

--- a/recipes/scanpy-scripts/0.0.5/post-link.sh
+++ b/recipes/scanpy-scripts/0.0.5/post-link.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+echo 'Post install test script "scanpy-scripts-post-install-tests.sh" requires'
+echo 'conda package "bats-core".'


### PR DESCRIPTION
Bioconda requires reviews prior to merging pull-requests (PRs). To facilitate this, once your PR is passing tests and ready to be merged, please add the `please review & merge` label so other members of the bioconda community can have a look at your PR and either make suggestions or merge it. Note that if you are not already a member of the bioconda project (meaning that you can't add this label), please ping `@bioconda/core` so that your PR can be reviewed and merged (please note if you'd like to be added to the bioconda project). Please see https://github.com/bioconda/bioconda-recipes/issues/15332 for more details.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Due to https://github.com/h5py/h5py/issues/1307, we need this updated recipe for a legacy build of scanpy-scripts (we use this specific build in some production processes), to pin h5py to before the breaking change. 
