### PR TITLE
Update deepnog: require PyTorch

### DIFF
--- a/recipes/deepnog/meta.yaml
+++ b/recipes/deepnog/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   # We should be platform-independent (no compiled code etc.)
   noarch: python
-  number: 0
+  number: 1
   entry_points:
     - deepnog = deepnog.client:main
   script: "{{ PYTHON }} -m pip install . -vv"

--- a/recipes/deepnog/meta.yaml
+++ b/recipes/deepnog/meta.yaml
@@ -19,20 +19,14 @@ build:
 
 requirements:
   host:
-    - biopython
-    - numpy
-    - pandas
     - pip
     - python
-    - pyyaml
-    - scikit-learn
-    - tensorboard
-    - tqdm
   run:
     - biopython
     - numpy
     - pandas
     - python
+    - pytorch
     - pyyaml
     - scikit-learn
     - tensorboard
@@ -40,7 +34,17 @@ requirements:
 
 test:
   commands:
-    - python --version
+    - deepnog --version
+    - deepnog --help
+    - deepnog infer --help
+    - deepnog train --help
+  imports:
+    - deepnog
+    - deepnog.client
+    - deepnog.learning
+    - deepnog.models
+    - deepnog.tests
+    - deepnog.utils
 
 about:
   home: https://github.com/univieCUBE/deepnog


### PR DESCRIPTION
`deepnog` requires PyTorch, which was previously not available from conda standard channels. Thus, the current deepnog recipe is omitting it, requiring the user to manually install the pytorch dependency from the pytorch channel.

Now it seems, conda-forge has pytorch, and we, therefore, include it in the requirements section. Also, we can now actually do tests in this recipe. Finally, I think we had some superfluous host requirements.
