### PR TITLE
update meta.yaml for ncfp v0.2.0 (PyPI)

### DIFF
--- a/recipes/ncfp/meta.yaml
+++ b/recipes/ncfp/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "ncfp" %}
-{% set version = "0.1.1" %}
+{% set version = "0.2.0" %}
 
 package:
   name: '{{ name|lower }}'
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 173ce1acfdef08e9174fc5a943c8d704c14d90f7e4bbe0321218c2f467a7d40e
+  sha256: 3400138b76698c68a069ae622b7c947dda56329c3e6039990fa820f119880340
 
 build:
   number: 0
@@ -22,6 +22,7 @@ requirements:
   run:
     - python >=3
     - biopython
+    - bioservices
     - tqdm
 
 test:


### PR DESCRIPTION
This PR should update the ncfp package from version 0.1.1 to 0.2.0.

- [PyPI ncfp](https://pypi.org/project/ncfp/)
- [GitHub ncfp](https://github.com/widdowquinn/ncfp)