### PR TITLE
Update gotree recipe : Corrected cmd version

### DIFF
--- a/recipes/gotree/build.sh
+++ b/recipes/gotree/build.sh
@@ -5,7 +5,7 @@ export CGO_ENABLED=0
 go get -u github.com/golang/dep/cmd/dep
 cd "$GOPATH/src/github.com/evolbioinfo/gotree"
 dep ensure
-go build -o ${PREFIX}/bin/gotree -ldflags "-X github.com/evolbioinfo/gotree/version.Version=${PKG_VERSION}" github.com/evolbioinfo/gotree
+go build -o ${PREFIX}/bin/gotree -ldflags "-X github.com/evolbioinfo/gotree/cmd.Version=${PKG_VERSION}" github.com/evolbioinfo/gotree
 
 # Gotree test data
 cp -r tests/data $PREFIX/gotree_test_data


### PR DESCRIPTION
This pull request corrects package version that was null when executing `gotree version`

