### PR TITLE
Add maf2synteny recipe

### DIFF
--- a/recipes/maf2synteny/Makefile.patch
+++ b/recipes/maf2synteny/Makefile.patch
@@ -1,0 +1,10 @@
+--- maf2synteny/Makefile	2020-10-25 19:12:17.057477058 +0700
++++ Makefile	2020-10-25 16:29:02.000000000 +0700
+@@ -1,6 +1,6 @@
+ SRC := src
+ export BIN_DIR = $(shell pwd)
+-export CXXFLAGS := -std=c++0x
++export CXXFLAGS := -std=c++0x -fPIE
+ 
+ .PHONY: clean all
+ 

--- a/recipes/maf2synteny/build.sh
+++ b/recipes/maf2synteny/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+make
+
+install -d "${PREFIX}/bin"
+install maf2synteny "${PREFIX}/bin/"

--- a/recipes/maf2synteny/meta.yaml
+++ b/recipes/maf2synteny/meta.yaml
@@ -1,0 +1,31 @@
+{% set version = "1.0" %}
+{% set sha256 = "e5757f4c83342d06032ca0a20683a3713ef2cf6e119024e7ca753522f3936539" %}
+
+package:
+  name: maf2synteny
+  version: {{ version }}
+
+source:
+  url: https://github.com/fenderglass/maf2synteny/archive/{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+  patches:
+    - Makefile.patch
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+
+test:
+  commands:
+    - maf2synteny -h
+
+about:
+  home: https://github.com/fenderglass/maf2synteny
+  license: BSD
+  license_file: LICENSE
+  summary: 'A tool that postprocesses whole genome alignment (for two or more genomes) and produces coarse-grained synteny blocks.'
+


### PR DESCRIPTION
Add maf2synteny, a synteny block generator from MAF multiple whole-genome alignments. Project URL: https://github.com/fenderglass/maf2synteny.
