### PR TITLE
Update gotree to 0.4.1

### DIFF
--- a/recipes/gotree/build.sh
+++ b/recipes/gotree/build.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 
 export CGO_ENABLED=0
+export GOPATH=$PWD
 
 go get -u github.com/golang/dep/cmd/dep
-cd "$GOPATH/src/github.com/evolbioinfo/gotree"
+
+cd src/github.com/evolbioinfo/${PKG_NAME}
 dep ensure
-go build -o ${PREFIX}/bin/gotree -ldflags "-X github.com/evolbioinfo/gotree/cmd.Version=${PKG_VERSION}" github.com/evolbioinfo/gotree
+go build -o ${PREFIX}/bin/${PKG_NAME} -ldflags "-X github.com/evolbioinfo/${PKG_NAME}/cmd.Version=${PKG_VERSION}" github.com/evolbioinfo/${PKG_NAME}
 
 # Gotree test data
 cp -r tests/data $PREFIX/gotree_test_data

--- a/recipes/gotree/build.sh
+++ b/recipes/gotree/build.sh
@@ -5,7 +5,7 @@ export CGO_ENABLED=0
 go get -u github.com/golang/dep/cmd/dep
 cd "$GOPATH/src/github.com/evolbioinfo/gotree"
 dep ensure
-go build -o ${PREFIX}/bin/gotree -ldflags "-X github.com/evolbioinfo/gotree/version.Version=${PKG_VERSION}" github.com/evolbioinfo/gotree
+go build -o ${PREFIX}/bin/gotree -ldflags "-X github.com/evolbioinfo/gotree/cmd.Version=${PKG_VERSION}" github.com/evolbioinfo/gotree
 
 # Gotree test data
 cp -r tests/data $PREFIX/gotree_test_data

--- a/recipes/gotree/meta.yaml
+++ b/recipes/gotree/meta.yaml
@@ -22,6 +22,7 @@ test:
   commands:
     - {{name}} -h
     - {{name}}_test.sh
+    - {{name}} version
 
 about:
   home: https://github.com/evolbioinfo/{{name}}

--- a/recipes/gotree/meta.yaml
+++ b/recipes/gotree/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.4.0" %}
+{% set version = "0.4.1" %}
 {% set name = "gotree" %}
 
 package:
@@ -11,7 +11,7 @@ build:
 
 source:
   - url: https://github.com/evolbioinfo/{{name}}/archive/v{{ version }}.tar.gz
-    sha256: 3b7610eb351624b06b2b785ec16fe102120b4f0e2bb3507d1f9f771d720ad050
+    sha256: 205851903d07d6ef47e339d9d5b80935adc2056f00739b156a3e3ab2852b8371
     folder: src/github.com/evolbioinfo/{{name}}/
 
 requirements:


### PR DESCRIPTION
Update gotree: 0.4.0 → 0.4.1
The recipe has also been modified to prevent build errors.