### PR TITLE
Adding bioconductor-apeglm as dependency to diffbind

### DIFF
--- a/recipes/bioconductor-diffbind/meta.yaml
+++ b/recipes/bioconductor-diffbind/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 'https://depot.galaxyproject.org/software/bioconductor-{{ name|lower }}/bioconductor-{{ name|lower }}_{{ version }}_src_all.tar.gz'
   md5: 2d617d6e6245d4ff697004185c9778d7
 build:
-  number: 0
+  number: 1
   rpaths:
     - lib/R/lib/
     - lib/
@@ -32,6 +32,7 @@ requirements:
     - 'bioconductor-s4vectors >=0.26.0,<0.27.0'
     - 'bioconductor-summarizedexperiment >=1.18.0,<1.19.0'
     - 'bioconductor-systempiper >=1.22.0,<1.23.0'
+    - 'bioconductor-apeglm >=1.10.0'
     - r-amap
     - r-base
     - r-dplyr
@@ -57,6 +58,7 @@ requirements:
     - 'bioconductor-s4vectors >=0.26.0,<0.27.0'
     - 'bioconductor-summarizedexperiment >=1.18.0,<1.19.0'
     - 'bioconductor-systempiper >=1.22.0,<1.23.0'
+    - 'bioconductor-apeglm >=1.10.0'
     - r-amap
     - r-base
     - r-dplyr


### PR DESCRIPTION
Deseq2 includes the function: lfcShrink which dependes on bioconductor-apeglm
Check: https://rdrr.io/bioc/DESeq2/man/lfcShrink.html
I'm adding this package as a requirement for Deseq2 that is used by Diffbind
