### PR TITLE
Update gmap to version 2020-06-30

### DIFF
--- a/recipes/gmap/meta.yaml
+++ b/recipes/gmap/meta.yaml
@@ -1,19 +1,19 @@
 {% set name = "GMAP" %}
 {% set version = "2020.06.01" %}
-{% set sha256 = "7917f9f78570943f419445e371f2cc948c6741e73c3cbb063391756f4479d365" %}
+{% set sha256 = "e60fcc85c55606503ddbd5a3ef7b5e61aecb38ac0c8a132e4aea8c8588ce38ee" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: http://research-pub.gene.com/gmap/src/gmap-gsnap-2020-06-01.tar.gz
+  url: http://research-pub.gene.com/gmap/src/gmap-gsnap-2020-06-30.tar.gz
   sha256: {{ sha256 }}
   patches:
     - single_quote_paths.patch
 
 build:
-  number: 1
+  number: 0
   binary_has_prefix_files:
     - bin/atoiindex
     - bin/cmetindex

--- a/recipes/gmap/meta.yaml
+++ b/recipes/gmap/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "GMAP" %}
-{% set version = "2020.06.01" %}
+{% set version = "2020.06.30" %}
 {% set sha256 = "e60fcc85c55606503ddbd5a3ef7b5e61aecb38ac0c8a132e4aea8c8588ce38ee" %}
 
 package:


### PR DESCRIPTION
Latest gmap release, which includes a number of clinically relevant bug fixes. See  http://research-pub.gene.com/gmap/ for details. This resolves issue #23395.