### PR TITLE
Update macrel: add atomicwrites to dependencies

### DIFF
--- a/recipes/macrel/meta.yaml
+++ b/recipes/macrel/meta.yaml
@@ -20,12 +20,10 @@ requirements:
   build:
     - {{ compiler('c') }}
   host:
-    - python >=3.8 # [osx]
-    - python # [linux]
+    - python
     - pip
   run:
-    - python >=3.8 # [osx]
-    - python # [linux]
+    - python
     - atomicwrites
     - ngless
     - megahit

--- a/recipes/macrel/meta.yaml
+++ b/recipes/macrel/meta.yaml
@@ -11,7 +11,7 @@ source:
  sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   skip: True # [py2k]
   entry_points:
     - macrel= macrel.main:main
@@ -26,6 +26,7 @@ requirements:
   run:
     - python >=3.8 # [osx]
     - python # [linux]
+    - atomicwrites
     - ngless
     - megahit
     - paladin


### PR DESCRIPTION
Missing dependency as reported on the macrel mailing-list

https://groups.google.com/g/ampsphere-users/c/8rMtGe3MFOo

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
