### PR TITLE
Update fastqc-rs recipe

### DIFF
--- a/recipes/fastqc-rs/meta.yaml
+++ b/recipes/fastqc-rs/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{version}}
 
 build:
-  number: 1
+  number: 2
 
 source:
   url: https://github.com/fastqc-rs/fastqc-rs/archive/v{{ version }}.tar.gz

--- a/recipes/fastqc-rs/meta.yaml
+++ b/recipes/fastqc-rs/meta.yaml
@@ -8,8 +8,8 @@ build:
   number: 1
 
 source:
-  url: https://github.com/fxwiegand/fastqc-rs/archive/v{{ version }}.tar.gz
-  sha256: beaf77260db814095bb4e8cd28eb392e35d9c09a55305890ad719e42ad2ce15c
+  url: https://github.com/fastqc-rs/fastqc-rs/archive/v{{ version }}.tar.gz
+  sha256: f05c65ff7f07e00e43ec48700c127c97f631bc2a3b2f2acf3e8f87984bb753c4
 
 requirements:
   build:
@@ -34,7 +34,7 @@ test:
     - fqc --help
 
 about:
-  home: https://github.com/fxwiegand/fastqc-rs
+  home: https://fastqc-rs.github.io
   license: MIT
   summary: |
     A fast quality control tool for FASTQ files written in rust.

--- a/recipes/fastqc-rs/meta.yaml
+++ b/recipes/fastqc-rs/meta.yaml
@@ -9,7 +9,7 @@ build:
 
 source:
   url: https://github.com/fastqc-rs/fastqc-rs/archive/v{{ version }}.tar.gz
-  sha256: f05c65ff7f07e00e43ec48700c127c97f631bc2a3b2f2acf3e8f87984bb753c4
+  sha256: beaf77260db814095bb4e8cd28eb392e35d9c09a55305890ad719e42ad2ce15c
 
 requirements:
   build:


### PR DESCRIPTION
This updates some necessary things after moving the [fastqc-rs repository](https://github.com/fastqc-rs/fastqc-rs) to its own [organization](https://github.com/fastqc-rs).