### PR TITLE
Add CHAP recipe

### DIFF
--- a/recipes/chap/LICENSE.TXT
+++ b/recipes/chap/LICENSE.TXT
@@ -1,0 +1,10 @@
+CHAP - The Channel Annotation Package
+
+Copyright (c) 2016 - 2018 Gianni Klesse, Shanlin Rao, Mark S. P. Sansom, and Stephen J. Tucker
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+

--- a/recipes/chap/build.sh
+++ b/recipes/chap/build.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Ugly hack since cmake things that tmglib.so should be present, even though
+# that is used for testing lapack and is not present in the final build
+# 
+# Just chop the offending chunks out of the cmake targets...
+
+lapack_targets=$(find $PREFIX/lib/cmake -name lapack-targets.cmake)
+lapack_targets_release=$(find $PREFIX/lib/cmake -name lapack-targets-release.cmake)
+
+sed -i.bak -e 's/foreach(_expectedTarget blas lapack tmglib)/foreach(_expectedTarget blas lapack)/' ${lapack_targets}
+sed -i.bak -e '/add_library(tmglib SHARED IMPORTED)/,+15d' ${lapack_targets}
+sed -i.bak -e '/set_property(TARGET tmglib APPEND PROPERTY IMPORTED_CONFIGURATIONS RELEASE)/,+5d' ${lapack_targets_release}
+
+mkdir build
+cd build
+cmake -DCMAKE_INSTALL_PREFIX=${PREFIX} ..
+make
+make install
+
+mv ${PREFIX}/chap/bin/* ${PREFIX}/bin
+
+

--- a/recipes/chap/meta.yaml
+++ b/recipes/chap/meta.yaml
@@ -1,0 +1,44 @@
+{% set version = "0.9.1" %}
+{% set gitversion = "0_9_1" %}
+{% set sha256 = "d9dab03ab89d14faa8300fc71cc5d3e3f89ca63435acb666bfae9e7ed51cd718" %}
+
+package:
+  name: chap
+  version: '{{version}}'
+
+source:
+  url: https://github.com/channotation/chap/archive/version_{{gitversion}}.tar.gz 
+  sha256: '{{sha256}}'
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - {{ compiler('cxx') }}
+    - cmake >=3.2
+  host:
+    - boost-cpp
+    - libcblas=3.8.0=8_*_netlib
+    - liblapacke=3.8.0=8_*_netlib
+    - gromacs=2018.6
+    - rapidjson
+    - intel-compute-runtime
+  run:
+    - boost-cpp
+    - libcblas=3.8.0=8_*_netlib
+    - liblapacke=3.8.0=8_*_netlib
+    - gromacs=2018.6
+    - rapidjson
+    - intel-compute-runtime
+
+test:
+  commands:
+    - chap -h
+
+about:
+  home: https://github.com/channotation/chap
+  license: MIT
+  license_file: LICENSE.TXT
+  summary: CHAP is a tool for the functional annotation of ion channel structures
+

--- a/recipes/chap/meta.yaml
+++ b/recipes/chap/meta.yaml
@@ -12,6 +12,7 @@ source:
 
 build:
   number: 0
+  skip: macos
 
 requirements:
   build:

--- a/recipes/chap/meta.yaml
+++ b/recipes/chap/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   number: 0
-  skip: macos
+  skip: True  # [osx]
 
 requirements:
   build:


### PR DESCRIPTION
Adds recipe for CHAP, which carries out functional annotation of ion channel structures

There are some unfortunate version pinnings here: Gromacs versions >2018 are not compatible with the software, while using libcblas/liblapacke versions > 3.8.0 fail to compile. The netlib versions of these libraries are also required instead of the openblas versions which don't include the necessary headers for the compilation to succeed.

The software is also described as being only tested on ubuntu, and my attempts to build on macos have failed.

