### PR TITLE
TIDDIT: fix TIDDIT executable.

### DIFF
--- a/recipes/tiddit/build.sh
+++ b/recipes/tiddit/build.sh
@@ -10,7 +10,7 @@ cd build
 cmake ..
 make
 cp ../bin/TIDDIT $PREFIX/bin
-cp -r lib/bamtools $PREFIX/lib  # Yes, this vendors bamtools :(
+cp lib/bamtools/src/api/libbamtools.* $PREFIX/lib  # Yes, this vendors bamtools :(
 cd ../src
 python -m pip install . --ignore-installed --no-deps -vv
 cd ../build

--- a/recipes/tiddit/build.sh
+++ b/recipes/tiddit/build.sh
@@ -10,7 +10,7 @@ cd build
 cmake ..
 make
 cp ../bin/TIDDIT $PREFIX/bin
-cp -r ../lib/bamtools $PREFIX/lib  # Yes, this vendors bamtools :(
+cp -r lib/bamtools $PREFIX/lib  # Yes, this vendors bamtools :(
 cd ../src
 python -m pip install . --ignore-installed --no-deps -vv
 cd ../build

--- a/recipes/tiddit/meta.yaml
+++ b/recipes/tiddit/meta.yaml
@@ -35,6 +35,6 @@ test:
 
 about:
   home: https://github.com/SciLifeLab/TIDDIT
-  license: GPL-3
+  license: GPL-3.0-only
   license_file: LICENSE
   summary: "TIDDIT - structural variant calling."

--- a/recipes/tiddit/meta.yaml
+++ b/recipes/tiddit/meta.yaml
@@ -29,6 +29,7 @@ requirements:
 
 test:
   commands:
+    - TIDDIT
     - TIDDIT.py
     - tiddit --help
 

--- a/recipes/tiddit/meta.yaml
+++ b/recipes/tiddit/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: e10ed13bd87ba622dc16ac7e371489977690198b3325ad172f3291e52b4437cf
 
 build:
-  number: 2
+  number: 3
   skip: True  # [osx]
 
 requirements:


### PR DESCRIPTION
Executing TIDDIT resulted in the following error:

TIDDIT: error while loading shared libraries: libbamtools.so.2.3.0: cannot open shared object file: No such file or directory

Caused by copying the bamutils source directory instead of the built
library files.  Added a test that executes the TIDDIT binary itself,
to catch issues such as these.
