### PR TITLE
Update raven-assembler meta.yaml

### DIFF
--- a/recipes/raven-assembler/meta.yaml
+++ b/recipes/raven-assembler/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = 'raven-assembler' %}
-{% set version = '1.3.0' %}
+{% set version = '1.4.0' %}
 
 package:
   name: {{ name }}
@@ -9,8 +9,8 @@ build:
   number: 0
 
 source:
-  url: https://github.com/lbcb-sci/raven/releases/download/{{ version }}/raven-v{{ version }}.tar.gz
-  sha256: 4109f98096ec6ac0bec2910841e0f14cd8f8a08aea6af6e334cf25be3f12aa57
+  url: https://github.com/lbcb-sci/raven/archive/{{ version }}.tar.gz
+  sha256: 047fdc7762ee1e8eccb3e53445e77481d20b82efa7534c8d15f79f9a5ddc673c
 
 requirements:
   build:


### PR DESCRIPTION
I have removed git submodules from the Raven repository, so the auto-generated release archives are sufficient for builds.