### PR TITLE
Add recipe for bio-ting

### DIFF
--- a/recipes/bio-ting/meta.yaml
+++ b/recipes/bio-ting/meta.yaml
@@ -14,6 +14,7 @@ build:
     - ting=ting.ting:main
     - imseq2ting=scripts.imseq2ting:main
   noarch: generic
+  script: "{{ PYTHON }} -m pip install . -vv"
 
 requirements:
   host:

--- a/recipes/bio-ting/meta.yaml
+++ b/recipes/bio-ting/meta.yaml
@@ -13,7 +13,7 @@ build:
   entry_points:
     - ting=ting.ting:main
     - imseq2ting=scripts.imseq2ting:main
-  script: "{{ PYTHON }} -m pip install . -vv"
+  noarch: generic
 
 requirements:
   host:

--- a/recipes/bio-ting/meta.yaml
+++ b/recipes/bio-ting/meta.yaml
@@ -13,7 +13,7 @@ build:
   entry_points:
     - ting=ting.ting:main
     - imseq2ting=scripts.imseq2ting:main
-  noarch: generic
+  noarch: python
   script: "{{ PYTHON }} -m pip install . -vv"
 
 requirements:

--- a/recipes/bio-ting/meta.yaml
+++ b/recipes/bio-ting/meta.yaml
@@ -1,0 +1,47 @@
+{% set version = "1.0.1" %}
+
+package:
+  name: bio-ting
+  version: "{{ version }}"
+
+source:
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  sha256: 97bcb35b8a01140c421e51e9c35c6f2dd3eb7e8c542aed616a979df2265471cc
+
+build:
+  number: 0
+  entry_points:
+    - ting=ting.ting:main
+    - imseq2ting=scripts.imseq2ting:main
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - networkx >=2.4,<2.5
+    - numpy >=1.17,<1.18
+    - pip
+    - python >=3.7
+    - scipy >=1.3,<1.4
+  run:
+    - networkx >=2.4,<2.5
+    - numpy >=1.17,<1.18
+    - python >=3.7
+    - scipy >=1.3,<1.4
+
+test:
+  imports:
+    - scripts
+    - ting
+  commands:
+    - ting --help
+    - imseq2ting --help
+
+about:
+  home: "https://github.com/FelixMoelder/ting"
+  license: MIT
+  summary: "ting is a tool clustering large scale T cell receptor repertoires by antigen-specificity"
+
+extra:
+  notes: 'The tool is available as command `ting`.'
+  recipe-maintainers:
+    - FelixMoelder

--- a/recipes/bio-ting/meta.yaml
+++ b/recipes/bio-ting/meta.yaml
@@ -30,7 +30,6 @@ requirements:
 
 test:
   imports:
-    - scripts
     - ting
   commands:
     - ting --help

--- a/recipes/bio-ting/meta.yaml
+++ b/recipes/bio-ting/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: "{{ version }}"
 
 source:
-  url: "https://pypi.io/packages/source/bio-ting/bio-ting/bio-ting-{{ version }}.tar.gz"
+  url: "https://pypi.io/packages/source/b/bio-ting/bio-ting-{{ version }}.tar.gz"
   sha256: 97bcb35b8a01140c421e51e9c35c6f2dd3eb7e8c542aed616a979df2265471cc
 
 build:

--- a/recipes/bio-ting/meta.yaml
+++ b/recipes/bio-ting/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: "{{ version }}"
 
 source:
-  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  url: "https://pypi.io/packages/source/bio-ting/bio-ting/bio-ting-{{ version }}.tar.gz"
   sha256: 97bcb35b8a01140c421e51e9c35c6f2dd3eb7e8c542aed616a979df2265471cc
 
 build:

--- a/recipes/bio-ting/meta.yaml
+++ b/recipes/bio-ting/meta.yaml
@@ -29,8 +29,6 @@ requirements:
     - scipy >=1.3,<1.4
 
 test:
-  imports:
-    - ting
   commands:
     - ting --help
     - imseq2ting --help


### PR DESCRIPTION
This PR adds a new recipe for [ting](http://github.com/FelixMoelder/ting) a tool for clustering antigen-specific T cell receptor repertoires.
A corresponding preprint has been published on [bioRxiv](https://www.biorxiv.org/content/10.1101/2020.05.04.069914v1) while the final manuscript is about to be submitted to peer-reviewing journal. 
