### PR TITLE
Tidy up lofreq recipe

### DIFF
--- a/recipes/lofreq/build.sh
+++ b/recipes/lofreq/build.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -eu -o pipefail
 
-./configure --with-htslib=${PREFIX}/lib  --prefix=${PREFIX}
-
+./configure --with-htslib=system --prefix=${PREFIX}
 make
 make install

--- a/recipes/lofreq/meta.yaml
+++ b/recipes/lofreq/meta.yaml
@@ -7,9 +7,9 @@ package:
 source:
   url: https://raw.githubusercontent.com/CSB5/lofreq/v{{ version }}/dist/lofreq_star-{{ version }}.tar.gz
   sha256: 43028af07faa23c7ec0e167855492ae7bd31c4e7f8158114e51ec12aba5fd184
- 
+
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
PR #22634 changed _build.sh_'s `--with-htslib` option to `--with-htslib=${PREFIX}/lib` without any explanation. This setting is incorrect as giving the _lib_ subdirectory does not supply the header files, so the build succeeded only because it implicitly fell back to use the build-env's system HTSlib from $CPPFLAGS/$LDFLAGS.

As requested on PR #22693, this reverts the recipe to use `--with-htslib=system` to explicitly use only the HTSlib already installed in the build-env:

> --with-htslib=system
> Ignores any nearby HTSlib source trees, and builds [the program] using an existing HTSlib installation in a system directory (i.e., a directory already being searched by $CPPFLAGS/$LDFLAGS).