### PR TITLE
Add sgkit recipe

### DIFF
--- a/recipes/sgkit/meta.yaml
+++ b/recipes/sgkit/meta.yaml
@@ -1,0 +1,61 @@
+{% set name = "sgkit" %}
+{% set version = "0.2.0a1" %}
+{% set sha256 = "bf67ceeff4e0e81e79d7f40423b90ac0d2d580def98ee9a7b163485e32498f75" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  noarch: python
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - python >=3.7
+    - setuptools
+    - setuptools_scm
+
+  run:
+    - python >=3.7
+    - numpy
+    - numba
+    - xarray
+    - dask[array]
+    - distributed
+    - dask-ml
+    - scipy
+    - zarr
+    - typing-extensions
+    - fsspec
+    # bgen support
+    - rechunker
+    - cbgen
+    # vcf support
+    - cyvcf2  # bioconda
+    - yarl
+    # plink support
+    - partd
+    # - bed-reader # No conda package 2021-04-06
+
+test:
+  imports:
+    - sgkit
+
+about:
+  home: https://pystatgen.github.io/sgkit
+  license: Apache Software
+  license_family: APACHE
+  license_file: LICENSE
+  summary: "Statistical genetics toolkit"
+  doc_url: https://pystatgen.github.io/sgkit
+  dev_url: https://github.com/pystatgen/sgki
+
+extra:
+  maintainers:
+    - jeromekelleher


### PR DESCRIPTION
This PR adds a recipe for [sgkit](https://pystatgen.github.io/sgkit/latest/), the statistical genetics toolkit. This is a Python package which leverages upstream PyData packages like xarray and zarr. We depend on packages like cyvcf2 which are only in bioconda, so Bioconda seems more appropriate than conda-forge.

The requirements are fairly involved; we need Numba, Dask, Zarr and Xarray as our main upstreams, and also cyvcf2, cbgen and bed-reader for handling genetics file formats.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
