### PR TITLE
Fix inStrain requirements and add test commands

### DIFF
--- a/recipes/instrain/meta.yaml
+++ b/recipes/instrain/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: "{{ PYTHON }} -m pip install . -vv --no-deps"
 
 requirements:
@@ -33,10 +33,15 @@ requirements:
     - scikit-learn
     - seaborn
     - tqdm
+    - numba
+    - lmfit
 
 test:
   imports:
     - inStrain
+  commands:
+    - inStrain profile --help
+    - inStrain compare --help
 
 about:
   home: "https://github.com/MrOlm/inStrain"


### PR DESCRIPTION
This PR adds `numba` and `lmfit` as requirements to the inStrain recipe. It also adds two test commands on top of the existing import test.

----

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
