### PR TITLE
Update braker2: add perl-math-utils for log_reg_prothints.pl

### DIFF
--- a/recipes/braker2/meta.yaml
+++ b/recipes/braker2/meta.yaml
@@ -13,7 +13,7 @@ source:
     - path.patch
 
 build:
-  number: 1
+  number: 2
   noarch: generic
 
 requirements:
@@ -35,6 +35,7 @@ requirements:
     - perl-list-moreutils
     - perl-list-util
     - perl-logger-simple
+    - perl-math-utils
     - perl-module-load-conditional
     - perl-posix
     - perl-mce


### PR DESCRIPTION
braker2 2.1.5 script log_reg_prothints.pl needs perl module Math::Utils for log_reg_prothints.pl:
```
$ conda create -c conda-forge -c bioconda -n braker2-env braker2=2.1.5=1
$ source activate braker2-env
(braker2-env) $ log_reg_prothints.pl
Can't locate Math/Utils.pm in @INC (you may need to install the Math::Utils module) (@INC contains: /home/user/.conda/envs/braker2-env/lib/site_perl/5.26.2/x86_64-linux-thread-multi /home/user/.conda/envs/braker2-env/lib/site_perl/5.26.2 /home/user/.conda/envs/braker2-env/lib/5.26.2/x86_64-linux-thread-multi /home/user/.conda/envs/braker2-env/lib/5.26.2 .) at /home/user/.conda/envs/braker2-env/bin/log_reg_prothints.pl line 9.
BEGIN failed--compilation aborted at /home/user/.conda/envs/braker2-env/bin/log_reg_prothints.pl line 9.
```
