### PR TITLE
Add tiledbvcf recipe

### DIFF
--- a/recipes/tiledbvcf/build-tiledbvcf-py.sh
+++ b/recipes/tiledbvcf/build-tiledbvcf-py.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -ex
+
+cd apis/python
+
+$PYTHON setup.py install --single-version-externally-managed --record record.txt --libtiledbvcf="${PREFIX}"

--- a/recipes/tiledbvcf/build-tiledbvcf-py.sh
+++ b/recipes/tiledbvcf/build-tiledbvcf-py.sh
@@ -1,7 +1,6 @@
-#!/bin/bash
-
+#!/usr/bin/env bash
 set -ex
 
 cd apis/python
 
-$PYTHON setup.py install --single-version-externally-managed --record record.txt --libtiledbvcf="${PREFIX}"
+$PYTHON setup.py install --single-version-externally-managed --record record.txt --libtiledbvcf="$PREFIX"

--- a/recipes/tiledbvcf/build.sh
+++ b/recipes/tiledbvcf/build.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -exo pipefail
+
+mkdir libtiledbvcf-build && cd libtiledbvcf-build
+cmake \
+  -DCMAKE_INSTALL_PREFIX:PATH="${PREFIX}" \
+  -DOVERRIDE_INSTALL_PREFIX=OFF \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DFORCE_EXTERNAL_HTSLIB=OFF \
+  ../libtiledbvcf
+
+make -j ${CPU_COUNT}

--- a/recipes/tiledbvcf/build.sh
+++ b/recipes/tiledbvcf/build.sh
@@ -1,10 +1,9 @@
-#!/bin/sh
-
+#!/usr/bin/env bash
 set -exo pipefail
 
 mkdir libtiledbvcf-build && cd libtiledbvcf-build
 cmake \
-  -DCMAKE_INSTALL_PREFIX:PATH="${PREFIX}" \
+  -DCMAKE_INSTALL_PREFIX:PATH=$PREFIX \
   -DOVERRIDE_INSTALL_PREFIX=OFF \
   -DCMAKE_BUILD_TYPE=Release \
   -DFORCE_EXTERNAL_HTSLIB=OFF \

--- a/recipes/tiledbvcf/install-libtiledbvcf.sh
+++ b/recipes/tiledbvcf/install-libtiledbvcf.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -exo pipefail
+
+cd libtiledbvcf-build
+make install-libtiledbvcf

--- a/recipes/tiledbvcf/install-libtiledbvcf.sh
+++ b/recipes/tiledbvcf/install-libtiledbvcf.sh
@@ -1,5 +1,4 @@
-#!/bin/sh
-
+#!/usr/bin/env bash
 set -exo pipefail
 
 cd libtiledbvcf-build

--- a/recipes/tiledbvcf/meta.yaml
+++ b/recipes/tiledbvcf/meta.yaml
@@ -1,0 +1,104 @@
+{% set name = "tiledbvcf" %}
+{% set version = "0.5.2" %}
+{% set sha256 = "b489e53a5e05ae5153bc82922757ab16086f8a6a5cc7484f35c0a652c9232547" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/TileDB-Inc/TileDB-VCF/archive/{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  skip: true  # [win or linux32 or py2k]
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - git
+    - cmake
+    - make
+  run:
+    - htslib >=1.8
+    - tiledb 2.0.*
+  host:
+    - htslib >=1.8
+    - tiledb 2.0.*
+
+test:
+  commands:
+    - conda inspect linkages -p $PREFIX libtiledbvcf  # [not win]
+    - conda inspect objects -p $PREFIX libtiledbvcf  # [osx]
+
+outputs:
+  - name: libtiledbvcf
+    version: {{ version }}
+    script: install-libtiledbvcf.sh
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+        - cmake
+        - make
+      host:
+        - htslib >=1.8
+        - tiledb 2.0.*
+      run:
+        - htslib >=1.8
+        - tiledb 2.0.*
+    test:
+      commands:
+        - tiledbvcf version
+
+  - name: tiledbvcf-py
+    version: {{ version }}
+    script: build-tiledbvcf-py.sh
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+        - cmake
+        - make
+      host:
+        - {{ pin_compatible('numpy', lower_bound='1.16') }}
+        - {{ pin_subpackage('libtiledbvcf', exact=True) }}
+        - python
+        - pyarrow 1.0.*
+        - pybind11
+        - rpdb
+        - wheel
+        - setuptools
+        - setuptools_scm
+        - setuptools_scm_git_archive
+      run:
+        - {{ pin_compatible('numpy', lower_bound='1.16') }}
+        - {{ pin_subpackage('libtiledbvcf', exact=True) }}
+        - python
+        - pyarrow 1.0.*
+        - pybind11
+        - pandas
+    imports:
+      - tiledbvcf
+    test:
+      commands:
+        - python -c "import tiledbvcf; tiledbvcf.version"
+
+about:
+  home: https://tiledb.com
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: 'Efficient and scalable storage engine for variant call data using TileDB.'
+  description: |
+    TileDB-VCF is a C++ library for storing genomic variant-call data using the TileDB storage engine. TileDB-VCF datasets can be created and queried using the command-line interface, Python module (with Dask integration), or Spark. VCF data is stored losslessly using highly compressed sparse arrays that can be accessed locally or remotely.
+  doc_url: https://docs.tiledb.com/genomics
+  dev_url: https://github.com/TileDB-Inc/TileDB-VCF
+
+extra:
+  recipe-maintainers:
+    - ihnorton
+    - shelnutt2
+    - aaronwolen

--- a/recipes/tiledbvcf/meta.yaml
+++ b/recipes/tiledbvcf/meta.yaml
@@ -50,8 +50,7 @@ outputs:
         - htslib >=1.8
         - tiledb 2.0.*
     test:
-      commands:
-        - tiledbvcf version
+      script: test-libtiledbvcf.sh
 
   - name: tiledbvcf-py
     version: {{ version }}
@@ -80,11 +79,9 @@ outputs:
         - pyarrow 1.0.*
         - pybind11
         - pandas
-    imports:
-      - tiledbvcf
     test:
-      commands:
-        - python -c "import tiledbvcf; tiledbvcf.version"
+      script:
+        - test-tiledbvcf.py
 
 about:
   home: https://tiledb.com

--- a/recipes/tiledbvcf/meta.yaml
+++ b/recipes/tiledbvcf/meta.yaml
@@ -63,7 +63,7 @@ outputs:
         - cmake
         - make
       host:
-        - {{ pin_compatible('numpy', lower_bound='1.16') }}
+        - numpy >=1.16,<2.0a0
         - {{ pin_subpackage('libtiledbvcf', exact=True) }}
         - python
         - pyarrow 1.0.*
@@ -74,7 +74,7 @@ outputs:
         - setuptools_scm
         - setuptools_scm_git_archive
       run:
-        - {{ pin_compatible('numpy', lower_bound='1.16') }}
+        - numpy >=1.16,<2.0a0
         - {{ pin_subpackage('libtiledbvcf', exact=True) }}
         - python
         - pyarrow 1.0.*

--- a/recipes/tiledbvcf/meta.yaml
+++ b/recipes/tiledbvcf/meta.yaml
@@ -52,6 +52,40 @@ outputs:
     test:
       script: test-libtiledbvcf.sh
 
+
+  - name: tiledbvcf-py
+    version: {{ version }}
+    script: build-tiledbvcf-py.sh
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+        - cmake
+        - make
+      host:
+        - numpy >=1.16,<2.0a0
+        - {{ pin_subpackage('libtiledbvcf', exact=True) }}
+        - python
+        - pyarrow 1.0.*
+        - pybind11
+        - rpdb
+        - wheel
+        - setuptools
+        - setuptools_scm
+        - setuptools_scm_git_archive
+      run:
+        - numpy >=1.16,<2.0a0
+        - {{ pin_subpackage('libtiledbvcf', exact=True) }}
+        - python
+        - pyarrow 1.0.*
+        - pybind11
+        - pandas
+    test:
+      imports:
+        - tiledbvcf
+      command:
+        - python -c "import tiledbvcf; tiledbvcf.version"
+
 about:
   home: https://tiledb.com
   license: MIT

--- a/recipes/tiledbvcf/meta.yaml
+++ b/recipes/tiledbvcf/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "tiledbvcf" %}
 {% set version = "0.5.2" %}
-{% set sha256 = "b489e53a5e05ae5153bc82922757ab16086f8a6a5cc7484f35c0a652c9232547" %}
+{% set sha256 = "701690757b5bb3c90e128ae446ab9d7fbb61c0a26ec0366f7de1ec45faa2b2a5" %}
 
 package:
   name: {{ name }}
@@ -51,37 +51,6 @@ outputs:
         - tiledb 2.0.*
     test:
       script: test-libtiledbvcf.sh
-
-  - name: tiledbvcf-py
-    version: {{ version }}
-    script: build-tiledbvcf-py.sh
-    requirements:
-      build:
-        - {{ compiler('c') }}
-        - {{ compiler('cxx') }}
-        - cmake
-        - make
-      host:
-        - numpy >=1.16,<2.0a0
-        - {{ pin_subpackage('libtiledbvcf', exact=True) }}
-        - python
-        - pyarrow 1.0.*
-        - pybind11
-        - rpdb
-        - wheel
-        - setuptools
-        - setuptools_scm
-        - setuptools_scm_git_archive
-      run:
-        - numpy >=1.16,<2.0a0
-        - {{ pin_subpackage('libtiledbvcf', exact=True) }}
-        - python
-        - pyarrow 1.0.*
-        - pybind11
-        - pandas
-    test:
-      script:
-        - test-tiledbvcf.py
 
 about:
   home: https://tiledb.com

--- a/recipes/tiledbvcf/test-libtiledbvcf.sh
+++ b/recipes/tiledbvcf/test-libtiledbvcf.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+tiledbvcf version

--- a/recipes/tiledbvcf/test-tiledbvcf.py
+++ b/recipes/tiledbvcf/test-tiledbvcf.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python3
+import tiledbvcf
+tiledbvcf.version

--- a/recipes/tiledbvcf/test-tiledbvcf.py
+++ b/recipes/tiledbvcf/test-tiledbvcf.py
@@ -1,3 +1,0 @@
-#!/usr/bin/env python3
-import tiledbvcf
-tiledbvcf.version


### PR DESCRIPTION
[TileDB-VCF](https://github.com/tileDB-Inc/tiledb-vcf) is a storage engine for genomic variant-call data based on [TileDB](https://github.com/tileDB-Inc/tiledb). This recipe provides both the library and command-line tool (`libtiledbvcf`), as well as the Python package (`tiledbvcf-py`). 

One note, when I build locally (*circleci* `0.1.9578+cf6a918 (homebrew)`; *bioconda/bioconda-utils-build-env* `46325e727d32`) the linter complains about using `{{ pin_compatible('numpy', lower_bound='1.16') }}` and errors out with `TypeError: <lambda>() got an unexpected keyword argument 'lower_bound')`. The build works fine if I replace the template variable with the rendered output (`numpy >=1.16,<2.0a0`) but I'm not sure why it's an issue since `lower_bound` is a [documented arg](https://docs.conda.io/projects/conda-build/en/latest/resources/variants.html#customizing-compatibility).

I'm happy to update the PR and remove `pin_compatible()` but would appreciate guidance on how best to address this issue.