### PR TITLE
Fix bioconductor-cytolib on macOS and rebuild dependent packages

### DIFF
--- a/recipes/bioconductor-cytolib/dyextension.patch
+++ b/recipes/bioconductor-cytolib/dyextension.patch
@@ -1,0 +1,13 @@
+diff --git a/R/build.R b/R/build.R
+index b4ed0ed..56844a1 100644
+--- a/R/build.R
++++ b/R/build.R
+@@ -55,7 +55,7 @@ cytolibLdFlags <- function() {
+ cytolibLibPath <- function(suffix = "") {
+    sysname <- Sys.info()['sysname']
+    cytolibSupported <- list(
+-      "Darwin" = paste("cytolib", suffix, ".so", sep = ""), 
++      "Darwin" = paste("cytolib", suffix, ".dylib", sep = ""),
+       "Linux" = paste("cytolib", suffix, ".so", sep = ""), 
+       "Windows" = paste("libcytolib", suffix, ".a", sep = ""),
+       "SunOS" = paste("cytolib", suffix, ".so", sep = "")

--- a/recipes/bioconductor-cytolib/meta.yaml
+++ b/recipes/bioconductor-cytolib/meta.yaml
@@ -11,8 +11,10 @@ source:
     - 'https://bioarchive.galaxyproject.org/{{ name }}_{{ version }}.tar.gz'
     - 'https://depot.galaxyproject.org/software/bioconductor-{{ name }}/bioconductor-{{ name }}_{{ version }}_src_all.tar.gz'
   md5: e86e6d9d880bbfdc85bceb973467edfb
+  patches:
+    - dyextension.patch
 build:
-  number: 0
+  number: 1
   rpaths:
     - lib/R/lib/
     - lib/


### PR DESCRIPTION
At least with Bioconductor 3.12, R library shared libraries on macOS do have the usual _.dylib_ extension. Patch bioconductor-cytolib to adjust `cytolibLibPath()` accordingly.

~Then enable building and bump the build numbers for all the bioconductor-* packages that depend on this library.~