### PR TITLE
Update Krona recipe to fix macOS installation

### DIFF
--- a/recipes/krona/build.sh
+++ b/recipes/krona/build.sh
@@ -2,6 +2,7 @@
 mkdir -p $PREFIX/opt/krona
 mv ./* $PREFIX/opt/krona
 cd $PREFIX/opt/krona
+find . -type f -name '._*' -delete
 ./install.pl --prefix=$PREFIX
 ln -s $PREFIX/opt/krona/updateTaxonomy.sh $PREFIX/bin/ktUpdateTaxonomy.sh
 mkdir $PREFIX/bin/scripts

--- a/recipes/krona/meta.yaml
+++ b/recipes/krona/meta.yaml
@@ -8,7 +8,7 @@ source:
 
 build:
   noarch: generic
-  number: 2
+  number: 3
 
 requirements:
   host:


### PR DESCRIPTION
The "._" files (https://apple.stackexchange.com/q/14980) get integrated into the metadata fields of the file system and are then removed. This makes the verification fail on macOS. 

See https://github.com/marbl/Krona/issues/141

````
$ tar tf KronaTools-2.7.1.tar | grep "\\._"
KronaTools-2.7.1/._updateTaxonomy.sh
KronaTools-2.7.1/lib/._KronaTools.pm
KronaTools-2.7.1/scripts/._accession2taxid.make
````

This is only a problem for Conda, not manual installation. Therefore, I would remove them here. It seemed weird to me to hardcode those three files, this is the reason for the find command.

It may be argued that they should not be in the release file at all. But again, it only affects Conda and could happen again in the future with other files.

----

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
