### PR TITLE
proteowizard with libraries

### DIFF
--- a/recipes/proteowizard/meta.yaml
+++ b/recipes/proteowizard/meta.yaml
@@ -10,12 +10,14 @@ source:
 
 build:
   number: 3
-  script: bash -c "./quickbuild.sh -j{{ CPU_COUNT }} address-model=64 runtime-link=shared && cp build-linux-x86_64/gcc-release-x86_64/* $PREFIX/bin"
+  script: bash -c "ln -s $BUILD_PREFIX/bin/x86_64-conda_cos6-linux-gnu-g++ /usr/bin/g++ && which g++ && ./quickbuild.sh -j{{ CPU_COUNT }} toolset=gcc address-model=64 runtime-link=shared && cp build-linux-x86_64/gcc-release-x86_64/* $PREFIX/bin"
   skip: True # [osx]
 
 requirements:
   build:
     - {{ compiler('cxx') }}
+  host:
+    - pthread-stubs
   run:
 
 

--- a/recipes/proteowizard/meta.yaml
+++ b/recipes/proteowizard/meta.yaml
@@ -9,8 +9,8 @@ source:
   sha256: 87d4d091133178b7efa106ed36f5dc34b333af57ee1c4eb41648e088f9f36082
 
 build:
-  number: 2
-  script: bash -c "./quickbuild.sh -j{{ CPU_COUNT }} address-model=64 runtime-link=shared executables && cp build-linux-x86_64/gcc-release-x86_64/* $PREFIX/bin"
+  number: 3
+  script: bash -c "./quickbuild.sh -j{{ CPU_COUNT }} address-model=64 runtime-link=shared && cp build-linux-x86_64/gcc-release-x86_64/* $PREFIX/bin"
   skip: True # [osx]
 
 requirements:


### PR DESCRIPTION
follow up to https://github.com/bioconda/bioconda-recipes/pull/19635

ping @glormph 

testing locally I have a single compile error left. any ideas?

Describe your pull request here

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
