### PR TITLE
MA 1.1.4 & python 3.6

### DIFF
--- a/recipes/ma/meta.yaml
+++ b/recipes/ma/meta.yaml
@@ -7,7 +7,7 @@ source:
   url: "https://github.com/ITBE-Lab/MA/archive/{{version}}.tar.gz"
   sha256: "{{sha256}}"
 build:
-  number: 0
+  number: 1
   skip: true # [osx or py2k]
 
 requirements:
@@ -16,10 +16,10 @@ requirements:
     - cmake
   host:
     - zlib
-    - python>=3.9
+    - python>=3.6
   run:
     - zlib
-    - python>=3.9
+    - python>=3.6
 test:
   commands:
     - maCMD -h

--- a/recipes/ma/meta.yaml
+++ b/recipes/ma/meta.yaml
@@ -16,10 +16,10 @@ requirements:
     - cmake
   host:
     - zlib
-    - python>=3.6
+    - python
   run:
     - zlib
-    - python>=3.6
+    - python
 test:
   commands:
     - maCMD -h


### PR DESCRIPTION
I tried updating MA via the autobump but checks failed with python<3.9 (https://github.com/bioconda/bioconda-recipes/pull/26601).
As far as I can tell, the checks failed because python 3.9 and 3.7 were mixed during building and testing.

This pull request exists because I'd like to have a python>=3.6 requirement. 