### PR TITLE
initial attempt to add bitsets

### DIFF
--- a/recipes/bitsets/meta.yaml
+++ b/recipes/bitsets/meta.yaml
@@ -11,6 +11,7 @@ source:
 build:
   number: 0
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv "
+  noarch: python
 
 requirements:
   host:

--- a/recipes/bitsets/meta.yaml
+++ b/recipes/bitsets/meta.yaml
@@ -1,0 +1,37 @@
+{% set name = "bitsets" %}
+{% set version = "0.7.16" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: https://files.pythonhosted.org/packages/26/41/91d45f9818e25a0ce04a725a60639cdcf615772bb825cee8e8f0e706f8cd/bitsets-0.7.16.zip 
+  sha256: "5324d8e14d3fbd9a345efd197b3e1b0833792403c0ae69010719002a5df026ed"
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv "
+
+requirements:
+  host:
+    - pip
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - bitsets
+
+about:
+  home: "https://github.com/xflr6/bitsets"
+  license: "MIT"
+  license_family: "MIT"
+  license_file: ""
+  summary: "Ordered subsets over a predefined domain"
+  doc_url: ""
+  dev_url: ""
+
+extra:
+  recipe-maintainers:
+    - smirarab


### PR DESCRIPTION
Bitsets is used by many bio packages. It is not available on conda-forge. Would be good to have it here. 