### PR TITLE
Update nim-falcon to 1.10.1

### DIFF
--- a/recipes/nim-falcon/meta.yaml
+++ b/recipes/nim-falcon/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "nim-falcon" %}
-{% set version = "1.8.0" %}
-{% set sha256 = "940cfeb92c1f8bf1b9f59e3ddd7c506278bebda9606bb2cc25dfc92b3d4b48e4" %}
+{% set version = "1.10.1" %}
+{% set sha256 = "7472108fa7daa0ae0c908a412610abfa4f417ce58148440e59316c0f4cd52d8c" %}
 
 package:
   name: {{ name|lower }}
@@ -23,7 +23,7 @@ build:
 requirements:
   host:
     - zlib
-    - htslib
+    - htslib>=1.10
     - pcre
 
 test:


### PR DESCRIPTION
Not sure why the bot found a later release of a different repo but not this one yet. Trying manually...