### PR TITLE
Adding fonts-conda-ecosystem to diffbind to solve missing fonts

### DIFF
--- a/recipes/bioconductor-diffbind/meta.yaml
+++ b/recipes/bioconductor-diffbind/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 'https://depot.galaxyproject.org/software/bioconductor-{{ name|lower }}/bioconductor-{{ name|lower }}_{{ version }}_src_all.tar.gz'
   md5: 2d617d6e6245d4ff697004185c9778d7
 build:
-  number: 1
+  number: 2
   rpaths:
     - lib/R/lib/
     - lib/
@@ -46,6 +46,7 @@ requirements:
     - libblas
     - liblapack
     - xorg-libxt
+    - fonts-conda-ecosystem
   run:
     - 'bioconductor-biocparallel >=1.22.0,<1.23.0'
     - 'bioconductor-deseq2 >=1.28.0,<1.29.0'
@@ -71,6 +72,7 @@ requirements:
     - r-rcolorbrewer
     - r-rcpp
     - xorg-libxt
+    - fonts-conda-ecosystem
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}


### PR DESCRIPTION
There are missing fonts while using this package.
It get's solved if adding: fonts-conda-ecosystem
See:
 * https://github.com/conda-forge/r-base-feedstock/issues/91
 * https://github.com/sigven/pcgr/issues/107

![condition_ES_vs_rB_diffbind_deseq2_plot](https://user-images.githubusercontent.com/8643256/90429667-188e9300-e094-11ea-9805-876617721455.png)
