### PR TITLE
Update gromacs to fix SIMD detection on OSX

### DIFF
--- a/recipes/gromacs/2020/build.sh
+++ b/recipes/gromacs/2020/build.sh
@@ -53,11 +53,51 @@ mkdir -p "${PREFIX}/etc/conda/activate.d"
 touch "${PREFIX}/bin/${gmx}"
 chmod +x "${PREFIX}/bin/${gmx}"
 
+# We need to find CPU-type descriptors so we know which GROMACS SIMD flavor
+# to use. On Darwin, `sysctl -a` can have lines that look like
+#
+# hw.optional.floatingpoint: 1
+# hw.optional.mmx: 1
+# hw.optional.sse: 1
+# hw.optional.sse2: 1
+# hw.optional.sse3: 1
+# hw.optional.supplementalsse3: 1
+# hw.optional.sse4_1: 1
+# hw.optional.sse4_2: 1
+# hw.optional.x86_64: 1
+# hw.optional.aes: 1
+# hw.optional.avx1_0: 1
+# hw.optional.rdrand: 1
+# hw.optional.f16c: 1
+# hw.optional.enfstrg: 1
+# hw.optional.fma: 1
+# hw.optional.avx2_0: 1
+# hw.optional.bmi1: 1
+# hw.optional.bmi2: 1
+# hw.optional.rtm: 0
+# hw.optional.hle: 0
+# hw.optional.adx: 1
+# hw.optional.mpx: 0
+# hw.optional.sgx: 0
+# hw.optional.avx512f: 0
+# hw.optional.avx512cd: 0
+# hw.optional.avx512dq: 0
+# hw.optional.avx512bw: 0
+# hw.optional.avx512vl: 0
+# hw.optional.avx512ifma: 0
+# hw.optional.avx512vbmi: 0
+#
+# so there we grep out lines that match that prefix and have the
+# feature (indicated by the final 1). On Linux, `cat /proc/cpuinfo`
+# can have lines that look like
+#
+# flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc art arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch cpuid_fault epb invpcid_single ssbd ibrs ibpb stibp ibrs_enhanced tpr_shadow vnmi flexpriority ept vpid ept_ad fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid mpx rdseed adx smap clflushopt intel_pt xsaveopt xsavec xgetbv1 xsaves dtherm ida arat pln pts hwp hwp_notify hwp_act_window hwp_epp pku ospke md_clear flush_l1d arch_capabilities
+#
+# where only the available features are listed. Either way, we then use
+# bash extended pattern matching to find the features we need.
 case "$OSTYPE" in
-  darwin*) hardware_info_command="sysctl -a | grep '^hw.optional\.(.*): 1$'"
-  ;;
-  *)       hardware_info_command="cat /proc/cpuinfo | grep -m1 '^flags'"
-  ;;
+  darwin*) hardware_info_command="sysctl -a | grep '^hw.optional\..*: 1$'" ;;
+  *)       hardware_info_command="cat /proc/cpuinfo | grep -m1 '^flags'" ;;
 esac
 
 { cat <<EOF
@@ -65,18 +105,22 @@ esac
 
 function _gromacs_bin_dir() {
   local arch
+  # Make a valid fallback choice that will always work (on x86 at least)
   arch='SSE2'
   case \$( ${hardware_info_command} ) in
-    *\ avx512f\ *)
+    # First, is there AVX512?
+    *avx512f*)
       test -d "${PREFIX}/bin.AVX_512" && \
         "${PREFIX}/bin.AVX_512/identifyavx512fmaunits" | grep -q '2' && \
         arch='AVX_512'
     ;;
-    *\ avx2\ *)
+    # Next, is there AVX2?
+    *avx2?(_0)*)
       test -d "${PREFIX}/bin.AVX2_256" && \
         arch='AVX2_256'
     ;;
-    *\ avx\ *)
+    # Finally, is there AVX?
+    *avx?(1_0)*)
       test -d "${PREFIX}/bin.AVX_256" && \
         arch='AVX_256'
   esac

--- a/recipes/gromacs/2020/build.sh
+++ b/recipes/gromacs/2020/build.sh
@@ -115,11 +115,11 @@ function _gromacs_bin_dir() {
         "${PREFIX}/bin.AVX_512/identifyavx512fmaunits" | grep -q '2' && \
         arch='AVX_512'
     ;;
-    *avx2*)
+    *\ avx2\ | *avx_2*)
       test -d "${PREFIX}/bin.AVX2_256" && \
         arch='AVX2_256'
     ;;
-    *avx*)
+    *\ avx\ * | *avx_1*)
       test -d "${PREFIX}/bin.AVX_256" && \
         arch='AVX_256'
   esac

--- a/recipes/gromacs/2020/build.sh
+++ b/recipes/gromacs/2020/build.sh
@@ -103,23 +103,21 @@ esac
 { cat <<EOF
 #! /bin/bash
 
+# Search first for AVX512, then AVX2, then AVX. Fall back on SSE2
 function _gromacs_bin_dir() {
   local arch
   # Make a valid fallback choice that will always work (on x86 at least)
   arch='SSE2'
   case \$( ${hardware_info_command} ) in
-    # First, is there AVX512?
     *avx512f*)
       test -d "${PREFIX}/bin.AVX_512" && \
         "${PREFIX}/bin.AVX_512/identifyavx512fmaunits" | grep -q '2' && \
         arch='AVX_512'
     ;;
-    # Next, is there AVX2?
     *avx2?(_0)*)
       test -d "${PREFIX}/bin.AVX2_256" && \
         arch='AVX2_256'
     ;;
-    # Finally, is there AVX?
     *avx?(1_0)*)
       test -d "${PREFIX}/bin.AVX_256" && \
         arch='AVX_256'

--- a/recipes/gromacs/2020/build.sh
+++ b/recipes/gromacs/2020/build.sh
@@ -115,11 +115,11 @@ function _gromacs_bin_dir() {
         "${PREFIX}/bin.AVX_512/identifyavx512fmaunits" | grep -q '2' && \
         arch='AVX_512'
     ;;
-    *avx2?(_0)*)
+    *avx2*)
       test -d "${PREFIX}/bin.AVX2_256" && \
         arch='AVX2_256'
     ;;
-    *avx?(1_0)*)
+    *avx*)
       test -d "${PREFIX}/bin.AVX_256" && \
         arch='AVX_256'
   esac

--- a/recipes/gromacs/2020/build.sh
+++ b/recipes/gromacs/2020/build.sh
@@ -96,8 +96,8 @@ chmod +x "${PREFIX}/bin/${gmx}"
 # where only the available features are listed. Either way, we then use
 # bash extended pattern matching to find the features we need.
 case "$OSTYPE" in
-  darwin*) hardware_info_command="sysctl -a | grep '^hw.optional\..*: 1$'" ;;
-  *)       hardware_info_command="cat /proc/cpuinfo | grep -m1 '^flags'" ;;
+  darwin*) hardware_info_command="sysctl -a | grep '^hw.optional\..*: 1$'";;
+  *)       hardware_info_command="cat /proc/cpuinfo | grep -m1 '^flags'";;
 esac
 
 { cat <<EOF

--- a/recipes/gromacs/2020/build.sh
+++ b/recipes/gromacs/2020/build.sh
@@ -53,13 +53,15 @@ mkdir -p "${PREFIX}/etc/conda/activate.d"
 touch "${PREFIX}/bin/${gmx}"
 chmod +x "${PREFIX}/bin/${gmx}"
 
-{ cat <<EOF
-#! /bin/bash
-
 case "$OSTYPE" in
   darwin*) hardware_info_command="sysctl -a | grep -m1 '^hw.optional'"
+  ;;
   *)       hardware_info_command="cat /proc/cpuinfo | grep -m1 '^flags'"
+  ;;
 esac
+
+{ cat <<EOF
+#! /bin/bash
 
 function _gromacs_bin_dir() {
   local arch

--- a/recipes/gromacs/2020/build.sh
+++ b/recipes/gromacs/2020/build.sh
@@ -115,7 +115,7 @@ function _gromacs_bin_dir() {
         "${PREFIX}/bin.AVX_512/identifyavx512fmaunits" | grep -q '2' && \
         arch='AVX_512'
     ;;
-    *\ avx2\ | *avx_2*)
+    *\ avx2\ * | *avx_2*)
       test -d "${PREFIX}/bin.AVX2_256" && \
         arch='AVX2_256'
     ;;

--- a/recipes/gromacs/2020/build.sh
+++ b/recipes/gromacs/2020/build.sh
@@ -96,17 +96,18 @@ chmod +x "${PREFIX}/bin/${gmx}"
 # where only the available features are listed. Either way, we then use
 # bash extended pattern matching to find the features we need.
 case "$OSTYPE" in
-  darwin*) hardware_info_command="sysctl -a | grep '^hw.optional\..*: 1$'";;
-  *)       hardware_info_command="cat /proc/cpuinfo | grep -m1 '^flags'";;
+    darwin*) hardware_info_command="sysctl -a | grep '^hw.optional\..*: 1$'"
+             ;;
+    *)       hardware_info_command="cat /proc/cpuinfo | grep -m1 '^flags'"
+             ;;
 esac
 
+# Search first for AVX512, then AVX2, then AVX. Fall back on SSE2
 { cat <<EOF
 #! /bin/bash
 
-# Search first for AVX512, then AVX2, then AVX. Fall back on SSE2
 function _gromacs_bin_dir() {
   local arch
-  # Make a valid fallback choice that will always work (on x86 at least)
   arch='SSE2'
   case \$( ${hardware_info_command} ) in
     *avx512f*)

--- a/recipes/gromacs/2020/build.sh
+++ b/recipes/gromacs/2020/build.sh
@@ -54,7 +54,7 @@ touch "${PREFIX}/bin/${gmx}"
 chmod +x "${PREFIX}/bin/${gmx}"
 
 case "$OSTYPE" in
-  darwin*) hardware_info_command="sysctl -a | grep -m1 '^hw.optional'"
+  darwin*) hardware_info_command="sysctl -a | grep '^hw.optional'"
   ;;
   *)       hardware_info_command="cat /proc/cpuinfo | grep -m1 '^flags'"
   ;;

--- a/recipes/gromacs/2020/build.sh
+++ b/recipes/gromacs/2020/build.sh
@@ -56,10 +56,15 @@ chmod +x "${PREFIX}/bin/${gmx}"
 { cat <<EOF
 #! /bin/bash
 
+case "$OSTYPE" in
+  darwin*) hardware_info_command="sysctl -a | grep -m1 '^hw.optional'"
+  *)       hardware_info_command="cat /proc/cpuinfo | grep -m1 '^flags'"
+esac
+
 function _gromacs_bin_dir() {
   local arch
   arch='SSE2'
-  case \$( cat /proc/cpuinfo | grep -m1 '^flags' ) in
+  case \$( ${hardware_info_command} ) in
     *\ avx512f\ *)
       test -d "${PREFIX}/bin.AVX_512" && \
         "${PREFIX}/bin.AVX_512/identifyavx512fmaunits" | grep -q '2' && \

--- a/recipes/gromacs/2020/build.sh
+++ b/recipes/gromacs/2020/build.sh
@@ -54,7 +54,7 @@ touch "${PREFIX}/bin/${gmx}"
 chmod +x "${PREFIX}/bin/${gmx}"
 
 case "$OSTYPE" in
-  darwin*) hardware_info_command="sysctl -a | grep '^hw.optional'"
+  darwin*) hardware_info_command="sysctl -a | grep '^hw.optional\.(.*): 1$'"
   ;;
   *)       hardware_info_command="cat /proc/cpuinfo | grep -m1 '^flags'"
   ;;

--- a/recipes/gromacs/2020/meta.yaml
+++ b/recipes/gromacs/2020/meta.yaml
@@ -3,7 +3,7 @@
 # http://manual.gromacs.org/documentation/
 {% set version = "2020.5" %}
 {% set md5sum = "0b4f28fadfa2b95f3c811346672a132e" %}
-{% set build = 2 %}
+{% set build = 3 %}
 
 
 package:


### PR DESCRIPTION
Fix GROMACS SIMD detection on osx. /proc/cpuinfo doesn't exist, but the fallback logic was providing the SSE2 version. Now it will run other versions on suitable hardware.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
