### PR TITLE
add biotdg: bioinformatics test data generator.

### DIFF
--- a/recipes/biotdg/meta.yaml
+++ b/recipes/biotdg/meta.yaml
@@ -11,6 +11,7 @@ source:
 
 build:
   number: 0
+  noarch: python
   entry_points:
     - biotdg = biotdg:main
   script: "{{ PYTHON }} -m pip install . -vv"

--- a/recipes/biotdg/meta.yaml
+++ b/recipes/biotdg/meta.yaml
@@ -1,0 +1,52 @@
+{% set name = "biotdg" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  sha256: 981d588a3be672fd62ec5eac402a87d5e5f0865d040d1a1b6ae2f8398f840cd1
+
+build:
+  number: 0
+  entry_points:
+    - biotdg = biotdg:main
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - biopython
+    - cyvcf2
+    - pip
+    - python >=3.6,<3.8
+    - setuptools
+  run:
+    - biopython
+    - cyvcf2
+    - python >=3.6,<3.8
+    - setuptools
+    - dwgsim
+
+test:
+  imports:
+    - biotdg
+  commands:
+    - biotdg --help
+    - biotdg --version
+
+about:
+  home: "https://github.com/biowdl/biotdg"
+  license: MIT
+  license_family: MIT
+  license_file: 
+  summary: "Bioinformatics Test Data Generator"
+  doc_url: "https://github.com/biowdl/biotdg"
+  dev_url: "https://github.com/biowdl/biotdg"
+
+extra:
+  recipe-maintainers:
+    - rhpvorderman
+    - DavyCats
+

--- a/recipes/biotdg/meta.yaml
+++ b/recipes/biotdg/meta.yaml
@@ -14,12 +14,10 @@ build:
   noarch: python
   entry_points:
     - biotdg = biotdg:main
-  script: "{{ PYTHON }} -m pip install . -vv"
+  script: "{{ PYTHON }} -m pip install . -vv --ignore-installed --no-deps"
 
 requirements:
   host:
-    - biopython
-    - cyvcf2
     - pip
     - python >=3.6,<3.8
     - setuptools
@@ -41,7 +39,7 @@ about:
   home: "https://github.com/biowdl/biotdg"
   license: MIT
   license_family: MIT
-  license_file: 
+  license_file: LICENSE
   summary: "Bioinformatics Test Data Generator"
   doc_url: "https://github.com/biowdl/biotdg"
   dev_url: "https://github.com/biowdl/biotdg"


### PR DESCRIPTION
Bionformatics Test Data Generator

This tool was made to generate test data transparently for genomes with mixed ploidies. (For example human male genome). 

NOTE: setuptools **is** needed as a runtime dependency. It is used to determine the version when using the `--version` flag.

----

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
* [x] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences**
      (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [ ] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

> Everyone has access to the following BiocondaBot commands, which can be given in a comment:
>
>  * `@BiocondaBot please update` will cause the BiocondaBot to merge the master branch into a PR
>  * `@BiocondaBot please add label` will add the `please review & merge` label.
>  * `@BiocondaBot please fetch artifacts` will post links to packages and docker containers built by the CI system. You can use this to test packages locally before merging.
>
> For members of the Bioconda project, the following command is also available:
>
>  * `@BiocondaBot please merge` will cause packages/containers to be uploaded and a PR merged. Someone must approve a PR first! This has the benefit of not wasting CI build time required by manually merging PRs.
>
> If you have questions, please post them in gitter or ping `@bioconda/core` in a comment (if you are not able to directly ping `@bioconda/core` then the bot will repost your comment and enable pinging).
