### PR TITLE
fix cffi dep version for sourmash

### DIFF
--- a/recipes/sourmash/meta.yaml
+++ b/recipes/sourmash/meta.yaml
@@ -29,7 +29,7 @@ requirements:
   run:
     - python
     - screed >=0.9
-    - cffi >= 1.14
+    - cffi >=1.14
     - numpy
     - matplotlib-base
     - scipy

--- a/recipes/sourmash/meta.yaml
+++ b/recipes/sourmash/meta.yaml
@@ -11,7 +11,7 @@ source:
 build:
   entry_points:
     - sourmash = sourmash.__main__:main
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -29,7 +29,7 @@ requirements:
   run:
     - python
     - screed >=0.9
-    - cffi
+    - cffi >= 1.14
     - numpy
     - matplotlib-base
     - scipy


### PR DESCRIPTION
There is a bug in `cffi` which affects [sourmash](https://github.com/dib-lab/sourmash/pull/911), but it is fixed in `cffi == 1.14.0`.

----

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences**
      (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).