### PR TITLE
Update snakemake-minimal

### DIFF
--- a/recipes/snakemake/meta.yaml
+++ b/recipes/snakemake/meta.yaml
@@ -40,7 +40,6 @@ requirements:
     - imagemagick >=7.0
     - oauth2client
     - slacker
-    - pulp
 
 test:
   imports:

--- a/recipes/snakemake/meta.yaml
+++ b/recipes/snakemake/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: d8bbde85fa8d93bd6312cae5d39247b316ead0589022aa7b48760374b1994b79
 
 build:
-  number: 1
+  number: 2
   noarch: generic
 
 requirements:
@@ -101,6 +101,7 @@ outputs:
         - gitpython
         - toposort
         - nbformat
+        - pulp
 
     test:
       imports:


### PR DESCRIPTION
This PR adds `pulp` as dependency for snakemake-minimal as it is required to provide core functionality.