### PR TITLE
Update nim-falcon (revert to 0.0.1)

### DIFF
--- a/recipes/nim-falcon/meta.yaml
+++ b/recipes/nim-falcon/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "nim-falcon" %}
-{% set version = "2.3.0" %}
-{% set sha256 = "d5267a4c9d59b46c6b7c88df42c4c94f18b01b960f7e7b8912247cdb4d9192df" %}
+{% set version = "3.0.1" %}
 
 package:
   name: {{ name|lower }}
@@ -13,12 +12,12 @@ extra:
     - should_be_noarch_generic # We use "skip", so this is a flawed lint-check.
 
 source:
-  url: https://github.com/bio-nim/nim-falcon/releases/download/v1.3.0/nim-falcon.tar.gz
-  sha256: {{ sha256 }}
+  url: https://github.com/bio-nim/{{ name }}/releases/download/0.0.1/{{ name }}-linux-64.tar.gz
+  sha256: 605ca8edbaafe85d24c2d1cb40885c0be7b82196550c17b4da7d1c529637c28f
 
 build:
+  skip: True # [osx]
   number: 0
-  skip: True  # [osx]
 
 requirements:
   host:
@@ -28,9 +27,11 @@ requirements:
 
 test:
   commands:
+    - fc_rr_hctg_track2.exe -h
+    - fc_rr_hctg_track.exe -h
+    - fc_consensus.exe -h
     - falconc -h
     - falconc rr-hctg-track2 -h
-    - falconc m4filt-contained -h
 
 about:
   home: https://github.com/bio-nim/nim-falcon


### PR DESCRIPTION
from 570776f10cd8f3c00869a50c9f68b83c6c3ef4d0

We want to move this soon. But for now, we are only trying to recover what existed before, used in the pb-assembly package. (pbipa now uses pb-falconc instead.)