### PR TITLE
[Picard] respect ${_JAVA_OPTIONS} and set default memory to 2GB

### DIFF
--- a/recipes/picard/meta.yaml
+++ b/recipes/picard/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: generic
-  number: 0
+  number: 1
 
 requirements:
   run:

--- a/recipes/picard/picard.sh
+++ b/recipes/picard/picard.sh
@@ -28,7 +28,7 @@ fi
 
 # extract memory and system property Java arguments from the list of provided arguments
 # http://java.dzone.com/articles/better-java-shell-script
-default_jvm_mem_opts="-Xms512m -Xmx1g"
+default_jvm_mem_opts="-Xms512m -Xmx2g"
 jvm_mem_opts=""
 jvm_prop_opts=""
 pass_args=""
@@ -44,17 +44,17 @@ for arg in "$@"; do
             jvm_mem_opts="$jvm_mem_opts $arg"
             ;;
          *)
-	    if [[ ${pass_args} == '' ]] #needed to avoid preceeding space on first arg e.g. ' MarkDuplicates'
-            then 
-                pass_args="$arg" 
-	    else
-                pass_args="$pass_args \"$arg\"" #quotes later arguments to avoid problem with ()s in MarkDuplicates regex arg
+            if [[ ${pass_args} == '' ]] #needed to avoid preceeding space on first arg e.g. ' MarkDuplicates'
+                then
+                    pass_args="$arg"
+            else
+                    pass_args="$pass_args \"$arg\"" #quotes later arguments to avoid problem with ()s in MarkDuplicates regex arg
             fi
             ;;
     esac
 done
 
-if [ "$jvm_mem_opts" == "" ]; then
+if [ "$jvm_mem_opts" == "" ] && [ -z ${_JAVA_OPTIONS+x} ]; then
     jvm_mem_opts="$default_jvm_mem_opts"
 fi
 


### PR DESCRIPTION
Bioconda requires reviews prior to merging pull-requests (PRs). To facilitate this, once your PR is passing tests and ready to be merged, please add the `please review & merge` label so other members of the bioconda community can have a look at your PR and either make suggestions or merge it. Note that if you are not already a member of the bioconda project (meaning that you can't add this label), please ping `@bioconda/core` so that your PR can be reviewed and merged (please note if you'd like to be added to the bioconda project). Please see https://github.com/bioconda/bioconda-recipes/issues/15332 for more details.

* [ x ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).

* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ X ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

The memory options set by ${_JAVA_OPTIONS} was not respected by the Picard bash wrapper script. I used the same solution as for the GATK wrapper.

Also, I raised the default memory which closes #9325
