### PR TITLE
Add perbase tool

### DIFF
--- a/recipes/perbase/build.sh
+++ b/recipes/perbase/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -euo
+
+# Add workaround for SSH-based Git connections from Rust/cargo.  See https://github.com/rust-lang/cargo/issues/2078 for details.
+# We set CARGO_HOME because we don't pass on HOME to conda-build, thus rendering the default "${HOME}/.cargo" defunct.
+export CARGO_NET_GIT_FETCH_WITH_CLI=true CARGO_HOME="$(pwd)/.cargo"
+
+RUST_BACKTRACE=1 cargo install --verbose --path . --root $PREFIX

--- a/recipes/perbase/meta.yaml
+++ b/recipes/perbase/meta.yaml
@@ -33,4 +33,4 @@ about:
   license: MIT
   license_family: MIT
   license_file: LICENSE
-  summary: Per-base metrics on BAM/CRAM files
+  summary: Per-base metrics on BAM/CRAM files.

--- a/recipes/perbase/meta.yaml
+++ b/recipes/perbase/meta.yaml
@@ -1,0 +1,36 @@
+{% set version = "0.1.0" %}
+{% set sha256 = "901de4b3d4b627169449d73c3873582db3139425f7675eae99be97659a229db7" %}
+
+package:
+  name: perbase
+  version: {{ version }}
+
+source:
+  url: https://github.com/sstadick/perbase/archive/v0.1.0.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 1
+
+requirements:
+  build:
+    - rust
+  host:
+    - xz
+    - zlib
+    - bzip2
+  run:
+    - xz
+    - zlib
+    - bzip2
+
+test:
+  commands:
+    - perbase -h
+
+about:
+  home: https://github.com/sstadick/perbase
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: Per-base metrics on BAM/CRAM files

--- a/recipes/perbase/meta.yaml
+++ b/recipes/perbase/meta.yaml
@@ -26,7 +26,7 @@ requirements:
 
 test:
   commands:
-    - perbase -h
+    - perbase --help
 
 about:
   home: https://github.com/sstadick/perbase

--- a/recipes/perbase/meta.yaml
+++ b/recipes/perbase/meta.yaml
@@ -10,7 +10,8 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 0
+  noarch: generic
 
 requirements:
   build:


### PR DESCRIPTION
This PR adds the tool `perbase` to bioconda. `perbase` is the initial release of a tool for per-base metrics generation. Currently it supports per-base depth with per-nucleotide resolution as well as per-base Ins/Del counts. 

I think I've followed all guidelines, please let me know if something is missing!