### PR TITLE
Update Hail: update to support hailtop.batch

### DIFF
--- a/recipes/hail/meta.yaml
+++ b/recipes/hail/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: unused
 
 build:
-  number: 0
+  number: 1
   skip: True  # [py2k or py == 38]
 
 requirements:

--- a/recipes/hail/meta.yaml
+++ b/recipes/hail/meta.yaml
@@ -35,7 +35,7 @@ requirements:
     - bokeh >1.1,<1.3
     - decorator <5
     - deprecated
-    - gcsfs ==0.2.1
+    - gcsfs
     - humanize
     - hurry.filesize
     - nest-asyncio
@@ -46,10 +46,14 @@ requirements:
     - scipy
     - tabulate ==0.8.3
     - tqdm ==4.42.1
+    - dill
+    - asyncinit
+    - google-cloud-sdk
 
 test:
   imports:
     - hail
+    - hailtop.batch
 
 about:
   home: https://hail.is

--- a/recipes/hail/meta.yaml
+++ b/recipes/hail/meta.yaml
@@ -49,6 +49,7 @@ requirements:
     - dill
     - asyncinit
     - google-cloud-sdk
+    - google-api-core
 
 test:
   imports:

--- a/recipes/hail/meta.yaml
+++ b/recipes/hail/meta.yaml
@@ -49,6 +49,7 @@ requirements:
     - dill
     - asyncinit
     - google-cloud-sdk
+    - google-cloud-storage
     - google-api-core
 
 test:


### PR DESCRIPTION
Update the Hail package to support Batch functionality: adds missing dependencies.

Also removing the redundant gcsfs ==0.2.1 pin.
