### PR TITLE
encyclopedia and mpa-portable: add fonts and fix permissions

### DIFF
--- a/recipes/encyclopedia/meta.yaml
+++ b/recipes/encyclopedia/meta.yaml
@@ -7,7 +7,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 0
+  number: 1
   noarch: generic
 
 source:
@@ -16,7 +16,7 @@ source:
 
 requirements:
   run:
-    - openjdk >=8
+    - openjdk >=11
     - python
 
 test:

--- a/recipes/mpa-portable/build.sh
+++ b/recipes/mpa-portable/build.sh
@@ -11,3 +11,5 @@ chmod 0755 "${PREFIX}/bin/mpa-portable"
 if [ -f $outdir/built/Comet/linux/comet.exe ] ; then chmod 0755 $outdir/built/Comet/linux/comet.exe ; fi
 if [ -f $outdir/built/X!Tandem/linux/linux_64bit/tandem ] ; then chmod 0755 $outdir/built/X!Tandem/linux/linux_64bit/tandem ; fi
 if [ -f $outdir/built/X!Tandem/linux/linux_32bit/tandem ] ; then chmod 0755 $outdir/built/X!Tandem/linux/linux_32bit/tandem ; fi
+find $outdir/ -type f -exec chmod ugo+r {} \;
+find $outdir/ -type d -exec chmod ugo+rx {} \;

--- a/recipes/mpa-portable/meta.yaml
+++ b/recipes/mpa-portable/meta.yaml
@@ -7,16 +7,17 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/compomics/meta-proteome-analyzer/releases/download/v{{ version }}/{{ name|lower }}-{{ version }}.zip
+  url: https://github.com/compomics/meta-proteome-analyzer/releases/download/portable-v{{ version }}/{{ name|lower }}-{{ version }}.zip
   sha256: {{ sha256 }}
 
 build:
   noarch: generic
-  number: 0
+  number: 1
 
 requirements:
   run:
-    - openjdk >=6
+    - fonts-conda-ecosystem
+    - openjdk >=11
     - python
 
 test:


### PR DESCRIPTION
Try to fix:

```
java.io.FileNotFoundException: /usr/local/share/mpa-portable-1.4.1-2/built/X!Tandem/linux/linux_64bit/taxonomy.xml (Permission denied)
```

for running in a docker container by using chmod.

Without fonts-conda-ecosystem and openjdk 11 we get

```
|  Exception in thread "main" java.lang.InternalError: java.lang.reflect.InvocationTargetException
|  at java.desktop/sun.font.FontManagerFactory$1.run(FontManagerFactory.java:86)
|  at java.base/java.security.AccessController.doPrivileged(Native Method)
|  at java.desktop/sun.font.FontManagerFactory.getInstance(FontManagerFactory.java:74)
|  at java.desktop/sun.font.SunFontManager.getInstance(SunFontManager.java:247)
|  at java.desktop/sun.font.FontDesignMetrics.getMetrics(FontDesignMetrics.java:265)
|  at java.desktop/sun.swing.SwingUtilities2.getFontMetrics(SwingUtilities2.java:1231)
|  at java.desktop/javax.swing.JComponent.getFontMetrics(JComponent.java:1646)
|  at java.desktop/javax.swing.text.PlainView.calculateLongestLine(PlainView.java:783)
|  at java.desktop/javax.swing.text.PlainView.updateMetrics(PlainView.java:332)
|  at java.desktop/javax.swing.text.PlainView.updateDamage(PlainView.java:670)
|  at java.desktop/javax.swing.text.PlainView.insertUpdate(PlainView.java:591)
|  at java.desktop/javax.swing.text.FieldView.insertUpdate(FieldView.java:294)
|  at java.desktop/javax.swing.plaf.basic.BasicTextUI$RootView.insertUpdate(BasicTextUI.java:1709)
|  at java.desktop/javax.swing.plaf.basic.BasicTextUI$UpdateHandler.insertUpdate(BasicTextUI.java:1968)
|  at java.desktop/javax.swing.text.AbstractDocument.fireInsertUpdate(AbstractDocument.java:203)
|  at java.desktop/javax.swing.text.AbstractDocument.handleInsertString(AbstractDocument.java:757)
|  at java.desktop/javax.swing.text.AbstractDocument.insertString(AbstractDocument.java:716)
|  at java.desktop/javax.swing.text.PlainDocument.insertString(PlainDocument.java:131)
|  at java.desktop/javax.swing.text.AbstractDocument.replace(AbstractDocument.java:675)
|  at java.desktop/javax.swing.text.JTextComponent.setText(JTextComponent.java:1729)
|  at java.desktop/javax.swing.JFormattedTextField$AbstractFormatter.install(JFormattedTextField.java:957)
|  at java.desktop/javax.swing.text.DefaultFormatter.install(DefaultFormatter.java:125)
|  at java.desktop/javax.swing.text.InternationalFormatter.install(InternationalFormatter.java:286)
|  at java.desktop/javax.swing.JFormattedTextField.setFormatter(JFormattedTextField.java:474)
|  at java.desktop/javax.swing.JFormattedTextField.setValue(JFormattedTextField.java:797)
|  at java.desktop/javax.swing.JFormattedTextField.setValue(JFormattedTextField.java:511)
|  at java.desktop/javax.swing.JSpinner$DefaultEditor.<init>(JSpinner.java:625)
|  at java.desktop/javax.swing.JSpinner$NumberEditor.<init>(JSpinner.java:1230)
|  at java.desktop/javax.swing.JSpinner$NumberEditor.<init>(JSpinner.java:1206)
|  at java.desktop/javax.swing.JSpinner$NumberEditor.<init>(JSpinner.java:1181)
|  at java.desktop/javax.swing.JSpinner.createEditor(JSpinner.java:252)
|  at java.desktop/javax.swing.JSpinner.<init>(JSpinner.java:157)
|  at de.mpa.client.settings.PostProcessingParameters$MetaProteinParameters.createPanel(PostProcessingParameters.java:172)
|  at de.mpa.client.settings.PostProcessingParameters$MetaProteinParameters.createLeftComponent(PostProcessingParameters.java:143)
|  at de.mpa.client.settings.PostProcessingParameters.initDefaults(PostProcessingParameters.java:61)
|  at de.mpa.client.settings.ParameterMap.<init>(ParameterMap.java:18)
|  at de.mpa.client.settings.PostProcessingParameters.<init>(PostProcessingParameters.java:39)
|  at de.mpa.client.Client.<init>(Client.java:49)
|  at de.mpa.client.Client.init(Client.java:108)
|  at de.mpa.cli.CmdLineInterface.call(CmdLineInterface.java:110)
|  at de.mpa.cli.CmdLineInterface.<init>(CmdLineInterface.java:76)
|  at de.mpa.cli.CmdLineInterface.main(CmdLineInterface.java:294)
|  Caused by: java.lang.reflect.InvocationTargetException
|  at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
|  at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
|  at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
|  at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:490)
|  at java.desktop/sun.font.FontManagerFactory$1.run(FontManagerFactory.java:84)
|  ... 41 more
|  Caused by: java.lang.NullPointerException
|  at java.desktop/sun.awt.FontConfiguration.getVersion(FontConfiguration.java:1262)
|  at java.desktop/sun.awt.FontConfiguration.readFontConfigFile(FontConfiguration.java:225)
|  at java.desktop/sun.awt.FontConfiguration.init(FontConfiguration.java:107)
|  at java.desktop/sun.awt.X11FontManager.createFontConfiguration(X11FontManager.java:719)
|  at java.desktop/sun.font.SunFontManager$2.run(SunFontManager.java:367)
|  at java.base/java.security.AccessController.doPrivileged(Native Method)
|  at java.desktop/sun.font.SunFontManager.<init>(SunFontManager.java:312)
|  at java.desktop/sun.awt.FcFontManager.<init>(FcFontManager.java:35)
|  at java.desktop/sun.awt.X11FontManager.<init>(X11FontManager.java:56)
|  ... 46 more
```

because the openjdk recipe up to version 10 did not require fontconfig. **Alternatively one could add fontconfig to fonts-conda-ecosystem.**



Describe your pull request here

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
