### PR TITLE
Fix bioconductor-cardinal 2.8.0 build

### DIFF
--- a/build-fail-blacklist
+++ b/build-fail-blacklist
@@ -1326,7 +1326,6 @@ recipes/r-stitch
 recipes/r-zerone
 
 # Fails on OSX
-recipes/bioconductor-cardinal
 recipes/bioconductor-cydar
 recipes/bioconductor-cytofast
 recipes/bioconductor-cytoml

--- a/recipes/bioconductor-cardinal/buildfixes.patch
+++ b/recipes/bioconductor-cardinal/buildfixes.patch
@@ -1,0 +1,15 @@
+diff --git a/src/Cardinal.h b/src/Cardinal.h
+index 2a1cd25..b14a8bf 100644
+--- a/src/Cardinal.h
++++ b/src/Cardinal.h
+@@ -4,10 +4,7 @@
+ 
+ #define R_NO_REMAP
+ 
+-extern "C"
+-{
+   #include <Rinternals.h>
+-}
+ 
+ #include "utils.h"
+ 

--- a/recipes/bioconductor-cardinal/meta.yaml
+++ b/recipes/bioconductor-cardinal/meta.yaml
@@ -11,8 +11,10 @@ source:
     - 'https://bioarchive.galaxyproject.org/{{ name }}_{{ version }}.tar.gz'
     - 'https://depot.galaxyproject.org/software/bioconductor-{{ name|lower }}/bioconductor-{{ name|lower }}_{{ version }}_src_all.tar.gz'
   md5: e358ff115c2546a210a758a29a5401c2
+  patches:
+    - buildfixes.patch
 build:
-  number: 0
+  number: 1
   rpaths:
     - lib/R/lib/
     - lib/


### PR DESCRIPTION
`<Rinternals.h>` provides its own `extern "C"`, and on macOS wrapping it again catches some C++ headers, leading to errors. (Assuming this has no adverse effects on Linux, I'll send this patch upstream too.)