### PR TITLE
Update augur: Sync dependency versions to those from upstream

### DIFF
--- a/recipes/augur/meta.yaml
+++ b/recipes/augur/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 2a131514c0aa31cabdb24357a116c8f81e79faff4087caed7b81640195056a9c
 
 build:
-  number: 0
+  number: 1
   noarch: python
   entry_points:
     - augur = augur.__main__:main
@@ -22,12 +22,12 @@ requirements:
 
   run:
     - python >=3.6
-    - bcbio-gff >=0.6.0
-    - biopython >=1.67
-    - jsonschema >=3.0.0
+    - bcbio-gff >=0.6.0,<0.7
+    - biopython >=1.67,<=1.76
+    - jsonschema >=3.0.0,<4
     - packaging >=19.2
     - pandas >=1.0.0,<2
-    - treetime >=0.7.4
+    - treetime >=0.8,<0.9
     - snakemake >=5.4.0
     - cvxopt >=1.1.9,<2
     - mafft

--- a/recipes/augur/meta.yaml
+++ b/recipes/augur/meta.yaml
@@ -52,3 +52,4 @@ about:
 extra:
   recipe-maintainers:
     - huddlej
+    - tsibley


### PR DESCRIPTION
These differences from Augur's setup.py came to my attention because a
too-new BioPython was pulled into a new environment, which visibly broke
`augur index`.