### PR TITLE
Adding dependencies to diffbind

### DIFF
--- a/recipes/bioconductor-diffbind/meta.yaml
+++ b/recipes/bioconductor-diffbind/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 'https://depot.galaxyproject.org/software/bioconductor-{{ name|lower }}/bioconductor-{{ name|lower }}_{{ version }}_src_all.tar.gz'
   md5: 2d617d6e6245d4ff697004185c9778d7
 build:
-  number: 0
+  number: 1
   rpaths:
     - lib/R/lib/
     - lib/
@@ -32,6 +32,7 @@ requirements:
     - 'bioconductor-s4vectors >=0.26.0,<0.27.0'
     - 'bioconductor-summarizedexperiment >=1.18.0,<1.19.0'
     - 'bioconductor-systempiper >=1.22.0,<1.23.0'
+    - 'bioconductor-apeglm >=1.10.0'
     - r-amap
     - r-base
     - r-dplyr
@@ -44,6 +45,7 @@ requirements:
     - r-rcpp
     - libblas
     - liblapack
+    - xorg-libxt
   run:
     - 'bioconductor-biocparallel >=1.22.0,<1.23.0'
     - 'bioconductor-deseq2 >=1.28.0,<1.29.0'
@@ -57,6 +59,7 @@ requirements:
     - 'bioconductor-s4vectors >=0.26.0,<0.27.0'
     - 'bioconductor-summarizedexperiment >=1.18.0,<1.19.0'
     - 'bioconductor-systempiper >=1.22.0,<1.23.0'
+    - 'bioconductor-apeglm >=1.10.0'
     - r-amap
     - r-base
     - r-dplyr
@@ -67,6 +70,7 @@ requirements:
     - r-locfit
     - r-rcolorbrewer
     - r-rcpp
+    - xorg-libxt
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}


### PR DESCRIPTION
Diffbind needs:
 * bioconductor-apeglm
 * xorg-libxt

This error is shown when plotting DiffBind graphs:
```
In grSoftVersion() :
  unable to load shared object '/usr/local/lib/R/modules//R_X11.so':
  libXt.so.6: cannot open shared object file: No such file or directory
```