### PR TITLE
Pin rich version to >=9.4.0

### DIFF
--- a/recipes/multiqc/meta.yaml
+++ b/recipes/multiqc/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 08a1180bc236fcaf1ab1beadd25d3ff9a681df83321ac59c7f5fab165fd796a4
 
 build:
-  number: 0
+  number: 1
   entry_points:
     - multiqc=multiqc.__main__:multiqc
   noarch: python
@@ -33,7 +33,7 @@ requirements:
     - numpy
     - pyyaml >=4
     - requests
-    - rich
+    - rich >=9.4.0
     - simplejson
     - spectra >=0.0.10
 


### PR DESCRIPTION
Fix for incorrect rich version being kept

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
