### PR TITLE
scalpel: fix build for Microassembler

### DIFF
--- a/recipes/scalpel/build.sh
+++ b/recipes/scalpel/build.sh
@@ -22,11 +22,13 @@ sed -i "s/bamtools samtools bcftools//g" Makefile
 chmod 0755 FindVariants.pl
 chmod 0755 FindSomatic.pl
 
-make INCLUDES="-I$PREFIX/include/bamtools -L $PREFIX/lib" Microassembler
-make INCLUDES="-I$PREFIX/include/bamtools -L $PREFIX/lib"
+ls -lh $BUILD_PREFIX/include/bamtools
+make INCLUDES="-I$BUILD_PREFIX/include/bamtools -L $BUILD_PREFIX/lib" Microassembler
+make INCLUDES="-I$BUILD_PREFIX/include/bamtools -L $BUILD_PREFIX/lib"
 
 outdir=$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM
 mkdir -p $outdir
 cp -r * $outdir
+mkdir -p $PREFIX/bin
 ln -s $outdir/scalpel-discovery $PREFIX/bin
 ln -s $outdir/scalpel-export $PREFIX/bin

--- a/recipes/scalpel/build.sh
+++ b/recipes/scalpel/build.sh
@@ -18,6 +18,9 @@ sed -i 's:$Bin:$RealBin:g' Utils.pm
 sed -i "s:system(\$cmd):system(\"/bin/bash -c '\$cmd'\"):g" Utils.pm
 # Avoid building samtools bcftools
 sed -i "s/bamtools samtools bcftools//g" Makefile
+# Use g++ in container
+sed -i.bak "s#g++#${CXX}#" Microassembler/Makefile
+sed -i.bak "s#g++#${CXX}#" Makefile
 
 chmod 0755 FindVariants.pl
 chmod 0755 FindSomatic.pl

--- a/recipes/scalpel/meta.yaml
+++ b/recipes/scalpel/meta.yaml
@@ -7,7 +7,7 @@ source:
   sha256: 506f731b3886def158c15fd8b74fa98390f304a507d2040972e6b09ddefac8f0
 
 build:
-  number: 1
+  number: 2
   skip: True # [osx]
 
 requirements:


### PR DESCRIPTION
Microassembler was not correctly building due to not finding bamtools
include files and libaries. Adjust to BUILD_PREFIX reference to enable.
Fixes bioconda/bioconda-recipes#19844

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences**
      (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).