### PR TITLE
Add GeMoMa recipe

### DIFF
--- a/recipes/gemoma/GeMoMa.py
+++ b/recipes/gemoma/GeMoMa.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python
+#
+# Wrapper script for Java Conda packages that ensures that the java runtime is invoked with the right options.
+# Adapted from https://github.com/bioconda/bioconda-recipes/blob/master/recipes/peptide-shaker/1.16.16/peptide-shaker.py (accessed June, 21th 2019).
+
+#
+# Program Parameters
+#
+import os
+import subprocess
+import sys
+import shutil
+from os import access
+from os import getenv
+from os import X_OK
+
+jar_file = 'GeMoMa-1.6.4.jar'
+default_jvm_mem_opts = ['-Xms1g', '-Xmx2g']
+original_string = "java -jar "+jar_file+" CLI"
+wrapper_string = "GeMoMa"
+
+# !!! End of parameter section. No user-serviceable code below this line !!!
+
+
+def real_dirname(path):
+    """Return the symlink-resolved, canonicalized directory-portion of path."""
+    return os.path.dirname(os.path.realpath(path))
+
+
+def java_executable():
+    """Return the executable name of the Java interpreter."""
+    java_home = getenv('JAVA_HOME')
+    java_bin = os.path.join('bin', 'java')
+
+    if java_home and access(os.path.join(java_home, java_bin), X_OK):
+        return os.path.join(java_home, java_bin)
+    else:
+        return 'java'
+
+
+def jvm_opts(argv):
+    """Construct list of Java arguments based on our argument list.
+
+    The argument list passed in argv must not include the script name.
+    The return value is a 3-tuple lists of strings of the form:
+      (memory_options, prop_options, passthrough_options)
+    """
+    mem_opts = []
+    prop_opts = []
+    pass_args = []
+
+    for arg in argv:
+        if arg.startswith('-D'):
+            prop_opts.append(arg)
+        elif arg.startswith('-XX'):
+            prop_opts.append(arg)
+        elif arg.startswith('-Xm'):
+            mem_opts.append(arg)
+        else:
+            pass_args.append(arg)
+
+    # In the original shell script the test coded below read:
+    #   if [ "$jvm_mem_opts" == "" ] && [ -z ${_JAVA_OPTIONS+x} ]
+    # To reproduce the behaviour of the above shell code fragment
+    # it is important to explictly check for equality with None
+    # in the second condition, so a null envar value counts as True!
+
+    if mem_opts == [] and getenv('_JAVA_OPTIONS') is None:
+        mem_opts = default_jvm_mem_opts
+
+    return (mem_opts, prop_opts, pass_args)
+
+
+def main():
+    java = java_executable()
+    (mem_opts, prop_opts, pass_args) = jvm_opts(sys.argv[1:])
+
+    jar_dir = real_dirname(sys.argv[0])
+    jar_arg = '-jar'
+    jar_path = os.path.join(jar_dir, jar_file)
+
+    cli = 'CLI'
+    cmd = [java] + mem_opts + prop_opts + [jar_arg] + [jar_path] + [cli] + pass_args
+
+#    print('wrapper script translating:')
+#    print(sys.argv)
+#    print('to:')
+#    print(cmd)
+#    print('=======================================================================================================================\n')
+
+#    print(original_string)
+#    print(wrapper_string)
+
+    #sys.exit(subprocess.call(cmd))
+    p = subprocess.Popen(cmd,stderr=subprocess.PIPE);
+    for line in iter(p.stderr.readline,b''):
+        tomod = line.decode("utf-8")
+        tomod = tomod.replace(original_string,wrapper_string)
+        print(tomod,end='')
+
+
+if __name__ == '__main__':
+    main()

--- a/recipes/gemoma/build.sh
+++ b/recipes/gemoma/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+outdir=$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM
+mkdir -p $outdir
+mkdir -p $PREFIX/bin
+cp -R * $outdir/
+cp $RECIPE_DIR/GeMoMa.py $outdir/GeMoMa
+ls -l $outdir
+ln -s $outdir/GeMoMa $PREFIX/bin/GeMoMa
+chmod 0755 "${PREFIX}/bin/GeMoMa"

--- a/recipes/gemoma/meta.yaml
+++ b/recipes/gemoma/meta.yaml
@@ -1,0 +1,53 @@
+{% set name = "GeMoMa" %}
+{% set version = "1.6.4" %}
+{% set sha256 = "8bca8f98b2ed25a150b816d3d8398023ce04fa4b00d104e15c5be11a3a8b26ab" %}
+
+about:
+  home: http://www.jstacs.de/index.php/GeMoMa
+  license: GPL3
+  summary: |
+    Gene Model Mapper (GeMoMa) is a homology-based gene prediction program.
+    GeMoMa uses the annotation of protein-coding genes in a reference genome to infer the annotation of protein-coding genes in a target genome.
+    Thereby, GeMoMa utilizes amino acid sequence and intron position conservation.
+    In addition, GeMoMa allows to incorporate RNA-seq evidence for splice site prediction.
+
+package:
+  name: gemoma
+  version: {{ version }}
+
+build:
+  noarch: generic
+  number: 1
+
+source:
+  url: http://www.jstacs.de/downloads/{{ name }}-{{ version }}.zip
+  sha256: '{{ sha256 }}'
+
+requirements:
+  host:
+  run:
+    - openjdk >=8
+    - python >=3.7
+    - mmseqs2 >=8.fac81
+    - blast >=2.2.31
+
+test:
+  commands:
+    - GeMoMa
+    - GeMoMa ERE test
+    - GeMoMa DenoiseIntrons test
+    - GeMoMa Extractor test
+    - GeMoMa GeMoMa test
+    - GeMoMa GAF test
+    - GeMoMa AnnotationFinalizer test
+    - GeMoMa GeMoMaPipeline test
+
+extra:
+  notes: |
+    GeMoMa is Java program that comes with a custom wrapper python script. By default
+    "-Xms1g -Xmx2g" is set in the wrapper. If you want to overwrite it you can
+    specify these values directly after your binaries. If you have _JAVA_OPTIONS
+    set globally this will take precedence.
+  identifiers:
+    - doi:10.1093/nar/gkw092
+    - doi:10.1186/s12859-018-2203-5

--- a/recipes/gemoma/meta.yaml
+++ b/recipes/gemoma/meta.yaml
@@ -17,7 +17,7 @@ package:
 
 build:
   noarch: generic
-  number: 1
+  number: 0
 
 source:
   url: http://www.jstacs.de/downloads/{{ name }}-{{ version }}.zip


### PR DESCRIPTION
Adds a recipe for GeMoMa, a homology-based gene prediction program that exploits intron position conservation and allows to used RNA-seq data. The software has been described and published in scientific literature, e.g., 
https://nar.oxfordjournals.org/content/44/9/e89
https://rdcu.be/QbKc

----
<code>@BiocondaBot please update</code>