### PR TITLE
Add president v0.2.1

### DIFF
--- a/recipes/president/meta.yaml
+++ b/recipes/president/meta.yaml
@@ -1,0 +1,42 @@
+{% set version = "0.2.1" %}
+{% set name = "president" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . --ignore-installed --no-deps -vv
+
+source:
+  url: https://gitlab.com/RKIBioinformaticsPipelines/{{ name }}/-/archive/v{{ version }}/{{ name }}-v{{ version }}.tar.gz
+  sha256: 26401ac4d15ea05b8ed21805e50d0c34ca7bf9436940ed1de682d275bc7f90ea
+
+requirements:
+  host:
+    - python >=3
+    - pip
+  run:
+    - python >=3
+    - pandas
+    - screed
+    - numpy
+    - pblat
+
+test:
+  imports:
+    - president
+  commands:
+    - president -h | grep {{ name }}
+
+about:
+  home: https://gitlab.com/RKIBioinformaticsPipelines/president
+  license: MIT
+  license_file: LICENSE
+  summary: 'Calculate pairwise nucleotide identity with respect to a reference sequence.'
+
+extra:
+  identifiers:
+    - biotools:president

--- a/recipes/president/meta.yaml
+++ b/recipes/president/meta.yaml
@@ -16,14 +16,14 @@ source:
 
 requirements:
   host:
-    - python >=3
-    - pip
+    - python >=3.8
+    - pip >=20.3.3
   run:
-    - python >=3
-    - pandas
-    - screed
-    - numpy
-    - pblat
+    - python >=3.8
+    - pandas >=1.2.1
+    - screed >=1.0.4
+    - numpy >=1.19.5
+    - pblat >=2.5
 
 test:
   imports:


### PR DESCRIPTION
president is a tool that computes pairwise nucleotide identities with respect to a reference sequence and reports if they are valid/invalid.
