### PR TITLE
Update drop 0.9.2

### DIFF
--- a/recipes/drop/meta.yaml
+++ b/recipes/drop/meta.yaml
@@ -30,7 +30,7 @@ requirements:
 
     # snakemake/wbuild
     - snakemake >=5.5.2
-    - wbuild >=1.7.0
+    - wbuild =1.7.0
     - pandoc
     - graphviz
 

--- a/recipes/drop/meta.yaml
+++ b/recipes/drop/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "drop" %}
-{% set version = "0.9.1" %}
+{% set version = "0.9.2" %}
 
 package:
   name: "{{ name|lower }}"
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/gagneurlab/{{ name }}/archive/{{ version }}.tar.gz
-  sha256: 621733fda4b337a164d41216938d1015ca0ef8c093a21c9ecbcd062c015148cf
+  sha256: 77c2335fe550ce855e0f36464dae2d5362784e4c6785a62d3c447a61db6da4c6
 
 build:
   number: 0


### PR DESCRIPTION
New `wbuild 1.7.1` is incompatible with `drop`. Constrained to `wbuild=1.7.0` in recipe.

This should overwrite the [autobump PR](https://github.com/bioconda/bioconda-recipes/pull/24540).


Info | Link
-- | --
Recipe | recipes/drop (click to view/edit other files)
Releases | https://github.com/gagneurlab/drop/tags
Recipe Maintainer(s) | @c-mertes, @mumichae
Author | @gagneurlab
