### PR TITLE
Update augur 9.0.0 dependencies

### DIFF
--- a/recipes/augur/meta.yaml
+++ b/recipes/augur/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 9e2632b807d998439ff4fad9bcb51f7c92fcd494680f6a1389bd2b61406c5b66
 
 build:
-  number: 0
+  number: 1
   noarch: python
   entry_points:
     - augur = augur.__main__:main
@@ -17,21 +17,19 @@ build:
 
 requirements:
   host:
-    - python >=3
+    - python >=3.6
     - pip
 
   run:
-    - python >=3
+    - python >=3.6
     - bcbio-gff >=0.6.0
     - biopython >=1.67
     - jsonschema >=3.0.0
     - packaging >=19.2
-    - pandas >=0.20.0,<1
+    - pandas >=1.0.0,<2
     - treetime >=0.7.4
     - snakemake >=5.4.0
-    - cvxopt >=1.1.9,<1.2
-    - matplotlib-base 2.*
-    - seaborn >=0.9.0,<0.10
+    - cvxopt >=1.1.9,<2
     - mafft
     - raxml
     - fasttree
@@ -49,3 +47,8 @@ about:
   license: AGPL-3.0
   summary: 'Process pathogen genome data for the Nextstrain platform'
   license_family: AGPL
+  license_file: LICENSE.txt
+
+extra:
+  recipe-maintainers:
+    huddlej


### PR DESCRIPTION
Updates recipe to reflect recent changes in augur's dependencies including a minimum Python version of 3.6 and support for pandas 1.0.0.

This PR also:

  - removes packages that are not true dependencies for augur including seaborn and matplotlib
  - bumps augur build number
  - specifies augur license file
  - adds a recipe maintainer
