### PR TITLE
gimmemotifs removed 3.6 restriction

### DIFF
--- a/recipes/gimmemotifs/meta.yaml
+++ b/recipes/gimmemotifs/meta.yaml
@@ -15,7 +15,7 @@ requirements:
   build:
     - {{ compiler('c') }}
   host:
-    - python
+    - python >3
     - setuptools
   run:
     - bedtools
@@ -41,7 +41,7 @@ requirements:
     - pyarrow
     - pybedtools
     - pysam
-    - python
+    - python >3
     - python-xxhash
     - pyyaml >=3.10
     - scikit-learn >=0.18

--- a/recipes/gimmemotifs/meta.yaml
+++ b/recipes/gimmemotifs/meta.yaml
@@ -40,7 +40,6 @@ requirements:
     - pillow
     - pyarrow
     - pybedtools
-    - pysam
     - python >3
     - python-xxhash
     - pyyaml >=3.10

--- a/recipes/gimmemotifs/meta.yaml
+++ b/recipes/gimmemotifs/meta.yaml
@@ -9,8 +9,7 @@ source:
   sha256: 917259c8a52ab8ea5c877e9b43f45e077b0ceb9a151ca52791fae67ee8689c0d 
 
 build:
-  number: 1 
-  skip: True  # [not py36]
+  number: 2 
 
 requirements:
   build:


### PR DESCRIPTION
Upstream conda-forge deps should now support 3.7 and 3.8.

----

* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
* [X] AFAIK, this recipe **is directly relevant to the biological sciences**
      (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [X] This PR updates an existing recipe.