### PR TITLE
revert nim-falcon

### DIFF
--- a/recipes/nim-falcon/meta.yaml
+++ b/recipes/nim-falcon/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "nim-falcon" %}
-{% set version = "1.10.1" %}
-{% set sha256 = "7472108fa7daa0ae0c908a412610abfa4f417ce58148440e59316c0f4cd52d8c" %}
+{% set version = "2.3.0" %}
+{% set sha256 = "d5267a4c9d59b46c6b7c88df42c4c94f18b01b960f7e7b8912247cdb4d9192df" %}
 
 package:
   name: {{ name|lower }}
@@ -13,7 +13,7 @@ extra:
     - should_be_noarch_generic # We use "skip", so this is a flawed lint-check.
 
 source:
-  url: https://github.com/bio-nim/nim-falcon/releases/download/v{{ version }}/nim-falcon.tar.gz
+  url: https://github.com/bio-nim/nim-falcon/releases/download/v1.3.0/nim-falcon.tar.gz
   sha256: {{ sha256 }}
 
 build:
@@ -23,12 +23,14 @@ build:
 requirements:
   host:
     - zlib
-    - htslib
+    - htslib 1.9*
     - pcre
 
 test:
   commands:
-    - falconc version
+    - falconc -h
+    - falconc rr-hctg-track2 -h
+    - falconc m4filt-contained -h
 
 about:
   home: https://github.com/bio-nim/nim-falcon


### PR DESCRIPTION
Most of this has moved to a different package (pb-falconc). This one is reverted here so old (pb-assembly) will continue to run.