### PR TITLE
Add fastqc-rs v0.1.0

### DIFF
--- a/recipes/fastqc-rs/build.sh
+++ b/recipes/fastqc-rs/build.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -e
+
+# taken from yacrd recipe, see: https://github.com/bioconda/bioconda-recipes/blob/2b02c3db6400499d910bc5f297d23cb20c9db4f8/recipes/yacrd/build.sh
+if [ "$(uname)" == "Darwin" ]; then
+
+    # apparently the HOME variable isn't set correctly, and circle ci output indicates the following as the home directory
+    export HOME="/Users/distiller"
+    echo "HOME is $HOME"
+
+    # according to https://github.com/rust-lang/cargo/issues/2422#issuecomment-198458960 removing circle ci default configuration solves cargo trouble downloading crates
+    git config --global --unset url.ssh://git@github.com.insteadOf
+
+fi
+
+# build statically linked binary with Rust
+C_INCLUDE_PATH=$PREFIX/include LIBRARY_PATH=$PREFIX/lib cargo install --path . --root $PREFIX

--- a/recipes/fastqc-rs/meta.yaml
+++ b/recipes/fastqc-rs/meta.yaml
@@ -15,6 +15,9 @@ requirements:
   build:
     - rust >=1.30
     - clangdev
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - pkg-config
   host:
     - clangdev
   run:

--- a/recipes/fastqc-rs/meta.yaml
+++ b/recipes/fastqc-rs/meta.yaml
@@ -24,6 +24,7 @@ requirements:
     - openssl
     - zlib
     - bzip2
+    - libfreetype6-dev
   run:
 
 test:

--- a/recipes/fastqc-rs/meta.yaml
+++ b/recipes/fastqc-rs/meta.yaml
@@ -15,6 +15,7 @@ requirements:
   build:
     - rust >=1.30
     - clangdev
+    - cmake
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - pkg-config

--- a/recipes/fastqc-rs/meta.yaml
+++ b/recipes/fastqc-rs/meta.yaml
@@ -1,0 +1,29 @@
+{% set version = "0.1.0" %}
+
+package:
+  name: fastqc-rs
+  version: {{version}}
+
+build:
+  number: 0
+
+source:
+  url: https://github.com/fxwiegand/fastqc-rs/archive/v{{ version }}.tar.gz
+  sha256: 7a269bc74df9cbba70237c4e26a5cc4dcc14637870c7ec2ed6b273eda55964fa
+
+requirements:
+  build:
+    - rust >=1.30
+    - clangdev
+  host:
+  run:
+
+test:
+  commands:
+    - rbt --help
+
+about:
+  home: https://github.com/fxwiegand/fastqc-rs
+  license: MIT
+  summary: |
+    A fast quality control tool for FASTQ files written in rust.

--- a/recipes/fastqc-rs/meta.yaml
+++ b/recipes/fastqc-rs/meta.yaml
@@ -25,8 +25,7 @@ requirements:
     - zlib
     - bzip2
     - freetype
-    - libxml2
-    - libexpat-dev
+    - expat
   run:
 
 test:

--- a/recipes/fastqc-rs/meta.yaml
+++ b/recipes/fastqc-rs/meta.yaml
@@ -20,7 +20,7 @@ requirements:
 
 test:
   commands:
-    - rbt --help
+    - fqc --help
 
 about:
   home: https://github.com/fxwiegand/fastqc-rs

--- a/recipes/fastqc-rs/meta.yaml
+++ b/recipes/fastqc-rs/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - openssl
     - zlib
     - bzip2
-    - freetype2
+    - freetype
   run:
 
 test:

--- a/recipes/fastqc-rs/meta.yaml
+++ b/recipes/fastqc-rs/meta.yaml
@@ -25,6 +25,7 @@ requirements:
     - zlib
     - bzip2
     - freetype
+    - libxml2
   run:
 
 test:

--- a/recipes/fastqc-rs/meta.yaml
+++ b/recipes/fastqc-rs/meta.yaml
@@ -26,11 +26,7 @@ requirements:
     - bzip2
     - freetype
     - libxml2
-    - libasound2-dev
-    - libssl-dev
-    - libfreetype6-dev
-    - libexpat1-dev
-    - libxcb-composite0-dev
+    - libexpat-dev
   run:
 
 test:

--- a/recipes/fastqc-rs/meta.yaml
+++ b/recipes/fastqc-rs/meta.yaml
@@ -16,6 +16,7 @@ requirements:
     - rust >=1.30
     - clangdev
   host:
+    - clangdev
   run:
 
 test:

--- a/recipes/fastqc-rs/meta.yaml
+++ b/recipes/fastqc-rs/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - openssl
     - zlib
     - bzip2
-    - libfreetype6-dev
+    - freetype2
   run:
 
 test:

--- a/recipes/fastqc-rs/meta.yaml
+++ b/recipes/fastqc-rs/meta.yaml
@@ -26,6 +26,11 @@ requirements:
     - bzip2
     - freetype
     - libxml2
+    - libasound2-dev
+    - libssl-dev
+    - libfreetype6-dev
+    - libexpat1-dev
+    - libxcb-composite0-dev
   run:
 
 test:

--- a/recipes/fastqc-rs/meta.yaml
+++ b/recipes/fastqc-rs/meta.yaml
@@ -20,6 +20,9 @@ requirements:
     - pkg-config
   host:
     - clangdev
+    - openssl
+    - zlib
+    - bzip2
   run:
 
 test:


### PR DESCRIPTION
This PR adds a recipe for [fastqc-rs](https://github.com/fxwiegand/fastqc-rs), a quality control tool for FASTQ files written in rust.