### PR TITLE
Update nextflow 21.04.0

### DIFF
--- a/recipes/nextflow/meta.yaml
+++ b/recipes/nextflow/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 1
+  number: 0
   noarch: generic
 
 source:

--- a/recipes/nextflow/meta.yaml
+++ b/recipes/nextflow/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "20.10.0" %}
+{% set version = "21.04.0" %}
 
 package:
   name: nextflow
@@ -10,15 +10,15 @@ build:
 
 source:
   url: https://www.nextflow.io/releases/v{{ version }}/nextflow
-  sha256: 54f76c83cbabe8ec68d6a878dcf921e647284499f4ae917356e594d873cb78dd
+  sha256: 9b7d117a108a5340ac4f2571c83382b18ced9d2789a8216825c9ad20b60ca02b
 
 requirements:
   host:
-    - openjdk >=8,<11
+    - openjdk >=8,<16
     - coreutils
     - curl
   run:
-    - openjdk >=8,<11
+    - openjdk >=8,<16
     - coreutils
     - curl
 


### PR DESCRIPTION
This PR updates nextflow to version 21.04.0

----

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
