### PR TITLE
Bump ARB (arb-bio) build number trying to fix install

### DIFF
--- a/recipes/arb-bio/build.sh
+++ b/recipes/arb-bio/build.sh
@@ -29,7 +29,7 @@ if [ -n "$wrong_prefix" ]; then
     echo "  $good_prefix"
     grep -rlI "$wrong_prefix" $(perl -e 'print "@INC"') | \
 	sort -u |\
-	xargs sed -ibak "s|$wrong_prefix|$good_prefix|g"
+	xargs sed -ibak "s|$wrong_prefix|$good_prefix|g" || true
     if perl -V | grep "$wrong_prefix"; then
 	echo "Failed to fix paths - expect breakage below"
     else

--- a/recipes/arb-bio/build.sh
+++ b/recipes/arb-bio/build.sh
@@ -88,8 +88,10 @@ make SHARED_LIB_SUFFIX=$SHARED_LIB_SUFFIX tarfile_quick \
 echo "====== FINISHED BUILD ========"
 
 
+echo -n Unpacking the new binary archive ...
 mkdir -p install/lib/arb
 tar -C install/lib/arb -xzf arb.tgz
+echo done
 
 
 # Manually relocate libraries and binaries
@@ -128,13 +130,19 @@ case `uname` in
     Linux)
 	ARB_BINS=`find install -type f -perm -a=x | \
 	    xargs file | grep ELF | cut -d : -f 1 | grep -v ' '`
+	echo "Found these binaries: $ARB_BINS"
+	set -x
+	file install/bin/arb_ntree || true
+	patchelf --set-rpath \$ORIGIN/../lib install/bin/arb_ntree || true
+	ldd install/bin/arb_ntree || true
 	echo "Patching rpath into binaries:"
 	for bin in $ARB_BINS; do
 	    if test -e "$bin"; then
 		echo -n "$bin ..."
-		patchelf --set-rpath \$ORIGIN/../lib "$bin"
+		patchelf --set-rpath \$ORIGIN/../lib "$bin" || true
 	    fi
 	done
+	set +x
 	;;
 esac
 

--- a/recipes/arb-bio/meta.yaml
+++ b/recipes/arb-bio/meta.yaml
@@ -31,7 +31,7 @@ source:
     - typeof.patch
 
 build:
-  number: 8
+  number: 9
 # constraining to perl >= 5.23 does not work via requirements, resulting in a 
 # broken build string. constraining via skip also doesn't work - the suggested
 # approach leads to str < int compare failure during lint. 


### PR DESCRIPTION
`conda create -n arb_env arb-bio` currently installs 6.0.6 build **4** instead of the current **8**. Build 4 is **broken**.

Forcing with `arb-bio=6.0.6=pl526h7e5b878_8` leads to `UnsatisfiableError`, as do all versions down to the broken build 4. 

Perhaps rebuilding will lead to an installable package... 