### PR TITLE
Update HTSlib recipe: patches to fix https/S3/GCS/etc plugins

### DIFF
--- a/recipes/htslib/meta.yaml
+++ b/recipes/htslib/meta.yaml
@@ -5,13 +5,15 @@ package:
   version: {{ version }}
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage('htslib', max_pin='x.x') }}
 
 source:
   url: https://github.com/samtools/htslib/releases/download/{{ version }}/htslib-{{ version }}.tar.bz2
   sha256: cffadd9baa6fce27b8fe0b01a462b489f06a5433dfe92121f667f40f632538d7
+  patches:
+    - plugin-fixes.patch
 
 requirements:
   build:

--- a/recipes/htslib/plugin-fixes.patch
+++ b/recipes/htslib/plugin-fixes.patch
@@ -1,0 +1,31 @@
+Backport variable name used in dlsym typo correction.
+Revert "Link libhts.so into plugins on Unix&macOS" on macOS.
+
+diff --git a/plugin.c b/plugin.c
+index dbbe03e..d5c1981 100644
+--- a/plugin.c
++++ b/plugin.c
+@@ -153,7 +153,7 @@ plugin_void_func *load_plugin(void **pluginp, const char *filename, const char *
+         const char *basename = slash? slash+1 : filename;
+         kputsn(basename, strcspn(basename, ".-+"), &symbolg);
+ 
+-        *(void **) &sym = dlsym(lib, symbol);
++        *(void **) &sym = dlsym(lib, symbolg.s);
+         free(symbolg.s);
+         if (sym == NULL) goto error;
+     }
+diff --git a/Makefile b/Makefile
+index 245b7a1..3bb21ad 100644
+--- a/Makefile
++++ b/Makefile
+@@ -310,8 +310,8 @@ hts-object-files: $(LIBHTS_OBJS)
+ %.so: %.pico libhts.so
+ 	$(CC) -shared -Wl,-E $(LDFLAGS) -o $@ $< libhts.so $(LIBS) -lpthread
+ 
+-%.bundle: %.o libhts.dylib
+-	$(CC) -bundle -Wl,-undefined,dynamic_lookup $(LDFLAGS) -o $@ $< libhts.dylib $(LIBS)
++%.bundle: %.o
++	$(CC) -bundle -Wl,-undefined,dynamic_lookup $(LDFLAGS) -o $@ $< $(LIBS)
+ 
+ %.cygdll: %.o libhts.dll.a
+ 	$(CC) -shared $(LDFLAGS) -o $@ $< libhts.dll.a $(LIBS)


### PR DESCRIPTION
Changes between HTSlib 1.10 and 1.11 have led to samtools/htslib#1176, preventing programs using bioconda's htslib from accessing files remotely over HTTPS, S3, etc. This problem will be fixed in upstream HTSlib in due course; this PR applies patches to fix the bioconda package in the meantime:

* Apply samtools/htslib#1150 to fix some externally-supplied plugins such as iRODS access;

* Revert part of samtools/htslib#1072 to fix the main HTTPS/S3/etc issue. This simply reverts the macOS part of this as it was unnecessary on macOS anyway (Linux was unaffected by the bug).

Patches applicable to HTSlib 1.11; will not be needed for future upstream versions.