### PR TITLE
Fix r-misha build on macOS

### DIFF
--- a/build-fail-blacklist
+++ b/build-fail-blacklist
@@ -1297,9 +1297,6 @@ recipes/r-qorts
 recipes/r-stitch
 recipes/r-zerone
 
-# Fails on OSX
-recipes/r-misha
-
 # Missing tarball
 recipes/r-prestor
 recipes/r-ngsplot-hg19

--- a/recipes/r-misha/meta.yaml
+++ b/recipes/r-misha/meta.yaml
@@ -7,9 +7,12 @@ package:
 source:
   url: 'https://github.com/tanaylab/misha/archive/4.0.10.zip'
   sha256: 94395cecac6125a30444a91d1dc8634eef28a51693660f2c53a44dc600790479
+  patches:
+    # Remove if misha updates such that src/FileUtils.cpp compiles on macOS
+    - omit-FileUtils.patch
 
 build:
-  number: 0
+  number: 1
   rpaths:
     - lib/R/lib
     - lib/

--- a/recipes/r-misha/omit-FileUtils.patch
+++ b/recipes/r-misha/omit-FileUtils.patch
@@ -1,0 +1,46 @@
+This code does not compile on non-Linux platforms as it uses Linux's sendfile.
+Fortunately it is currently unused anyway.
+
+diff --git a/src/FileUtils.cpp b/src/FileUtils.cpp
+index ffbe0f0..b85affb 100644
+--- a/src/FileUtils.cpp
++++ b/src/FileUtils.cpp
+@@ -3,13 +3,13 @@
+ #include <stdio.h>
+ #include <string.h>
+ #include <unistd.h>
+-#include <sys/sendfile.h>
+ #include <sys/stat.h>
+ #include <sys/types.h>
+ 
+ #include "FileUtils.h"
+ #include "TGLException.h"
+ 
++#if 0
+ struct FD {
+     int fd{-1};
+     ~FD() {
+@@ -48,3 +48,4 @@ void FileUtils::move_file(const char *src, const char *tgt)
+             TGLError(errno, "Error moving file %s to %s: %s\n", src, tgt);
+     }
+ }
++#endif
+diff --git a/src/FileUtils.h b/src/FileUtils.h
+index 3f141a7..320a1f3 100644
+--- a/src/FileUtils.h
++++ b/src/FileUtils.h
+@@ -1,6 +1,7 @@
+ #ifndef FILEUTILS_H_INCLUDED
+ #define FILEUTILS_H_INCLUDED
+ 
++#if 0
+ namespace FileUtils {
+     // Makes a fast copy of a file while preserving permissions.
+     // Throws TGLException on error, TGLException::code contains errno.
+@@ -10,5 +11,6 @@ namespace FileUtils {
+     // Throws TGLException on error, TGLException::code contains errno.
+     void move_file(const char *src, const char *tgt);
+ }
++#endif
+ 
+ #endif


### PR DESCRIPTION
A bonus post-hackathon PR to eliminate this “Fails on OSX” section of _build-fail-blacklist_…

This package contains code that uses a Linux-specific `sendfile()` system call. Fortunately the code in question (`FileUtils::copy_file()`/`move_file()`) is unused anyway, so we just patch to remove the problematic code.

Implementing an additional alternative instead so the code compiles everywhere has been proposed upstream in PR tanaylab/misha#2.