### PR TITLE
[Update] watchdog-wms - let conda handle javafx

### DIFF
--- a/recipes/watchdog-wms/build.sh
+++ b/recipes/watchdog-wms/build.sh
@@ -14,6 +14,9 @@ cp -R * "${OUT}/"
 # remove the GNU mac binary and install it using conda
 rm "${OUT}/core_lib/external/getopt_mac"
 
+# use the javafx library installed by conda
+rm -r "${OUT}/jars/libs/modules/"
+
 # rename the sh scripts
 mv "${OUT}/watchdog.sh" "${OUT}/watchdog-cmd.sh"
 mv "${OUT}/workflowDesigner.sh" "${OUT}/watchdog-gui.sh"

--- a/recipes/watchdog-wms/meta.yaml
+++ b/recipes/watchdog-wms/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: generic
-  number: 0
+  number: 1
 
 requirements:
   host:


### PR DESCRIPTION
Javafx JAR files are causing an error when the GUI is started. However, the GUI starts anyway using SWT instead of ES2. 

The change of the build script uses the javafx libraries that are installed via conda.

> Loading library prism_es2 from resource failed: java.lang.UnsatisfiedLinkError: /root/.openjfx/cache/11.0.2/libprism_es2.so: libGL.so.1: cannot open shared object file: No such file or directory
java.lang.UnsatisfiedLinkError: /root/.openjfx/cache/11.0.2/libprism_es2.so: libGL.so.1: cannot open shared object file: No such file or directory
	at java.base/java.lang.ClassLoader$NativeLibrary.load0(Native Method)
	at java.base/java.lang.ClassLoader$NativeLibrary.load(ClassLoader.java:2430)
	at java.base/java.lang.ClassLoader$NativeLibrary.loadLibrary(ClassLoader.java:2487)
	at java.base/java.lang.ClassLoader.loadLibrary0(ClassLoader.java:2684)
	at java.base/java.lang.ClassLoader.loadLibrary(ClassLoader.java:2617)
	at java.base/java.lang.Runtime.load0(Runtime.java:767)
	at java.base/java.lang.System.load(System.java:1831)
	at javafx.graphics/com.sun.glass.utils.NativeLibLoader.installLibraryFromResource(NativeLibLoader.java:205)
	at javafx.graphics/com.sun.glass.utils.NativeLibLoader.loadLibraryFromResource(NativeLibLoader.java:185)
	at javafx.graphics/com.sun.glass.utils.NativeLibLoader.loadLibraryInternal(NativeLibLoader.java:157)
	at javafx.graphics/com.sun.glass.utils.NativeLibLoader.loadLibrary(NativeLibLoader.java:52)
	at javafx.graphics/com.sun.prism.es2.ES2Pipeline.lambda$static$0(ES2Pipeline.java:68)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at javafx.graphics/com.sun.prism.es2.ES2Pipeline.<clinit>(ES2Pipeline.java:50)
	at java.base/java.lang.Class.forName0(Native Method)
	at java.base/java.lang.Class.forName(Class.java:315)
	at javafx.graphics/com.sun.prism.GraphicsPipeline.createPipeline(GraphicsPipeline.java:187)
	at javafx.graphics/com.sun.javafx.tk.quantum.QuantumRenderer$PipelineRunnable.init(QuantumRenderer.java:91)
	at javafx.graphics/com.sun.javafx.tk.quantum.QuantumRenderer$PipelineRunnable.run(QuantumRenderer.java:124)
	at java.base/java.lang.Thread.run(Thread.java:834)

