### PR TITLE
Updates deepvariant recipe

### DIFF
--- a/recipes/deepvariant/dv_make_examples.py
+++ b/recipes/deepvariant/dv_make_examples.py
@@ -56,6 +56,7 @@ def main():
            "{py_exe} {bin_dir}/make_examples.zip "
            "--mode calling --ref {args.ref} --reads {args.reads} {regions} "
            "{gvcf} "
+           "--sample_name {args.sample} "
            "--examples {args.examples}/{args.sample}.tfrecord@{args.cores}.gz --task {{}} "
            "::: {split_inputs}")
     sys.exit(subprocess.call(cmd.format(**locals()), shell=True))

--- a/recipes/deepvariant/meta.yaml
+++ b/recipes/deepvariant/meta.yaml
@@ -19,7 +19,7 @@ source:
   sha256: '{{ sha256 }}'
 
 build:
-  number: 0
+  number: 1
   skip: true  # [osx or not py36]
 
 requirements:


### PR DESCRIPTION
This PR adds a the missing `--sample_name` argument to `dv_make_examples.py`. Without this flag the samples in vcfs will be named `default`, which causes problems, eg when merging vcfs.

----

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
