### PR TITLE
stacks kmer_filter returns wrong exit code

### DIFF
--- a/recipes/stacks/kmer_exit.patch
+++ b/recipes/stacks/kmer_exit.patch
@@ -1,0 +1,19 @@
+# patch wrong exit codes of kmer filter
+# reported upstream: https://groups.google.com/forum/#!topic/stacks-users/fS3iJOYz6-s
+--- src/kmer_filter.cc	2020-07-06 17:23:10.417045722 +0200
++++ src/kmer_filter.cc	2020-07-06 17:22:54.553176195 +0200
+@@ -111,12 +111,12 @@
+         if (kmer_distr) {
+             generate_kmer_dist(kmers);
+             if (write_k_freq == false)
+-                exit(1);
++                exit(0);
+         }
+ 
+         if (write_k_freq) {
+             write_kmer_freq(k_freq_path, kmers);
+-            exit(1);
++            exit(0);
+         }
+ 
+         cerr << "Filtering reads by kmer frequency...\n";

--- a/recipes/stacks/meta.yaml
+++ b/recipes/stacks/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 0
+  number: 1
   skip: True  # [osx]
 
 source:
@@ -13,6 +13,7 @@ source:
   url: http://catchenlab.life.illinois.edu/stacks/source/stacks-{{ version }}.tar.gz
   patches:
     - at.patch
+    - kmer_exit.patch
 
 requirements:
   build:


### PR DESCRIPTION
when using the options

--write-k-freq: write kmers along with their frequency of occurrence and exit.
--k-dist: print k-mer frequency distribution and exit.

issue has been reported here: https://groups.google.com/forum/#!topic/stacks-users/fS3iJOYz6-s

seems much easier to me to introduce a patch here instead of dealing with the nonsense exit code.




Describe your pull request here

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
