### PR TITLE
fix that stops buil.sh overwriting another directory

### DIFF
--- a/recipes/riboseqc/build.sh
+++ b/recipes/riboseqc/build.sh
@@ -6,6 +6,6 @@ if [[ $target_platform =~ linux.* ]] || [[ $target_platform == win-32 ]] || [[ $
   grep -v '^Priority: ' DESCRIPTION.old > DESCRIPTION
   $R CMD INSTALL --build .
 else
-  mkdir -p $PREFIX/lib/R/library/here
-  mv * $PREFIX/lib/R/library/here
+  mkdir -p $PREFIX/lib/R/library/riboseqc
+  mv * $PREFIX/lib/R/library/riboseqc
 fi

--- a/recipes/riboseqc/meta.yaml
+++ b/recipes/riboseqc/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   noarch: generic
-  number: 0
+  number: 1
   rpaths:
     - lib/R/lib/
     - lib/


### PR DESCRIPTION
Previously had wrong directory name in build.sh - would possibly have interfered with another package 'here'
----

> Bioconda requires reviews prior to merging pull-requests (PRs). To facilitate this, once your PR is passing tests and ready to be merged, please add the `please review & merge` label so other members of the bioconda community can have a look at your PR and either make suggestions or merge it.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences**
      (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

> Everyone has access to the following BiocondaBot commands, which can be given in a comment:
>
>  * `@BiocondaBot please update` will cause the BiocondaBot to merge the master branch into a PR
>  * `@BiocondaBot please add label` will add the `please review & merge` label.
>  * `@BiocondaBot please fetch artifacts` will post links to packages and docker containers built by the CI system. You can use this to test packages locally before merging.
>
> For members of the Bioconda project, the following command is also available:
>
>  * `@BiocondaBot please merge` will cause packages/containers to be uploaded and a PR merged. Someone must approve a PR first! This has the benefit of not wasting CI build time required by manually merging PRs.
>
> If you have questions, please post them in gitter or ping `@bioconda/core` in a comment (if you are not able to directly ping `@bioconda/core` then the bot will repost your comment and enable pinging).
