### PR TITLE
Fix UCSC-CellBrowser 0.5.43 issue with anndata and h5py 2.10

### DIFF
--- a/recipes/ucsc-cell-browser/0.5.43/meta.yaml
+++ b/recipes/ucsc-cell-browser/0.5.43/meta.yaml
@@ -1,0 +1,56 @@
+{% set version = '0.5.43' %}
+{% set name = "cellbrowser" %}
+
+package:
+  name: ucsc-cell-browser
+  version: "{{ version }}"
+
+source:
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  sha256: "adbd9bcf3eed4068f9487c5b8166982e250d501c3578f8e2ed897ad90ae14cf5"
+
+build:
+  number: 1
+  entry_points:
+    - cbBuild = cellbrowser.cellbrowser:cbBuildCli
+    - cbScanpy = cellbrowser.cellbrowser:cbScanpyCli
+    - cbSeurat = cellbrowser.seurat:cbSeuratCli
+    - cbTool = cellbrowser.convert:cbToolCli
+    - cbUpgrade = cellbrowser.cellbrowser:cbUpgradeCli
+    - cbGuessGencode = cellbrowser.guessgenes:cbGuessGencodeCli
+    - cbMarkerAnnotate = cellbrowser.geneinfo:cbMarkerAnnotateCli
+    - cbImportScanpy = cellbrowser.convert:cbImportScanpyCli
+    - cbImportSeurat = cellbrowser.seurat:cbImportSeurat2Cli
+    - cbImportCellranger = cellbrowser.convert:cbCellrangerCli
+  noarch: python
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv"
+
+requirements:
+    host:
+        - python >=3.6
+        - pip
+    run:
+        - python >=3.6
+        - numpy
+        - anndata <0.7.0
+        - h5py <2.10
+
+test:
+    imports:
+        - RangeHTTPServer
+        - cellbrowser
+    commands:
+        - which cbBuild
+        - which cbGuessGencode
+        - which cbMarkerAnnotate
+        - which cbScanpy
+        - which cbImportScanpy
+        - which cbImportCellranger
+        - which cbTool
+        - which cbUpgrade
+
+about:
+  home: http://cells.ucsc.edu
+  license: GPL
+  license_file: LICENSE
+  summary: A browser for single-cell data, main site at http://cells.ucsc.edu


### PR DESCRIPTION
Bioconda requires reviews prior to merging pull-requests (PRs). To facilitate this, once your PR is passing tests and ready to be merged, please add the `please review & merge` label so other members of the bioconda community can have a look at your PR and either make suggestions or merge it. Note that if you are not already a member of the bioconda project (meaning that you can't add this label), please ping `@bioconda/core` so that your PR can be reviewed and merged (please note if you'd like to be added to the bioconda project). Please see https://github.com/bioconda/bioconda-recipes/issues/15332 for more details.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

This PR fixes an old (but relevant to us) version of UCSC CellBrowser to avoid the issues generated between anndata and h5py 2.10 recently released (https://github.com/h5py/h5py/issues/1307).