### PR TITLE
Use extended image for irida-uploader

### DIFF
--- a/recipes/irida-uploader/meta.yaml
+++ b/recipes/irida-uploader/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: cbda43597711a080972d8ae799704b5fbbc8d1a942aa8789ce4b9b3c8c3e1b37
 
 build:
-  number: 0
+  number: 1
   noarch: generic
   entry_points:
     - irida-uploader=iridauploader.core.cli:main
@@ -48,3 +48,7 @@ about:
   author: Jeffrey Thiessen
   doc_url: 'https://irida-uploader.readthedocs.io/en/latest'
   dev_url: 'https://github.com/phac-nml/irida-uploader'
+
+extra:
+  container:
+    extended-base: True


### PR DESCRIPTION
irida-uploader use DNS resolution as part of its upload process. The default busybox based image used for bioconda has [broken resolv.conf](https://github.com/bioconda/bioconda-recipes/issues/11583) when used as a bases for Singularity images. This patch switches the irida-uploader recipt to use the extended image to resolve this problem.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
