### PR TITLE
Add pTrimmer

### DIFF
--- a/recipes/ptrimmer/build.sh
+++ b/recipes/ptrimmer/build.sh
@@ -1,3 +1,5 @@
 #!/bin/sh
 
-make CC=$CC LIBDIR=$PREFIX/lib INCLUDE=$PREFIX/include
+make CC=$CC LIBDIR=-L$PREFIX/lib INCLUDE=-I$PREFIX/include
+mkdir -p $PREFIX/bin
+mv pTrimmer-* $PREFIX/bin/ptrimmer

--- a/recipes/ptrimmer/build.sh
+++ b/recipes/ptrimmer/build.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-make CC=$CC
+make CC=$CC LIBDIR=$PREFIX/lib INCLUDE=$PREFIX/include

--- a/recipes/ptrimmer/build.sh
+++ b/recipes/ptrimmer/build.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+make

--- a/recipes/ptrimmer/build.sh
+++ b/recipes/ptrimmer/build.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-make
+make CC=$CC

--- a/recipes/ptrimmer/meta.yaml
+++ b/recipes/ptrimmer/meta.yaml
@@ -24,7 +24,8 @@ requirements:
 
 about:
   home: https://github.com/DMU-lilab/pTrimmer
-  license: GPL-3.0
+  license: GNU General Public License v3 (GPL-3.0)
+  license_family: GPL
   license_file: LICENSE
   summary: Used to trim off the primer sequence from mutiplex amplicon sequencing
 

--- a/recipes/ptrimmer/meta.yaml
+++ b/recipes/ptrimmer/meta.yaml
@@ -9,7 +9,7 @@ build:
 
 source:
   url: https://github.com/DMU-lilab/pTrimmer/archive/48eaccf3bd3bb5c3cfc770699eb994d0456b3fb2.tar.gz
-  sha256: 1b15f4f24ecc239f1ea2a39b1bb111b6e1d80f0d
+  sha256: 36e854d722abc480e458cdf95f80d49f23962470d1eb3f523a274be86beddf17
 
 requirements:
   build:

--- a/recipes/ptrimmer/meta.yaml
+++ b/recipes/ptrimmer/meta.yaml
@@ -1,0 +1,32 @@
+{% set version = "1.3.1" %}
+
+package:
+  name: pTrimmer
+  version: {{ version }}
+
+build:
+  number: 0
+
+source:
+  url: https://github.com/DMU-lilab/pTrimmer/archive/48eaccf3bd3bb5c3cfc770699eb994d0456b3fb2.tar.gz
+  sha256: 1b15f4f24ecc239f1ea2a39b1bb111b6e1d80f0d
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+  host:
+    - ncurses
+    - zlib
+  run:
+    - ncurses
+    - zlib
+
+about:
+  home: https://github.com/DMU-lilab/pTrimmer
+  license: GPL-3.0
+  license_file: LICENSE
+  summary: Used to trim off the primer sequence from mutiplex amplicon sequencing
+
+test:
+  commands:
+    - pTrimmer --help

--- a/recipes/ptrimmer/meta.yaml
+++ b/recipes/ptrimmer/meta.yaml
@@ -4,8 +4,9 @@ package:
   name: ptrimmer
   version: {{ version }}
 
-build:
+build
   number: 0
+  skip: True  # [osx]
 
 source:
   url: https://github.com/DMU-lilab/pTrimmer/archive/48eaccf3bd3bb5c3cfc770699eb994d0456b3fb2.tar.gz

--- a/recipes/ptrimmer/meta.yaml
+++ b/recipes/ptrimmer/meta.yaml
@@ -4,7 +4,7 @@ package:
   name: ptrimmer
   version: {{ version }}
 
-build
+build:
   number: 0
   skip: True  # [osx]
 

--- a/recipes/ptrimmer/meta.yaml
+++ b/recipes/ptrimmer/meta.yaml
@@ -30,4 +30,4 @@ about:
 
 test:
   commands:
-    - ptrimmer --help
+    - which ptrimmer

--- a/recipes/ptrimmer/meta.yaml
+++ b/recipes/ptrimmer/meta.yaml
@@ -1,7 +1,7 @@
 {% set version = "1.3.1" %}
 
 package:
-  name: pTrimmer
+  name: ptrimmer
   version: {{ version }}
 
 build:
@@ -29,4 +29,4 @@ about:
 
 test:
   commands:
-    - pTrimmer --help
+    - ptrimmer --help

--- a/recipes/ptrimmer/meta.yaml
+++ b/recipes/ptrimmer/meta.yaml
@@ -31,4 +31,4 @@ about:
 
 test:
   commands:
-    - pTrimmer --help 2> >(grep "Usage")
+    - ptrimmer --help 2> >(grep "Usage")

--- a/recipes/ptrimmer/meta.yaml
+++ b/recipes/ptrimmer/meta.yaml
@@ -31,4 +31,4 @@ about:
 
 test:
   commands:
-    - which ptrimmer
+    - pTrimmer --help 2> >(grep "Usage")

--- a/recipes/ptrimmer/meta.yaml
+++ b/recipes/ptrimmer/meta.yaml
@@ -31,4 +31,4 @@ about:
 
 test:
   commands:
-    - ptrimmer --help 2> >(grep "Usage")
+    - ptrimmer --help 2>&1 >/dev/null | grep "Usage"


### PR DESCRIPTION
This PR adds the recipe for pTrimmer.
As there is no Github Release available for pTrimmer the hash of the latest commit is used for building.