### PR TITLE
Fix version string in calitas recipe to be the version not the sha hash.

### DIFF
--- a/recipes/calitas/meta.yaml
+++ b/recipes/calitas/meta.yaml
@@ -3,7 +3,7 @@
 
 package:
   name: calitas
-  version: {{ shahash }}
+  version: {{ version }}
 
 source:
   url: https://github.com/editasmedicine/calitas/releases/download/v{{ version }}/calitas-{{ version }}.jar


### PR DESCRIPTION
Yesterday I submitted PR #26954 to add a new recipe for CALITAS.  The tests ran fine locally and in CI, but once the PR was merged I searched in bioconda and realized that the version was mistakenly set to the sha hash value instead of a reasonable version string.  This PR remedies that.

----

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
