### PR TITLE
Update graphtyper to 2.3

### DIFF
--- a/recipes/graphtyper/meta.yaml
+++ b/recipes/graphtyper/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "graphtyper" %}
-{% set version = "2.2.1" %}
+{% set version = "2.3" %}
 
 package:
   name: {{ name }}
@@ -30,21 +30,17 @@ requirements:
     - boost-cpp
     - zlib
     - bzip2
-    - lz4
     - xz
-    - zstd
   run:
     - boost-cpp
     - zlib
     - bzip2
-    - lz4
     - xz
-    - zstd
 
 test:
   commands:
     - graphtyper construct -h
-    - graphtyper call -h
+    - graphtyper genotype -h
 
 about:
   home: https://github.com/DecodeGenetics/graphtyper


### PR DESCRIPTION
Updates graphtyper to version 2.3. Removes lz4 and zstd dependencies as they are no longer used. Replaces 'call' with 'genotype' in test commands because call is no longer used.