### PR TITLE
Update ivar recipe to include samtools dependency

### DIFF
--- a/recipes/ivar/meta.yaml
+++ b/recipes/ivar/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: "{{ sha256 }}"
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -28,6 +28,7 @@ requirements:
     - xz
     - zlib
     - libdeflate
+    - samtools
   run:
     - htslib
     - curl
@@ -35,10 +36,12 @@ requirements:
     - xz
     - zlib
     - libdeflate
+    - samtools
 
 test:
   commands:
     - ivar version
+    - samtools --version
 
 about:
   home: https://andersen-lab.github.io/ivar/html/


### PR DESCRIPTION
I have added samtools as a runtime dependency.

A few of the ivar tools take input from samtools. For example:

```
ivar consensus
Usage: samtools mpileup -aa -A -d 0 -Q 0 <input.bam> | ivar consensus -p <prefix> 
```

So, when building rules in nextflow or snakemake it would be nice to have docker containers with samtools and ivar ready to go --- or automatically create the appropriate ivar conda environment with samtools already in it.
