### PR TITLE
Update SibeliaZ to version 1.2.3

### DIFF
--- a/recipes/sibeliaz/meta.yaml
+++ b/recipes/sibeliaz/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "1.2.2" %}
-{% set sha256 = "159716b619db8ddfe07ac5c048a6937aa193a9ddc9a0d80389242be4b873b343" %}
+{% set version = "1.2.3" %}
+{% set sha256 = "e9dca65710af1aa14c19bd908545280de200705c2e924cd7bbb1b0b1b71135a2" %}
 
 package:
   name: sibeliaz


### PR DESCRIPTION
Update version of SibeliaZ to v1.2.3: https://github.com/medvedevgroup/SibeliaZ/blob/master/NEWS.md