### PR TITLE
Update gmap to version 2020-06-01

### DIFF
--- a/recipes/gmap/meta.yaml
+++ b/recipes/gmap/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "GMAP" %}
-{% set version = "2020.04.08" %}
-{% set sha256 = "640f3628826e059ca10f92ff0b8ca4ae62a6784e54316ece39bd834f7e71f740" %}
+{% set version = "2020.06.01" %}
+{% set sha256 = "7917f9f78570943f419445e371f2cc948c6741e73c3cbb063391756f4479d365" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: http://research-pub.gene.com/gmap/src/gmap-gsnap-2020-04-08.tar.gz
+  url: http://research-pub.gene.com/gmap/src/gmap-gsnap-2020-06-01.tar.gz
   sha256: {{ sha256 }}
 
 build:

--- a/recipes/gmap/meta.yaml
+++ b/recipes/gmap/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 0
   binary_has_prefix_files:
     - bin/atoiindex
     - bin/cmetindex


### PR DESCRIPTION
Latest gmap release, which includes a number of clinically relevant bug fixes. This will resolve #22456

