### PR TITLE
CryptoGenotyper v1.0  bioconda release

### DIFF
--- a/recipes/cryptogenotyper/meta.yaml
+++ b/recipes/cryptogenotyper/meta.yaml
@@ -28,7 +28,6 @@ test:
   commands:
     - "cryptogenotyper -h"
     - "blastn -h"
-    - "clustalw -help"
 
 about:
     home: https://github.com/phac-nml/CryptoGenotyper

--- a/recipes/cryptogenotyper/meta.yaml
+++ b/recipes/cryptogenotyper/meta.yaml
@@ -26,7 +26,7 @@ requirements:
 
 test:
   commands:
-    - "crypto_typer -h"
+    - "cryptogenotyper -h"
     - "blastn -h"
     - "clustalw -help"
 

--- a/recipes/cryptogenotyper/meta.yaml
+++ b/recipes/cryptogenotyper/meta.yaml
@@ -1,0 +1,36 @@
+{% set version = "1.0" %}
+
+package:
+    name: cryptogenotyper
+    version: {{ version }}
+
+source:
+  url: https://github.com/phac-nml/CryptoGenotyper/archive/{{ version }}.tar.gz
+  sha256: 23a36abf10fd494a845549f2190743355ca642795419140779af8ff6090a5269
+
+build:
+    number: 0
+    noarch: python
+    script: python -m pip install --no-deps --ignore-installed .
+
+requirements:
+    host:
+        - python >=3.4
+        - pip
+    run:
+        - python >=3.4
+        - numpy >=1.15.4
+        - biopython >=1.70,<1.78
+        - blast ==2.9.0
+        - clustalw >=2.1
+
+test:
+  commands:
+    - "crypto_typer -h"
+    - "blastn -h"
+    - "clustalw -help"
+
+about:
+    home: https://github.com/phac-nml/CryptoGenotyper
+    license: Apache License, Version 2.0
+    summary: 'This package crypto_typer: tool to subtype the parasite, Cryptosporidium, based on the 18S and gp60 markers.'


### PR DESCRIPTION
First tool release on Cryptosporidium species identification. This tools helps to quickly identify this parasite and resolve chromatogram from Sanger sequencing available from [https://github.com/phac-nml/CryptoGenotyper](https://github.com/phac-nml/CryptoGenotyper)
