### PR TITLE
Add stringtie version 1.3.3b

### DIFF
--- a/recipes/stringtie/1.3.3b/build.sh
+++ b/recipes/stringtie/1.3.3b/build.sh
@@ -5,7 +5,7 @@ export LIBRARY_PATH=${PREFIX}/lib
 
 wget http://ccb.jhu.edu/software/stringtie/dl/prepDE.py
 
-make release
+make release CC=$CXX LINKER=$CXX
 mkdir -p $PREFIX/bin
 mv stringtie $PREFIX/bin
 

--- a/recipes/stringtie/1.3.3b/build.sh
+++ b/recipes/stringtie/1.3.3b/build.sh
@@ -2,6 +2,8 @@
 export C_INCLUDE_PATH=${PREFIX}/include
 export CPLUS_INCLUDE_PATH=${PREFIX}/include
 export LIBRARY_PATH=${PREFIX}/lib
+export CFLAGS="$CFLAGS -I${C_INCLUDE_PATH}"
+export LDFLAGS="$LDFLAGS -L$LIBRARY_PATH"
 
 wget http://ccb.jhu.edu/software/stringtie/dl/prepDE.py
 

--- a/recipes/stringtie/1.3.3b/build.sh
+++ b/recipes/stringtie/1.3.3b/build.sh
@@ -11,7 +11,7 @@ pushd samtools-0.1.18
 make CC=${CC} CFLAGS="${CFLAGS}" lib
 popd
 
-make release CC=$CXX LINKER=$CXX LFLAGS=${LDFLAGS}
+make release CC="$CXX" LINKER="$CXX" LFLAGS="${LDFLAGS}"
 mkdir -p $PREFIX/bin
 mv stringtie $PREFIX/bin
 

--- a/recipes/stringtie/1.3.3b/build.sh
+++ b/recipes/stringtie/1.3.3b/build.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+export C_INCLUDE_PATH=${PREFIX}/include
+export CPLUS_INCLUDE_PATH=${PREFIX}/include
+export LIBRARY_PATH=${PREFIX}/lib
+
+wget http://ccb.jhu.edu/software/stringtie/dl/prepDE.py
+
+make release
+mkdir -p $PREFIX/bin
+mv stringtie $PREFIX/bin
+
+if [ "$PY3K" == 1 ]; then
+    2to3 -w prepDE.py
+fi
+sed -i.bak 's|/usr/bin/env python2|/usr/bin/env python|' prepDE.py
+mv prepDE.py $PREFIX/bin
+chmod +x $PREFIX/bin/prepDE.py

--- a/recipes/stringtie/1.3.3b/build.sh
+++ b/recipes/stringtie/1.3.3b/build.sh
@@ -5,6 +5,10 @@ export LIBRARY_PATH=${PREFIX}/lib
 
 wget http://ccb.jhu.edu/software/stringtie/dl/prepDE.py
 
+pushd samtools-0.1.18
+make CC=${CC} CFLAGS="${CFLAGS}" lib
+popd
+
 make release CC=$CXX LINKER=$CXX
 mkdir -p $PREFIX/bin
 mv stringtie $PREFIX/bin

--- a/recipes/stringtie/1.3.3b/build.sh
+++ b/recipes/stringtie/1.3.3b/build.sh
@@ -11,7 +11,7 @@ pushd samtools-0.1.18
 make CC=${CC} CFLAGS="${CFLAGS}" lib
 popd
 
-make release CC=$CXX LINKER=$CXX
+make release CC=$CXX LINKER=$CXX LFLAGS=${LDFLAGS}
 mkdir -p $PREFIX/bin
 mv stringtie $PREFIX/bin
 

--- a/recipes/stringtie/1.3.3b/meta.yaml
+++ b/recipes/stringtie/1.3.3b/meta.yaml
@@ -1,0 +1,37 @@
+package:
+  name: stringtie
+  version: 1.3.3b
+
+build:
+  number: 0
+  skip: True  # [not py27]
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+  host:
+    - zlib
+    - gnu-wget
+  run:
+    - zlib
+    - python
+
+source:
+  sha256: 7fc6130029569083c36ad176919bc7d2a52b6436642a6276e665cb1d31cc0bfb
+  url: http://ccb.jhu.edu/software/stringtie/dl/stringtie-1.3.3b.tar.gz
+
+test:
+  commands:
+    - "stringtie 2>&1 | grep Assemble"
+    - prepDE.py --help
+
+about:
+  home: http://ccb.jhu.edu/software/stringtie/
+  license: Artistic License 2.0
+  summary: Transcriptome assembly and quantification for RNA-seq
+
+extra:
+  identifiers:
+    - biotools:StringTie
+    - doi:10.1038/nbt.3122

--- a/recipes/stringtie/1.3.3b/meta.yaml
+++ b/recipes/stringtie/1.3.3b/meta.yaml
@@ -14,7 +14,7 @@ requirements:
     - gnu-wget
   run:
     - zlib
-    - python <3
+    - python
 
 source:
   sha256: 7fc6130029569083c36ad176919bc7d2a52b6436642a6276e665cb1d31cc0bfb

--- a/recipes/stringtie/1.3.3b/meta.yaml
+++ b/recipes/stringtie/1.3.3b/meta.yaml
@@ -4,7 +4,6 @@ package:
 
 build:
   number: 0
-  skip: True  # [not py27]
 
 requirements:
   build:
@@ -15,7 +14,7 @@ requirements:
     - gnu-wget
   run:
     - zlib
-    - python
+    - python <3
 
 source:
   sha256: 7fc6130029569083c36ad176919bc7d2a52b6436642a6276e665cb1d31cc0bfb


### PR DESCRIPTION
Adding a previous version of stringtie (1.3.3b) that I need to use to reproduce a previous analysis.  Related to https://github.com/bioconda/bioconda-recipes/issues/21982

I copied the `1.3.3` directory, modified the URL and SHA256 checksum.  That's it!