### PR TITLE
deepvariant: update 0.10.0: fix zipfile issue, finalize deps

### DIFF
--- a/recipes/deepvariant/build.sh
+++ b/recipes/deepvariant/build.sh
@@ -17,6 +17,14 @@ WGS_MODEL_DIR=`ls -d $SHAREDIR/models/DeepVariant/*/DeepVariant*wgs_standard`
 WES_MODEL_DIR=`ls -d $SHAREDIR/models/DeepVariant/*/DeepVariant*wes_standard`
 cd $SRC_DIR
 
+# TF slim is difficult because there is an existing tf-slim package in conda-forge
+# https://github.com/conda-forge/tf-slim-feedstock
+# which is different than the google one: https://github.com/google-research/tf-slim
+# This appears to be a temporary situation: https://github.com/google-research/tf-slim/issues/6
+# so temporarily install via pip in the build.sh to avoid conflicts
+# https://github.com/google/deepvariant/blob/4b937f03a1336d1dc6fd4c0eef727e1f83d2152a/run-prereq.sh#L109
+pip install --no-deps git+https://github.com/google-research/tf-slim.git
+
 # models installed in post-link script
 rm -rf $TGT/models
 
@@ -26,8 +34,9 @@ do
 	unzip -d $ZIPBIN $PREFIX/$BINARY_DIR/$ZIPBIN.zip
 	sed -i.bak "s|PYTHON_BINARY = '/usr/bin/python3.6'|PYTHON_BINARY = sys.executable|" $ZIPBIN/__main__.py
 	rm -f $ZIPBIN/*.bak
+	rm -f $ZIPBIN.zip
 	cd $ZIPBIN
-	zip -r ../$ZIPBIN.zip *
+	zip -q --symlinks -r ../$ZIPBIN.zip *
 	cd ..
 	mv $ZIPBIN.zip $PREFIX/$BINARY_DIR
 done

--- a/recipes/deepvariant/meta.yaml
+++ b/recipes/deepvariant/meta.yaml
@@ -19,7 +19,7 @@ source:
   sha256: '{{ sha256 }}'
 
 build:
-  number: 2
+  number: 3
   skip: true  # [osx or not py36]
 
 requirements:
@@ -35,6 +35,13 @@ requirements:
   run:
     - openjdk >=8,<9
     - python 3.6.*
+    # TF slim is difficult because there is an existing tf-slim package in conda-forge
+    # https://github.com/conda-forge/tf-slim-feedstock
+    # which is different than the google one: https://github.com/google-research/tf-slim
+    # This appears to be a temporary situation: https://github.com/google-research/tf-slim/issues/6
+    # so temporarily install via pip in the build.sh to avoid conflicts
+    - absl-py
+    # - tf-slim
     - google-cloud-sdk
     - zlib
     - boost
@@ -51,6 +58,7 @@ requirements:
     - psutil
     - requests
     - scipy
+    - altair
     - oauth2client
     - six
     - crcmod

--- a/recipes/deepvariant/post-link.sh
+++ b/recipes/deepvariant/post-link.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eu -o pipefail
 
-MODEL_VERSION="0.9.0"
+MODEL_VERSION="0.10.0"
 
 GSUTIL=$PREFIX/bin/gsutil
 for MODEL_TYPE in wgs wes


### PR DESCRIPTION
Hopefully last deepvariant revision bump after additional debugging work

- Fixes deepvariant issue with zipfile synlink references causing:
  ```
  TypeError: allele_count_linear_candidates_from_allele_counter() argument counter is
    not valid for ::learning::genomics::deepvariant::AlleleCounter
    (deepvariant.python.allelecounter.AlleleCounter instance given):
    expecting deepvariant.python.allelecounter.AlleleCounter instance, got
    deepvariant.python.allelecounter.AlleleCounter instance
  ```
  By adding `--symlinks` when recreating zipfile, thanks to reading
  through deepvariant build patch (https://github.com/google/deepvariant/issues/199#issuecomment-570115804)
  Fixes bcbio/bcbio-nextgen#3048

- Includes missing dependencies in new version: altair and absl.
  Includes custom Google tf-slim which duplicates other tf-slims and is
  in the process of being merged into a single package.
  Fixes bcbio/bcbio-nextgen#3150

- Bumps model version to include correct version