### PR TITLE
Rebuild htslib with current conda-forge libdeflate

### DIFF
--- a/recipes/htslib/meta.yaml
+++ b/recipes/htslib/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 1
+  number: 2
   run_exports:
     - {{ pin_subpackage('htslib', max_pin='x.x') }}
 


### PR DESCRIPTION
Bump htslib so there is a current htslib package that is installable using only data from the channels' _current_repodata.json_ files (in particular, conda-forge's _current_repodata.json_). Fixes #22824 and fixes #25567, though libdeflate updates will need to be monitored on an ongoing basis or other additional steps taken.