### PR TITLE
[racon] Update build and bump version

### DIFF
--- a/recipes/racon/build.sh
+++ b/recipes/racon/build.sh
@@ -3,7 +3,7 @@
 mkdir -p $PREFIX/bin
 mkdir build
 cd build
-cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${PREFIX} -Dracon_build_wrapper=ON -DCMAKE_CXX_FLAGS="-mno-avx2 " ..
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${PREFIX} -Dracon_build_wrapper=ON -Dspoa_optimize_for_portability=ON ..
 make
 chmod +w bin/racon_wrapper
 make install

--- a/recipes/racon/meta.yaml
+++ b/recipes/racon/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "Racon" %}
-{% set version = "1.4.10" %}
+{% set version = "1.4.11" %}
 
 package:
   name: {{ name|lower }}

--- a/recipes/racon/meta.yaml
+++ b/recipes/racon/meta.yaml
@@ -10,7 +10,7 @@ build:
 
 source:
   url: https://github.com/lbcb-sci/racon/releases/download/{{ version }}/racon-v{{ version }}.tar.gz
-  sha256: 016fb3affb977303a5f5ad27339a7044fa3d9b89a6ea3c7734479f864155a0c2
+  sha256: 470efcc4b9985f47ffa1f384940034950ebf20b213a88637f2b79f4eb0b0cb2f
   patches:
     - racon_wrapper.patch
 


### PR DESCRIPTION
I have updated the build for Racon as some users have problems running the executable on their machines. The cause is the `-march=native` compiler flag which will be replaced with -msse4.1 if cmake is run with flag `-Dspoa_optimize_for_portability=ON`. This flag is present from version `v1.4.11` which was released moments ago.

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences**
      (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).
