### PR TITLE
Update recipe for ncrf by changing requirement to python <3

### DIFF
--- a/recipes/ncrf/meta.yaml
+++ b/recipes/ncrf/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 0
+  number: 1
 
 source:
   url: https://github.com/makovalab-psu/NoiseCancellingRepeatFinder/archive/v{{ version }}.tar.gz
@@ -17,7 +17,7 @@ requirements:
   build:
     - {{ compiler('c') }}
   run:
-    - python >=3
+    - python <3
 test:
   commands:
     - NCRF --version 2>&1 | grep {{ version }}


### PR DESCRIPTION
The associated python scripts of [NCRF](https://github.com/makovalab-psu/NoiseCancellingRepeatFinder) need python <3. The previous meta.yaml was in conflict with this.


----


<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
