### PR TITLE
Update Hail to 0.2.61, allow Python 3.7

### DIFF
--- a/recipes/hail/meta.yaml
+++ b/recipes/hail/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   number: 0
-  skip: True  # [py2k or py == '38']
+  skip: True  # [py2k or py == 38]
 
 requirements:
   build:

--- a/recipes/hail/meta.yaml
+++ b/recipes/hail/meta.yaml
@@ -12,6 +12,7 @@ source:
 
 build:
   number: 0
+  skip: True  # [py2k or py == '38']
 
 requirements:
   build:
@@ -19,7 +20,7 @@ requirements:
     - make
     - rsync
   host:
-    - python >=3.6,<=3.7
+    - python
     - pyspark >=2.4,<2.4.2
     - openjdk 8.*
     - lz4

--- a/recipes/hail/meta.yaml
+++ b/recipes/hail/meta.yaml
@@ -30,22 +30,22 @@ requirements:
     - python
     - openjdk 8.*
     - pyspark >=2.4,<2.4.2
-    #- aiohttp
-    #- aiohttp-session
-    #- bokeh >1.1,<1.3
-    #- decorator <5
-    #- deprecated
-    #- gcsfs ==0.2.1
+    - aiohttp
+    - aiohttp-session
+    - bokeh >1.1,<1.3
+    - decorator <5
+    - deprecated
+    - gcsfs ==0.2.1
     - humanize
     - hurry.filesize
     - nest-asyncio
     - parsimonious
     - pyjwt
-    #- python-json-logger ==0.1.11
+    - python-json-logger ==0.1.11
     - requests
     - scipy
-    #- tabulate ==0.8.3
-    #- tqdm ==4.42.1
+    - tabulate ==0.8.3
+    - tqdm ==4.42.1
 
 test:
   imports:

--- a/recipes/hail/meta.yaml
+++ b/recipes/hail/meta.yaml
@@ -11,7 +11,6 @@ source:
   sha256: unused
 
 build:
-  skip: True  # [py>37]
   number: 0
 
 requirements:
@@ -20,7 +19,7 @@ requirements:
     - make
     - rsync
   host:
-    - python
+    - python >=3.6,<=3.7
     - pyspark >=2.4,<2.4.2
     - openjdk 8.*
     - lz4

--- a/recipes/hail/meta.yaml
+++ b/recipes/hail/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'hail' %}
-{% set version = '0.2.58' %}
+{% set version = '0.2.61' %}
 
 package:
   name: {{ name|lower }}
@@ -11,7 +11,7 @@ source:
   sha256: unused
 
 build:
-  skip: True  # [py!=36]
+  skip: True  # [py>37]
   number: 0
 
 requirements:

--- a/recipes/hail/meta.yaml
+++ b/recipes/hail/meta.yaml
@@ -29,23 +29,23 @@ requirements:
   run:
     - python
     - openjdk 8.*
-    - pyspark 2.4.*
-    - aiohttp
-    - aiohttp-session
-    - bokeh >1.1,<1.3
-    - decorator <5
-    - deprecated
-    - gcsfs ==0.2.1
+    - pyspark >=2.4,<2.4.2
+    #- aiohttp
+    #- aiohttp-session
+    #- bokeh >1.1,<1.3
+    #- decorator <5
+    #- deprecated
+    #- gcsfs ==0.2.1
     - humanize
     - hurry.filesize
     - nest-asyncio
     - parsimonious
     - pyjwt
-    - python-json-logger ==0.1.11
+    #- python-json-logger ==0.1.11
     - requests
     - scipy
-    - tabulate ==0.8.3
-    - tqdm ==4.42.1
+    #- tabulate ==0.8.3
+    #- tqdm ==4.42.1
 
 test:
   imports:


### PR DESCRIPTION
Hail supports python3 up to 3.7, so easing the restriction to allow 3.7 in addition to 3.6.

Plus, updating the Hail version.
