### PR TITLE
Update libsbml to contain extensions

### DIFF
--- a/recipes/libsbml/build.sh
+++ b/recipes/libsbml/build.sh
@@ -8,6 +8,14 @@ cmake -DCMAKE_INSTALL_PREFIX=${PREFIX} \
       -DWITH_SWIG=OFF \
       -DLIBSBML_DEPENDENCY_DIR="${PREFIX}" \
       -DLIBXML_INCLUDE_DIR=${PREFIX}/include/libxml2 \
+      -DENABLE_COMP=ON \
+      -DENABLE_FBC=ON \
+      -DENABLE_GROUPS=ON \
+      -DENABLE_L3V2EXTENDEDMATH=ON \
+      -DENABLE_LAYOUT=ON \
+      -DENABLE_MULTI=ON \
+      -DENABLE_QUAL=ON \
+      -DENABLE_RENDER=ON \
       ..
 make -j"${CPU_COUNT}"
 make install

--- a/recipes/libsbml/meta.yaml
+++ b/recipes/libsbml/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "5.18.0" %}
-{% set sha256 = "900a8a41682c6fe69b162bce45e4221d7e23f30acb6c3d3516d1d931f353936a" %}
+{% set sha256 = "6c01be2306ec0c9656b59cb082eb7b90176c39506dd0f912b02e08298a553360" %}
 
 package:
   name: libsbml
@@ -10,8 +10,7 @@ build:
 
 source:
   url:
-    - https://sourceforge.net/projects/sbml/files/libsbml/{{ version }}/stable/libSBML-{{ version }}-core-src.tar.gz
-    - https://depot.galaxyproject.org/software/libsbml/libsbml_{{ version }}_src_all.tar.gz
+    - https://sourceforge.net/projects/sbml/files/libsbml/{{ version }}/stable/libSBML-{{ version }}-core-plus-packages-src.tar.gz
   sha256: {{ sha256 }}
 
 requirements:

--- a/recipes/libsbml/meta.yaml
+++ b/recipes/libsbml/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 4
+  number: 5
 
 source:
   url:


### PR DESCRIPTION
- added popular extensions to libsbml compilation to enable proper
  usage in constraint-based modelling
- these extensions are needed for example to use sbml in R (sybiSBML)
- linux distributions often contain these extensions by default, for
  example debian: https://salsa.debian.org/med-team/libsbml