### PR TITLE
Attempt to fix sambamba crash on macOS Catalina

### DIFF
--- a/recipes/sambamba/meta.yaml
+++ b/recipes/sambamba/meta.yaml
@@ -9,20 +9,20 @@ source:
   sha256: f03a415a3bc572e9ad3807936fde6eea1720e85611a8890c8bb91218c598bc38
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
     - {{ compiler('c') }}
   host:
-    - ldc
+    - ldc >=1.17.0
     - bzip2
     - htslib
     - zlib
     - xz
     - git  # needed for BioD
   run:
-    - ldc
+    - ldc >=1.17.0
     - bzip2
     - zlib
     - xz


### PR DESCRIPTION
**Note**: This will currently fail because LDC 1.17.0 isn’t available on conda-forge.

Sambamba crashes with
```
Symbol not found: _dyld_enumerate_tlv_storage
```
This is filed as [D bug 20019](https://issues.dlang.org/show_bug.cgi?id=20019) and has been [fixed in D 2.087.1](https://dlang.org/changelog/2.087.1.html).

This PR simply bumps the required LDC version to LDC 1.17.0, which is the first version to [include that fixed version](https://github.com/ldc-developers/ldc/blob/master/CHANGELOG.md#ldc-1170-2019-08-25).

The most recent Sambamba version 0.7.1 has been built with LDC 1.13, according to the [CI logs](https://app.circleci.com/jobs/github/bioconda/bioconda-recipes/84656).

* dlang PR:  dlang/druntime#2666
* sambamba bug report: biod/sambamba#424