### PR TITLE
update iqtree to enable date inference via lsd2 in cmake call of iqtree build

### DIFF
--- a/recipes/iqtree/build.sh
+++ b/recipes/iqtree/build.sh
@@ -12,7 +12,7 @@ fi
 mkdir build
 cd build
 
-$BUILD_PREFIX/bin/cmake -D CMAKE_INSTALL_PREFIX:PATH=$PREFIX -DIQTREE_FLAGS=omp ..
+$BUILD_PREFIX/bin/cmake -D CMAKE_INSTALL_PREFIX:PATH=$PREFIX -DUSE_LSD2=ON -DIQTREE_FLAGS=omp ..
 
 make --jobs "${CPU_COUNT}"
 make install

--- a/recipes/iqtree/meta.yaml
+++ b/recipes/iqtree/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 0
+  number: 1
 
 source:
   - url: https://github.com/Cibiv/IQ-TREE/archive/v{{ version }}.tar.gz


### PR DESCRIPTION
Pass `-DUSE_LSD2=ON` to `cmake` for iqtree to enable least-squares dating (`lsd2` was already included as a source)

Previously, an error would be thrown if the `--date` flag were specified.

----

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
