### PR TITLE
Update deepvariant to enable GPU support

### DIFF
--- a/recipes/deepvariant/meta.yaml
+++ b/recipes/deepvariant/meta.yaml
@@ -19,7 +19,7 @@ source:
   sha256: '{{ sha256 }}'
 
 build:
-  number: 2
+  number: 3
   skip: true  # [osx or not py36]
 
 requirements:
@@ -48,7 +48,7 @@ requirements:
     - htslib
     - numpy
     - curl
-    - tensorflow 2.0.*
+    - tensorflow-gpu 2.0.*
     - tensorflow-estimator 2.0.*
     - protobuf
     - contextlib2


### PR DESCRIPTION
This PR changes the dependency from `tensorflow` to `tensorflow-gpu`. This in turns allows for GPU support and very significant performance improvements. I am not aware of any drawbacks to this beyond the additional dependencies introduced, e.g. `cudatoolkit` and `cudnn`. Installation works fine on non-GPU machines as well.

----

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
