### PR TITLE
Update HyPhy to 2.5.3 and disable AVX extensions

### DIFF
--- a/recipes/hyphy/build.sh
+++ b/recipes/hyphy/build.sh
@@ -1,5 +1,5 @@
 export CXXFLAGS=-I$PREFIX/include
 export LDFLAGS=-L$PREFIX/lib
-cmake -DCMAKE_INSTALL_PREFIX=$PREFIX .
+cmake -DCMAKE_INSTALL_PREFIX=$PREFIX -DNOAVX=ON .
 make hyphy HYPHYMPI
 make install

--- a/recipes/hyphy/meta.yaml
+++ b/recipes/hyphy/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: '{{ sha256 }}'
 
 build:
-  number: 1
+  number: 0
 
 requirements:
   build:

--- a/recipes/hyphy/meta.yaml
+++ b/recipes/hyphy/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: '{{ sha256 }}'
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:

--- a/recipes/hyphy/meta.yaml
+++ b/recipes/hyphy/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "2.5.2" %}
-{% set sha256 = "bf3d095ebd613bd03c4bf75eb964175781f530484f67dd1a4d201fa51945c319" %}
+{% set version = "2.5.3" %}
+{% set sha256 = "18fd3db1d16581c645933904478a9742be85a0b444d8fdf18098ef99cf299fef" %}
 
 package:
   name: hyphy
@@ -10,7 +10,7 @@ source:
   sha256: '{{ sha256 }}'
 
 build:
-  number: 2
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
Although this disables AVX, I believe it also disables FMA, which is new enough that some commonly deployed CPUs do not support it.

----

> Bioconda requires reviews prior to merging pull-requests (PRs). To facilitate this, once your PR is passing tests and ready to be merged, please add the `please review & merge` label so other members of the bioconda community can have a look at your PR and either make suggestions or merge it.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences**
      (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).

> Everyone has access to the following BiocondaBot commands, which can be given in a comment:
>
>  * `@BiocondaBot please update` will cause the BiocondaBot to merge the master branch into a PR
>  * `@BiocondaBot please add label` will add the `please review & merge` label.
>  * `@BiocondaBot please fetch artifacts` will post links to packages and docker containers built by the CI system. You can use this to test packages locally before merging.
>
> For members of the Bioconda project, the following command is also available:
>
>  * `@BiocondaBot please merge` will cause packages/containers to be uploaded and a PR merged. Someone must approve a PR first! This has the benefit of not wasting CI build time required by manually merging PRs.
>
> If you have questions, please post them in gitter or ping `@bioconda/core` in a comment (if you are not able to directly ping `@bioconda/core` then the bot will repost your comment and enable pinging).
