### PR TITLE
Update anvio 6.2 recipe to set critical version numbers

### DIFF
--- a/recipes/anvio-minimal/meta.yaml
+++ b/recipes/anvio-minimal/meta.yaml
@@ -10,13 +10,12 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: python -m pip install --no-deps --ignore-installed -vv .
 
 requirements:
   host:
-    #This pins to an old snakeMake that predated 3.7
     - python >=3
     - pip
   run:
@@ -28,20 +27,22 @@ requirements:
     - scipy
     - scikit-learn
     - django
-    - cherrypy
     - requests
     - psutil ==5.4.3
     - mistune
     - six
     - pandas ==0.25.1
     - matplotlib-base
-    - pyani ==0.2.10
     - statsmodels
-    - snakemake-minimal ==5.2.4
     - colored
     - illumina-utils
     - tabulate
     - numba
+    # these three are critical versions. any changes must be
+    # tested with extra attention:
+    - pyani ==0.2.10
+    - cherrypy ==8.0.0
+    - snakemake-minimal ==5.10.0
 test:
   commands:
     - anvi-pan-genome --help


### PR DESCRIPTION
This is a followup PR to #21241 and corrects the version numbers for `cherrypy` and `snakemake-minimal`.

Thank you.