### PR TITLE
Update cd-hit-auxtools

### DIFF
--- a/recipes/cd-hit-auxtools/meta.yaml
+++ b/recipes/cd-hit-auxtools/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "4.6.8" %}
-{% set sha256 = "37d685e4aa849314401805fe4d4db707e1d06070368475e313d6f3cb8fb65949" %}
+{% set version = "4.8.1" %}
+{% set sha256 = "f8bc3cdd7aebb432fcd35eed0093e7a6413f1e36bbd2a837ebc06e57cdb20b70" %}
 
 package:
   name: cd-hit-auxtools

--- a/recipes/cd-hit-auxtools/meta.yaml
+++ b/recipes/cd-hit-auxtools/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 0001-Append-compiler-linker-flags.patch
 
 build:
-  number: 2
+  number: 0
 
 requirements:
   build:


### PR DESCRIPTION
Update cd-hit-auxtools to the current version 4.8.1

Project repository can be found here https://github.com/weizhongli/cdhit
