### PR TITLE
Update: sourmash -> remove bam2fasta dep

### DIFF
--- a/recipes/sourmash/meta.yaml
+++ b/recipes/sourmash/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 72533b69ebe5ba592679377537426173a75aebbc5d2572b925115aa6769a689c
 
 build:
-  number: 0
+  number: 1
   noarch: generic
 
 requirements:
@@ -19,7 +19,6 @@ requirements:
     - numpy
     - matplotlib-base
     - scipy
-    - bam2fasta >=1.0.1
 
 test:
   imports:


### PR DESCRIPTION
sourmash 4.0 remove the dependency on bam2fasta, updating recipe to reflect it.
