### PR TITLE
Update of bioconductor-org.mm.eg.db from version 3.11.1 to version 3.11.4 to fix broken links

### DIFF
--- a/recipes/bioconductor-org.mm.eg.db/meta.yaml
+++ b/recipes/bioconductor-org.mm.eg.db/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.11.1" %}
+{% set version = "3.11.4" %}
 {% set name = "org.Mm.eg.db" %}
 {% set bioc = "3.11" %}
 
@@ -8,9 +8,7 @@ package:
 source:
   url:
     - 'https://bioconductor.org/packages/{{ bioc }}/data/annotation/src/contrib/{{ name }}_{{ version }}.tar.gz'
-    - 'https://bioarchive.galaxyproject.org/{{ name }}_{{ version }}.tar.gz'
-    - 'https://depot.galaxyproject.org/software/bioconductor-{{ name|lower }}/bioconductor-{{ name|lower }}_{{ version }}_src_all.tar.gz'
-  md5: 203cd5c0f1b9dbfa62164cc95b92d8ba
+  md5: cd4775fe4b6a1dd62c30ef8cdff0c465
 build:
   number: 0
   rpaths:
@@ -38,5 +36,4 @@ extra:
   parent_recipe:
     name: bioconductor-org.mm.eg.db
     path: recipes/bioconductor-org.mm.eg.db
-    version: 3.6.0
-
+    version: 3.11.1

--- a/recipes/bioconductor-org.mm.eg.db/post-link.sh
+++ b/recipes/bioconductor-org.mm.eg.db/post-link.sh
@@ -1,11 +1,9 @@
 #!/bin/bash
-FN="org.Mm.eg.db_3.11.1.tar.gz"
+FN="org.Mm.eg.db_3.11.4.tar.gz"
 URLS=(
-  "https://bioconductor.org/packages/3.11/data/annotation/src/contrib/org.Mm.eg.db_3.11.1.tar.gz"
-  "https://bioarchive.galaxyproject.org/org.Mm.eg.db_3.11.1.tar.gz"
-  "https://depot.galaxyproject.org/software/bioconductor-org.mm.eg.db/bioconductor-org.mm.eg.db_3.11.1_src_all.tar.gz"
+  "https://bioconductor.org/packages/3.11/data/annotation/src/contrib/"$FN
 )
-MD5="203cd5c0f1b9dbfa62164cc95b92d8ba"
+MD5="cd4775fe4b6a1dd62c30ef8cdff0c465"
 
 # Use a staging area in the conda dir rather than temp dirs, both to avoid
 # permission issues as well as to have things downloaded in a predictable


### PR DESCRIPTION
Update of bioconductor-org.mm.eg.db to v3.11.4 to fix broken links of the recipe for the package version 3.11.1 which is currently out there. The update is related to issue #22806 and resolves the second of the two broken packages mentioned in that issue.