### PR TITLE
Fix bioconductor-qckitfastq build on macOS

### DIFF
--- a/build-fail-blacklist
+++ b/build-fail-blacklist
@@ -1301,7 +1301,6 @@ recipes/r-stitch
 recipes/r-zerone
 
 # Fails on OSX
-recipes/bioconductor-qckitfastq
 recipes/r-misha
 
 # Missing tarball

--- a/recipes/bioconductor-qckitfastq/meta.yaml
+++ b/recipes/bioconductor-qckitfastq/meta.yaml
@@ -11,8 +11,11 @@ source:
     - 'https://bioarchive.galaxyproject.org/{{ name }}_{{ version }}.tar.gz'
     - 'https://depot.galaxyproject.org/software/bioconductor-{{ name }}/bioconductor-{{ name }}_{{ version }}_src_all.tar.gz'
   md5: 38b274f57ce99990e00e1b79ea50bf82
+  patches:
+    # Patch can be removed when MACOSX_DEPLOYMENT_TARGET >= 10.12
+    - shared_timed_mutex.patch
 build:
-  number: 0
+  number: 1
   rpaths:
     - lib/R/lib/
     - lib/

--- a/recipes/bioconductor-qckitfastq/shared_timed_mutex.patch
+++ b/recipes/bioconductor-qckitfastq/shared_timed_mutex.patch
@@ -1,0 +1,20 @@
+Avoid enumerable_thread_local.h and enumerable_thread_local_iterator.h,
+which are included via <seqan/find.h>.
+
+These headers use std::shared_timed_mutex, which is not available in Apple's
+system libc++ prior to macOS 10.12. However calc_adapter_content.cpp does not
+in fact use these classes, so it suffices to avoid including the headers.
+
+diff --git a/src/calc_adapter_content.cpp b/src/calc_adapter_content.cpp
+index ef13e4d..6863322 100644
+--- a/src/calc_adapter_content.cpp
++++ b/src/calc_adapter_content.cpp
+@@ -4,6 +4,8 @@
+ #include "gzstream.h"
+ #include "zlib.h"
+ #ifndef __WIN32
++#define INCLUDE_SEQAN_ALIGN_PARALLEL_ENUMERABLE_THREAD_LOCAL_H_
++#define INCLDUE_SEQAN_ALIGN_PARALLEL_ENUMERABLE_THREAD_LOCAL_ITERATOR_H_
+ #include <seqan/find.h>
+ #include <seqan/sequence.h>
+ #endif


### PR DESCRIPTION
Rather than futz around with `MACOSX_DEPLOYMENT_TARGET`, simply patch to avoid the problematic header — which is not needed in any way by the code anyway.

Avoid #including an unneeded seqan header that uses a std datatype that's not available in macOS's libc++ prior to macOS 10.12. This patch can be removed when `MACOSX_DEPLOYMENT_TARGET` is raised past 10.12.