### PR TITLE
Augustus script bamToWig.py needs USSC fatToTwoBit and twoBitInfo

### DIFF
--- a/recipes/augustus/meta.yaml
+++ b/recipes/augustus/meta.yaml
@@ -23,7 +23,7 @@ source:
     - patches/src.makefile.patch
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -61,6 +61,9 @@ requirements:
     - suitesparse
     - openblas
     - libcblas
+    # Needed by bamToWig.py
+    - ucsc-fattotwobit
+    - ucsc-twobitinfo
 
 test:
   commands:

--- a/recipes/augustus/meta.yaml
+++ b/recipes/augustus/meta.yaml
@@ -62,7 +62,7 @@ requirements:
     - openblas
     - libcblas
     # Needed by bamToWig.py
-    - ucsc-fattotwobit
+    - ucsc-fatotwobit
     - ucsc-twobitinfo
 
 test:


### PR DESCRIPTION
Bioconda requires reviews prior to merging pull-requests (PRs). To facilitate this, once your PR is passing tests and ready to be merged, please add the `please review & merge` label so other members of the bioconda community can have a look at your PR and either make suggestions or merge it. Note that if you are not already a member of the bioconda project (meaning that you can't add this label), please ping `@bioconda/core` so that your PR can be reviewed and merged (please note if you'd like to be added to the bioconda project). Please see https://github.com/bioconda/bioconda-recipes/issues/15332 for more details.

* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
* [ ] This PR adds a new recipe.
* [X] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Without this:

```
$ bamToWig.py -g scaffolds.fa -b sortedByCoord.out.bam -o sortedByCoord.wig
Was unable to locate twoBitInfo on your system, will try to download it from http://hgdownload.soe.ucsc.edu/admin/exe/linux.x86_64/twoBitInfo...
Traceback (most recent call last):
  File "/mnt/xxx/apps/conda/bin/bamToWig.py", line 154, in <module>
    with urllib.request.urlopen(tool_url) as response, open(key, 'wb') as out_file:
AttributeError: module 'urllib' has no attribute 'request'
```

and:

```
$ bamToWig.py -g scaffolds.fa -b sortedByCoord.out.bam -o sortedByCoord.wig
Was unable to locate faToTwoBit on your system, will try to download it from http://hgdownload.soe.ucsc.edu/admin/exe/linux.x86_64/faToTwoBit...
Traceback (most recent call last):
...
```

The missing import was fixed upstream:
https://github.com/Gaius-Augustus/Augustus/issues/93