### PR TITLE
nanopolish: fix macOS build

### DIFF
--- a/recipes/nanopolish/build.sh
+++ b/recipes/nanopolish/build.sh
@@ -10,10 +10,10 @@ mkdir -p $PREFIX/bin
 
 # Linker options aren't passed to minimap2
 pushd minimap2
-make CFLAGS="$CFLAGS" LIBS="-L$PREFIX/lib -lm -lz -pthread" libminimap2.a
+make CFLAGS="$CFLAGS" CXXFLAGS="$CXXFLAGS" LIBS="-L$PREFIX/lib -lm -lz -pthread" libminimap2.a
 popd
 
-make HDF5=noinstall EIGEN=noinstall HTS=noinstall MINIMAP=noinstall CXXFLAGS="-Iminimap2 -g -O3" LDFLAGS="$LDFLAGS -pthread -fopenmp"
+make HDF5=noinstall EIGEN=noinstall HTS=noinstall MINIMAP=noinstall CXXFLAGS="$CXXFLAGS -Iminimap2 -g -O3" LDFLAGS="$LDFLAGS -pthread -fopenmp"
 cp nanopolish $PREFIX/bin
 cp scripts/nanopolish_makerange.py $PREFIX/bin
 cp scripts/nanopolish_merge.py $PREFIX/bin

--- a/recipes/nanopolish/meta.yaml
+++ b/recipes/nanopolish/meta.yaml
@@ -6,8 +6,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 0
-  skip: True  # [osx]
+  number: 1
   binary_relocation: False
 
 source:


### PR DESCRIPTION
Fix the nanopolish build on macOS.

Fast5 uses `static_assert`, which is from C++11 — which is later than the default language standard on conda's macOS compiler. Explicitly pass `$CXXFLAGS` down, as it includes `-std=c++14` and so makes `static_assert` available.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
