### PR TITLE
Adding standard link to the homer installation folder

### DIFF
--- a/recipes/homer/build.sh
+++ b/recipes/homer/build.sh
@@ -1,10 +1,9 @@
 #! /bin/bash
 
-outdir=$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM
+outdir=$PREFIX/share/$PKG_NAME
 mkdir -p $outdir
 mkdir -p $outdir/bin
 mkdir -p $PREFIX/bin
-ln -s $outdir $PREFIX/share/$PKG_NAME
 chmod +x configureHomer.pl
 cp configureHomer.pl $outdir/
 

--- a/recipes/homer/build.sh
+++ b/recipes/homer/build.sh
@@ -4,6 +4,7 @@ outdir=$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM
 mkdir -p $outdir
 mkdir -p $outdir/bin
 mkdir -p $PREFIX/bin
+ln -s $outdir $PREFIX/share/$PKG_NAME
 chmod +x configureHomer.pl
 cp configureHomer.pl $outdir/
 

--- a/recipes/homer/meta.yaml
+++ b/recipes/homer/meta.yaml
@@ -14,7 +14,6 @@ source:
     sha256: 37e36fb10387a90050251683d35fe568657941b863b2088dcb0d09d9b1b59477
 
 build:
-  skip: True  # [osx]
   number: 3
 
 # dependencies according to README.txt installed by configureHomer.pl
@@ -24,8 +23,6 @@ requirements:
   build:
     - {{ compiler('cxx') }}
   host:
-    - python
-    - setuptools
     - perl
     - wget
     - unzip

--- a/recipes/homer/meta.yaml
+++ b/recipes/homer/meta.yaml
@@ -15,6 +15,8 @@ source:
 
 build:
   number: 3
+  # Ships pre-built binaries that install_name_tool isn't able to fix.
+  skip: True  # [osx]
 
 # dependencies according to README.txt installed by configureHomer.pl
 # are ghostscript, weblogo v2 NOT v2.8 and blat. Note, however, that there

--- a/recipes/homer/meta.yaml
+++ b/recipes/homer/meta.yaml
@@ -15,7 +15,7 @@ source:
 
 build:
   skip: True  # [osx]
-  number: 2
+  number: 3
 
 # dependencies according to README.txt installed by configureHomer.pl
 # are ghostscript, weblogo v2 NOT v2.8 and blat. Note, however, that there

--- a/recipes/homer/meta.yaml
+++ b/recipes/homer/meta.yaml
@@ -32,6 +32,8 @@ requirements:
     - zip
   run:
     - perl
+    - wget
+    - unzip
 
 test:
   commands:


### PR DESCRIPTION
For using homer with a standard installation path `/usr/local/share/homer` as a link to the current installation path.
This help external scripts to use the standard path for installing genomes and databases.
