### PR TITLE
Fix bioconductor-gmapr build on macOS

### DIFF
--- a/build-fail-blacklist
+++ b/build-fail-blacklist
@@ -1301,7 +1301,6 @@ recipes/r-stitch
 recipes/r-zerone
 
 # Fails on OSX
-recipes/bioconductor-gmapr
 recipes/bioconductor-qckitfastq
 recipes/r-misha
 

--- a/recipes/bioconductor-gmapr/build.sh
+++ b/recipes/bioconductor-gmapr/build.sh
@@ -8,4 +8,6 @@ CXX=$CXX
 CXX98=$CXX
 CXX11=$CXX
 CXX14=$CXX" > ~/.R/Makevars
+# Remove object files (if present) that should not be in the source tarball
+rm -f src/samtools/*.[oa]
 $R CMD INSTALL --build .

--- a/recipes/bioconductor-gmapr/meta.yaml
+++ b/recipes/bioconductor-gmapr/meta.yaml
@@ -11,8 +11,10 @@ source:
     - 'https://bioarchive.galaxyproject.org/{{ name }}_{{ version }}.tar.gz'
     - 'https://depot.galaxyproject.org/software/bioconductor-{{ name|lower }}/bioconductor-{{ name|lower }}_{{ version }}_src_all.tar.gz'
   md5: d0c0244da3538780ab07c6b88b431db2
+  patches:
+    - shlib_ext.patch
 build:
-  number: 0
+  number: 1
   rpaths:
     - lib/R/lib/
     - lib/

--- a/recipes/bioconductor-gmapr/shlib_ext.patch
+++ b/recipes/bioconductor-gmapr/shlib_ext.patch
@@ -1,0 +1,13 @@
+diff --git a/src/Makefile b/src/Makefile
+index 769ba52..406af26 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -29,7 +29,7 @@ DFLAGS = -D_USE_KNETFILE -D_FILE_OFFSET_BITS=64 \
+ PKG_CPPFLAGS += -I$(INCLUDE_DIR)
+ PKG_LIBS += $(GSTRUCT_LIB) $(SAMTOOLS_LIB) -lz
+ 
+-SHLIB = gmapR.so
++SHLIB = gmapR$(SHLIB_EXT)
+ 
+ all: $(SHLIB) gmap
+ 


### PR DESCRIPTION
Build the shared library as `gmapR$(SHLIB_EXT)` rather than hard-coding the filename `gmapR.so`.

Ensure that `src/samtools/*.[oa]` gets rebuilt — in gmapR_1.32.0.tar.gz at least, the source tarball incorrectly already contains built-for-Linux `*.o` files, which breaks building on other platforms.