### PR TITLE
Add recipe: COBS

### DIFF
--- a/recipes/cobs/build.sh
+++ b/recipes/cobs/build.sh
@@ -14,5 +14,8 @@ cmake -DCMAKE_BUILD_TYPE=RELEASE \
       -DBoost_NO_SYSTEM_PATHS=ON \
       ..
 make VERBOSE=1
-echo "installing"
-make install CFLAGS="-L${PREFIX}/lib -I${PREFIX}/include"
+
+cp src/cobs $PREFIX/bin
+
+echo "cmake-powered unit test"
+CTEST_OUTPUT_ON_FAILURE=1 make test

--- a/recipes/cobs/build.sh
+++ b/recipes/cobs/build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -eu -o pipefail
+
+mkdir -p $PREFIX/bin
+mkdir -p $PREFIX/lib
+
+mkdir -p build
+cd build
+cmake -DCMAKE_BUILD_TYPE=RELEASE \
+      -DCONDA_BUILD=TRUE \
+      -DBoost_NO_BOOST_CMAKE=ON \
+      -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9 \
+      -DCMAKE_INSTALL_PREFIX:PATH=$PREFIX \
+      -DBoost_NO_SYSTEM_PATHS=ON \
+      ..
+make VERBOSE=1
+echo "installing"
+make install CFLAGS="-L${PREFIX}/lib -I${PREFIX}/include"

--- a/recipes/cobs/meta.yaml
+++ b/recipes/cobs/meta.yaml
@@ -1,0 +1,38 @@
+{% set version = "0.0.1" %}
+{% set sha256 = "f4784e0c8863c266c2b826078bfe46fca4943fcde5799337891c333c9e0d29b4" %}
+
+package:
+  name: cobs
+  version: {{ version }}
+
+build:
+  number: 0
+
+source:
+  git_url: https://github.com/bingmann/cobs
+  git_rev: 1915fc061bbe47946116b4a051ed7b4e3f3eca15
+  sha256: {{sha256}}
+
+requirements:
+  build:
+    - {{ compiler('cxx') }}
+    - {{ compiler('c') }}
+    - cmake
+  host:
+    - boost-cpp
+
+about:
+  home: https://panthema.net/cobs
+  license: MIT
+  summary: Compact Bit-Sliced Signature Index (for Genomic k-Mer Data or q-Grams)
+  license_file: LICENSE
+
+test:
+  commands:
+    - cobs
+
+extra:
+  recipe-maintainers:
+    - luizirber
+  skip-lints:
+    - uses_vcs_url

--- a/recipes/cobs/meta.yaml
+++ b/recipes/cobs/meta.yaml
@@ -20,6 +20,8 @@ requirements:
     - cmake
   host:
     - boost-cpp
+  run:
+    - boost-cpp
 
 about:
   home: https://panthema.net/cobs


### PR DESCRIPTION
Add new recipe for [COBS](https://panthema.net/cobs), based on the Salmon and dashing recipes.

## TODO:

- [ ] ask for a version and tag in original repo
- [ ] run tests
- [ ] python extension

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
