### PR TITLE
Update old dependencies with new ones

### DIFF
--- a/recipes/treesapp/meta.yaml
+++ b/recipes/treesapp/meta.yaml
@@ -26,14 +26,19 @@ requirements:
   run:
     - python
     - numpy
-    - scipy >=1.4.1
-    - biopython >=1.68
+    - scipy >=1.5.2
+    - scikit-learn ==0.23.1
+    - biopython >=1.77
     - pygtrie >=2.3.2
     - ete3 >=3.1.1
     - six >=1.14.0
-    - joblib >=0.14.1
+    - tqdm >=4.48.2
+    - joblib ==0.15.1
     - matplotlib-base >=3.1.2
     - seaborn >=0.9.0
+    - packaging >=20.3
+    - samsum ==0.1.2
+    - pyfastx >=0.6.15
     - hmmer >=3.1
     - prodigal >=2.6.2
     - fasttree >=2.1.9
@@ -41,8 +46,6 @@ requirements:
     - epa-ng >=0.3.6
     - raxml-ng >=0.9.0
     - mafft >=7.407
-    - samsum ==0.1.2
-    - pyfastx >=0.6.15
 
 test:
   imports:

--- a/recipes/treesapp/meta.yaml
+++ b/recipes/treesapp/meta.yaml
@@ -38,10 +38,11 @@ requirements:
     - prodigal >=2.6.2
     - fasttree >=2.1.9
     - bwa >=0.7.3
-    - raxml ==8.2.12
+    - epa-ng >=0.3.6
+    - raxml-ng >=0.9.0
     - mafft >=7.407
     - samsum ==0.1.2
-    - pyfastx ==0.6.10
+    - pyfastx >=0.6.15
 
 test:
   imports:


### PR DESCRIPTION
TreeSAPP no longer uses the original RAxML software. It now uses EPA-NG and RAxML-NG for phylogenetic placement and inference, respectively. It also needs a newer version of pyfastx. 

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
