### PR TITLE
Updated snakemake

### DIFF
--- a/recipes/snakemake/meta.yaml
+++ b/recipes/snakemake/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: b11b7ac30808f573883d5db79595ac62db6d1416b24fd71e1a27dc7b3e5678e8
 
 build:
-  number: 0
+  number: 1
   noarch: generic
 
 requirements:

--- a/recipes/snakemake/meta.yaml
+++ b/recipes/snakemake/meta.yaml
@@ -32,7 +32,7 @@ requirements:
     - boto3
     - jsonschema
     - jinja2
-    - pygraphviz
+    - pygraphviz >=1.5
     - networkx >=2.0
     - pygments
     # older versions of imagemagick sometimes fail on PDF -> PNG conversion


### PR DESCRIPTION
This PR sets the pygraphviz requirement to version 1.5 as snakemake may be installed with an older version of pygraphviz. This results in an error when creating a snakemake report.