### PR TITLE
Update build.sh to add *.py scripts to bin

### DIFF
--- a/recipes/braker2/build.sh
+++ b/recipes/braker2/build.sh
@@ -5,4 +5,5 @@ mkdir -p ${PREFIX}/bin
 chmod +x scripts/*.pl
 cp scripts/*.pl ${PREFIX}/bin/
 cp scripts/*.pm ${PREFIX}/bin/
+cp scripts/*.py ${PREFIX}/bin/
 cp -r scripts/cfg/ ${PREFIX}/bin/

--- a/recipes/braker2/meta.yaml
+++ b/recipes/braker2/meta.yaml
@@ -13,7 +13,7 @@ source:
     - path.patch
 
 build:
-  number: 1
+  number: 2
   noarch: generic
 
 requirements:


### PR DESCRIPTION
Fix problem with unavailability of *.py scripts in /bin/ of Braker v2.1.6