### PR TITLE
Update treesapp meta.yml

### DIFF
--- a/recipes/treesapp/meta.yaml
+++ b/recipes/treesapp/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 7941ae0c46ec1844518befa98e8ab490af93ba3d3cb968294a6c35d7c13c2b9c
 
 build:
-  number: 0
+  number: 1
   # Skipping py>=38 because Py3.8 builds are not available for old versions of dependencies.
   # Dependencies (pyfastx, specifically) are likely pinned downed too strictly.
   skip: True  # [py<30 or py>=38]
@@ -23,6 +23,7 @@ requirements:
   host:
     - pip
     - python
+    - setuptools >=50.0.0
   run:
     - python
     - numpy >=1.18.1
@@ -47,6 +48,7 @@ requirements:
     - raxml-ng >=1.0.1
     - mafft >=7.471
     - vsearch >=2.15.0
+    - mmseqs2 >=12.113e3
 
 test:
   imports:

--- a/recipes/treesapp/meta.yaml
+++ b/recipes/treesapp/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 7941ae0c46ec1844518befa98e8ab490af93ba3d3cb968294a6c35d7c13c2b9c
 
 build:
-  number: 1
+  number: 0
   # Skipping py>=38 because Py3.8 builds are not available for old versions of dependencies.
   # Dependencies (pyfastx, specifically) are likely pinned downed too strictly.
   skip: True  # [py<30 or py>=38]


### PR DESCRIPTION
For some reason the changes made to treesapp's meta.yml file in the version bump PR #25406 were not merged into master. Hopefully by including those missing edits it will build successfully, as it did before.