### PR TITLE
Update vcf2maf: use most recent sha256sum

### DIFF
--- a/recipes/vcf2maf/meta.yaml
+++ b/recipes/vcf2maf/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "1.6.18" %}
-{% set sha256 = "c69c9c8a0b1a141a88d1f6facefc92013d0a740c63e1c1ae66037022dd00cb80" %}
+{% set sha256 = "4740b9621c0e3d7105eed0be32870e190b1e798d1dc53069836837d3296338b9" %}
 
 package:
   name: vcf2maf
@@ -7,11 +7,11 @@ package:
 
 build:
   noarch: generic
-  number: 1
+  number: 2
 
 source:
   url: https://github.com/mskcc/vcf2maf/archive/v{{ version }}.tar.gz
-  sha256: dc0058ac9b0a8173a77646afe6f74a3e639f9cafa919cf8c0ad284c0adc4cfc8
+  sha256: '{{ sha256 }}'
 
 requirements:
   run:


### PR DESCRIPTION
Updating vcf2maf to use the most recent v1.6.18 tagged release. 
Note that it seems this release keeps on getting updated (most recently on August 13th 2020) but not re-tagged.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
