### PR TITLE
Rebuild packages that depend on bioconductor-rbowtie

### DIFF
--- a/build-fail-blacklist
+++ b/build-fail-blacklist
@@ -1305,9 +1305,7 @@ recipes/r-zerone
 
 # Fails on OSX
 recipes/bioconductor-gmapr
-recipes/bioconductor-macpet
 recipes/bioconductor-qckitfastq
-recipes/bioconductor-quasr
 recipes/r-misha
 
 # Missing tarball

--- a/recipes/bioconductor-macpet/meta.yaml
+++ b/recipes/bioconductor-macpet/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 'https://depot.galaxyproject.org/software/bioconductor-{{ name|lower }}/bioconductor-{{ name|lower }}_{{ version }}_src_all.tar.gz'
   md5: 1bc7c8b71eaf1281f43d28693820402c
 build:
-  number: 0
+  number: 1
   rpaths:
     - lib/R/lib/
     - lib/

--- a/recipes/bioconductor-quasr/meta.yaml
+++ b/recipes/bioconductor-quasr/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 'https://depot.galaxyproject.org/software/bioconductor-{{ name|lower }}/bioconductor-{{ name|lower }}_{{ version }}_src_all.tar.gz'
   md5: 5b6157ae70b4df1b8c5c4f033c64b2c6
 build:
-  number: 0
+  number: 1
   rpaths:
     - lib/R/lib/
     - lib/


### PR DESCRIPTION
Now that PR #25327 has fixed bioconductor-rbowtie on macOS, rebuild packages that depend on it.