### PR TITLE
Add gcta v1.93.2beta

### DIFF
--- a/recipes/gcta/build.sh
+++ b/recipes/gcta/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+mkdir -p $PREFIX/bin
+cp gcta64 $PREFIX/bin/gcta64

--- a/recipes/gcta/meta.yaml
+++ b/recipes/gcta/meta.yaml
@@ -1,0 +1,32 @@
+{% set name = "gcta" %}
+{% set version = "1.93.2beta" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  - url: https://cnsgenomics.com/software/{{ name }}/bin/{{ name }}_{{ version }}.zip # [linux]
+    sha256: 44354f4909666b760ab3cf538dc143ee3feff5540c2ad237a098766ff9829374 # [linux]
+  - url: https://cnsgenomics.com/software/{{ name }}/bin/{{ name }}_{{ version }}_mac.zip # [osx]
+    sha256: b92f4ac51e5e5cb04c8eb93d07605efb9f8847ec0afcb8df2717200f995b6fe7 # [osx]
+
+build:
+  number: 0
+
+test:
+  commands:
+    - gcta64 | grep "Analysis started"
+
+about:
+  home: "https://cnsgenomics.com/software/gcta/"
+  license: MIT
+  summary: GCTA (Genome-wide Complex Trait Analysis) estimates the proportion of phenotypic variance explained by all genome-wide SNPs for complex traits.
+
+extra:
+  identifiers:
+    - biotools:gcta
+    - doi:10.1016/j.ajhg.2010.11.011 
+  skip-lints:
+    - should_be_noarch_generic
+    - should_not_be_noarch_source


### PR DESCRIPTION
Adding gcta v1.93.2beta.

The software is precompiled and distributed as an executable. 
I have include sources for linux and osx. 