### PR TITLE
Update PanPhlAn 3.0 to PanPhlAn 3.1

### DIFF
--- a/recipes/panphlan/meta.yaml
+++ b/recipes/panphlan/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: "{{ version }}"
 
 source:
-  url: "https://github.com/SegataLab/panphlan/archive/{{ version }}.tar.gz2
+  url: "https://github.com/SegataLab/panphlan/archive/{{ version }}.tar.gz"
   sha256: 5a29d729eb6362a1b6905d09e18dc22e75d12a358b984dcb50cfe11955737245
 
 build:

--- a/recipes/panphlan/meta.yaml
+++ b/recipes/panphlan/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "panphlan" %}
-{% set version = "3.0" %}
+{% set version = "3.1" %}
 
 package:
   name: "{{ name|lower }}"
@@ -17,20 +17,18 @@ build:
 requirements:
   host:
     - pip
-    - python >=3
+    - python >=3.7
   run:
-    - python >=3
-    - matplotlib-base
+    - python >=3.7
+    - bowtie2 >=2.3.0
+    - samtools >=1.9
     - numpy
     - pandas
-    - scikit-learn
     - scipy
-    - seaborn
 
 test:
   commands:
     - panphlan_download_pangenome.py --help
-    - panphlan_find_gene_grp.py --help
     - panphlan_map.py --help
     - panphlan_profiling.py --help
       

--- a/recipes/panphlan/meta.yaml
+++ b/recipes/panphlan/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: "https://github.com/SegataLab/panphlan/archive/{{ version }}.tar.gz"
-  sha256: 5a29d729eb6362a1b6905d09e18dc22e75d12a358b984dcb50cfe11955737245
+  sha256: 09bfba7842d27318714e42e75276bf852cee870696bf9c208ed8cebd957b3870
 
 build:
   noarch: python

--- a/recipes/panphlan/meta.yaml
+++ b/recipes/panphlan/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: "{{ version }}"
 
 source:
-  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  url: "https://github.com/SegataLab/panphlan/archive/{{ version }}.tar.gz2
   sha256: 5a29d729eb6362a1b6905d09e18dc22e75d12a358b984dcb50cfe11955737245
 
 build:


### PR DESCRIPTION
New version of PanPhlAn is out on the PanPhlAn repository (version 3.1): On top of that the dependencies were not complete, PanPhlAn needs bowtie2 and samtools to run
