### PR TITLE
Update bioconda/jalview to 2.11.1.0

### DIFF
--- a/recipes/jalview/jalview.sh
+++ b/recipes/jalview/jalview.sh
@@ -6,6 +6,9 @@
 # Note, in order to run commandline-only calls use 
 #   -nodisplay
 #
+# By default, this wrapper executes java -version to determine the JRE version
+# Set JALVIEW_JRE=j1.8 or JALVIEW_JRE=j11 to skip the version check 
+#
 ###############################
 
 # Find original directory of bash script, resolving symlinks
@@ -19,9 +22,10 @@ done
 DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"; # get final path of this script
 
 # decide which jalview jar to launch - either 'j11' or 'j1.8'
-J_VERSION="j11"
+if [[ "$JALVIEW_JRE" != "j11" && "$JALVIEW_JRE" != "j1.8" ]]; then
+  JALVIEW_JRE="j11"
+  # if java 8 is installed we pick the j1.8 build
+  if [[ $( java -version 2>&1 | grep '"1.8' ) != "" ]]; then JALVIEW_JRE=j1.8; fi
+fi
 
-# if java 8 is installed we pick the j1.8 build
-if [[ $( conda list openjdk | egrep -e 'openjdk\W+8' ) ]]; then J_VERSION=j1.8; fi
-
-java -jar $DIR/jalview-all-${J_VERSION}.jar ${@};
+java -jar $DIR/jalview-all-${JALVIEW_JRE}.jar ${@};

--- a/recipes/jalview/meta.yaml
+++ b/recipes/jalview/meta.yaml
@@ -42,3 +42,4 @@ about:
 extra:
   notes: |
     This wrapper and installation is primarily for commandline-only use.
+    Set JALVIEW_JRE=j1.8 or JALVIEW_JRE=j11 to specify the java runtime if you need jalview to start up as quickly as possible

--- a/recipes/jalview/meta.yaml
+++ b/recipes/jalview/meta.yaml
@@ -1,23 +1,23 @@
 package:
   name: jalview
-  version: 2.11.0
+  version: 2.11.1.0
 
 build:
-  number: 1
+  number: 0 
   noarch: generic
 
 source:
-  url: http://www.jalview.org/source/jalview_2_11_0.tar.gz
-  sha256: "18fd7d6377a46bf7a45a9c1f6ee17a3cffe0ed429555ba5bb713c1ad1e59da7f"
+  url: http://www.jalview.org/source/jalview_2_11_1_0.tar.gz
+  sha256: "80423601e439a4620a8f27f42f96d496a297d4d9e1ea68e818fb8b06151f44b5"
 
 requirements:
   build:
-    # jalview 2.11.0 requires Java 11 or greater to build.
+    # jalview 2.11 series requires Java 11 or greater to build.
     - gradle >5.0
     - openjdk 11
     - xorg-libxtst
   run:
-    # Jalview 2.11.0 can run as 1.8 or java 9+ 
+    # Jalview 2.11.1.0 can run as 1.8 or java 9+ 
     # Version number reference: https://github.com/conda/conda/issues/6948#issuecomment-369360906
     - openjdk >=8.0.192
     - xorg-libxtst
@@ -31,11 +31,13 @@ test:
 about:
   home: http://www.jalview.org/
   license: GPL3
-  summary: Jalview is a free program for multiple sequence alignment editing, visualisation and analysis.
+  summary: Jalview is a free program for multiple sequence alignment editing, visualisation, analysis and figure generation.
   description: |
-    Jalview is a free program for multiple sequence alignment editing, visualisation and analysis.
+    Jalview is a free program for multiple sequence alignment editing, visualisation, analysis and figure generation.
     Use it to view and edit sequence alignments, analyse them with phylogenetic trees and principal
-    components analysis (PCA) plots and explore molecular structures and annotation.
+    components analysis (PCA) plots and explore molecular structures and annotation. It is also able
+    to import and annotate DNA and Protein products from VCF files and retrieve data and annotation from
+    Uniprot, Ensembl, ENA, Rfam, Pfam and the PDBe.
 
 extra:
   notes: |


### PR DESCRIPTION
Updates Jalview build to 2.11.1.0 release (2020-04-22), refined jalview summary/description and improved logic for detecting installed java version at launch time.

----

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
