### PR TITLE
Add macrel at v0.2

### DIFF
--- a/recipes/macrel/build.sh
+++ b/recipes/macrel/build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+mkdir -p $PREFIX/bin
+
+cd prodigal_modified
+make CC=$CC --quiet # conda will add $CC to environment
+chmod +x prodigal
+cd ..
+
+cp $SRC_DIR/prodigal_modified/prodigal $PREFIX/bin/prodigal_sm
+
+$PYTHON -m pip install --disable-pip-version-check --no-cache-dir --ignore-installed --no-deps -vv .
+

--- a/recipes/macrel/meta.yaml
+++ b/recipes/macrel/meta.yaml
@@ -1,0 +1,58 @@
+{% set name = "macrel" %}
+{% set version = "0.2" %}
+{% set sha256 = "a27937bd750ce604abf834a4da449aa4eee25759de38ee9cbb566f234d53cb9c" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+  
+source:
+ url: https://github.com/BigDataBiology/macrel/archive/v{{ version }}.tar.gz
+ sha256: {{ sha256 }}
+
+build:
+  number: 0
+  # ngless is unavailable on osx
+  skip: True # [osx]
+  entry_points:
+    - macrel= macrel.main:main
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+  host:
+    - python
+    - pip
+  run:
+    - python
+    - ngless
+    - megahit
+    - paladin
+    - pandas
+    - rpy2
+    - tzlocal
+    - r-base
+    - r-essentials
+    - r-peptides
+    - r-randomforest
+
+test:
+  imports:
+    - macrel
+  commands:
+    - macrel --version
+
+about:
+  home: https://github.com/BigDataBiology/macrel
+  license: MIT
+  license_file: LICENSE
+  summary: "A module for AMP (antimicrobial peptide) prediction"
+  description: |
+    Used for the prediction of AMPs in (meta)genomes.
+  dev_url: https://github.com/BigDataBiology/macrel
+  
+extra:
+  recipe-maintainers:
+    - luispedro
+  identifiers:
+    - "doi:10.1101/2019.12.17.880385" # bioRxiv preprint


### PR DESCRIPTION
Adds macrel

It's a pretty standard Python package, except that we also ship a modified version of `prodigal`, which is installed as `prodigal_sm`

More information:

http://big-data-biology.org/software/macrel
https://www.biorxiv.org/content/10.1101/2019.12.17.880385v1
(which uses the old name of the tool, FACS; we'll update asap)


----

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
* [x] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences**
      (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).

