### PR TITLE
secuTrialR recipe

### DIFF
--- a/recipes/r-secutrialr/build.sh
+++ b/recipes/r-secutrialr/build.sh
@@ -1,0 +1,1 @@
+$R CMD INSTALL --build .

--- a/recipes/r-secutrialr/build.sh
+++ b/recipes/r-secutrialr/build.sh
@@ -1,1 +1,0 @@
-$R CMD INSTALL --build .

--- a/recipes/r-secutrialr/meta.yaml
+++ b/recipes/r-secutrialr/meta.yaml
@@ -12,6 +12,7 @@ source:
 build:
   noarch: generic
   number: 0
+  script: $R CMD INSTALL --build .
 
 requirements:
   host:

--- a/recipes/r-secutrialr/meta.yaml
+++ b/recipes/r-secutrialr/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   noarch: generic
   number: 0
-  script: $R CMD INSTALL --build .
+  script: R CMD INSTALL --build .
 
 requirements:
   host:

--- a/recipes/r-secutrialr/meta.yaml
+++ b/recipes/r-secutrialr/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: "{{ version }}"
 
 source:
-  url: "{{ github }}/archive/v{{ version }}.tar.gz"
+  url: "{{ github }}/archive/{{ version }}.tar.gz"
   sha256: 9dae54b415cf94ed1d3a386ea60415dacaaa7737a17e37e9aa424e668ddaab46
 
 build:

--- a/recipes/r-secutrialr/meta.yaml
+++ b/recipes/r-secutrialr/meta.yaml
@@ -15,9 +15,9 @@ build:
 
 requirements:
   host:
-    - r-base >=3.5
+    - r-base
   run:
-    - r-base >=3.5
+    - r-base
     - r-haven >=2.2.0
     - r-readr
     - r-readxl

--- a/recipes/r-secutrialr/meta.yaml
+++ b/recipes/r-secutrialr/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   noarch: generic
   number: 0
-  script: R CMD INSTALL --build .
+  script: "R CMD INSTALL --build ."
 
 requirements:
   host:

--- a/recipes/r-secutrialr/meta.yaml
+++ b/recipes/r-secutrialr/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   noarch: generic
   number: 0
-  script: R CMD INSTALL --build .
+  script: $R CMD INSTALL --build .
 
 requirements:
   host:

--- a/recipes/r-secutrialr/meta.yaml
+++ b/recipes/r-secutrialr/meta.yaml
@@ -35,7 +35,6 @@ requirements:
     - r-testthat
     - r-tufte
     - r-lintr
-
   run:
     - r-base
     - r-haven >=2.2.0

--- a/recipes/r-secutrialr/meta.yaml
+++ b/recipes/r-secutrialr/meta.yaml
@@ -12,11 +12,30 @@ source:
 build:
   noarch: generic
   number: 0
-  script: "R CMD INSTALL --build ."
+  script: R CMD INSTALL --build .
 
 requirements:
   host:
     - r-base
+    - r-haven >=2.2.0
+    - r-readr
+    - r-readxl
+    - r-tcltk2
+    - r-igraph
+    - r-stringr
+    - r-tibble
+    - r-magrittr
+    - r-purrr
+    - r-tidyr
+    - r-dplyr
+    - r-rlang
+    - r-lubridate
+    - r-knitr
+    - r-rmarkdown
+    - r-testthat
+    - r-tufte
+    - r-lintr
+
   run:
     - r-base
     - r-haven >=2.2.0

--- a/recipes/r-secutrialr/meta.yaml
+++ b/recipes/r-secutrialr/meta.yaml
@@ -1,0 +1,52 @@
+{% set version = "1.0.0" %}
+{% set github = "https://github.com/SwissClinicalTrialOrganisation/secuTrialR" %}
+
+package:
+  name: r-secutrialr
+  version: "{{ version }}"
+
+source:
+  url: "{{ github }}/archive/v{{ version }}.tar.gz"
+  sha256: 9dae54b415cf94ed1d3a386ea60415dacaaa7737a17e37e9aa424e668ddaab46
+
+build:
+  noarch: generic
+  number: 0
+
+requirements:
+  host:
+    - r-base >=3.5
+  run:
+    - r-base >=3.5
+    - r-haven >=2.2.0
+    - r-readr
+    - r-readxl
+    - r-tcltk2
+    - r-igraph
+    - r-stringr
+    - r-tibble
+    - r-magrittr
+    - r-purrr
+    - r-tidyr
+    - r-dplyr
+    - r-rlang
+    - r-lubridate
+    - r-knitr
+    - r-rmarkdown
+    - r-testthat
+    - r-tufte
+    - r-lintr
+
+test:
+  commands:
+    - $R -e "library('secuTrialR')"
+
+about:
+  home: https://swissclinicaltrialorganisation.github.io/secuTrialR/
+  dev_url: "{{ github }}"
+  license: MIT
+  summary: Handling of Data from the Clinical Data Management System secuTrial 
+
+extra:
+  recipe-maintainers:
+    - PatrickRWright


### PR DESCRIPTION
We created the R package secuTrialR for interactinging with clinical trials databases and I would like to add it to Bioconda because some people may like to use it in this environment at some point.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
