### PR TITLE
pb-assembly: fix version for pb-falcon dependency

### DIFF
--- a/recipes/pb-assembly/meta.yaml
+++ b/recipes/pb-assembly/meta.yaml
@@ -2,13 +2,12 @@ package:
   name: pb-assembly
   version: "0.0.6"
 build:
-  number: 6
+  number: 7
   noarch: generic
 requirements:
   run:
     - python
-    - pb-falcon>=0.3.0
-    - pb-dazzler
+    - pb-falcon>=0.3.0,<1.0
     - nim-falcon
     - pb-dazzler
     - pbgcpp


### PR DESCRIPTION
The fix is needed in order to have the most recent pb-falcon version
installed (> 0.3.0). Otherwise, a version where fc_ovl_filter does not
have the --min-idt and --ignore-indels options is installed (2.2.1-0).
This makes it impossible to use the newest configuration files for HiFi
reads.

Bioconda requires reviews prior to merging pull-requests (PRs). To facilitate this, once your PR is passing tests and ready to be merged, please add the `please review & merge` label so other members of the bioconda community can have a look at your PR and either make suggestions or merge it. Note that if you are not already a member of the bioconda project (meaning that you can't add this label), please ping `@bioconda/core` so that your PR can be reviewed and merged (please note if you'd like to be added to the bioconda project). Please see https://github.com/bioconda/bioconda-recipes/issues/15332 for more details.

* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
