### PR TITLE
Update sigmut

### DIFF
--- a/recipes/sigmut/README.txt
+++ b/recipes/sigmut/README.txt
@@ -1,0 +1,3 @@
+Please modify this branch so that to prepare a pull request to the
+master for a 1.1 sigmut bioconda build that point to this repo and to the artbio/sigmut repo for dependencies
+

--- a/recipes/sigmut/README.txt
+++ b/recipes/sigmut/README.txt
@@ -1,3 +1,0 @@
-Please modify this branch so that to prepare a pull request to the
-master for a 1.1 sigmut bioconda build that point to this repo and to the artbio/sigmut repo for dependencies
-

--- a/recipes/sigmut/meta.yaml
+++ b/recipes/sigmut/meta.yaml
@@ -7,11 +7,11 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/lgpdv/{{ name }}/archive/{{ version }}.tar.gz
+  url: https://github.com/artbio/{{ name }}/archive/{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   noarch: generic
 
 requirements:
@@ -30,13 +30,13 @@ test:
     - sigprofiler -ig GRCh38
 
 about:
-  home: https://github.com/lgpdv/sigmut
+  home: https://github.com/artbio/sigmut
   license: BSD 2-Clause
   license_family: BSD
   license_file: LICENSE
   summary: 'Wrapper of SigProfiler (Copyright(c) 2019, Erik Bergstrom [Alexandrov Lab])'
-  dev_url: https://github.com/lgpdv/sigmut
+  dev_url: https://github.com/artbio/sigmut
 
 extra:
   recipe-maintainers:
-    - lgpdv
+    - artbio https://github.com/ARTbio


### PR DESCRIPTION
Describe your pull request here

This PR fixes the references of the sigmut bioconda-recipes maintainers.

In addition, the source code for the python sigprofiler wrapper is now at https://github.com/ARTbio/sigmut for sustainability of its development.

The code was previously hosted in a @lgpdv repository https://github.com/lgpdv/sigmut; @lgpdv was previously member of the ARTbio GitHub organisation


----
