### PR TITLE
Update maker to 3.01.03

### DIFF
--- a/recipes/maker/meta.yaml
+++ b/recipes/maker/meta.yaml
@@ -12,7 +12,6 @@ source:
     - "mpi_init.patch"
 
 build:
-  noarch: generic
   number: 0
 
 requirements:

--- a/recipes/maker/meta.yaml
+++ b/recipes/maker/meta.yaml
@@ -2,11 +2,11 @@
 
 package:
   name: maker
-  version: 2.31.11
+  version: 3.01.03
 
 source:
-  url: http://yandell.topaz.genetics.utah.edu/maker_downloads/static/maker-2.31.11.tgz
-  sha256: 129ce1d33df8ae29d417f0dac0df756398c5b76bdd58213233e94e735fe38c37
+  url: http://yandell.topaz.genetics.utah.edu/maker_downloads/static/maker-3.01.03.tgz
+  sha256: f36cc7ef584c215955a4d9fdd46287a49f7508bbe59c6fe78d50e0c6e99192ae
   patches:
     - "repeatmasker_check.patch"
     - "mpi_init.patch"
@@ -16,6 +16,8 @@ build:
   number: 0
 
 requirements:
+  build:
+    - {{ compiler('c') }}
   host:
     - augustus >=3.2.3
     - blast {{ blast_version }}
@@ -29,13 +31,11 @@ requirements:
     - perl-dbd-pg
     - perl-dbd-sqlite
     - perl-dbi
-    - perl-file-which
     - perl-io-all
     - perl-io-prompt
     - perl-inline-c >=0.78
     - perl-perlio-gzip
     - perl-forks
-    - perl-list-moreutils
     - perl-perl-unsafe-signals
     - mpich
     - trnascan-se ==1.3.1
@@ -54,16 +54,14 @@ requirements:
     - perl-dbd-pg
     - perl-dbd-sqlite
     - perl-dbi
-    - perl-file-which
     - perl-io-all
     - perl-io-prompt
     - perl-inline-c >=0.78
     - perl-perlio-gzip
     - perl-forks
-    - perl-list-moreutils
     - perl-perl-unsafe-signals
     - mpich
-    - trnascan-se ==1.3.1
+    - trnascan-se
     - postgresql
     # GeneMarkS, GeneMark-ES and FGENESH are optional requirements but are not free
 

--- a/recipes/maker/meta.yaml
+++ b/recipes/maker/meta.yaml
@@ -75,3 +75,4 @@ extra:
   identifiers:
     - biotools:maker
     - usegalaxy-eu:maker
+

--- a/recipes/maker/meta.yaml
+++ b/recipes/maker/meta.yaml
@@ -53,7 +53,7 @@ requirements:
     - perl-forks
     - perl-perl-unsafe-signals
     - mpich
-    - rapsearch
+    - rapsearch # [not osx]
     - trnascan-se
     - postgresql
     # GeneMarkS, GeneMark-ES and FGENESH are optional requirements but are not free

--- a/recipes/maker/meta.yaml
+++ b/recipes/maker/meta.yaml
@@ -18,12 +18,6 @@ requirements:
   build:
     - {{ compiler('c') }}
   host:
-    - augustus >=3.2.3
-    - blast {{ blast_version }}
-    - exonerate
-    - repeatmasker >=4.1.1
-    - snap
-    - snoscan
     - perl
     - perl-bioperl-core >=1.007002
     - perl-bit-vector
@@ -37,12 +31,11 @@ requirements:
     - perl-forks
     - perl-perl-unsafe-signals
     - mpich
-    - trnascan-se ==1.3.1
-    - postgresql
   run:
     - augustus >=3.2.3
     - blast {{ blast_version }}
     - exonerate
+    - evidencemodeler
     - repeatmasker >=4.1.1
     - rmblast {{ blast_version }} # blast and rmblast must be pinned to the same version as they share some libraries
     - snap
@@ -60,6 +53,7 @@ requirements:
     - perl-forks
     - perl-perl-unsafe-signals
     - mpich
+    - rapsearch
     - trnascan-se
     - postgresql
     # GeneMarkS, GeneMark-ES and FGENESH are optional requirements but are not free

--- a/recipes/maker/mpi_init.patch
+++ b/recipes/maker/mpi_init.patch
@@ -19,41 +19,8 @@
 +carp "Calling MPI_Init";
 +MPI_Init();
 +
---- src/bin/maker
-+++ src/bin/maker
-@@ -198,6 +198,11 @@ Options:
-      -cpus|c  <integer>  Tells how many cpus to use for BLAST analysis.
-                          Note: this is for BLAST and not for MPI!
- 
-+     -mpi                Forces MAKER to use MPI (overriding MPI autodetection).
-+                         Useful if MAKER doesn't correctly detect that it was
-+                         launched using an MPI process manager, or if running
-+                         in a Singularity container.
-+
-      -force|f            Forces MAKER to delete old files before running again.
- 			 This will require all blast analyses to be rerun.
- 
-@@ -247,7 +252,8 @@ my %OPT;
- carp "Calling GetOptions pre-init" if($main::debug);
- Getopt::Long::Configure(qw(pass_through));
- GetOptions("MPICC=s" => \$OPT{MPICC}, #hidden
--	   "MPIDIR=s" => \$OPT{MPIDIR},); #hidden
-+	   "MPIDIR=s" => \$OPT{MPIDIR},   #hidden
-+	   "mpi" => \$main::mpi);
- 
- #--set MPI configuration if specified on the command line
- if($OPT{MPICC} || $OPT{MPIDIR}){
 --- src/lib/Parallel/Application/MPI.pm
 +++ src/lib/Parallel/Application/MPI.pm
-@@ -165,7 +165,7 @@ sub _load {
-     require Proc::Signal;
- 
-     my $name = Proc::Signal::get_pname_by_id($$);
--    if($name =~ /(mpiexec|mpirun|mpdrun|mpdexec|mpd|smpd|orted|orterun|pmi_proxy|hydra|mpispawn|exec\d+)$/){
-+    if($main::mpi or $name =~ /(mpiexec|mpirun|mpdrun|mpdexec|mpd|smpd|orted|orterun|pmi_proxy|hydra|mpispawn|exec\d+)$/){
- 	require MAKER::ConfigData;
- 	my $mpi_support = MAKER::ConfigData->feature('mpi_support');
- 	if(! $mpi_support){
 @@ -232,7 +232,9 @@ sub _bind {
  
      eval{

--- a/recipes/maker/repeatmasker_check.patch
+++ b/recipes/maker/repeatmasker_check.patch
@@ -1,6 +1,15 @@
---- lib/GI.pm	2014-12-01 23:37:10.000000000 +0100
-+++ lib/GI.pm	2020-12-12 10:22:03.306721820 +0100
-@@ -4354,33 +4354,14 @@
+--- a/lib/GI.pm
++++ b/lib/GI.pm
+@@ -3845,7 +3845,7 @@ sub set_defaults {
+       my @all_alts = grep {-f $_ && -x $_} (File::Glob::bsd_glob("{$FindBin::RealBin/../exe/*/*,$FindBin::RealBin/../exe/*/bin/*}"));
+       foreach my $exe (@exes) {
+ 	  my @alts = grep {/\/$exe$/} @all_alts;
+-	  my $loc = shift @alts || File::Which::which($exe) || '';
++	  my $loc = shift @alts || File::Which::which($exe eq 'evm' ? 'evidence_modeler.pl' : $exe) || '';
+ 	  if(! $loc && $exe eq 'blasta'){ #find blasta using blastx
+ 	      ($loc) = (map {Cwd::abs_path($_)} grep {Cwd::abs_path($_) =~ /blasta$/} (File::Which::where('blastx')));
+ 	  }
+@@ -4950,33 +4950,14 @@ sub load_control_files {
     confess "ERROR: Could not build output directory $CTL_OPT{out_base}\n"
          if(! -d $CTL_OPT{out_base});
  
@@ -11,7 +20,8 @@
         my $exe = Cwd::abs_path($CTL_OPT{RepeatMasker});
         my ($lib) = $exe =~ /(.*\/)RepeatMasker$/;
 -       die "ERROR: Could not determine if RepBase is installed\n" if(! $lib);
--
++       die "ERROR: Could not determine if DFam is installed\n" if(! $lib);
+ 
 -       $lib .= "Libraries/RepeatMaskerLib.embl";
 -       die "ERROR: Could not determine if RepBase is installed\n" if(! -f $lib);
 -
@@ -25,8 +35,7 @@
 -           }
 -       }
 -       close($IN);
-+       die "ERROR: Could not determine if DFam is installed\n" if(! $lib);
- 
+-
 -       if(! $rb_flag){
 -	   warn "WARNING: RepBase is not installed for RepeatMasker. This limits\n".
 -	       "RepeatMasker's functionality and makes the model_org option in the\n".
@@ -39,7 +48,7 @@
     }
  
     #--set an initialization lock so steps are locked to a single process
-@@ -4530,7 +4511,7 @@
+@@ -5196,7 +5177,7 @@ sub generate_control_files {
         print OUT "protein_gff=$O{protein_gff}  #aligned protein homology evidence from an external GFF3 file\n";
         print OUT "\n";
         print OUT "#-----Repeat Masking (leave values blank to skip repeat masking)\n";


### PR DESCRIPTION
This PR updates MAKER to 3.01.03. Includes new evidencemodeler and repsearch dependencies. 

Note that I attempted to trim the meta.yaml "host" section per my understanding of the minimum of what's needed to be there for build.sh to work; please fix if incorrect or unconventional.