### PR TITLE
Add scikit-learn dependency to macrel

### DIFF
--- a/recipes/macrel/meta.yaml
+++ b/recipes/macrel/meta.yaml
@@ -11,7 +11,7 @@ source:
  sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   # ngless is unavailable on osx
   skip: True # [osx]
   entry_points:
@@ -29,12 +29,12 @@ requirements:
     - megahit
     - paladin
     - pandas
+    - scikit-learn
     - rpy2
     - tzlocal
     - r-base
     - r-essentials
     - r-peptides
-    - r-randomforest
 
 test:
   imports:


### PR DESCRIPTION
New version uses scikit-learn instead of r-randomForest, so update to
that.

* [x] This PR updates an existing recipe.

> Everyone has access to the following BiocondaBot commands, which can be given in a comment:
>
>  * `@BiocondaBot please update` will cause the BiocondaBot to merge the master branch into a PR
>  * `@BiocondaBot please add label` will add the `please review & merge` label.
>  * `@BiocondaBot please fetch artifacts` will post links to packages and docker containers built by the CI system. You can use this to test packages locally before merging.
>
> For members of the Bioconda project, the following command is also available:
>
