### PR TITLE
Ngless v1.2.0 macosx build

### DIFF
--- a/build-fail-blacklist
+++ b/build-fail-blacklist
@@ -1375,8 +1375,5 @@ recipes/merfishtools
 recipes/gvcftools
 recipes/seer
 
-# recipe needs some work (use conda-forge::ghc instead of a temporary one during the build and ensure compile/link flags are always used)
-recipes/ngless
-
 # needs to be patched to use conda-forge::google-cloud-sdk => then we can remove all funky custom setup(cmdclass={...}) and non-public setuptools imports which break the build
 recipes/firecloud

--- a/recipes/ngless/build.sh
+++ b/recipes/ngless/build.sh
@@ -1,10 +1,23 @@
 #!/usr/bin/env bash
 
+set -e -o pipefail -x
+
+if [ "$(uname)" == "Darwin" ]; then
+    # On Mac OS X, we use prebuilt binaries. It's not the best solution, but
+    # the solution below does not work on Mac OS X
+    mkdir -p ${PREFIX}/bin
+    chmod +x bin/ngless
+    cp -pir bin/ngless ${PREFIX}/bin
+
+    mkdir -p ${PREFIX}/share
+    chmod +x share/ngless/bin/* share/ngless/bin/*/*
+    cp -pir share/ngless ${PREFIX}/share
+    exit 0
+fi
+
 
 # This tour de force script is mostly copy&pasted from
 # https://github.com/conda-forge/git-annex-feedstock
-
-set -e -o pipefail -x
 
 
 

--- a/recipes/ngless/build.sh
+++ b/recipes/ngless/build.sh
@@ -71,6 +71,16 @@ if [[ -f "${HOST_LIBPTHREAD}" ]]; then
 fi
 
 
+# Ensure that GHC build platform is x86_64-unknown-linux (which GHC knows how to target),
+# rather than x86_64-conda-linux (which GHC does not know about).
+# Suggested by @isuruf on github; see
+# https://github.com/conda-forge/git-annex-feedstock/pull/96/commits/796678ac2cc106e67c4f1f89fb2e92c2ff153616 and
+# https://github.com/conda-forge/git-annex-feedstock/runs/945996913
+#
+unset host_alias
+unset build_alias
+
+
 #######################################################################################################
 # Install bootstrap ghc
 #######################################################################################################

--- a/recipes/ngless/meta.yaml
+++ b/recipes/ngless/meta.yaml
@@ -1,6 +1,7 @@
 {% set name = "ngless" %}
 {% set version = "1.2.0" %}
 {% set sha256 = "7541de26727c48d053cd9e53b50d152362e226985739886d0ac0a26b2fb61c44" %}
+{% set osx_binaries_sha256 = "0403981f9c85ee1e06947f3d29c06ca4c6ec4c0b17ac1a709da1c230f609aaa2" %}
 
 {% set ghc_src_version = "8.6.5" %}
 {% set ghc_src_sha256 = "4d4aa1e96f4001b934ac6193ab09af5d6172f41f5a5d39d8e43393b9aafee361" %}
@@ -12,36 +13,38 @@ package:
   version: {{ version }}
 
 source:
-  - url: https://github.com/ngless-toolkit/ngless/archive/v{{ version }}.tar.gz
-    sha256: {{ sha256 }}
-    folder: ngless
+  - url: https://github.com/ngless-toolkit/ngless/archive/v{{ version }}.tar.gz # [linux]
+    sha256: {{ sha256 }} # [linux]
+    folder: ngless # [linux]
   - url: https://downloads.haskell.org/~ghc/{{ ghc_bootstrap_version }}/ghc-{{ ghc_bootstrap_version }}-x86_64-centos67-linux.tar.xz  # [linux]
     sha256: {{ ghc_bootstrap_linux_sha256 }}  # [linux]
-    folder: ghc_bootstrap
+    folder: ghc_bootstrap # [linux]
 
-  - url: https://downloads.haskell.org/~ghc/{{ ghc_src_version }}/ghc-{{ ghc_src_version }}-src.tar.xz
-    sha256: {{ ghc_src_sha256 }}
-    folder: ghc_src
+  - url: https://downloads.haskell.org/~ghc/{{ ghc_src_version }}/ghc-{{ ghc_src_version }}-src.tar.xz # [linux]
+    sha256: {{ ghc_src_sha256 }} # [linux]
+    folder: ghc_src # [linux]
+
+  - url: https://github.com/ngless-toolkit/ngless/releases/download/v{{ version }}/NGLess-{{ version }}-osx.zip # [osx]
+    sha256: {{ osx_binaries_sha256 }} # [osx]
 
 
 build:
-  number: 1
-  skip: True # [osx]
+  number: 2
 
 
 requirements:
   build:
-    - {{ compiler('c') }}
-    - {{ compiler('cxx') }}
-    - make
-    - perl
-    - coreutils
-    - binutils
-    - pkg-config
-    - automake
-    - autoconf
-    - libtool
-    - stack >=1.9.3
+    - {{ compiler('c') }} # [linux]
+    - {{ compiler('cxx') }} # [linux]
+    - make # [linux]
+    - perl # [linux]
+    - coreutils # [linux]
+    - binutils # [linux]
+    - pkg-config # [linux]
+    - automake # [linux]
+    - autoconf # [linux]
+    - libtool # [linux]
+    - stack >=1.9.3 # [linux]
   host:
     - gmp
     - xz
@@ -50,7 +53,7 @@ requirements:
     - backports.lzma
     - libiconv
     - openssh
-    - wget
+    - wget # [linux]
   run:
     - python
 


### PR DESCRIPTION
Update NGLess recipe

For Linux, fixes `build.sh` to run on newer conda.

For Mac OS X, installs the prebuilt binaries (as the approach used on Linux seems to fail with some OSX-internal errors).

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
