### PR TITLE
Update snakemake

### DIFF
--- a/recipes/snakemake/meta.yaml
+++ b/recipes/snakemake/meta.yaml
@@ -40,6 +40,7 @@ requirements:
     - imagemagick >=7.0
     - oauth2client
     - slacker
+    - xorg-libxau
 
 test:
   imports:

--- a/recipes/snakemake/meta.yaml
+++ b/recipes/snakemake/meta.yaml
@@ -40,6 +40,7 @@ requirements:
     - imagemagick >=7.0
     - oauth2client
     - slacker
+    # libXau is currently a missing dep for graphviz (linked by lib/graphviz/libgvplugin_pango.so)
     - xorg-libxau
 
 test:

--- a/recipes/snakemake/meta.yaml
+++ b/recipes/snakemake/meta.yaml
@@ -50,6 +50,8 @@ test:
     - export GIT\_PYTHON_REFRESH=warn
     - snakemake --version
     - snakemake --version | grep "{{ version }}"
+    # Generate a report to check whether graphviz dependencies (libXau) are properly installed:
+    - 'printf %s\\n "rule empty:" > Snakefile && snakemake --cores 1 --report'
 
 about:
   home: https://snakemake.github.io

--- a/recipes/snakemake/meta.yaml
+++ b/recipes/snakemake/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 94cfed2f47f6441cca6cf9d53cffdc11eb78dd1758d96c0af9cd5e453247363e
 
 build:
-  number: 0
+  number: 1
   noarch: generic
 
 requirements:

--- a/recipes/snakemake/meta.yaml
+++ b/recipes/snakemake/meta.yaml
@@ -52,6 +52,8 @@ test:
     - snakemake --version | grep "{{ version }}"
     # Generate a report to check whether graphviz dependencies (libXau) are properly installed:
     - 'printf %s\\n "rule empty:" > Snakefile && snakemake --cores 1 --report'
+    # Remove test artifacts from command above.
+    - rm -rf .snakemake Snakefile report.html
 
 about:
   home: https://snakemake.github.io


### PR DESCRIPTION
This PR adds `xorg-libxau` to the snakemake recipe as is is required by the `graphviz` dependancy.