### PR TITLE
Update antismash: pin biopython to versions including bio.alphabet

### DIFF
--- a/recipes/antismash/meta.yaml
+++ b/recipes/antismash/meta.yaml
@@ -7,7 +7,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 3
+  number: 4
   noarch: python
 
 source:
@@ -21,7 +21,7 @@ requirements:
   run:
     - python >=3.5
     - numpy
-    - biopython >=1.71
+    - biopython >=1.71,<=1.77
     - helperlibs >=0.2.0
     - jinja2
     - pysvg-py3


### PR DESCRIPTION
Biopython has removed Bio.alphabet in 1.78, which is required by antismash. Biopython is therefore additionally pinned to <=1.77. 


