### PR TITLE
Rebuild packages that depend on bioconductor-cytolib

### DIFF
--- a/build-fail-blacklist
+++ b/build-fail-blacklist
@@ -1319,22 +1319,8 @@ recipes/r-stitch
 recipes/r-zerone
 
 # Fails on OSX
-recipes/bioconductor-cydar
-recipes/bioconductor-cytofast
-recipes/bioconductor-cytoml
-recipes/bioconductor-cytotree
-recipes/bioconductor-flowclust
-recipes/bioconductor-flowcore
-recipes/bioconductor-flowfp
-recipes/bioconductor-flowmatch
-recipes/bioconductor-flowsom
-recipes/bioconductor-flowspy
-recipes/bioconductor-flowworkspace
 recipes/bioconductor-gmapr
-recipes/bioconductor-immunoclust
 recipes/bioconductor-macpet
-recipes/bioconductor-ncdfflow
-recipes/bioconductor-opencyto
 recipes/bioconductor-qckitfastq
 recipes/bioconductor-quasr
 recipes/bioconductor-rbowtie

--- a/recipes/bioconductor-cydar/meta.yaml
+++ b/recipes/bioconductor-cydar/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 'https://depot.galaxyproject.org/software/bioconductor-{{ name }}/bioconductor-{{ name }}_{{ version }}_src_all.tar.gz'
   md5: 14960771a2c34e9ea07b12fb1e4a7dd9
 build:
-  number: 0
+  number: 1
   rpaths:
     - lib/R/lib/
     - lib/

--- a/recipes/bioconductor-cytofast/meta.yaml
+++ b/recipes/bioconductor-cytofast/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 'https://depot.galaxyproject.org/software/bioconductor-{{ name }}/bioconductor-{{ name }}_{{ version }}_src_all.tar.gz'
   md5: 6ac0a15cc689d5f1cd0be744a7e82640
 build:
-  number: 0
+  number: 1
   rpaths:
     - lib/R/lib/
     - lib/

--- a/recipes/bioconductor-cytoml/meta.yaml
+++ b/recipes/bioconductor-cytoml/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.2.0" %}
+{% set version = "2.2.1" %}
 {% set name = "CytoML" %}
 {% set bioc = "3.12" %}
 
@@ -10,7 +10,7 @@ source:
     - 'https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/{{ name }}_{{ version }}.tar.gz'
     - 'https://bioarchive.galaxyproject.org/{{ name }}_{{ version }}.tar.gz'
     - 'https://depot.galaxyproject.org/software/bioconductor-{{ name|lower }}/bioconductor-{{ name|lower }}_{{ version }}_src_all.tar.gz'
-  md5: 546ff946bde3d089119e7dd4bd091deb
+  md5: f576108f0a4c938e007344013dd1ed64
 build:
   number: 0
   rpaths:

--- a/recipes/bioconductor-cytotree/meta.yaml
+++ b/recipes/bioconductor-cytotree/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.0.2" %}
+{% set version = "1.0.3" %}
 {% set name = "CytoTree" %}
 {% set bioc = "3.12" %}
 
@@ -10,7 +10,7 @@ source:
     - 'https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/{{ name }}_{{ version }}.tar.gz'
     - 'https://bioarchive.galaxyproject.org/{{ name }}_{{ version }}.tar.gz'
     - 'https://depot.galaxyproject.org/software/bioconductor-{{ name|lower }}/bioconductor-{{ name|lower }}_{{ version }}_src_all.tar.gz'
-  md5: 4434f4284fe2e81d2bdfb063c836e1a6
+  md5: 5f5c264b11fa159315fc9e00141cd2a3
 build:
   number: 0
   rpaths:

--- a/recipes/bioconductor-flowclust/meta.yaml
+++ b/recipes/bioconductor-flowclust/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 'https://depot.galaxyproject.org/software/bioconductor-{{ name|lower }}/bioconductor-{{ name|lower }}_{{ version }}_src_all.tar.gz'
   md5: 2d3dcaa969333d4349d27ac632842c98
 build:
-  number: 0
+  number: 1
   rpaths:
     - lib/R/lib/
     - lib/

--- a/recipes/bioconductor-flowcore/meta.yaml
+++ b/recipes/bioconductor-flowcore/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 'https://depot.galaxyproject.org/software/bioconductor-{{ name|lower }}/bioconductor-{{ name|lower }}_{{ version }}_src_all.tar.gz'
   md5: 91e684d2d8b4dce1b428623af4f0e5a6
 build:
-  number: 0
+  number: 1
   rpaths:
     - lib/R/lib/
     - lib/

--- a/recipes/bioconductor-flowfp/meta.yaml
+++ b/recipes/bioconductor-flowfp/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 'https://depot.galaxyproject.org/software/bioconductor-{{ name|lower }}/bioconductor-{{ name|lower }}_{{ version }}_src_all.tar.gz'
   md5: d531813828d4146460b0ad96480b1154
 build:
-  number: 0
+  number: 1
   rpaths:
     - lib/R/lib/
     - lib/

--- a/recipes/bioconductor-flowmatch/meta.yaml
+++ b/recipes/bioconductor-flowmatch/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 'https://depot.galaxyproject.org/software/bioconductor-{{ name|lower }}/bioconductor-{{ name|lower }}_{{ version }}_src_all.tar.gz'
   md5: 50d8d33e231da92626959bac1f9097b4
 build:
-  number: 0
+  number: 1
   rpaths:
     - lib/R/lib/
     - lib/

--- a/recipes/bioconductor-flowsom/meta.yaml
+++ b/recipes/bioconductor-flowsom/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 'https://depot.galaxyproject.org/software/bioconductor-{{ name|lower }}/bioconductor-{{ name|lower }}_{{ version }}_src_all.tar.gz'
   md5: 0b3ed517ffa60ece0dc570cff28f3102
 build:
-  number: 0
+  number: 1
   rpaths:
     - lib/R/lib/
     - lib/

--- a/recipes/bioconductor-flowspy/meta.yaml
+++ b/recipes/bioconductor-flowspy/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 'https://depot.galaxyproject.org/software/bioconductor-{{ name|lower }}/bioconductor-{{ name|lower }}_{{ version }}_src_all.tar.gz'
   md5: 830236ad7171c51a75182ec5e79a60e2
 build:
-  number: 0
+  number: 1
   rpaths:
     - lib/R/lib/
     - lib/

--- a/recipes/bioconductor-flowworkspace/meta.yaml
+++ b/recipes/bioconductor-flowworkspace/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 'https://depot.galaxyproject.org/software/bioconductor-{{ name|lower }}/bioconductor-{{ name|lower }}_{{ version }}_src_all.tar.gz'
   md5: be33b717762a7ec832b28fefad7c671a
 build:
-  number: 0
+  number: 1
   rpaths:
     - lib/R/lib/
     - lib/

--- a/recipes/bioconductor-immunoclust/meta.yaml
+++ b/recipes/bioconductor-immunoclust/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 'https://depot.galaxyproject.org/software/bioconductor-{{ name|lower }}/bioconductor-{{ name|lower }}_{{ version }}_src_all.tar.gz'
   md5: 6e84e0b42638123e20c964a536780ee6
 build:
-  number: 0
+  number: 1
   rpaths:
     - lib/R/lib/
     - lib/

--- a/recipes/bioconductor-ncdfflow/meta.yaml
+++ b/recipes/bioconductor-ncdfflow/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 'https://depot.galaxyproject.org/software/bioconductor-{{ name|lower }}/bioconductor-{{ name|lower }}_{{ version }}_src_all.tar.gz'
   md5: c60d11ee9f5c4a260096b128cf85644e
 build:
-  number: 0
+  number: 1
   rpaths:
     - lib/R/lib/
     - lib/

--- a/recipes/bioconductor-opencyto/meta.yaml
+++ b/recipes/bioconductor-opencyto/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 'https://depot.galaxyproject.org/software/bioconductor-{{ name|lower }}/bioconductor-{{ name|lower }}_{{ version }}_src_all.tar.gz'
   md5: ea991d8f53811caae5a761cfd911a306
 build:
-  number: 0
+  number: 1
   rpaths:
     - lib/R/lib/
     - lib/


### PR DESCRIPTION
Followup to PR #25292. This rebuilds recipes/bioconductor-cydar, -cyto*, -flow*, -immunoclust, -ncdfflow, and -opencyto — it appears (from the previous build logs) that this needs to be done in two stages to ensure that the dependent packages are built using the freshly-built corrected bioconductor-cytolib from the previous PR.

For CytoML and CytoTree, it seems that while these have been listed in _build-fail-blacklist_ the upstream versions present in Bioconductor have changed. So this PR updates them to the upstream version actually present in Bioconductor 3.12 rather than bumping the build numbers as for the other dozen packages. (Just bumping the build number for these two wasn't enough: trying to download the non-bioc-3.12 source tarballs just resulted in 404.)