### PR TITLE
Update of bioconductor-org.Hs.eg.db to v3.11.4 from v3.11.1

### DIFF
--- a/recipes/bioconductor-org.hs.eg.db/meta.yaml
+++ b/recipes/bioconductor-org.hs.eg.db/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.11.1" %}
+{% set version = "3.11.4" %}
 {% set name = "org.Hs.eg.db" %}
 {% set bioc = "3.11" %}
 
@@ -8,9 +8,7 @@ package:
 source:
   url:
     - 'https://bioconductor.org/packages/{{ bioc }}/data/annotation/src/contrib/{{ name }}_{{ version }}.tar.gz'
-    - 'https://bioarchive.galaxyproject.org/{{ name }}_{{ version }}.tar.gz'
-    - 'https://depot.galaxyproject.org/software/bioconductor-{{ name|lower }}/bioconductor-{{ name|lower }}_{{ version }}_src_all.tar.gz'
-  md5: 390e3adf5f73220baad5ab4c3472648b
+  md5: d41d8cd98f00b204e9800998ecf8427e
 build:
   number: 0
   rpaths:
@@ -38,5 +36,4 @@ extra:
   parent_recipe:
     name: bioconductor-org.hs.eg.db
     path: recipes/bioconductor-org.hs.eg.db
-    version: 3.6.0
-
+    version: 3.11.1

--- a/recipes/bioconductor-org.hs.eg.db/meta.yaml
+++ b/recipes/bioconductor-org.hs.eg.db/meta.yaml
@@ -8,7 +8,7 @@ package:
 source:
   url:
     - 'https://bioconductor.org/packages/{{ bioc }}/data/annotation/src/contrib/{{ name }}_{{ version }}.tar.gz'
-  md5: d41d8cd98f00b204e9800998ecf8427e
+  md5: 87f20cd6ba544e12aa0bb044215e0729
 build:
   number: 0
   rpaths:

--- a/recipes/bioconductor-org.hs.eg.db/post-link.sh
+++ b/recipes/bioconductor-org.hs.eg.db/post-link.sh
@@ -3,7 +3,7 @@ FN="org.Hs.eg.db_3.11.4.tar.gz"
 URLS=(
   "https://bioconductor.org/packages/3.11/data/annotation/src/contrib/"$FN
 )
-MD5="d41d8cd98f00b204e9800998ecf8427e"
+MD5="87f20cd6ba544e12aa0bb044215e0729"
 
 # Use a staging area in the conda dir rather than temp dirs, both to avoid
 # permission issues as well as to have things downloaded in a predictable

--- a/recipes/bioconductor-org.hs.eg.db/post-link.sh
+++ b/recipes/bioconductor-org.hs.eg.db/post-link.sh
@@ -1,11 +1,9 @@
 #!/bin/bash
-FN="org.Hs.eg.db_3.11.1.tar.gz"
+FN="org.Hs.eg.db_3.11.4.tar.gz"
 URLS=(
-  "https://bioconductor.org/packages/3.11/data/annotation/src/contrib/org.Hs.eg.db_3.11.1.tar.gz"
-  "https://bioarchive.galaxyproject.org/org.Hs.eg.db_3.11.1.tar.gz"
-  "https://depot.galaxyproject.org/software/bioconductor-org.hs.eg.db/bioconductor-org.hs.eg.db_3.11.1_src_all.tar.gz"
+  "https://bioconductor.org/packages/3.11/data/annotation/src/contrib/"$FN
 )
-MD5="390e3adf5f73220baad5ab4c3472648b"
+MD5="d41d8cd98f00b204e9800998ecf8427e"
 
 # Use a staging area in the conda dir rather than temp dirs, both to avoid
 # permission issues as well as to have things downloaded in a predictable


### PR DESCRIPTION

Update of bioconductor-org.Hs.eg.db to v3.11.4 to fix broken links of the recipe for the package version 3.11.1 which is currently out there. The update is related to issue #22806 and resolves one of the two mentioned broken packages.
