### PR TITLE
update ectyper 1.0.0

### DIFF
--- a/recipes/ectyper/meta.yaml
+++ b/recipes/ectyper/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.9.1" %}
+{% set version = "1.0.0" %}
 
 package:
     name: ectyper
@@ -6,7 +6,7 @@ package:
 
 source:
     url: https://github.com/phac-nml/ecoli_serotyping/archive/{{ version }}.tar.gz
-    sha256: f5a5cf2e90f1d4f8b6ecdd2f2c912287220ff0bae6953b04772313107d188c3f   
+    sha256: 552f1f3b1efb3b938d8b3464779ea8a50cdae4cd98f3c2f68a85c0ea90960389   
 
 build:
     number: 0
@@ -30,7 +30,6 @@ requirements:
         - blast >=2.7.1.*
         - seqtk >=1.2.*
         - requests >=2.*.*
-        - portalocker >=1.5.*
 test:
     import:
         - ectyper


### PR DESCRIPTION
Update to a current E.coli serotyping tool as auto-update by bot failed. Cancel the other PR #22323.
