### PR TITLE
deepvariant: 0.10.0 requires p36, adjust pinnings

### DIFF
--- a/recipes/deepvariant/meta.yaml
+++ b/recipes/deepvariant/meta.yaml
@@ -10,7 +10,7 @@ package:
 # - Uses pre-built binaries, building problematic due to clif dependency
 # - Need recent kernel with GLIBC > 2.23 due to pre-built htslib
 # - Build patches __main__.py in zip files to generalize python dependency
-# - Requires numpy 1.14, want to sync with CONDA_NPY
+# - Requires numpy 1.16, want to sync with CONDA_NPY
 # - Uses python wrappers that don't expose all underlying options
 # - Ships with pre-built model. Longer term will need way to fetch models on demand.
 
@@ -19,8 +19,8 @@ source:
   sha256: '{{ sha256 }}'
 
 build:
-  number: 0
-  skip: true  # [osx or not py27]
+  number: 1
+  skip: true  # [osx or not py36]
 
 requirements:
   host:
@@ -34,20 +34,20 @@ requirements:
     # - bazel
   run:
     - openjdk >=8,<9
-    - python
+    - python 3.6.*
     - google-cloud-sdk
     - zlib
     - boost
     - htslib
     - numpy
     - curl
-    - tensorflow 1.12.*
+    - tensorflow 2.0.*
     - protobuf
     - contextlib2
     - enum34
     - intervaltree
     - mock
-    - numpy 1.14.*
+    - numpy 1.16.*
     - psutil
     - requests
     - scipy


### PR DESCRIPTION
Fix auto-update of deepvariant to match latest pinnings in new release (py36, numpy 1.16, tensorflow 2.0.0)

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences**
      (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).