### PR TITLE
Update DeepBGC: Require Biopython <= 1.76

### DIFF
--- a/recipes/deepbgc/meta.yaml
+++ b/recipes/deepbgc/meta.yaml
@@ -12,36 +12,36 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   entry_points:
     - deepbgc = deepbgc.main:main
   script: python setup.py install --single-version-externally-managed --record=record.txt
 
 requirements:
   host:
-    - python>=3.5
+    - python >=3.5
     - setuptools
-    - biopython>=1.70,<=1.76 # support for structured comments from version 1.70
-    - scikit-learn>=0.18.2 # needed for antiSMASH compatibility
-    - pandas>=0.24.1
-    - numpy>=1.16.1
-    - keras>=2.2.4,<2.3.0
-    - tensorflow>=1.12.0,<2.0.0
+    - biopython >=1.70,<=1.76  # support for structured comments from version 1.70
+    - scikit-learn >=0.18.2  # needed for antiSMASH compatibility
+    - pandas >=0.24.1
+    - numpy >=1.16.1
+    - keras >=2.2.4,<2.3.0
+    - tensorflow >=1.12.0,<2.0.0
     - matplotlib-base >=2.2.3
-    - appdirs>=1.4.3
-    - pytest>=4.3.0
-    - pytest-mock>=1.10.1
-    - appdirs>=1.4.3
+    - appdirs >=1.4.3
+    - pytest >=4.3.0
+    - pytest-mock >=1.10.1
+    - appdirs >=1.4.3
   run:
     - python >=3.5
-    - biopython>=1.70 # support for structured comments from version 1.70
-    - scikit-learn>=0.18.2 # needed for antiSMASH compatibility
-    - pandas>=0.24.1
-    - numpy>=1.16.1
-    - keras>=2.2.4,<2.3.0
-    - tensorflow>=1.12.0,<2.0.0
+    - biopython >=1.70,<=1.76  # support for structured comments from version 1.70
+    - scikit-learn >=0.18.2  # needed for antiSMASH compatibility
+    - pandas >=0.24.1
+    - numpy >=1.16.1
+    - keras >=2.2.4,<2.3.0
+    - tensorflow >=1.12.0,<2.0.0
     - matplotlib-base >=2.2.3
-    - appdirs>=1.4.3
+    - appdirs >=1.4.3
     - hmmer >=3.1b2 # needed for antiSMASH compatibility
     - prodigal
 
@@ -61,4 +61,5 @@ about:
   home: https://github.com/Merck/DeepBGC
   license: MIT
   license_family: MIT
+  license_file: LICENSE
   summary: DeepBGC - Biosynthetic Gene Cluster detection and classification

--- a/recipes/deepbgc/meta.yaml
+++ b/recipes/deepbgc/meta.yaml
@@ -61,5 +61,4 @@ about:
   home: https://github.com/Merck/DeepBGC
   license: MIT
   license_family: MIT
-  license_file: LICENSE
   summary: DeepBGC - Biosynthetic Gene Cluster detection and classification

--- a/recipes/deepbgc/meta.yaml
+++ b/recipes/deepbgc/meta.yaml
@@ -21,7 +21,7 @@ requirements:
   host:
     - python>=3.5
     - setuptools
-    - biopython>=1.70 # support for structured comments from version 1.70
+    - biopython>=1.70,<=1.76 # support for structured comments from version 1.70
     - scikit-learn>=0.18.2 # needed for antiSMASH compatibility
     - pandas>=0.24.1
     - numpy>=1.16.1


### PR DESCRIPTION
Require Biopython <= 1.76 for DeepBGC recipe

@BiocondaBot please add label
