### PR TITLE
Update HapCut2 to 1.3.1

### DIFF
--- a/recipes/hapcut2/meta.yaml
+++ b/recipes/hapcut2/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "HapCUT2" %}
-{% set version = "1.2" %}
+{% set version = "1.3.1" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
Update [HapCut2](https://bioconda.github.io/recipes/hapcut2/README.html) from 1.2 to 1.3.1