### PR TITLE
Orthofinder dev

### DIFF
--- a/recipes/orthofinder/build.sh
+++ b/recipes/orthofinder/build.sh
@@ -5,7 +5,9 @@ mkdir -p $PREFIX/bin
 cp orthofinder.py $PREFIX/bin/orthofinder
 
 # scripts_of now contains the config.json file
-cp -r scripts_of $PREFIX/bin/
+mkdir $PREFIX/bin/scripts_of
+cp -r scripts_of/*py $PREFIX/bin/scripts_of/
+cp scripts_of/config.json $PREFIX/bin/scripts_of/config.json
 
 cp -r tools $PREFIX/bin/
 

--- a/recipes/orthofinder/meta.yaml
+++ b/recipes/orthofinder/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 build:
   noarch: generic
-  number: 1
+  number: 2
 
 source:
   url: https://github.com/davidemms/OrthoFinder/releases/download/{{ version }}/OrthoFinder_source.tar.gz

--- a/recipes/orthofinder/meta.yaml
+++ b/recipes/orthofinder/meta.yaml
@@ -18,7 +18,7 @@ requirements:
     - python >=2.7
     - scipy
     - blast
-    - diamond
+    - diamond <=0.9.24
     - mcl
     - fastme
     - mafft


### PR DESCRIPTION
The OrthoFinder recipe copied a directory of binaries that OrthoFinder used. This is unnecessary since the bioconda recipes should be used to install dependencies instead. I've updated the recipe so as not to copy this directory. I've also updated the diamond requirement to <=0.9.24 as there is an outstanding issue after this release that is causing a crash for many mac users. I will monitor the situation with this issue and remove the version requirement once it's no longer needed.
https://github.com/bbuchfink/diamond/issues/303
https://github.com/davidemms/OrthoFinder/issues/328

Thanks
David


* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences**
      (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
