### PR TITLE
Update sra-tools (add missing curl dependency, rebuild hdf5)

### DIFF
--- a/recipes/sra-tools/meta.yaml
+++ b/recipes/sra-tools/meta.yaml
@@ -19,7 +19,7 @@ source:
     folder: ngs
 
 build:
-  number: 1
+  number: 2
   skip: True  # [osx]
 
 requirements:
@@ -39,6 +39,7 @@ requirements:
     - hdf5
     - perl-xml-libxml
     - perl-uri
+    - curl
 
 test:
   commands:


### PR DESCRIPTION
Fixes gh-22929.

This is my first contribution to bioconda.

I just increased the build number of the sra-tools recipe to trigger a rebuild of sra-tools, to use an updated hdf5 1.10.6 dependency

Otherwise:

- `conda create -n myenv sra-tools hdf5=1.10.6` installs `sra-tools 2.8.0` (old version that does not depend on hdf5)
- `conda install sra-tools` on an environment with `hdf5=1.10.6` also installs `sra-tools 2.8.0` to prevent the downgrade.
- `conda install sra-tools=2.10.7` will downgrade hdf5 from 1.10.6 to 1.10.5.

So the main reason for this rebuild is to facilitate the installation of the *latest* version of sra-tools.

Feel free to close this PR, if you believe it does not make sense to trigger a sra-tools rebuild for this reason.

