### PR TITLE
Update maker to version 2.31.11

### DIFF
--- a/recipes/maker/meta.yaml
+++ b/recipes/maker/meta.yaml
@@ -20,8 +20,6 @@ requirements:
     - augustus >=3.2.3
     - blast {{ blast_version }}
     - exonerate
-    - infernal
-    - mir-prefer
     - repeatmasker
     - snap
     - snoscan
@@ -46,8 +44,6 @@ requirements:
     - augustus >=3.2.3
     - blast {{ blast_version }}
     - exonerate
-    - infernal
-    - mir-prefer
     - repeatmasker
     - rmblast {{ blast_version }} # blast and rmblast must be pinned to the same version as they share some libraries
     - snap

--- a/recipes/maker/meta.yaml
+++ b/recipes/maker/meta.yaml
@@ -2,18 +2,18 @@
 
 package:
   name: maker
-  version: 2.31.10
+  version: 2.31.11
 
 source:
-  url: http://yandell.topaz.genetics.utah.edu/maker_downloads/static/maker-2.31.10.tgz
-  md5: 30e3ff1b4bad0218ebf20d049638e864
+  url: http://yandell.topaz.genetics.utah.edu/maker_downloads/static/maker-2.31.11.tgz
+  sha256: 129ce1d33df8ae29d417f0dac0df756398c5b76bdd58213233e94e735fe38c37
   patches:
     - "repeatmasker_check.patch"
     - "mpi_init.patch"
 
 build:
   noarch: generic
-  number: 17
+  number: 0
 
 requirements:
   host:

--- a/recipes/maker/meta.yaml
+++ b/recipes/maker/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - augustus >=3.2.3
     - blast {{ blast_version }}
     - exonerate
-    - repeatmasker
+    - repeatmasker >=4.1.1
     - snap
     - snoscan
     - perl
@@ -44,7 +44,7 @@ requirements:
     - augustus >=3.2.3
     - blast {{ blast_version }}
     - exonerate
-    - repeatmasker
+    - repeatmasker >=4.1.1
     - rmblast {{ blast_version }} # blast and rmblast must be pinned to the same version as they share some libraries
     - snap
     - snoscan

--- a/recipes/maker/meta.yaml
+++ b/recipes/maker/meta.yaml
@@ -40,7 +40,7 @@ requirements:
     - perl-list-moreutils
     - perl-perl-unsafe-signals
     - mpich
-    - trnascan-se
+    - trnascan-se ==1.3.1
     - postgresql
   run:
     - augustus >=3.2.3

--- a/recipes/maker/repeatmasker_check.patch
+++ b/recipes/maker/repeatmasker_check.patch
@@ -5,7 +5,7 @@
  
     #--make sure repbase is installed
 -   if($CTL_OPT{model_org}){
-+   if($CTL_OPT{model_org} and !defined($ENV{'REPEATMASKER_LIB_DIR'})){
++   if($CTL_OPT{model_org} and !defined($ENV{'LIBDIR'})){
         my $exe = Cwd::abs_path($CTL_OPT{RepeatMasker});
         my ($lib) = $exe =~ /(.*\/)RepeatMasker$/;
         die "ERROR: Could not determine if RepBase is installed\n" if(! $lib);

--- a/recipes/orthofinder/meta.yaml
+++ b/recipes/orthofinder/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "2.4.1" %}
-{% set sha256 = "be3f7a25a100d80242a13c93a3a8d235fbff2b368549d489b69bb4306ae4deb5" %}
+{% set version = "2.5.1" %}
+{% set sha256 = "543fdf1e1b15f21826e3b93c1ffad15b30f84886cbc5222bf549f85275e9420c" %}
 
 package:
   name: orthofinder
@@ -7,7 +7,7 @@ package:
 
 build:
   noarch: generic
-  number: 1
+  number: 0
 
 source:
   url: https://github.com/davidemms/OrthoFinder/releases/download/{{ version }}/OrthoFinder_source.tar.gz


### PR DESCRIPTION
Patch-level update; per RELEASE file:

> *maker_functional_fasta and maker_functional_gff handle newer UniProt/Swiss-Prot
 format. Also fix for newer genemark command line structure.

Also an attempt to fix https://github.com/bioconda/bioconda-recipes/issues/25559
