### PR TITLE
Update GeMoMa version & fix exit status

### DIFF
--- a/recipes/gemoma/GeMoMa.py
+++ b/recipes/gemoma/GeMoMa.py
@@ -96,8 +96,9 @@ def main():
     for line in iter(p.stderr.readline,b''):
         tomod = line.decode("utf-8")
         tomod = tomod.replace(original_string,wrapper_string)
-        print(tomod,end='')
+        print(tomod,end='',file=sys.stderr)
 
+    exit(p.wait())
 
 if __name__ == '__main__':
     main()

--- a/recipes/gemoma/GeMoMa.py
+++ b/recipes/gemoma/GeMoMa.py
@@ -14,7 +14,7 @@ from os import access
 from os import getenv
 from os import X_OK
 
-jar_file = 'GeMoMa-1.6.4.jar'
+jar_file = 'GeMoMa-1.7.1.jar'
 default_jvm_mem_opts = ['-Xms1g', '-Xmx2g']
 original_string = "java -jar "+jar_file+" CLI"
 wrapper_string = "GeMoMa"

--- a/recipes/gemoma/meta.yaml
+++ b/recipes/gemoma/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "GeMoMa" %}
-{% set version = "1.6.4" %}
-{% set sha256 = "8bca8f98b2ed25a150b816d3d8398023ce04fa4b00d104e15c5be11a3a8b26ab" %}
+{% set version = "1.7.1" %}
+{% set sha256 = "457f4189f359fce867beaf5450b673abb9808cf12b2817e0aabaecfec643fc0a" %}
 
 about:
   home: http://www.jstacs.de/index.php/GeMoMa
@@ -17,7 +17,7 @@ package:
 
 build:
   noarch: generic
-  number: 1
+  number: 0
 
 source:
   url: http://www.jstacs.de/downloads/{{ name }}-{{ version }}.zip
@@ -41,6 +41,8 @@ test:
     - GeMoMa GAF test
     - GeMoMa AnnotationFinalizer test
     - GeMoMa GeMoMaPipeline test
+    - GeMoMa AddAttribute test
+    - GeMoMa SyntenyChecker test
 
 extra:
   notes: |


### PR DESCRIPTION
Update gemoma to the latest version ([currently 1.7.1](http://www.jstacs.de/index.php/GeMoMa#Version_history))

Currently, GeMoMa wrapper script always exits with status 0. This PR suggests making the exit status of the GeMoMa wrapper script consistent with the exit status of the `java -jar /path/to/GeMoMa-1.7.1.jar ...` subprocess. This is particularly important when GeMoMa is in a workflow, as a false 0 exit status makes debugging the workflow difficult (FWIW, this issue was first noticed when trying to debug GUSHR from braker2 2.1.6, which internally invokes GeMoMa).