### PR TITLE
Updated entrez-direct to version 13.9, please merge

### DIFF
--- a/recipes/entrez-direct/meta.yaml
+++ b/recipes/entrez-direct/meta.yaml
@@ -1,6 +1,6 @@
-{% set version = "13.8" %}
-{% set date = "20200831" %}
-{% set sha256 = "80d1e292a80cafc78df09f009bbd71765aa4f1e2f37f80fcca8a6d54319e1f79" %}
+{% set version = "13.9" %}
+{% set date = "20200916" %}
+{% set sha256 = "8736d9aede063c9b1df9719d6b2d9d15ae3823fd06adc58d165f64e87e6ebca8" %}
 
 package:
   name: entrez-direct


### PR DESCRIPTION
EDirect 13.9 is now public, with the following release notes:

`xtract -fasta` splits long sequences into groups of 50 letters.

`xtract -select` restores -in to indicate name of identifier file.

Redesigned EDirect selected by running `export USE_NEW_EDIRECT=true` to set environment variable.

New implementation also chosen by adding `-newmode` as the first argument to individual efetch, efilter, einfo, elink, epost, esearch, esummary, and nquire commands.

The EDirect reimplementation is still activated by running:

    export USE_NEW_EDIRECT=true

It is version 14.0, and will become the default sometime later this year.

In addition to the release notes, the curl call in nquire uses the "--connect-timeout 20" flag. This eliminates the 300 second maximum data transfer limit, but doesn't hang indefinitely if the server is not responding.

Error reporting has also been improved, and einfo -help shows commands to force several error messages:

    nquire -url http://api.geonames.org/countryCode -lat 41.796 -lng "\-87.577"

    einfo -db NONE

    esearch -db pubmed -query "1233456789 [NONE]"

    elink -db pubmed -id 123456789 -related

    efetch -db pubmed -id 123456789 -format docsum

Elink and epost support a -log argument, which prints periods on the terminal as a primitive progress monitor. This was added because elink always splits large sets into groups of 500, to eliminate silent server truncation without causing sporadic server timeouts, and that could take multiple minutes to complete for a large link operation.

The history server is now synchronized between the main and backup locations, and the active server's IP address is no longer buried in the web environment string. The code that extracted that value and chose the proper location for subsequent calls is thus obsolete, and has been removed.

Describe your pull request here

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
