### PR TITLE
Update genometreetk dependencies

### DIFF
--- a/recipes/genometreetk/meta.yaml
+++ b/recipes/genometreetk/meta.yaml
@@ -22,6 +22,8 @@ requirements:
     - biolib >=0.1.0
     - dendropy >=4.0.0
     - numpy >=1.8.0
+    - hmmer
+    - fasttree
     - python
 
 test:

--- a/recipes/genometreetk/meta.yaml
+++ b/recipes/genometreetk/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: db69f8989adf93d61a2209be8812a1b35a4ed4e582b3ef2a9709966c3267366a
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: "{{ PYTHON }} -m pip install . -vv"
 


### PR DESCRIPTION
Added `hmmer` and `fasttree` to `genometreetk`'s dependencies. These are necessary for running the program and were not included in the recipe.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
