### PR TITLE
Add recipe for f5c

### DIFF
--- a/recipes/f5c/build.sh
+++ b/recipes/f5c/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 mkdir -p $PREFIX/bin
-cp f5c_x86_64_linux $PREFIX/bin
+cp f5c_x86_64_linux $PREFIX/bin/f5c

--- a/recipes/f5c/build.sh
+++ b/recipes/f5c/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 scripts/install-hts.sh
 ./configure
-make CC=$CC CXX=$CXX -D__STDC_FORMAT_MACROS=1
+make CC=$CC CXX=$CXX
 mkdir -p $PREFIX/bin
 cp f5c $PREFIX/bin/f5c

--- a/recipes/f5c/build.sh
+++ b/recipes/f5c/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 scripts/install-hts.sh
 ./configure
-make CC=$CC CXX=$CXX
+make CC=$CC CXX=$CXX -D__STDC_FORMAT_MACROS=1
 mkdir -p $PREFIX/bin
 cp f5c $PREFIX/bin/f5c

--- a/recipes/f5c/build.sh
+++ b/recipes/f5c/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 scripts/install-hts.sh
 ./configure
-make
+make CC=$CC CXX=$CXX
 mkdir -p $PREFIX/bin
 cp f5c $PREFIX/bin/f5c

--- a/recipes/f5c/build.sh
+++ b/recipes/f5c/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 scripts/install-hts.sh
 ./configure
-make CC=$CC CXX=$CXX
+make CC=$CC CXX=$CXX CFLAGS="-g -Wall -O2 -std=c++11"
 mkdir -p $PREFIX/bin
 cp f5c $PREFIX/bin/f5c

--- a/recipes/f5c/build.sh
+++ b/recipes/f5c/build.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
+scripts/install-hts.sh
+./configure
+make
 mkdir -p $PREFIX/bin
-cp f5c_x86_64_linux $PREFIX/bin/f5c
+cp f5c $PREFIX/bin/f5c

--- a/recipes/f5c/build.sh
+++ b/recipes/f5c/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+mkdir -p $PREFIX/bin
+cp f5c_x86_64_linux $PREFIX/bin

--- a/recipes/f5c/build.sh
+++ b/recipes/f5c/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 scripts/install-hts.sh
 ./configure
-make CC=$CC CXX=$CXX CFLAGS="-g -Wall -O2 -std=c++11"
+make CC=$CC CXX=$CXX CFLAGS="-g -Wall -O2 -std=c++11 -D__STDC_FORMAT_MACROS"
 mkdir -p $PREFIX/bin
 cp f5c $PREFIX/bin/f5c

--- a/recipes/f5c/conda_build_config.yaml
+++ b/recipes/f5c/conda_build_config.yaml
@@ -1,0 +1,4 @@
+c_compiler:
+  - gcc # [linux]
+cxx_compiler:
+  - gxx # [linux]

--- a/recipes/f5c/conda_build_config.yaml
+++ b/recipes/f5c/conda_build_config.yaml
@@ -1,4 +1,0 @@
-c_compiler:
-  - gcc # [linux]
-cxx_compiler:
-  - gxx # [linux]

--- a/recipes/f5c/meta.yaml
+++ b/recipes/f5c/meta.yaml
@@ -20,6 +20,8 @@ requirements:
     - zlib
   run:
     - zlib
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
 
 test:
   commands:

--- a/recipes/f5c/meta.yaml
+++ b/recipes/f5c/meta.yaml
@@ -1,0 +1,33 @@
+{% set name = "f5c" %}
+{% set version = "0.4" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/hasindu2008/f5c/releases/download/v0.4/f5c-v0.4-binaries.tar.gz
+  sha256: 2da529a976f890ba553122a8deecb5be2f64cf4146eed8eb1a62f170bafafc71
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+  host:
+    - zlib
+  run:
+    - zlib
+
+test:
+  commands:
+    - f5c --help
+    - f5c --version
+
+about:
+  home: https://github.com/hasindu2008/f5c
+  license: MIT
+  license_file: LICENSE
+  summary: 'An optimised re-implementation of the call-methylation and eventalign modules in Nanopolish. Given a set of basecalled Nanopore reads and the raw signals, f5c call-methylation detects the methylated cytosine and f5c eventalign aligns raw nanopore DNA signals (events) to the base-called read.'
+
+extra:
+

--- a/recipes/f5c/meta.yaml
+++ b/recipes/f5c/meta.yaml
@@ -19,6 +19,7 @@ requirements:
   host:
     - zlib
     - hdf5
+    - wget
   run:
     - zlib
     - hdf5

--- a/recipes/f5c/meta.yaml
+++ b/recipes/f5c/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  
+
 requirements:
   build:
     - {{ compiler('c') }}
@@ -31,6 +31,3 @@ about:
   license: MIT
   license_file: LICENSE
   summary: 'An optimised re-implementation of the call-methylation and eventalign modules in Nanopolish.'
-
-extra:
-

--- a/recipes/f5c/meta.yaml
+++ b/recipes/f5c/meta.yaml
@@ -9,6 +9,9 @@ source:
   url: https://github.com/hasindu2008/f5c/releases/download/v0.4/f5c-v0.4-binaries.tar.gz
   sha256: 2da529a976f890ba553122a8deecb5be2f64cf4146eed8eb1a62f170bafafc71
 
+build:
+  number: 0
+  
 requirements:
   build:
     - {{ compiler('c') }}
@@ -27,7 +30,7 @@ about:
   home: https://github.com/hasindu2008/f5c
   license: MIT
   license_file: LICENSE
-  summary: 'An optimised re-implementation of the call-methylation and eventalign modules in Nanopolish. Given a set of basecalled Nanopore reads and the raw signals, f5c call-methylation detects the methylated cytosine and f5c eventalign aligns raw nanopore DNA signals (events) to the base-called read.'
+  summary: 'An optimised re-implementation of the call-methylation and eventalign modules in Nanopolish.'
 
 extra:
 

--- a/recipes/f5c/meta.yaml
+++ b/recipes/f5c/meta.yaml
@@ -6,8 +6,8 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/hasindu2008/f5c/releases/download/v0.4/f5c-v0.4-binaries.tar.gz
-  sha256: 2da529a976f890ba553122a8deecb5be2f64cf4146eed8eb1a62f170bafafc71
+  url: https://github.com/hasindu2008/f5c/releases/download/v0.4/f5c-v0.4-release.tar.gz
+  sha256: a33ef3c792451d315988bd5a0e58915d7feae06ee5ee9852db0c47718a44d250
 
 build:
   number: 0
@@ -18,10 +18,10 @@ requirements:
     - {{ compiler('cxx') }}
   host:
     - zlib
+    - hdf5
   run:
     - zlib
-    - {{ compiler('c') }}
-    - {{ compiler('cxx') }}
+    - hdf5
 
 test:
   commands:


### PR DESCRIPTION
Add recipe for f5c

----

f5c is an optimised re-implementation of the call-methylation and eventalign modules in Nanopolish. Given a set of basecalled Nanopore reads and the raw signals, f5c call-methylation detects the methylated cytosine and f5c eventalign aligns raw nanopore DNA signals (events) to the base-called read. 
