### PR TITLE
Update pyseer to 1.3.6

### DIFF
--- a/recipes/pyseer/meta.yaml
+++ b/recipes/pyseer/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.3.3" %}
+{% set version = "1.3.4" %}
 
 package:
   name: pyseer
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/p/pyseer/pyseer-{{ version }}.tar.gz
-  sha256: 3a4555aa8c4cfc70f714a09d449252fbea943062468d1736a9050c992ca2471b
+  sha256: b597b76bbe1088aafe58bd58e224bd5fe6f733eaa5424e630b74d83aff19a00c
 
 
 build:
@@ -70,3 +70,4 @@ about:
 extra:
    identifiers:
      - doi:10.1093/bioinformatics/bty539
+     - doi:10.1101/852426v1

--- a/recipes/pyseer/meta.yaml
+++ b/recipes/pyseer/meta.yaml
@@ -1,12 +1,12 @@
-{% set version = "1.3.4" %}
+{% set version = "1.3.6" %}
 
 package:
   name: pyseer
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/p/pyseer/pyseer-{{ version }}.tar.gz
-  sha256: b597b76bbe1088aafe58bd58e224bd5fe6f733eaa5424e630b74d83aff19a00c
+  url: https://github.com/mgalardini/pyseer/releases/download/{{ version }}/pyseer-{{ version }}.tar.gz
+  sha256: fcf50a2cf6861b4be03bc57f1eda457d4bc48d49aa9b697df449dd5450ca8347
 
 
 build:


### PR DESCRIPTION
Manual update of the `pyseer` recipe, as it is not present in pypi any longer, but available as a tarball in github releases. The recipe is otherwise the same.

----
<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
