### PR TITLE
Update sra-tools to 2.10.8

### DIFF
--- a/recipes/sra-tools/meta.yaml
+++ b/recipes/sra-tools/meta.yaml
@@ -1,7 +1,7 @@
-{% set version = "2.10.7" %}
-{% set bioconda_version = "2.10.7" %}
-{% set vdb_version = "2.10.7" %}
-{% set ngs_version = "2.10.5" %}
+{% set version = "2.10.8" %}
+{% set bioconda_version = "2.10.8" %}
+{% set vdb_version = "2.10.8" %}
+{% set ngs_version = "2.10.8" %}
 
 package:
   name: sra-tools
@@ -9,17 +9,17 @@ package:
 
 source:
   - url: https://github.com/ncbi/sra-tools/archive/{{version}}.tar.gz
-    sha256: b81e24c6025f180a8c5ee57052f3ce7f9e53117178c783dc07f740fc2c77d5f2
+    sha256: 4adb969a9a998f6a50020f99aa66f6ae27916f7dc83ddf6722fc0fea4a3a4d17
     folder: sra-tools
   - url: https://github.com/ncbi/ncbi-vdb/archive/{{vdb_version}}.tar.gz
-    sha256: ca8c87b7a852dca4cb44256bd05bc9353eac862a6158b2cfed75e81c7dbe3f22
+    sha256: 7a593aa22584db9443bb56ac01409707bca01b8f9601fe530dac81b73f1a44df
     folder: ncbi-vdb
   - url: https://github.com/ncbi/ngs/archive/{{ngs_version}}.tar.gz
-    sha256: c39ee65a625e3646e0212c5d8be846e45d368c644a053d3b54cf63f53853f02f
+    sha256: f20fae21439b69b6a3573c864a175e0f9aa47ca6dd12bea15e429b7c5a9b81b5
     folder: ngs
 
 build:
-  number: 2
+  number: 0
   skip: True  # [osx]
 
 requirements:


### PR DESCRIPTION
I'm encountering a few of the errors fixed by 2.10.8 in my pipeline so I'd like to (try to) update the bioconda package to latest.
