### PR TITLE
Bump sourmash to 3.2.0 and add bam2fasta dependency

### DIFF
--- a/recipes/sourmash/meta.yaml
+++ b/recipes/sourmash/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.1.0" %}
+{% set version = "3.2.0" %}
 
 package:
   name: sourmash
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/s/sourmash/sourmash-{{ version }}.tar.gz
-  sha256: 29fa5525f6acd268966aeb3ee2ac20cfe488cba304b8ae0db1aecb14d2735b55
+  sha256: b297d1857949a32dd8b4b509de5ef1f1c3b1d9e3ba69d7fb8384fe66e9da5c98
 
 build:
   entry_points:
@@ -35,6 +35,7 @@ requirements:
     - scipy
     - khmer >=2.1
     - deprecation
+    - bam2fasta >=1.0.1
 
 test:
   imports:


### PR DESCRIPTION
Bump sourmash to 3.2.0 and add bam2fasta dependency

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences**
      (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

(is `autobump` not working?)