### PR TITLE
Update RagTag recipe to add missing dependencies minimap2 and mummer

### DIFF
--- a/recipes/ragtag/meta.yaml
+++ b/recipes/ragtag/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: ea70463bd2566bd64d080f4958154a9a70e7c5d771bd1485f80f541a3fd457d5
 
 build:
-  number: 0
+  number: 1
   script: "{{ PYTHON }} -m pip install . -vv"
   noarch: python
 
@@ -26,6 +26,8 @@ requirements:
     - numpy
     - pysam
     - python >3
+    - minimap2
+    - mummer
 
 test:
   imports:


### PR DESCRIPTION
RagTag requires either minimap2 or nucmer (mummer) for sequence alignment, as [described in the README.md](https://github.com/malonge/RagTag#dependencies).