### PR TITLE
Update pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,24 +1,24 @@
-**Replace this sentence with a detailed description of your pull request**
+<!-- Describe your pull request here -->
 
 ----
 
-> Bioconda requires reviews prior to merging pull-requests (PRs). To facilitate this, once your PR is passing tests and ready to be merged, please add the `please review & merge` label so other members of the bioconda community can have a look at your PR and either make suggestions or merge it.
+Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).
 
-* [ ] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
-* [ ] This PR adds a new recipe.
-* [ ] AFAIK, this recipe **is directly relevant to the biological sciences**
-      (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
-* [ ] This PR updates an existing recipe.
-* [ ] This PR does something else (explain below).
+* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title
+* New recipes not directly relevant to the biological sciences need to be submitted to [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda
+* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please add the `please review & merge` label.
+* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.
 
-> Everyone has access to the following BiocondaBot commands, which can be given in a comment:
->
->  * `@BiocondaBot please update` will cause the BiocondaBot to merge the master branch into a PR
->  * `@BiocondaBot please add label` will add the `please review & merge` label.
->  * `@BiocondaBot please fetch artifacts` will post links to packages and docker containers built by the CI system. You can use this to test packages locally before merging.
->
-> For members of the Bioconda project, the following command is also available:
->
->  * `@BiocondaBot please merge` will cause packages/containers to be uploaded and a PR merged. Someone must approve a PR first! This has the benefit of not wasting CI build time required by manually merging PRs.
->
-> If you have questions, please post them in gitter or ping `@bioconda/core` in a comment (if you are not able to directly ping `@bioconda/core` then the bot will repost your comment and enable pinging).
+<details>
+  <summary>BiocondaBot commands</summary>
+      
+Everyone has access to the following BiocondaBot commands, which can be given in a comment:
+
+  * `@BiocondaBot please update` will cause the BiocondaBot to merge the master branch into a PR
+  * `@BiocondaBot please add label` will add the `please review & merge` label.
+  * `@BiocondaBot please fetch artifacts` will post links to packages and docker containers built by the CI system. You can use this to test packages locally before merging.
+
+For members of the Bioconda project, the following command is also available:
+
+ * `@BiocondaBot please merge` will cause packages/containers to be uploaded and a PR merged. Someone must approve a PR first! This has the benefit of not wasting CI build time required by manually merging PRs.
+</details>


### PR DESCRIPTION
This PR makes the following changes to the PR template. My main intention was to remove the checkboxes and to simplify the text so that there is a chance that it is actually read.

* Contributors are no longer asked to confirm that they have read the guidelines: New contributors will already have been asked to read the contributer guidelines on their first PR. For existing contributors, it is just an annoyance being asked to re-check that box every time. A link to the guidelines still exists.
* The checkboxes for categorizing adding vs updating a recipe are gone. Instead, contributors are asked to phrase the title appropriately. From my experience of reviewing PRs, this is a lot more helpful as the title is the natural place to look for this information.
* The instructions contained in the other checkboxes have been converted to running text.
* Note that checkboxes are slightly misused at the moment: They are intended to be part of a to-do list that wants all of its items to be checked, but in the current checklist, some items are mutually exclusive.
* This is also reflected in the [pull request overview list](https://github.com/bioconda/bioconda-recipes/pulls) where all (non-bot) PRs have a a "x of 5" next to their description. Since we never reach 5 out of 5 here, this is not very helpful information and just adds clutter to the list.
* The bot commands overview was moved to a collapsed section in order to reduce the amount of space the text takes.