### PR TITLE
Update Parsnp 1.5.0

### DIFF
--- a/recipes/parsnp/build.sh
+++ b/recipes/parsnp/build.sh
@@ -1,6 +1,34 @@
 #!/bin/bash
 
+
 mkdir -p  "$PREFIX/bin"
 
-cp parsnp $PREFIX/bin/
+cd muscle
+./autogen.sh
+
+if [ `uname` == Darwin ]; then
+    ./configure --prefix=$PWD --disable-shared 
+else
+    ./configure --prefix=$PWD CXXFLAGS='-fopenmp'
+fi
+make install
+
+cd ..
+./autogen.sh
+export ORIGIN=\$ORIGIN
+if [ `uname` == Darwin ]; then
+    ./configure LDFLAGS='-Wl,-rpath,$$ORIGIN/../muscle/lib'
+else
+    ./configure LDFLAGS='-Wl,-rpath,$$ORIGIN/../muscle/lib' CXXFLAGS='-fopenmp'
+fi
+make LDADD='-lMUSCLE-3.7' 
+make install
+
+
+cp parsnp $PREFIX/bin 
+cp Parsnp.py $PREFIX/bin
+cp template.ini $PREFIX/bin
+cp -R bin $PREFIX/bin 
+cp -R muscle $PREFIX/bin 
+cp -R examples $PREFIX/bin
 

--- a/recipes/parsnp/meta.yaml
+++ b/recipes/parsnp/meta.yaml
@@ -1,27 +1,45 @@
-{% set version = "1.2" %}
-{% set base = "https://github.com/marbl/parsnp/releases/download" %}
-{% set sha256linux = "ec60bab2306005baca374cc84b4d4dd20dd124e7ea0eee88ec59d9e5a95ce548" %}
-{% set sha256osx = "fe8992fb148541cc753670a151bab9ccbd62a23bdec8be9a9c69999e3ca9ff02" %}
+{% set version = "1.5.0" %}
+{% set archive_base = "https://github.com/marbl/parsnp/archive" %}
+{% set sha256sourcearchive = "647812a63c2160836f0301b7f369da4f7f498f6edd573b1da116433bf68b927b" %}
 
 package:
   name: parsnp
   version: '{{version}}'
 
 source:
-  - url: '{{base}}/v{{version}}/parsnp-Linux64-v{{version}}.tar.gz'   # [linux]
-    sha256: '{{sha256linux}}'                                         # [linux]
-  - url: '{{base}}/v{{version}}/parsnp-OSX64-v{{version}}.tar.gz'     # [osx]
-    sha256: '{{sha256osx}}'                                           # [osx]
+  url: "{{archive_base}}/v{{version}}.tar.gz"  
+  sha256: "{{sha256sourcearchive}}"
 
 build:
   number: 0
 
 requirements:
   build:
+    - {{ compiler('cxx') }}
+    - automake 1.15
+    - autoconf
+    - libtool
+    - make
+    - openmp
+    - llvm-openmp  # [osx]
   host:
     - zlib
+    - openmp
+    - llvm-openmp  # [osx]
   run:
+    - openmp
+    - llvm-openmp  # [osx]
+    - harvesttools
+    - fasttree
+    - phipack
+    - numpy
     - zlib
+    - phipack
+    - raxml
+    - fasttree
+    - fastani
+    - mash
+    - harvesttools
 
 about:
   home: https://github.com/marbl/parsnp

--- a/recipes/parsnp/run_test.sh
+++ b/recipes/parsnp/run_test.sh
@@ -1,10 +1,7 @@
-#!/bin/bash
-set -euo pipefail
+#!/usr/bin/env bash
 
-TESTDATA="https://harvest.readthedocs.io/en/latest/_downloads/mers49.tar.gz"
-curl -O $TESTDATA >/dev/null
-tar -xvf mers49.tar.gz >/dev/null
-
-parsnp -V >/dev/null
-parsnp -g ./ref/EMC_2012.gbk -d ./mers49 -C 1000 -c -o test >/dev/null
-
+curl https://github.com/marbl/harvest/raw/master/docs/content/parsnp/mers_examples.tar.gz -L --output mers_examples.tar.gz
+tar -xzvf mers_examples.tar.gz
+parsnp -V 
+parsnp -g mers_virus/ref/England1.gbk -d mers_virus/genomes/*.fna -C 1000 -c -o test --verbose --use-fasttree
+parsnp -r ! -d mers_virus/genomes/*.fna -o test2 --verbose


### PR DESCRIPTION
Updating Parsnp. For some reason, I'm unable to get the Muscle library to build using the `-fopenmp` flag on OSX even when using the `llvm-openmp` dependency...

For now, the parsnp build will only work serially

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
