### PR TITLE
Fix seqmagick 0.8.4 requirements to specify biopython >= 1.78

### DIFF
--- a/recipes/seqmagick/meta.yaml
+++ b/recipes/seqmagick/meta.yaml
@@ -10,7 +10,7 @@ build:
   noarch: python
   entry_points:
     - seqmagick = seqmagick.scripts.cli:main
-  number: 0
+  number: 1
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:

--- a/recipes/seqmagick/meta.yaml
+++ b/recipes/seqmagick/meta.yaml
@@ -18,10 +18,10 @@ requirements:
     - python >3
     - pip
     - nose
-    - biopython >=1.70,<=1.77
+    - biopython >=1.78
   run:
     - python >3
-    - biopython >=1.70,<=1.77
+    - biopython >=1.78
     - pygtrie
 
 test:


### PR DESCRIPTION
This makes meta.yaml more closely match seqmagick's own setup.py which fixes seqmagick's --line-wrap feature.  Fixes #26546.