### PR TITLE
Update Trinity recipe to 2.10.0

### DIFF
--- a/recipes/trinity/meta.yaml
+++ b/recipes/trinity/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "Trinity" %}
-{% set version = "2.9.1" %}
-{% set sha256 = "98d98bc21cd5dd32b408ed52586d01a15873b49b96de3264d42616bdcfc9d455" %}
+{% set version = "2.10.0" %}
+{% set sha256 = "4b349456363c84d36fee5f3608f608101510bfa5ae607a0939c8391aa931fd50" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://github.com/trinityrnaseq/trinityrnaseq/releases/download/v2.9.1/trinityrnaseq-v{{ version }}.FULL.tar.gz
+  url: https://github.com/trinityrnaseq/trinityrnaseq/releases/download/v{{ version }}/trinityrnaseq-v{{ version }}.FULL.tar.gz
   sha256: {{ sha256 }}
   patches:
     - makefile.patch


### PR DESCRIPTION
Describe your pull request here

Updates Trinity from 2.9.1 to 2.10.0. 

Trinity 2.10.0 resolves `Illegal division by zero` error which occurs sometimes during `In silico Read Normalization` step.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
