### PR TITLE
Update PSASS version and URL

### DIFF
--- a/recipes/psass/meta.yaml
+++ b/recipes/psass/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "3.0.1b" %}
-{% set sha256 = "6f3af8bd9e7e3e18de3c4ecdd8d2163aa57253264359f4ca72a5ca7e56ecd249" %}
+{% set version = "3.1.0" %}
+{% set sha256 = "6c22fb2db52df76bdf8e5073895da11678a35c4a0e1500245e19d13c1f67df2b" %}
 
 package:
   name: psass
@@ -9,7 +9,7 @@ build:
   number: 0
 
 source:
-  url: https://github.com/RomainFeron/PSASS/archive/{{ version }}.tar.gz 
+  url: https://github.com/SexGenomicsToolkit/PSASS/archive/{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 requirements:


### PR DESCRIPTION
This PR updates PSASS to 3.1.0 and replaces the URL with that of the new repository 
