### PR TITLE
Update krona 2.7.1 recipe

### DIFF
--- a/recipes/krona/2.7.1/build.sh
+++ b/recipes/krona/2.7.1/build.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+mkdir -p $PREFIX/opt/krona
+mv ./* $PREFIX/opt/krona
+cd $PREFIX/opt/krona
+find . -type f -name '._*' -delete
+./install.pl --prefix=$PREFIX
+ln -s $PREFIX/opt/krona/updateTaxonomy.sh $PREFIX/bin/ktUpdateTaxonomy.sh
+mkdir $PREFIX/bin/scripts
+ln -s $PREFIX/opt/krona/scripts/taxonomy.make $PREFIX/bin/scripts/taxonomy.make
+ln -s $PREFIX/opt/krona/scripts/extractTaxonomy.pl $PREFIX/bin/scripts/extractTaxonomy.pl
+chmod +x $PREFIX/bin/scripts/extractTaxonomy.pl
+
+echo 1 > $PREFIX/opt/krona/taxonomy/placeholder

--- a/recipes/krona/2.7.1/meta.yaml
+++ b/recipes/krona/2.7.1/meta.yaml
@@ -1,0 +1,34 @@
+package:
+  name: krona
+  version: 2.7.1
+
+source:
+  sha256: 8fb35e742085ad7cd6ae202fcac05b55e95470361dd409e670fdb62c7e7e6a1a
+  url: https://github.com/marbl/Krona/releases/download/v2.7.1/KronaTools-2.7.1.tar
+
+build:
+  noarch: generic
+  number: 4
+
+requirements:
+  host:
+    - perl
+  run:
+    - perl
+    - curl
+    - make
+
+test:
+  commands:
+    - ktImportTaxonomy
+    - ktImportXML
+
+about:
+  home: https://github.com/marbl/Krona
+  license: BSD
+  summary: 'Krona Tools is a set of scripts to create Krona charts from several Bioinformatics
+            tools as well as from text and XML files.'
+
+extra:
+  identifiers:
+    - biotools:krona

--- a/recipes/krona/2.7.1/meta.yaml
+++ b/recipes/krona/2.7.1/meta.yaml
@@ -17,6 +17,7 @@ requirements:
     - perl
     - curl
     - make
+    - tar
 
 test:
   commands:

--- a/recipes/krona/2.7.1/post-link.sh
+++ b/recipes/krona/2.7.1/post-link.sh
@@ -1,0 +1,14 @@
+echo "
+Krona installed.  You still need to manually update the taxonomy
+databases before Krona can generate taxonomic reports.  The update
+script is ktUpdateTaxonomy.sh.  The default location for storing
+taxonomic databases is $PREFIX/opt/krona/taxonomy
+
+If you would like the taxonomic data stored elsewhere, simply replace
+this directory with a symlink.  For example:
+
+rm -rf $PREFIX/opt/krona/taxonomy
+mkdir /path/on/big/disk/taxonomy
+ln -s /path/on/big/disk/taxonomy $PREFIX/opt/krona/taxonomy
+ktUpdateTaxonomy.sh
+" > $PREFIX/.messages.txt


### PR DESCRIPTION
Add `make` to krona 2.7.1 recipe, which is required for `ktUpdateTaxonomy`. 

Current BioContainer lead to the following error when running `ktUpdateTaxonomy.sh taxonomy`:
```
/usr/local/bin/ktUpdateTaxonomy.sh: line 163: [: ==: unary operator expected
/usr/local/bin/ktUpdateTaxonomy.sh: line 287: make: command not found
```