### PR TITLE
Update reqs for pbipa

### DIFF
--- a/recipes/pbipa/meta.yaml
+++ b/recipes/pbipa/meta.yaml
@@ -11,7 +11,7 @@ source:
     sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   skip: True # [osx]
 
 extra:
@@ -26,12 +26,12 @@ requirements:
     - htslib
     - pcre
   run:
-    - htslib
+    - htslib>=1.10
     - networkx
-    - snakemake-minimal
+    - snakemake
     - racon
     - pbmm2
-    - nim-falcon
+    - pb-falconc
     - samtools>=1.10
     - minimap2
 

--- a/recipes/pbipa/meta.yaml
+++ b/recipes/pbipa/meta.yaml
@@ -28,7 +28,7 @@ requirements:
   run:
     - htslib>=1.10
     - networkx
-    - snakemake
+    - snakemake-minimal
     - racon
     - pbmm2
     - pb-falconc


### PR DESCRIPTION
Pull falconc from `pb-falconc` instead of `nim-falcon`, so we can revert the latter and fix older falcon.