### PR TITLE
dinopy: Fix pinned numpy dep; simplify recipe

### DIFF
--- a/recipes/dinopy/build.sh
+++ b/recipes/dinopy/build.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-# fix name_install_tool issue, see https://github.com/bioconda/bioconda-recipes/pull/3124
-if [[ $OSTYPE == darwin* ]]; then
-     export LDFLAGS="${LDFLAGS} -headerpad_max_install_names"
-fi
-
-
-$PYTHON setup.py install --single-version-externally-managed --record=record.txt

--- a/recipes/dinopy/meta.yaml
+++ b/recipes/dinopy/meta.yaml
@@ -8,19 +8,21 @@ source:
 
 build:
   skip: True # [py27]
-  number: 2
+  number: 3
+  script: pip install --no-deps --ignore-installed -vv .
 
 requirements:
   build:
     - {{ compiler('cxx') }}
   host:
     - python
-    - setuptools
+    - pip
     - cython >=0.22
+    - numpy
     - numpy >=1.17
   run:
     - python
-    - numpy >=1.17
+    - {{ pin_compatible('numpy') }}
 
 test:
   imports:


### PR DESCRIPTION
Dinopy compiles against NumPy's sources and as such we need to ensure that the `numpy` run dependency does not use older versions as those used during build. This is done via `pin_compatible`. Adding an additional constraint-less `numpy` dependency furthermore ensures that we pick up the NumPy version from the pinnings which uses the lowest supported version. In other words: We build against the oldest possible version so that we can use any compatible newer version at run time.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
