### PR TITLE
deepvariant: additional py36 fixes; point to anaconda python

### DIFF
--- a/recipes/deepvariant/build.sh
+++ b/recipes/deepvariant/build.sh
@@ -24,7 +24,7 @@ rm -rf $TGT/models
 for ZIPBIN in make_examples call_variants postprocess_variants
 do
 	unzip -d $ZIPBIN $PREFIX/$BINARY_DIR/$ZIPBIN.zip
-	sed -i.bak "s|PYTHON_BINARY = '/usr/bin/python'|PYTHON_BINARY = sys.executable|" $ZIPBIN/__main__.py
+	sed -i.bak "s|PYTHON_BINARY = '/usr/bin/python3.6'|PYTHON_BINARY = sys.executable|" $ZIPBIN/__main__.py
 	rm -f $ZIPBIN/*.bak
 	cd $ZIPBIN
 	zip -r ../$ZIPBIN.zip *

--- a/recipes/deepvariant/dv_make_examples.py
+++ b/recipes/deepvariant/dv_make_examples.py
@@ -20,7 +20,7 @@ class DVHelp(argparse._HelpAction):
         conda_path = os.path.dirname(os.path.realpath(sys.executable))
         lib_path = os.path.join(os.path.dirname(conda_path), "lib")
         py_exe = sys.executable
-        cmd = ("export LD_LIBRARY_PATH={lib_path}:$LD_LIBRARY_PATH && "
+        cmd = ("export LD_LIBRARY_PATH={lib_path}:\"$LD_LIBRARY_PATH\" && "
                "{py_exe} {bin_dir}/make_examples.zip --help")
         print(subprocess.check_output(cmd.format(**locals()), shell=True))
         print()
@@ -46,7 +46,7 @@ def main():
     py_exe = sys.executable
     split_inputs = " ".join(str(x) for x in range(0, int(args.cores)))
     regions = ("--regions %s" % args.regions) if args.regions else ""
-    cmd = ("export PATH={conda_path}:$PATH && export LD_LIBRARY_PATH={lib_path}:$LD_LIBRARY_PATH && "
+    cmd = ("export PATH={conda_path}:\"$PATH\" && export LD_LIBRARY_PATH={lib_path}:\"$LD_LIBRARY_PATH\" && "
            "parallel --eta --halt 2 --joblog {args.logdir}/log --res {args.logdir} "
            "{py_exe} {bin_dir}/make_examples.zip "
            "--mode calling --ref {args.ref} --reads {args.reads} {regions} "

--- a/recipes/deepvariant/dv_postprocess_variants.py
+++ b/recipes/deepvariant/dv_postprocess_variants.py
@@ -20,7 +20,7 @@ class DVHelp(argparse._HelpAction):
         conda_path = os.path.dirname(os.path.realpath(sys.executable))
         lib_path = os.path.join(os.path.dirname(conda_path), "lib")
         py_exe = sys.executable
-        cmd = ("export LD_LIBRARY_PATH={lib_path}:$LD_LIBRARY_PATH && "
+        cmd = ("export LD_LIBRARY_PATH={lib_path}:\"$LD_LIBRARY_PATH\" && "
                "{py_exe} {bin_dir}/postprocess_variants.zip --help")
         print(subprocess.check_output(cmd.format(**locals()), shell=True))
         print()
@@ -40,7 +40,7 @@ def main():
     conda_path = os.path.dirname(os.path.realpath(sys.executable))
     lib_path = os.path.join(os.path.dirname(conda_path), "lib")
     py_exe = sys.executable
-    cmd = ("export LD_LIBRARY_PATH={lib_path}:$LD_LIBRARY_PATH && "
+    cmd = ("export LD_LIBRARY_PATH={lib_path}:\"$LD_LIBRARY_PATH\" && "
            "{py_exe} {bin_dir}/postprocess_variants.zip "
            "--ref {args.ref} --infile {args.infile} --outfile {args.outfile}")
     sys.exit(subprocess.call(cmd.format(**locals()), shell=True))

--- a/recipes/deepvariant/meta.yaml
+++ b/recipes/deepvariant/meta.yaml
@@ -19,7 +19,7 @@ source:
   sha256: '{{ sha256 }}'
 
 build:
-  number: 1
+  number: 2
   skip: true  # [osx or not py36]
 
 requirements:


### PR DESCRIPTION
Additional fixes for deepvariant with py36:

- Correctly fix hardcoded references to python3.6 in zip files
- Escape environmental variables in scripts

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
* [ ] This PR adds a new recipe.
* [x] AFAIK, this recipe **is directly relevant to the biological sciences**
      (otherwise, please submit to the more general purpose [conda-forge channel](https://conda-forge.org/docs/)).
* [x] This PR updates an existing recipe.
* [ ] This PR does something else (explain below).