### PR TITLE
Switch jvarkit-wgscoverageplotter to a python wrapper

### DIFF
--- a/recipes/jvarkit-wgscoverageplotter/build.sh
+++ b/recipes/jvarkit-wgscoverageplotter/build.sh
@@ -6,47 +6,8 @@ OUT="$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM"
 mkdir -p $OUT
 mkdir -p $PREFIX/bin
 cp dist/$TOOL.jar $OUT/
+JAR="$OUT/${TOOL}.jar"
 
-cat <<END >$PREFIX/bin/${TOOL}.sh
-#!/bin/bash
-# Wraps wgscoverageplotter.jar
-set -o pipefail
+sed "s^XXJARPATHXX^$JAR^" $RECIPE_DIR/${TOOL}.py > $PREFIX/bin/${TOOL}.py
 
-# extract memory and system property Java arguments from the list of provided arguments
-# http://java.dzone.com/articles/better-java-shell-script
-default_jvm_mem_opts="-Xms512m -Xmx1g"
-jvm_mem_opts=""
-jvm_prop_opts=""
-pass_args=""
-for arg in "\$@"; do
-    case \$arg in
-        '-D'*)
-            jvm_prop_opts="\$jvm_prop_opts $arg"
-            ;;
-        '-XX'*)
-            jvm_prop_opts="\$jvm_prop_opts $arg"
-            ;;
-         '-Xm'*)
-            jvm_mem_opts="\$jvm_mem_opts $arg"
-            ;;
-         *)
-            pass_args="\$pass_args \$arg"
-            ;;
-    esac
-done
-
-if [ "\$jvm_mem_opts" == "" ] && [ -z \${_JAVA_OPTIONS+x} ]; then
-    jvm_mem_opts="\$default_jvm_mem_opts"
-fi
-
-java=\$(which java)
-pass_arr=(\$pass_args)
-if [[ \${pass_arr[0]} == org* ]]
-then
-    eval "\$java" $\jvm_mem_opts $\jvm_prop_opts -cp "$OUT/${TOOL}.jar" \$pass_args
-else
-    eval "\$java" $\jvm_mem_opts $\jvm_prop_opts -jar "$OUT/${TOOL}.jar" \$pass_args
-fi
-exit
-END
-chmod a+x $PREFIX/bin/${TOOL}.sh
+chmod a+x $PREFIX/bin/${TOOL}.py

--- a/recipes/jvarkit-wgscoverageplotter/meta.yaml
+++ b/recipes/jvarkit-wgscoverageplotter/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: generic
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipes/jvarkit-wgscoverageplotter/meta.yaml
+++ b/recipes/jvarkit-wgscoverageplotter/meta.yaml
@@ -22,7 +22,7 @@ requirements:
 
 test:
   commands:
-    - {{ tool }}.sh --help | grep wgscoverageplotter
+    - {{ tool }}.py --help | grep wgscoverageplotter
 
 about:
   home: http://lindenb.github.io/jvarkit/WGSCoveragePlotter.html

--- a/recipes/jvarkit-wgscoverageplotter/meta.yaml
+++ b/recipes/jvarkit-wgscoverageplotter/meta.yaml
@@ -19,6 +19,7 @@ requirements:
 
   run:
     - openjdk >=11
+    - python >=2
 
 test:
   commands:

--- a/recipes/jvarkit-wgscoverageplotter/wgscoverageplotter.py
+++ b/recipes/jvarkit-wgscoverageplotter/wgscoverageplotter.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+#
+# Wrapper script for Java Conda packages that ensures that the java runtime
+# is invoked with the right options. Adapted from the bash script (http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in/246128#246128).
+
+#
+# Program Parameters
+#
+import os
+import subprocess
+import sys
+import shutil
+from os import access
+from os import getenv
+from os import X_OK
+
+default_jvm_mem_opts = ['-Xms512m', '-Xmx4g']
+
+# !!! End of parameter section. No user-serviceable code below this line !!!
+
+def java_executable():
+    """Return the executable name of the Java interpreter."""
+    java_home = getenv('JAVA_HOME')
+    java_bin = os.path.join('bin', 'java')
+
+    if java_home and access(os.path.join(java_home, java_bin), X_OK):
+        return os.path.join(java_home, java_bin)
+    else:
+        return 'java'
+
+
+def jvm_opts(argv):
+    """Construct list of Java arguments based on our argument list.
+
+    The argument list passed in argv must not include the script name.
+    The return value is a 3-tuple lists of strings of the form:
+      (memory_options, prop_options, passthrough_options)
+    """
+    mem_opts = []
+    prop_opts = []
+    pass_args = []
+
+    for arg in argv:
+        if arg.startswith('-D'):
+            prop_opts.append(arg)
+        elif arg.startswith('-XX'):
+            prop_opts.append(arg)
+        elif arg.startswith('-Xm'):
+            mem_opts.append(arg)
+        else:
+            pass_args.append(arg)
+
+    # In the original shell script the test coded below read:
+    #   if [ "$jvm_mem_opts" == "" ] && [ -z ${_JAVA_OPTIONS+x} ]
+    # To reproduce the behaviour of the above shell code fragment
+    # it is important to explictly check for equality with None
+    # in the second condition, so a null envar value counts as True!
+
+    if mem_opts == [] and getenv('_JAVA_OPTIONS') is None:
+        mem_opts = default_jvm_mem_opts
+
+    return (mem_opts, prop_opts, pass_args)
+
+def main():
+    java = java_executable()
+
+    (mem_opts, prop_opts, pass_args) = jvm_opts(sys.argv[1:])
+
+    jar_path = 'XXJARPATHXX'
+
+    java_args = [java] + mem_opts + prop_opts + ['-jar'] + [jar_path] + pass_args
+    sys.exit(subprocess.run(java_args))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This replaces the shell script wrapper for jvarkit's wgscoverageplotter with a Python based one. The Python wrapper handles parameters with possible shell metacharacters better.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
