### PR TITLE
Update ntJoin 1.0.5 recipe

### DIFF
--- a/recipes/ntjoin/build.sh
+++ b/recipes/ntjoin/build.sh
@@ -12,7 +12,7 @@ mkdir -p ${PREFIX}/bin/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM/src
 cp ntJoin ${PREFIX}/bin/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM
 cp src/indexlr ${PREFIX}/bin/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM/src/indexlr
 cp bin/*py ${PREFIX}/bin/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM/bin
-cp bin/ntjoin_assemble.py ${PREFIX}/bin
+cp bin/*py ${PREFIX}/bin
 
 echo "#!/bin/bash" > ${PREFIX}/bin/ntJoin
 echo "make -f $(command -v ${PREFIX}/bin/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM/ntJoin) \$@" >> ${PREFIX}/bin/ntJoin

--- a/recipes/ntjoin/build.sh
+++ b/recipes/ntjoin/build.sh
@@ -12,6 +12,7 @@ mkdir -p ${PREFIX}/bin/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM/src
 cp ntJoin ${PREFIX}/bin/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM
 cp src/indexlr ${PREFIX}/bin/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM/src/indexlr
 cp bin/*py ${PREFIX}/bin/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM/bin
+cp bin/ntjoin_assemble.py ${PREFIX}/bin
 
 echo "#!/bin/bash" > ${PREFIX}/bin/ntJoin
 echo "make -f $(command -v ${PREFIX}/bin/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM/ntJoin) \$@" >> ${PREFIX}/bin/ntJoin

--- a/recipes/ntjoin/meta.yaml
+++ b/recipes/ntjoin/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 84a396f4397a32da15925ce481d1fdf00df859c8b21458c13d9f2535b1faa597 
 
 build:
-  number: 0
+  number: 1
   skip: True  # [py<30]
 
 requirements:
@@ -26,7 +26,8 @@ requirements:
     - pybedtools
     - pymannkendall
     - bedtools >=2.21.0
-    - samtools
+    - pysam >=0.16.0
+    - samtools >=1.10
     - python
     - zlib
     - make
@@ -34,6 +35,8 @@ requirements:
 test:
   commands:
     - ntJoin help 
+    - samtools --help
+    - ${PREFIX}/bin/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM/bin/ntjoin_assemble.py -h
 
 about:
   home: http://www.bcgsc.ca/platform/bioinfo/software/ntjoin

--- a/recipes/ntjoin/meta.yaml
+++ b/recipes/ntjoin/meta.yaml
@@ -36,7 +36,7 @@ test:
   commands:
     - ntJoin help 
     - samtools --help
-    - ${PREFIX}/bin/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM/bin/ntjoin_assemble.py -h
+    - ntjoin_assemble.py -h
 
 about:
   home: http://www.bcgsc.ca/platform/bioinfo/software/ntjoin


### PR DESCRIPTION
Bumping build of ntJoin recipe, due to errors seen when installing on Mac and linux. (reported by a user and I reproduced https://github.com/bcgsc/ntJoin/issues/58)
Pysam import was throwing an error, which I found I could solve by specifying a newer pysam version:
```
conda install ntjoin pysam=0.16.0
```
So, updated recipe to specify pysam and samtools versions as newer ones to hopefully avoid that error with the `conda install`. Also added a couple more tests to hopefully catch any import issues in the CI if present.

Logs of errors:
Mac:
Error:
```
conda install ntjoin
(test_ntjoin_c) Laurens-MacBook-Pro:ntjoin laurencoombe$ /Users/laurencoombe/Documents/Work/GSC/miniconda/envs/test_ntjoin_c/bin/share/ntjoin-1.0.5-0/bin/ntjoin_assemble.py 
Traceback (most recent call last):
  File "/Users/laurencoombe/Documents/Work/GSC/miniconda/envs/test_ntjoin_c/bin/share/ntjoin-1.0.5-0/bin/ntjoin_assemble.py", line 19, in <module>
    import pybedtools
  File "/Users/laurencoombe/Documents/Work/GSC/miniconda/envs/test_ntjoin_c/lib/python3.6/site-packages/pybedtools/__init__.py", line 18, in <module>
    from . import contrib
  File "/Users/laurencoombe/Documents/Work/GSC/miniconda/envs/test_ntjoin_c/lib/python3.6/site-packages/pybedtools/contrib/__init__.py", line 3, in <module>
    from . import venn_maker
  File "/Users/laurencoombe/Documents/Work/GSC/miniconda/envs/test_ntjoin_c/lib/python3.6/site-packages/pybedtools/contrib/venn_maker.py", line 12, in <module>
    from pybedtools import helpers
  File "/Users/laurencoombe/Documents/Work/GSC/miniconda/envs/test_ntjoin_c/lib/python3.6/site-packages/pybedtools/helpers.py", line 13, in <module>
    import pysam
  File "/Users/laurencoombe/Documents/Work/GSC/miniconda/envs/test_ntjoin_c/lib/python3.6/site-packages/pysam/__init__.py", line 5, in <module>
    from pysam.libchtslib import *
ImportError: dlopen(/Users/laurencoombe/Documents/Work/GSC/miniconda/envs/test_ntjoin_c/lib/python3.6/site-packages/pysam/libchtslib.cpython-36m-darwin.so, 2): Library not loaded: @rpath/libhts.2.dylib
  Referenced from: /Users/laurencoombe/Documents/Work/GSC/miniconda/envs/test_ntjoin_c/lib/python3.6/site-packages/pysam/libchtslib.cpython-36m-darwin.so
  Reason: image not found
```
with pysam version specified:
```
   conda install ntjoin pysam=0.16.0
   (test_ntjoin_c) Laurens-MacBook-Pro:ntjoin laurencoombe$ /Users/laurencoombe/Documents/Work/GSC/miniconda/envs/test_ntjoin_c/bin/share/ntjoin-1.0.5-0/bin/ntjoin_assemble.py 
usage: ntjoin_assemble.py [-h] -s S [-l L] -r R [-p P] [-n N] -k K [-g G] [-G G] [--mkt] [-m M] [-t T] [-v] [--agp] [--no_cut] FILES [FILES ...]
ntjoin_assemble.py: error: the following arguments are required: FILES, -s, -r, -k
```

Linux:
Error:
```
conda install ntjoin
(testing_ntjoin) [lcoombe@hpce705 ntjoin]$ /projects/btl/lcoombe/miniconda3/envs/testing_ntjoin/bin/share/ntjoin-1.0.5-0/bin/ntjoin_assemble.py 
Traceback (most recent call last):
  File "/projects/btl/lcoombe/miniconda3/envs/testing_ntjoin/bin/share/ntjoin-1.0.5-0/bin/ntjoin_assemble.py", line 19, in <module>
    import pybedtools
  File "/projects/btl/lcoombe/miniconda3/envs/testing_ntjoin/lib/python3.6/site-packages/pybedtools/__init__.py", line 18, in <module>
    from . import contrib
  File "/projects/btl/lcoombe/miniconda3/envs/testing_ntjoin/lib/python3.6/site-packages/pybedtools/contrib/__init__.py", line 3, in <module>
    from . import venn_maker
  File "/projects/btl/lcoombe/miniconda3/envs/testing_ntjoin/lib/python3.6/site-packages/pybedtools/contrib/venn_maker.py", line 12, in <module>
    from pybedtools import helpers
  File "/projects/btl/lcoombe/miniconda3/envs/testing_ntjoin/lib/python3.6/site-packages/pybedtools/helpers.py", line 13, in <module>
    import pysam
  File "/projects/btl/lcoombe/miniconda3/envs/testing_ntjoin/lib/python3.6/site-packages/pysam/__init__.py", line 5, in <module>
    from pysam.libchtslib import *
ImportError: libhts.so.2: cannot open shared object file: No such file or directory
```

With pysam version: 
```
(testing_ntjoin_d) [lcoombe@hpce705 ntjoin]$  conda install ntjoin pysam=0.16.0
(testing_ntjoin_d) [lcoombe@hpce705 ntjoin]$ /projects/btl/lcoombe/miniconda3/envs/testing_ntjoin_d/bin/share/ntjoin-1.0.5-0/bin/ntjoin_assemble.py 
usage: ntjoin_assemble.py [-h] -s S [-l L] -r R [-p P] [-n N] -k K [-g G] [-G G] [--mkt] [-m M] [-t T] [-v] [--agp] [--no_cut] FILES [FILES ...]
ntjoin_assemble.py: error: the following arguments are required: FILES, -s, -r, -k
```
----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
