### PR TITLE
berokka - fix broken bioperl vs perl

### DIFF
--- a/recipes/berokka/meta.yaml
+++ b/recipes/berokka/meta.yaml
@@ -1,31 +1,37 @@
+{% set name = "berokka" %}
+{% set user = "tseemann" %}
 {% set version = "0.2.3" %}
 {% set sha256 = "460f4272768e205008aa8aa885d1df5bab9af2c5b404c261e00573c6a30a641f" %}
 
 package:
-  name: berokka
+  name: '{{name}}'
   version: '{{version}}'
 
 source:
-  url: https://github.com/tseemann/berokka/archive/v{{version}}.tar.gz
+  url: https://github.com/{{user}}/{{name}}/archive/v{{version}}.tar.gz
   sha256: '{{sha256}}'
 
 build:
   noarch: generic
-  number: 0
+  number: 1
 
 requirements:
-  build:
+  host:
+    - perl >=5.26
+    - perl-bioperl >=1.7.2
+    - blast >=2.7
   run:
-    - perl
-    - perl-bioperl >=1.7
-    - blast >=2.3
+    - perl >=5.26
+    - perl-bioperl >=1.7.2
+    - blast >=2.7
 
 test:
   commands:
-    - berokka -h | grep 'canu'
+    - {{name}} --version | grep '{{version}}'
+    - {{name}} --help | grep 'fuzz'
 
 about:
-  home: https://github.com/tseemann/berokka
+  home: https://github.com/{{user}}/[{name}}
   license: GPL-3.0
   license_family: GPL
   license_file: LICENSE


### PR DESCRIPTION
* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences**
      (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

Perl and Bioperl seem to mistmatched:

```
berokka -h
Can't locate Bio/SeqIO.pm in @INC (you may need to install the Bio::SeqIO module) (@INC contains: /scratch/punim0401/miniconda3/envs/berokka_env/lib/site_perl/5.26.2/x86_64-linux-thread-multi /scratch/punim0401/miniconda3/envs/berokka_env/lib/site_perl/5.26.2 /scratch/punim0401/miniconda3/envs/berokka_env/lib/5.26.2/x86_64-linux-thread-multi /scratch/punim0401/miniconda3/envs/berokka_env/lib/5.26.2 .) at /scratch/punim0401/miniconda3/envs/berokka_env/bin/berokka line 4.
```
