### PR TITLE
mummer4: added a patch that fixes promer

### DIFF
--- a/recipes/mummer4/0001-sort-mgaps-file-before-postpro.-on-behalf-of-jervied.patch
+++ b/recipes/mummer4/0001-sort-mgaps-file-before-postpro.-on-behalf-of-jervied.patch
@@ -1,0 +1,95 @@
+From 32bd3e6d8a35060459319fe244a1d673b4997500 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Hermann=20Schw=C3=A4rzler?= <hermann.schwaerzler@uibk.ac.at>
+Date: Wed, 30 Jan 2019 09:47:17 +0100
+Subject: [PATCH] sort mgaps file before postpro. (on behalf of @jerviedog -
+ fixes #55 (and #74 ?))
+
+---
+ scripts/promer.pl | 66 +++++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 66 insertions(+)
+
+diff --git a/scripts/promer.pl b/scripts/promer.pl
+index 8932515..756ecb4 100644
+--- a/scripts/promer.pl
++++ b/scripts/promer.pl
+@@ -346,6 +346,8 @@ sub main ( )
+ 
+     #-- Run postpro and assert return value is zero
+     print (STDERR "4: FINISHING DATA\n");
++    sort_mgaps("$qry_file","$pfx.mgaps");
++
+     $err[0] = $tigr->runCommand
+ 	("$postpro_path $psw -x $blsm -b $blen ".
+ 	 "$ref_file $qry_file $pfx < $pfx.mgaps");
+@@ -379,4 +381,68 @@ sub main ( )
+ 
+ exit ( main ( ) );
+ 
++sub sort_mgaps {
++    # Input, file names, strings
++    my $qry = shift;
++    my $mgaps = shift;
++    # read query file
++    my @qry_entries = ();
++    my $fh;
++    open($fh, "$qry") || die "couldn't read file $qry\n";
++    while(my $line = <$fh>) {
++	chomp $line;
++	next unless $line=~/^\>(\S+)/;
++	push(@qry_entries,$1);
++    }
++    close($fh);
++    # read mgaps file
++    my %mgaps_lines = ();
++    my %dna_pep = (); # used to look up the peptides in a dna seq
++    open($fh, "$mgaps") || die "couldn't read file $mgaps\n";
++    my $pos = 0;
++    my $pos_old = $pos;
++    my $cur_entry = ""; # e.g. 3210101.5
++    while(1) {
++	my $line=<$fh>;
++	last unless defined $line;
++	chomp $line;
++	if($line=~/^\>\s*(\S+)/) {
++	    $cur_entry = $1;
++	    # find out the corresponding dna id in query file
++	    die "wrong format $cur_entry\n"
++		unless $cur_entry=~/^(.+)\.[\d+]$/;
++	    my $dna = $1;
++	    if(exists($dna_pep{$dna})) {
++		push(@{$dna_pep{$dna}},$cur_entry);
++	    }
++	    else {
++		$dna_pep{$dna} = [$cur_entry];
++	    }
++	    # find out the lines corresponding to the current entry
++	    if(exists($mgaps_lines{$cur_entry})) {
++		push(@{$mgaps_lines{$cur_entry}},"$line\n");
++	    }
++	    else {
++		$mgaps_lines{$cur_entry} = ["$line\n"];
++	    }
++	}
++	else {
++	    push(@{$mgaps_lines{$cur_entry}},"$line\n");
++	}
++    }
++    close($fh);
++    # sort the query file
++    open($fh,">$mgaps") || die "couldn't write to file $mgaps\n";
++    my $oldfh = select($fh);
++    foreach my $dna (@qry_entries) {
++	foreach my $pep (@{$dna_pep{$dna}}) {
++	    my $ref_line = $mgaps_lines{$pep};
++	    foreach my $line(@{$ref_line}) {
++		print $line;
++	    }
++	}
++    }
++    select($oldfh);
++    close($fh);
++}
+ #-- END OF SCRIPT
+-- 
+2.24.0
+

--- a/recipes/mummer4/meta.yaml
+++ b/recipes/mummer4/meta.yaml
@@ -11,9 +11,10 @@ source:
   patches:
     - Makefile.am.patch # replaces some double quotes with single quotes to accomodate filepaths with '@' (Galaxy)
     - Makefile.in.patch
+    - 0001-sort-mgaps-file-before-postpro.-on-behalf-of-jervied.patch  # fixes https://github.com/mummer4/mummer/issues/55
 
 build:
-  number: 4
+  number: 5
 
 requirements:
   build:


### PR DESCRIPTION
mummer4: added a patch that fixes promer .  One component of mummer4 has a bug that stops it from working.   A patch has been submitted ( https://github.com/mummer4/mummer/pull/94 ) but is not yet merged.  This patch changes only the promer script and does not affect any other parts of mummer4.

----

> Bioconda requires reviews prior to merging pull-requests (PRs). To facilitate this, once your PR is passing tests and ready to be merged, please add the `please review & merge` label so other members of the bioconda community can have a look at your PR and either make suggestions or merge it.

* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
* [ ] This PR adds a new recipe.
* [X] AFAIK, this recipe **is directly relevant to the biological sciences**
      (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

> Everyone has access to the following BiocondaBot commands, which can be given in a comment:
>
>  * `@BiocondaBot please update` will cause the BiocondaBot to merge the master branch into a PR
>  * `@BiocondaBot please add label` will add the `please review & merge` label.
>  * `@BiocondaBot please fetch artifacts` will post links to packages and docker containers built by the CI system. You can use this to test packages locally before merging.
>
> For members of the Bioconda project, the following command is also available:
>
>  * `@BiocondaBot please merge` will cause packages/containers to be uploaded and a PR merged. Someone must approve a PR first! This has the benefit of not wasting CI build time required by manually merging PRs.
>
> If you have questions, please post them in gitter or ping `@bioconda/core` in a comment (if you are not able to directly ping `@bioconda/core` then the bot will repost your comment and enable pinging).
