### PR TITLE
Fix bioconductor-rbowtie build on macOS

### DIFF
--- a/build-fail-blacklist
+++ b/build-fail-blacklist
@@ -1309,7 +1309,6 @@ recipes/bioconductor-gmapr
 recipes/bioconductor-macpet
 recipes/bioconductor-qckitfastq
 recipes/bioconductor-quasr
-recipes/bioconductor-rbowtie
 recipes/r-misha
 
 # Missing tarball

--- a/recipes/bioconductor-rbowtie/build.sh
+++ b/recipes/bioconductor-rbowtie/build.sh
@@ -4,7 +4,7 @@ grep -v '^Priority: ' DESCRIPTION.old > DESCRIPTION
 mkdir -p ~/.R
 echo -e "CC=$CC
 FC=$FC
-CXX=$CXX -headerpad
+CXX=$CXX
 CXX98=$CXX
 CXX11=$CXX
 CXX14=$CXX" > ~/.R/Makevars

--- a/recipes/bioconductor-rbowtie/ldflags.patch
+++ b/recipes/bioconductor-rbowtie/ldflags.patch
@@ -1,0 +1,41 @@
+diff --git a/src/SpliceMap/Makefile b/src/SpliceMap/Makefile
+index 47b853d..3047d14 100644
+--- a/src/SpliceMap/Makefile
++++ b/src/SpliceMap/Makefile
+@@ -8,6 +8,7 @@
+ #CXXFLAGS=`"${R_HOME}/bin/R" CMD config CXXFLAGS`
+ CXX=`"${R_HOME}/bin/R" CMD config CXX`
+ CXXFLAGS=`"${R_HOME}/bin/R" CMD config CXXFLAGS`
++LDFLAGS=`"${R_HOME}/bin/R" CMD config LDFLAGS`
+ 
+ all: SpliceMap
+ 
+@@ -15,22 +16,22 @@ clean:
+ 	rm *.o SpliceMap runSpliceMap_QuasR sortsam amalgamateSAM getSpliceMapUnmapped fuseReorder
+ 
+ SpliceMap: runSpliceMap_QuasR sortsam amalgamateSAM getSpliceMapUnmapped fuseReorder params.o cfgfile.o SpliceMap_utils_QuasR.o main.cpp main.h
+-	$(CXX) $(CXXFLAGS) -o SpliceMap main.cpp SpliceMap_utils_QuasR.o params.o cfgfile.o
++	$(CXX) $(LDFLAGS) $(CXXFLAGS) -o SpliceMap main.cpp SpliceMap_utils_QuasR.o params.o cfgfile.o
+ 
+ runSpliceMap_QuasR: SpliceMap_utils_QuasR.o params.o cfgfile.o runSpliceMap_QuasR.cpp runSpliceMap_QuasR.h 
+-	$(CXX) $(CXXFLAGS) -o runSpliceMap_QuasR SpliceMap_utils_QuasR.o cfgfile.o runSpliceMap_QuasR.cpp params.o
++	$(CXX) $(LDFLAGS) $(CXXFLAGS) -o runSpliceMap_QuasR SpliceMap_utils_QuasR.o cfgfile.o runSpliceMap_QuasR.cpp params.o
+ 
+ sortsam: sortsam.cpp sortsam.h SpliceMap_utils_QuasR.o params.o
+-	$(CXX) $(CXXFLAGS) -o sortsam sortsam.cpp SpliceMap_utils_QuasR.o params.o
++	$(CXX) $(LDFLAGS) $(CXXFLAGS) -o sortsam sortsam.cpp SpliceMap_utils_QuasR.o params.o
+ 
+ amalgamateSAM: amalgamateSAM.cpp amalgamateSAM.h SpliceMap_utils_QuasR.o params.o
+-	$(CXX) $(CXXFLAGS) -o amalgamateSAM amalgamateSAM.cpp SpliceMap_utils_QuasR.o params.o
++	$(CXX) $(LDFLAGS) $(CXXFLAGS) -o amalgamateSAM amalgamateSAM.cpp SpliceMap_utils_QuasR.o params.o
+ 
+ getSpliceMapUnmapped: getSpliceMapUnmapped.cpp
+-	$(CXX) $(CXXFLAGS) -o getSpliceMapUnmapped getSpliceMapUnmapped.cpp
++	$(CXX) $(LDFLAGS) $(CXXFLAGS) -o getSpliceMapUnmapped getSpliceMapUnmapped.cpp
+ 
+ fuseReorder: fuseReorder.cpp
+-	$(CXX) $(CXXFLAGS) -o fuseReorder fuseReorder.cpp
++	$(CXX) $(LDFLAGS) $(CXXFLAGS) -o fuseReorder fuseReorder.cpp
+ 
+ SpliceMap_utils_QuasR.o: SpliceMap_utils_QuasR.cpp SpliceMap_utils_QuasR.h
+ 	$(CXX) $(CXXFLAGS) -c SpliceMap_utils_QuasR.cpp

--- a/recipes/bioconductor-rbowtie/meta.yaml
+++ b/recipes/bioconductor-rbowtie/meta.yaml
@@ -11,8 +11,10 @@ source:
     - 'https://bioarchive.galaxyproject.org/{{ name }}_{{ version }}.tar.gz'
     - 'https://depot.galaxyproject.org/software/bioconductor-{{ name|lower }}/bioconductor-{{ name|lower }}_{{ version }}_src_all.tar.gz'
   md5: 4bc513afbcdfcf0354377fffad908e6e
+  patches:
+    - ldflags.patch
 build:
-  number: 0
+  number: 1
   rpaths:
     - lib/R/lib/
     - lib/


### PR DESCRIPTION
This was failing due to no `-headerpad` option being used when building the executables down in src/SpliceMap. Patch the Makefile to use R's LDFLAGS (alongside the existing R's CXXFLAGS) when building these executables, as (at least with conda's R) that provides `‑Wl,‑headerpad_max_install_names`.

@mbstadler: I'm happy to make a PR against **fmicompbio/Rbowtie** once this has demonstrated that it builds successfully on both Linux and macOS. Or if you want to apply _ldflags.patch_ to the repository yourself in due course, that's probably even easier.