### PR TITLE
Update sourmash to 3.3.1

### DIFF
--- a/build-fail-blacklist
+++ b/build-fail-blacklist
@@ -48,7 +48,6 @@ recipes/stream
 recipes/pftools
 recipes/fastspar
 recipes/bufet
-recipes/sourmash
 recipes/mapsplice
 recipes/pasta
 recipes/moods

--- a/recipes/sourmash/build.sh
+++ b/recipes/sourmash/build.sh
@@ -36,7 +36,7 @@ libdir=${exec_prefix}/lib
 
 Name: sourmash
 Description: Compute MinHash signatures for nucleotide (DNA/RNA) and protein sequences.
-Version: 0.4.0
+Version: 0.7.0
 Cflags: -I${includedir}
 Libs: -L${libdir} -lsourmash
 EOF

--- a/recipes/sourmash/meta.yaml
+++ b/recipes/sourmash/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.3.0" %}
+{% set version = "3.3.1" %}
 
 package:
   name: sourmash
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/s/sourmash/sourmash-{{ version }}.tar.gz
-  sha256: 2bdf64fdb306123fee0f2ba8e6b58caf2ff4a73a25cbe1fe563dd7de141c648f
+  sha256: 8d3404f095a90ed3365c429104f3a9526ef3a3b4db8c9bd944f4b0cde8b59f28
 
 build:
   entry_points:

--- a/recipes/sourmash/meta.yaml
+++ b/recipes/sourmash/meta.yaml
@@ -11,7 +11,7 @@ source:
 build:
   entry_points:
     - sourmash = sourmash.__main__:main
-  number: 1
+  number: 0
 
 requirements:
   build:


### PR DESCRIPTION
Manually bumping to 3.3.1, seems like `autobump` didn't work?

(It might be because I uploaded the wheels before the source to PyPI?)

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
