### PR TITLE
Update trf to version 4.09.1

### DIFF
--- a/recipes/trf/build.sh
+++ b/recipes/trf/build.sh
@@ -1,5 +1,5 @@
-#!/bin/bash
+#!/bin/sh
 
-mkdir -p $PREFIX/bin
-cp trf409* $PREFIX/bin/trf
-chmod +x $PREFIX/bin/trf
+./configure --prefix=$PREFIX CPPFLAGS=-DUNIXCONSOLE
+make
+make install

--- a/recipes/trf/meta.yaml
+++ b/recipes/trf/meta.yaml
@@ -1,22 +1,21 @@
 {% set name = "trf" %}
-{% set version = "4.09" %}
+{% set version = "4.09.1" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  - url: https://tandem.bu.edu/trf/downloads/trf409.legacylinux64  # [linux]
-    md5: a88e4b47ddef4961c832a93a7cb6a35d  # [linux]
-  - url: https://tandem.bu.edu/trf/downloads/trf409.macosx  # [osx]
-    md5: 14784824b6c2fae52f4b5c289ef67255  # [osx]
+  - url: https://github.com/Benson-Genomics-Lab/TRF/archive/v{{ version }}.tar.gz
+    sha256: 516015b625473350c3d1c9b83cac86baea620c8418498ab64c0a67029c3fb28a
+     
 
 build:
-  number: 2
+  number: 0
 
 requirements:
   build:
-
+    - {{ compiler('c') }}
   run:
 
 test:
@@ -25,12 +24,10 @@ test:
 
 about:
   home: https://tandem.bu.edu/trf/trf.html
-  license: Custom
+  license: AGPL-3.0
+  license_file: COPYING
   summary: 'Tandem Repeats Finder is a program to locate and display tandem repeats in DNA sequences.'
 
 extra:
   identifiers:
     - biotools:Trf
-  skip-lints:
-    - should_be_noarch_generic
-    - should_not_be_noarch_source


### PR DESCRIPTION
Update trf to version 4.09.1. This is the first open-source version available.