### PR TITLE
mob_suite: Add post-link script to run mob_init

### DIFF
--- a/recipes/mob_suite/meta.yaml
+++ b/recipes/mob_suite/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: python -m pip install --no-deps --ignore-installed .
 

--- a/recipes/mob_suite/post-link.sh
+++ b/recipes/mob_suite/post-link.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+mob_init


### PR DESCRIPTION
Bioconda requires reviews prior to merging pull-requests (PRs). To facilitate this, once your PR is passing tests and ready to be merged, please add the `please review & merge` label so other members of the bioconda community can have a look at your PR and either make suggestions or merge it. Note that if you are not already a member of the bioconda project (meaning that you can't add this label), please ping `@bioconda/core` so that your PR can be reviewed and merged (please note if you'd like to be added to the bioconda project). Please see https://github.com/bioconda/bioconda-recipes/issues/15332 for more details.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

mob_suite depends on a database of plasmid sequences. These aren't installed automatically, but a utility script called `mob_init` is provided to download and install the databases.

When mob_suite is installed into an automated system (such as Galaxy), it won't have full functionality until the databases are installed using `mob_init`. This PR adds a `post-link.sh` script to run `mob_init`.