### PR TITLE
Update pileuppy to 1.0.1

### DIFF
--- a/recipes/pileuppy/meta.yaml
+++ b/recipes/pileuppy/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pileuppy" %}
-{% set version = "1.0.0" %}
+{% set version = "1.0.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://gitlab.com/tprodanov/{{ name }}/-/archive/v{{ version }}/{{ name }}-v{{ version }}.tar.gz
-  sha256: 466f44a976090010e988353b693395c992b5cf29f1a41f6aef8dfbb1b25fec3d
+  sha256: de62c479ea7b71dc601cb54722fd8a8dbc595de48caddaa33d7b6a21ff453581
 
 build:
   noarch: python


### PR DESCRIPTION
Update [`pileuppy`](https://bioconda.github.io/recipes/pileuppy/README.html): **1.0.0** → **1.0.1**

There was an automatic pull request [here](https://github.com/bioconda/bioconda-recipes/pull/23328), but it seems like the tests fail because of the network error.