### PR TITLE
Specify gsl version

### DIFF
--- a/recipes/phylocsf/meta.yaml
+++ b/recipes/phylocsf/meta.yaml
@@ -6,7 +6,6 @@ package:
 
 build:
   number: 1
-  skip: True  # [osx]
 
 source:
   url: https://github.com/RomainFeron/PhyloCSF/archive/{{ version }}-conda.tar.gz
@@ -15,15 +14,16 @@ source:
 requirements:
   build:
     - {{ compiler('cxx') }}
-    - glpk
-    - gsl==2.5
     - m4
     - pkg-config
-    - ocaml
-    - unzip
     - wget
+    - unzip
+  host:
+    - glpk
+    - gsl
+    - ocaml
   run:
-    - gsl==2.5
+    - gsl
     - ocaml
 
 test:

--- a/recipes/phylocsf/meta.yaml
+++ b/recipes/phylocsf/meta.yaml
@@ -6,6 +6,7 @@ package:
 
 build:
   number: 1
+  skip: True  # [osx]
 
 source:
   url: https://github.com/RomainFeron/PhyloCSF/archive/{{ version }}-conda.tar.gz

--- a/recipes/phylocsf/meta.yaml
+++ b/recipes/phylocsf/meta.yaml
@@ -5,7 +5,8 @@ package:
   version: {{ version }}
 
 build:
-  number: 0
+  number: 1
+  skip: True  # [osx]
 
 source:
   url: https://github.com/RomainFeron/PhyloCSF/archive/{{ version }}-conda.tar.gz
@@ -15,14 +16,14 @@ requirements:
   build:
     - {{ compiler('cxx') }}
     - glpk
-    - gsl
+    - gsl==2.5
     - m4
     - pkg-config
     - ocaml
     - unzip
     - wget
   run:
-    - gsl
+    - gsl==2.5
     - ocaml
 
 test:


### PR DESCRIPTION
PhyloCSF requires libgsl.so.23, which is not available with the last version of gsl. 
I specified gsl version 2.5 to make sure this lib is available.
For some reason it doesn't build on osx anymore and the error is too complex for me to handle at the moment, so I disabled building for osx.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
* [x] This PR updates an existing recipe.