### PR TITLE
Update trnascan-se to 2.0.7

### DIFF
--- a/recipes/trnascan-se/meta.yaml
+++ b/recipes/trnascan-se/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "tRNAscan-SE" %}
-{% set version = "2.0.6" %}
+{% set version = "2.0.7" %}
 
 package:
   name: {{ name|lower }}
@@ -10,7 +10,7 @@ build:
 
 source:
   url: http://lowelab.ucsc.edu/software/trnascan-se-{{ version }}.tar.gz
-  sha256: 7d59dc040f41f5c50af26d83f61b7a0992243be4e12d26bdf613dc004dc73011
+  sha256: 61defa5c74693ac55b4b3dd48ac666a9de8663f63b527b9c56489b71286bba3d
 
 requirements:
   build:
@@ -21,7 +21,7 @@ requirements:
     - perl
   run:
     - perl
-    - infernal ==1.1.2
+    - infernal >=1.1.2
 
 test:
   commands:


### PR DESCRIPTION
Also allow infernal >= 1.1.2 as a dependency (trnascan-se INSTALL explicitly mentions internal 1.1.2, but as infernal 1.1.3 was _relatively_ recent, I suspect trnascan-se documentation just hasn't been updated yet).