### PR TITLE
Add VIRULIGN v1.0.2

### DIFF
--- a/recipes/virulign/build.sh
+++ b/recipes/virulign/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+mkdir build
+pushd build
+cmake -DCMAKE_BUILD_TYPE=Release ..
+make
+
+mkdir -p $PREFIX/bin
+cp ./src/virulign ${PREFIX}/bin/

--- a/recipes/virulign/meta.yaml
+++ b/recipes/virulign/meta.yaml
@@ -28,6 +28,6 @@ test:
 
 about:
   home: https://github.com/rega-cev/virulign
-  license: GPL-3.0-only
+  license: GPL-2.0-only
   license_file: LICENSE.txt
   summary: {{ name }} is a tool for codon-correct pairwise alignments, with an augmented functionality to annotate the alignment according the positions of the proteins.

--- a/recipes/virulign/meta.yaml
+++ b/recipes/virulign/meta.yaml
@@ -24,7 +24,7 @@ requirements:
 
 test:
   commands:
-    - virulign -h
+    - virulign -h 2>&1 | grep "virulign"
 
 about:
   home: https://github.com/rega-cev/virulign

--- a/recipes/virulign/meta.yaml
+++ b/recipes/virulign/meta.yaml
@@ -7,7 +7,7 @@ package:
   version: {{ version }}
 
 source:
-  - url: https://github.com/rega-cev/{{ name }}/archive/v{{ version }}.tar.gz
+  - url: https://github.com/rega-cev/{{ name|lower }}/archive/v{{ version }}.tar.gz
     sha256: {{ sha256 }}
 
 build:
@@ -17,8 +17,10 @@ requirements:
   build:
     - {{ compiler('cxx') }}
     - cmake>=3.12
-#  host:
-#  run:
+  host:
+    - openmp
+  run:
+    - openmp
 
 test:
   commands:

--- a/recipes/virulign/meta.yaml
+++ b/recipes/virulign/meta.yaml
@@ -1,0 +1,31 @@
+{% set name = "VIRULIGN" %}
+{% set version = "1.0.2" %}
+{% set sha256 = "3e6934d5b5f37ff60b3aed94472b8076a6e79ea870f7e0ad5c4208a4d13d3c09" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  - url: https://github.com/rega-cev/{{ name }}/archive/v{{ version }}.tar.gz
+    sha256: {{ sha256 }}
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - {{ compiler('cxx') }}
+    - cmake>=3.12
+#  host:
+#  run:
+
+test:
+  commands:
+    - virulign -h
+
+about:
+  home: https://github.com/rega-cev/virulign
+  license: GPL-3.0-only
+  license_file: LICENSE.txt
+  summary: {{ name }} is a tool for codon-correct pairwise alignments, with an augmented functionality to annotate the alignment according the positions of the proteins.


### PR DESCRIPTION
Please add the recipe for VIRULIGN v1.0.2. This is a bioinformatics software for codon-correct pairwise alignments, with an augmented functionality to annotate the alignment according the positions of the proteins.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
