### PR TITLE
Update dependencies for braker2

### DIFF
--- a/recipes/braker2/meta.yaml
+++ b/recipes/braker2/meta.yaml
@@ -13,7 +13,7 @@ source:
     - path.patch
 
 build:
-  number: 0
+  number: 1
   noarch: generic
 
 requirements:
@@ -36,16 +36,16 @@ requirements:
     - perl-logger-simple
     - perl-module-load-conditional
     - perl-posix
-    - augustus >=3.3.1
+    - augustus >=3.3.3
     - bamtools >=2.5.1
     - samtools >=1.7
     - spaln >=2.3.1
     - exonerate >=2.2.0
     - blast >=2.2.31
     - makehub
-    - eval
+    - genomethreader>=1.7.0
+    - diamond>=0.9.24
       #    - genemark-et >=4.33
-      #    - genomethreader >=1.7.9
 
 test:
   commands:
@@ -69,4 +69,3 @@ extra:
     - doi:10.13140/RG.2.2.12857.62564
   notes:
     - GeneMark software can be used for free, but requires a license file and should be additionally installed on the machine where the BRAKER2 environment is.
-    - GenomeThreader software can be used for free, but all warranties are excluded and thus the user should additionally install it on the machine where the BRAKER2 environment is.


### PR DESCRIPTION
BRAKER 2.1.4 [requires Augustus >= 3.3.3](https://github.com/Gaius-Augustus/BRAKER/issues/22#issuecomment-531294856), and supports DIAMOND as an alternative to NCBI BLAST+.

genomethreader is now available in bioconda, and it seems the license [should no longer be an issue](https://github.com/genometools/genomethreader/blob/bfc6a051a8d06451e028af2f1dec58c88296c96f/CHANGELOG#L19)?

----

* [X] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
* [ ] This PR adds a new recipe.
* [ ] AFAIK, this recipe **is directly relevant to the biological sciences**
      (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [X] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).