### PR TITLE
add samtools to control-freec

### DIFF
--- a/recipes/control-freec/meta.yaml
+++ b/recipes/control-freec/meta.yaml
@@ -12,7 +12,7 @@ source:
     - perl_shebang.patch
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -22,6 +22,7 @@ requirements:
     - perl
     - r-base
     - bioconductor-rtracklayer
+    - samtools
 
 test:
   commands:


### PR DESCRIPTION
Control-FreeC needs samtools in order to read BAM-files.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
