### PR TITLE
Add mysql perl-module dependency install command

### DIFF
--- a/recipes/perl-atlas-modules/meta.yaml
+++ b/recipes/perl-atlas-modules/meta.yaml
@@ -11,7 +11,7 @@ source:
 # If this is a new build for the same version, increment the build
 # number. If you do not include this key, it defaults to 0.
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
@@ -29,6 +29,7 @@ requirements:
    - perl-date-manip
    - perl-datetime
    - perl-datetime-format-strptime
+   - perl-dbd-mysql
    - perl-dbd-pg>3.5.3
    - perl-dbi
    - perl-devel-symdump
@@ -100,6 +101,7 @@ requirements:
    - perl-date-manip
    - perl-datetime
    - perl-datetime-format-strptime
+   - perl-dbd-mysql
    - perl-dbd-pg>3.5.3
    - perl-dbi
    - perl-devel-symdump


### PR DESCRIPTION
This adds Perl MySQL conda package to the dependencies, which is needed for the ArrayExpress curation scripts and checker daemon to interact with the submissions tracking database.
