### PR TITLE
Update: GMAP: bioconda recipe for version 2020.10.14

### DIFF
--- a/recipes/gmap/2020.06.30/build.sh
+++ b/recipes/gmap/2020.06.30/build.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+export C_INCLUDE_PATH=${PREFIX}/include
+export LD_LIBRARY_PATH=${PREFIX}/lib
+export LDFLAGS="-L${PREFIX}/lib"
+
+./configure --prefix=${PREFIX} --with-simd-level=sse42
+make -j 2
+make install prefix=${PREFIX}

--- a/recipes/gmap/2020.06.30/meta.yaml
+++ b/recipes/gmap/2020.06.30/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "GMAP" %}
-{% set version = "2020.10.14" %}
-{% set sha256 = "cf1166cc1381ab740b2230018a3108be4f174ea386ca9e094cf522466a9adaca" %}
+{% set version = "2020.06.30" %}
+{% set sha256 = "e60fcc85c55606503ddbd5a3ef7b5e61aecb38ac0c8a132e4aea8c8588ce38ee" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: http://research-pub.gene.com/gmap/src/gmap-gsnap-2020-10-14.tar.gz
+  url: http://research-pub.gene.com/gmap/src/gmap-gsnap-2020-06-30.tar.gz
   sha256: {{ sha256 }}
   patches:
     - single_quote_paths.patch

--- a/recipes/gmap/meta.yaml
+++ b/recipes/gmap/meta.yaml
@@ -13,7 +13,7 @@ source:
     - single_quote_paths.patch
 
 build:
-  number: 1
+  number: 0
   binary_has_prefix_files:
     - bin/atoiindex
     - bin/cmetindex

--- a/recipes/gmap/meta.yaml
+++ b/recipes/gmap/meta.yaml
@@ -13,7 +13,7 @@ source:
     - single_quote_paths.patch
 
 build:
-  number: 0
+  number: 1
   binary_has_prefix_files:
     - bin/atoiindex
     - bin/cmetindex


### PR DESCRIPTION
Update of GMAP to version 2020.10.14. This is particularly relevant since it fixes a few issues with genome dbs and alignments in special cases. 

Changelog details available at: http://research-pub.gene.com/gmap/

----
<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
