### PR TITLE
Added a missing file for Kaiju

### DIFF
--- a/recipes/kaiju/build.sh
+++ b/recipes/kaiju/build.sh
@@ -28,3 +28,4 @@ cp kaiju-mkbwt $PREFIX/bin
 cp kaiju-mkfmi $PREFIX/bin
 cp kaiju-convertMAR.py $PREFIX/bin
 cp kaiju-taxonlistEuk.tsv $PREFIX/bin
+cp kaiju-excluded-accessions.txt $PREFIX/bin

--- a/recipes/kaiju/meta.yaml
+++ b/recipes/kaiju/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 174ab6b6841d3d9164ec06f76a219a391d461d271b4a00fe8cf9cd87e689b05e
 
 build:
-  number: 0
+  number: 1
   no_link:
     - bin/kaiju-makedb.sh
 


### PR DESCRIPTION
`kaiju-excluded-accessions.txt` was added in the newest release. Without it, `kaiju-makedb` crashes for me on the latest version (1.7.3).
```
$ kaiju-makedb -t 8 -s rvdb
Error: File kaiju-excluded-accessions.txt not found in <condaenv>/bin
```
It is available next to the executables. Is it ok to place it in the bin dir? The same thing is done for the `kaiju-taxonlistEuk.tsv`. The location is hard coded.

@pmenzel Just tagged you to notify you of this proposed change.

----

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences**
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

