### PR TITLE
build 2 CryptoGenotyper v1.0 update

### DIFF
--- a/recipes/cryptogenotyper/meta.yaml
+++ b/recipes/cryptogenotyper/meta.yaml
@@ -11,7 +11,7 @@ source:
 build:
     number: 2
     noarch: python
-    script: python -m pip install --no-deps --ignore-installed .
+    script: python -m pip install --no-deps --ignore-installed . -vv
 
 requirements:
     host:

--- a/recipes/cryptogenotyper/meta.yaml
+++ b/recipes/cryptogenotyper/meta.yaml
@@ -6,10 +6,10 @@ package:
 
 source:
   url: https://github.com/phac-nml/CryptoGenotyper/archive/{{ version }}.tar.gz
-  sha256: b1855cbad37e9d6ccbe6b9df39b0908640d8bf3c2004cc71602dab7977dd8d11
+  sha256: 560b50538f2ebcaf9fc4beeb77d2ad749812ae2979343620bf6313bebc8dea5a 
 
 build:
-    number: 1
+    number: 2
     noarch: python
     script: python -m pip install --no-deps --ignore-installed .
 


### PR DESCRIPTION
Updated software database to include better coverage of some species. This is build #2 as the tool announcement manuscript will rely on this version.