### PR TITLE
Update snakemake

### DIFF
--- a/recipes/snakemake/meta.yaml
+++ b/recipes/snakemake/meta.yaml
@@ -40,6 +40,7 @@ requirements:
     - imagemagick >=7.0
     - oauth2client
     - slacker
+    - pulp
 
 test:
   imports:

--- a/recipes/snakemake/meta.yaml
+++ b/recipes/snakemake/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: d8bbde85fa8d93bd6312cae5d39247b316ead0589022aa7b48760374b1994b79
 
 build:
-  number: 0
+  number: 1
   noarch: generic
 
 requirements:


### PR DESCRIPTION
Snakemake currently fails when executing as pulp is missing as a dependency (as described [here](https://github.com/snakemake/snakemake/issues/584) and [here](https://github.com/snakemake/snakemake-wrappers/pull/160#issuecomment-680223328))
To fix this `pulp` has been added to the recipe.
