### PR TITLE
Update ostir to 1.0.4

### DIFF
--- a/recipes/ostir/meta.yaml
+++ b/recipes/ostir/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "OSTIR" %}
-{% set version = "1.0.3" %}
+{% set version = "1.0.4" %}
 
 package:
   name: "{{ name|lower }}"
@@ -7,7 +7,7 @@ package:
 
 source:
   url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
-  sha256: 27b160afbd62588de60f3d8c6944482551b8ec64b5aaf90c1ac41e5032bf5fa0
+  sha256: c1b1f9ff1c661d001e4ff0e375152197a096ce9766f0dc56bd54cde19b28b4d6
 
 build:
   number: 0
@@ -22,7 +22,7 @@ requirements:
     - python >=3.7
   run:
     - python >=3.7
-    - viennarna >=2.4.17
+    - viennarna >=2.4.18
 
 test:
   imports:
@@ -32,7 +32,7 @@ test:
     - ostir -i TTCTAGActttaatttaacgtaaataaggaagtcattATGGCGAGCTCTGAAGACGTTATCAAAGAGTTCATGCGTTTCAAAGTTCGTATGGA -t string
 
 about:
-  home: "https://github.com/barricklab/rbs-calculator"
+  home: "https://github.com/barricklab/ostir"
   license: "GNU General Public v3 or later (GPLv3+)"
   license_family: GPL3
   license_file: "LICENSE"


### PR DESCRIPTION
In addition, this recipe UPDATES the project URL to reflect the release name and updates the dependencies to require a more recent version of vienna.