### PR TITLE
Add simuG

### DIFF
--- a/recipes/simug/build.sh
+++ b/recipes/simug/build.sh
@@ -2,5 +2,5 @@
 
 mkdir -p $PREFIX/bin/
 
-cp simuG/simuG.pl $PREFIX/bin/simuG
-cp simuG/vcf2model.pl $PREFIX/bin/vcf2model
+cp simuG.pl $PREFIX/bin/simuG
+cp vcf2model.pl $PREFIX/bin/vcf2model

--- a/recipes/simug/build.sh
+++ b/recipes/simug/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+mkdir -p $PREFIX/bin/
+
+cp simuG.pl $PREFIX/bin/simuG
+cp vcf2model.pl $PREFIX/bin/vcf2model

--- a/recipes/simug/build.sh
+++ b/recipes/simug/build.sh
@@ -2,5 +2,5 @@
 
 mkdir -p $PREFIX/bin/
 
-cp simuG.pl $PREFIX/bin/simuG
-cp vcf2model.pl $PREFIX/bin/vcf2model
+cp simuG/simuG.pl $PREFIX/bin/simuG
+cp simuG/vcf2model.pl $PREFIX/bin/vcf2model

--- a/recipes/simug/build.sh
+++ b/recipes/simug/build.sh
@@ -4,3 +4,5 @@ mkdir -p $PREFIX/bin/
 
 cp simuG.pl $PREFIX/bin/simuG
 cp vcf2model.pl $PREFIX/bin/vcf2model
+sed -i.bak '1 s|^.*$|#!/usr/bin/env perl|g' $PREFIX/bin/simuG
+sed -i.bak '1 s|^.*$|#!/usr/bin/env perl|g' $PREFIX/bin/vcf2model

--- a/recipes/simug/meta.yaml
+++ b/recipes/simug/meta.yaml
@@ -21,8 +21,8 @@ requirements:
 
 test:
   commands:
-    - simuG -h
-    - vcf2model -h
+    - simuG -h 2>&1 | grep Usage
+    - vcf2model -h 2>&1 | grep Usage
 
 about:
   home: https://github.com/yjx1217/simuG

--- a/recipes/simug/meta.yaml
+++ b/recipes/simug/meta.yaml
@@ -21,8 +21,8 @@ requirements:
 
 test:
   commands:
-    - simuG -h | grep Usage
-    - vcf2model -h | grep Usage
+    - simuG -h 2>&1 | grep Usage
+    - vcf2model -h 2>&1 | grep Usage
 
 about:
   home: https://github.com/yjx1217/simuG

--- a/recipes/simug/meta.yaml
+++ b/recipes/simug/meta.yaml
@@ -1,0 +1,36 @@
+{% set version = "1.0.0" %}
+
+package:
+  name: simug
+  version: {{ version }}
+
+source:
+  url: https://github.com/yjx1217/simuG/releases/download/v{{ version }}/simuG-v{{ version }}.tar.gz
+  sha256: 01ff2d213a5ae7b7441bb7b8a0c456bf0682f6e2f88929657787c4217d57021d
+
+build:
+  number: 0
+  noarch: generic
+
+requirements:
+  run:
+   - perl=5
+   - perl-pod-usage
+   - perl-getopt-long
+   - perl-list-util
+
+test:
+  commands:
+    - simuG -h | grep Usage
+    - vcf2model -h | grep Usage
+
+about:
+  home: https://github.com/yjx1217/simuG
+  license: MIT License
+  license_family: MIT
+  license_file: 'LICENSE.md'
+  summary: A simple, flexible, and powerful tool to simulate genome sequences with pre-defined or random genomic variants.
+
+extra:
+  recipe-maintainers:
+    - tedil

--- a/recipes/simug/meta.yaml
+++ b/recipes/simug/meta.yaml
@@ -21,8 +21,8 @@ requirements:
 
 test:
   commands:
-    - simuG -h 2>&1 | grep Usage
-    - vcf2model -h 2>&1 | grep Usage
+    - simuG -h
+    - vcf2model -h
 
 about:
   home: https://github.com/yjx1217/simuG


### PR DESCRIPTION
This PR adds [simuG](https://github.com/yjx1217/simuG), a tool for simulating genomic sequences with pre-defined or random variants.
This recipe provides both scripts provided by simuG: `simuG` and `vcf2model` (this recipe omits the perl script suffix).
