### PR TITLE
Remove pytest from CheckV's dependencies

### DIFF
--- a/recipes/checkv/meta.yaml
+++ b/recipes/checkv/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 58cd490dc7e57e2aaf0590dcb937c9ae35d139e9eadd26aaf03622790bd6915c
 
 build:
-  number: 0 
+  number: 1
   noarch: python
   entry_points:
     - checkv=checkv.cli:cli
@@ -30,7 +30,6 @@ requirements:
     - diamond ==0.9.32
     - hmmer
     - prodigal
-    - pytest  
 
 test:
   commands:


### PR DESCRIPTION
Pytest was removed from CheckV's dependencies.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
