### PR TITLE
Trinity -- export TRINITY_HOME ENV variable 

### DIFF
--- a/recipes/trinity/build.sh
+++ b/recipes/trinity/build.sh
@@ -62,5 +62,10 @@ sed -i 's/my $TRIMMOMATIC_DIR = "\([^"]\+\)"/my $TRIMMOMATIC_DIR = '"'"'\1'"'"'/
 
 find $TRINITY_HOME -type f -name "*.bak" -print0 | xargs -0 rm -f
 
-# make it easier to find TRINITY_HOME
-ln -sf $TRINITY_HOME $PREFIX/opt/TRINITY_HOME
+# export TRINITY_HOME as ENV variable 
+mkdir -p ${PREFIX}/etc/conda/activate.d/
+echo "export TRINITY_HOME=${TRINITY_HOME}" > ${PREFIX}/etc/conda/activate.d/${PKG_NAME}-${PKG_VERSION}.sh
+
+mkdir -p ${PREFIX}/etc/conda/deactivate.d/
+echo "unset TRINITY_HOME" > ${PREFIX}/etc/conda/deactivate.d/${PKG_NAME}-${PKG_VERSION}.sh
+

--- a/recipes/trinity/meta.yaml
+++ b/recipes/trinity/meta.yaml
@@ -12,7 +12,7 @@ source:
     - patch
 
 build:
-  number: 4
+  number: 5
   skip: True  # [osx]
 
 requirements:


### PR DESCRIPTION
Bioconda requires reviews prior to merging pull-requests (PRs). To facilitate this, once your PR is passing tests and ready to be merged, please add the `please review & merge` label so other members of the bioconda community can have a look at your PR and either make suggestions or merge it. Note that if you are not already a member of the bioconda project (meaning that you can't add this label), please ping `@bioconda/core` so that your PR can be reviewed and merged (please note if you'd like to be added to the bioconda project). Please see https://github.com/bioconda/bioconda-recipes/issues/15332 for more details.

* [ ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

This will set the $TRINITY_HOME env variable when the Conda environment is activated and then unset that variable when deactivated. 