### PR TITLE
Add leviosam recipe

### DIFF
--- a/recipes/leviosam/build.sh
+++ b/recipes/leviosam/build.sh
@@ -1,0 +1,5 @@
+mkdir -p build;
+cd build;
+cmake -DCMAKE_INSTALL_PREFIX=${PREFIX} ${SRC_DIR}
+make;
+make install

--- a/recipes/leviosam/meta.yaml
+++ b/recipes/leviosam/meta.yaml
@@ -1,0 +1,32 @@
+{% set version = "0.3.1.1" %}
+
+package:
+    name: leviosam
+    version: {{ version }}
+
+source:
+  url: https://github.com/alshai/levioSAM/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 1d078a825a57bfe245779389569d7d92324270876e3cc71e761e09c4c1774664
+
+build:
+  number: 1
+
+requirements:
+    build:
+        - {{ compiler('cxx') }}
+        - cmake
+    host:
+        - htslib >=1.11
+        - sdsl-lite >=2.1.1
+    run:
+        - htslib >=1.11
+        - sdsl-lite >=2.1.1
+        - libstdcxx-ng >=9.3.0
+        - libgcc-ng >=9.3.0
+        - zlib >=1.2.11,<1.3.0a0
+
+about:
+    home: "https://github.com/alshai/levioSAM"
+    license: MIT
+    license_file: LICENSE
+    summary: "lift-over of alignments for variant-aware references"

--- a/recipes/leviosam/meta.yaml
+++ b/recipes/leviosam/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.3.1.1" %}
+{% set version = "0.3.1.2" %}
 
 package:
     name: leviosam
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/alshai/levioSAM/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 1d078a825a57bfe245779389569d7d92324270876e3cc71e761e09c4c1774664
+  sha256: 948694d8d1e710e38b0d9b4a804ecca8c688bdfe994d6067d88852ed34e0c4f3
 
 build:
   number: 1
@@ -25,6 +25,9 @@ requirements:
         - libgcc-ng >=9.3.0
         - zlib >=1.2.11,<1.3.0a0
 
+test:
+    commands:
+        - leviosam -h
 about:
     home: "https://github.com/alshai/levioSAM"
     license: MIT

--- a/recipes/leviosam/meta.yaml
+++ b/recipes/leviosam/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 948694d8d1e710e38b0d9b4a804ecca8c688bdfe994d6067d88852ed34e0c4f3
 
 build:
-  number: 1
+  number: 0
 
 requirements:
     build:

--- a/recipes/leviosam/meta.yaml
+++ b/recipes/leviosam/meta.yaml
@@ -21,8 +21,6 @@ requirements:
     run:
         - htslib >=1.11
         - sdsl-lite >=2.1.1
-        - libstdcxx-ng >=9.3.0
-        - libgcc-ng >=9.3.0
         - zlib >=1.2.11,<1.3.0a0
 
 test:

--- a/recipes/leviosam/meta.yaml
+++ b/recipes/leviosam/meta.yaml
@@ -12,16 +12,17 @@ build:
   number: 0
 
 requirements:
-    build:
-        - {{ compiler('cxx') }}
-        - cmake
-    host:
-        - htslib >=1.11
-        - sdsl-lite >=2.1.1
-    run:
-        - htslib >=1.11
-        - sdsl-lite >=2.1.1
-        - zlib >=1.2.11,<1.3.0a0
+  build:
+    - {{ compiler('cxx') }}
+    - cmake
+    - make
+  host:
+    - htslib >=1.11
+    - sdsl-lite >=2.1.1
+  run:
+    - htslib >=1.11
+    - sdsl-lite >=2.1.1
+    - zlib >=1.2.11,<1.3.0a0
 
 test:
     commands:


### PR DESCRIPTION
This conda recipe is for levioSAM - a lift-over tool for SAM/BAM files for variant-aware references described in a VCF file.

preprint is here: https://www.biorxiv.org/content/10.1101/2021.02.05.429867v1
the github repo is here: https://github.com/alshai/levioSAM