### PR TITLE
Update anvi'o meta package to 6.2

### DIFF
--- a/recipes/anvio/meta.yaml
+++ b/recipes/anvio/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "6.1" %}
+{% set version = "6.2" %}
 
 package:
   name: anvio
@@ -6,7 +6,7 @@ package:
 
 build:
   noarch: generic
-  number: 1
+  number: 0
 
 requirements:
   run:
@@ -15,7 +15,7 @@ requirements:
     - mcl
     - muscle
     - hmmer
-    - diamond=0.9.14
+    - diamond ==0.9.14
     - blast
     - megahit
     - bowtie2
@@ -24,16 +24,24 @@ requirements:
     - centrifuge
     - trimal
     - iqtree
+    - fastani
+    - r
+    - r-stringi
+    - r-tidyverse
+    - r-magrittr
+    - r-optparse
+    - bioconductor-qvalue
+    - trnascan-se
 
 test:
   commands:
-    - anvi-pan-genome --help
-    - anvi-script-reformat-fasta --help
-    - anvi-profile --version
+    - anvi-self-test --version
+    - anvi-self-test --help
 
 about:
   home: http://merenlab.org/software/anvio/index.html
   license: GPL-3.0-or-later
   license_family: GPL3
+  license_file: LICENSE.txt
   summary: "An interactive analysis and visualization platform for omics data"
   dev_url:  https://github.com/merenlab/anvio

--- a/recipes/anvio/meta.yaml
+++ b/recipes/anvio/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - trimal
     - iqtree
     - fastani
-    - r
+    - r-base
     - r-stringi
     - r-tidyverse
     - r-magrittr

--- a/recipes/anvio/meta.yaml
+++ b/recipes/anvio/meta.yaml
@@ -42,6 +42,5 @@ about:
   home: http://merenlab.org/software/anvio/index.html
   license: GPL-3.0-or-later
   license_family: GPL3
-  license_file: LICENSE.txt
   summary: "An interactive analysis and visualization platform for omics data"
   dev_url:  https://github.com/merenlab/anvio


### PR DESCRIPTION
This is an update to the anvi'o meta package (anvi'o minimal recipe for 6.2 has been recently pushed, and is already merged and the package is available through bioconda).