### PR TITLE
Update pairtools recipe because its repo changed the owner.

### DIFF
--- a/recipes/pairtools/meta.yaml
+++ b/recipes/pairtools/meta.yaml
@@ -1,7 +1,6 @@
 {% set name = "pairtools" %}
 {% set version = "0.3.0" %}
 
-
 package:
   name: {{ name|lower }}
   version: {{ version }}
@@ -11,8 +10,8 @@ source:
   sha256: 4931da4b5fcb327d13c9564e6fdda1acf2335e16213a55d2620fe340ae918b53
 
 build:
-  number: 3
-  skip: True # [py<35]
+  number: 4
+  skip: True  # [py<35]
   entry_points:
     - pairtools = pairtools:cli
 
@@ -24,7 +23,6 @@ requirements:
     - setuptools
     - cython
     - numpy
-
   run:
     - python
     - coreutils
@@ -51,7 +49,6 @@ about:
   license_file: LICENSE
   doc_url: http://pairtools.readthedocs.io/
   dev_url: https://github.com/open2c/pairtools
-
 
 extra:
   container:

--- a/recipes/pairtools/meta.yaml
+++ b/recipes/pairtools/meta.yaml
@@ -44,13 +44,13 @@ test:
     - pairtools --help
 
 about:
-  home: https://github.com/mirnylab/pairtools
+  home: https://github.com/open2c/pairtools
   license: MIT
   license_family: MIT
   summary: 'CLI tools to process mapped Hi-C data'
   license_file: LICENSE
   doc_url: http://pairtools.readthedocs.io/
-  dev_url: https://github.com/mirnylab/pairtools
+  dev_url: https://github.com/open2c/pairtools
 
 
 extra:


### PR DESCRIPTION
Updating the meta.yaml file to point the recipe to the new URL with the updated owner.