### PR TITLE
Use newer macOS image on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ variables:
       command: .circleci/setup.sh
   macos: &macos
     macos:
-      xcode: 11.3.0
+      xcode: 9.4.1
     environment:
       LC_ALL: en_US.UTF-8
       LANG: en_US.UTF-8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ variables:
       command: .circleci/setup.sh
   macos: &macos
     macos:
-      xcode: "8.3.3"
+      xcode: 11.3.0
     environment:
       LC_ALL: en_US.UTF-8
       LANG: en_US.UTF-8


### PR DESCRIPTION
* [ ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences** (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [x] This PR does something else (explain below).

We are going to be removing support for Xcode 8.3.3 soon. This project is currently the biggest user of that image. Upgrading to the latest Xcode image will ensure that your build is stable for as long as possible.

