### PR TITLE
Update scirpy (update dependencies upon version bump) 

### DIFF
--- a/recipes/scirpy/meta.yaml
+++ b/recipes/scirpy/meta.yaml
@@ -20,12 +20,12 @@ build:
 requirements:
   # The way the version is resolved from SCM (flit + get_version)
   # requires all dependencies to be installed at build time. 
-  host:
+ host:
     - python >=3.6
     - flit
     - get_version
-    - anndata >=0.7.1
-    - scanpy>=1.4.6
+    - anndata >=0.7.3
+    - scanpy>=1.5.1
     - pandas>=0.21
     - numpy=1.18
     - scipy
@@ -35,11 +35,12 @@ requirements:
     - python-igraph
     - networkx
     - squarify
+    - tqdm>=4.29.1
   run:
     - python >=3.6
     - get_version
-    - anndata >=0.7.1
-    - scanpy>=1.4.6
+    - anndata >=0.7.3
+    - scanpy>=1.5.1
     - pandas>=0.21
     - numpy
     - scipy
@@ -49,6 +50,7 @@ requirements:
     - python-igraph
     - networkx
     - squarify
+    - tqdm>=4.29.1
 
 test:
   imports:

--- a/recipes/scirpy/meta.yaml
+++ b/recipes/scirpy/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "scirpy" %}
-{% set version = "0.1.2" %}
+{% set version = "0.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
-  sha256: 7ed4038b634abce0b035ecd6dc47b695c68a8234d3635d4a234ac54ca5af6f32 
+  sha256: a1ac7e823a0f9eea8a8977035a6c4e4a393448da706c29055ac18cccdea6acee 
   folder: "{{ name }}-{{ version }}"
 
 build:

--- a/recipes/scirpy/meta.yaml
+++ b/recipes/scirpy/meta.yaml
@@ -20,7 +20,7 @@ build:
 requirements:
   # The way the version is resolved from SCM (flit + get_version)
   # requires all dependencies to be installed at build time. 
- host:
+  host:
     - python >=3.6
     - flit
     - get_version


### PR DESCRIPTION
the latest version of scirpy requires the latest version of scanpy. 