### PR TITLE
pb-assembly: restore pb-falcon version requirements

### DIFF
--- a/recipes/pb-assembly/meta.yaml
+++ b/recipes/pb-assembly/meta.yaml
@@ -1,13 +1,13 @@
 package:
   name: pb-assembly
-  version: "0.0.6"
+  version: "0.0.7"
 build:
-  number: 7
+  number: 0
   noarch: generic
 requirements:
   run:
     - python
-    - pb-falcon>=0.3.0,<1.0
+    - pb-falcon>=0.3.0
     - nim-falcon
     - pb-dazzler
     - pbgcpp


### PR DESCRIPTION
Most recent pb-falcon (2.2.1-0) version works with HiFi reads.
Error reported in commit
https://github.com/bioconda/bioconda-recipes/pull/18462
could be resolved.

Bioconda requires reviews prior to merging pull-requests (PRs). To facilitate this, once your PR is passing tests and ready to be merged, please add the `please review & merge` label so other members of the bioconda community can have a look at your PR and either make suggestions or merge it. Note that if you are not already a member of the bioconda project (meaning that you can't add this label), please ping `@bioconda/core` so that your PR can be reviewed and merged (please note if you'd like to be added to the bioconda project). Please see https://github.com/bioconda/bioconda-recipes/issues/15332 for more details.

* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
* [ ] This PR adds a new recipe.
* [X ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
