### PR TITLE
remove git info to force version to not report tag

### DIFF
--- a/recipes/canu/build.sh
+++ b/recipes/canu/build.sh
@@ -5,6 +5,7 @@ set -e
 
 mkdir -p "$PREFIX/bin"
 
+rm -rf ./.git*
 pushd src
 make clean TARGET_DIR=$PREFIX CC=$CC CXX=$CXX
 make TARGET_DIR=$PREFIX CC=$CC CXX=$CXX


### PR DESCRIPTION
By default, canu will read the git information and report the version as something like:
```
canu branch v2.1-maintenance +0 changes (r10117 5638f7d9a5379373310ab62c28aa0cdbd864722d)
```
or
```
canu branch HEAD +0 changes (r10117 5638f7d9a5379373310ab62c28aa0cdbd864722d)
```

Users probably want something like
```
canu 2.1.1
```
which is what will be reported if the .git folders aren't present.