### PR TITLE
Update braker2: add TSEBRA

### DIFF
--- a/recipes/braker2/build.sh
+++ b/recipes/braker2/build.sh
@@ -9,3 +9,11 @@ cp scripts/*.py ${PREFIX}/bin/
 cp -r scripts/cfg/ ${PREFIX}/bin/
 chmod +x gushr.py
 cp gushr.py ${PREFIX}/bin/
+
+# install TSEBRA
+sed -i'' -e 's#from \([^ ]*\) import#from tsebra_mod.\1 import#' tsebra/bin/*.py
+mv tsebra/bin/tsebra.py tsebra/bin/fix_gtf_ids.py ${PREFIX}/bin
+mkdir -p ${SP_DIR}/tsebra_mod
+mv tsebra/bin/* ${SP_DIR}/tsebra_mod
+mkdir ${PREFIX}/config
+mv tsebra/config/* ${PREFIX}/config

--- a/recipes/braker2/meta.yaml
+++ b/recipes/braker2/meta.yaml
@@ -15,9 +15,12 @@ source:
   sha256: 28f1faff34a75b0bea79510fddc8eddf2ba0d0aca18030c5af252364bf708eab
   patches:
     - gushr.py.patch
+- url: https://github.com/Gaius-Augustus/TSEBRA/archive/refs/tags/v1.0.1.tar.gz
+  sha256: afe4c008d964d3554e1e6804e8330cd392d4daa38f1aa0a2739c1e8fbd6278fc
+  folder: tsebra
 
 build:
-  number: 4
+  number: 5
   noarch: generic
 
 requirements:
@@ -67,6 +70,8 @@ test:
     - findGenesInIntrons.pl 2>&1 | grep "findGenesInIntrons.pl" > /dev/null
     - startAlign.pl
     - "gushr.py -h | grep -q 'usage: gushr.py'"
+    - "fix_gtf_ids.py -h | grep -q usage:"
+    - "tsebra.py -h | grep -q usage:"
 
 about:
   home: https://github.com/Gaius-Augustus/BRAKER


### PR DESCRIPTION
[TSEBRA](https://github.com/Gaius-Augustus/TSEBRA), a transcript selector for BRAKER, was recently released & [recommended for use in BRAKER](https://github.com/Gaius-Augustus/BRAKER/commit/0798591b7ad5a45b7ede6ebafad32d57f4c6cb6e) when both protein & RNA-Seq data are available. As TSEBRA operates on BRAKER-specific GFF/GTF files, it seems to make sense to bundle this directly in the BRAKER bioconda package, instead of creating standalone package.

This PR proposes adding the fix_gtf_ids.py and tsebra.py scripts to ${PREFIX}/bin so they are in the user's PATH, and the remaining TSEBRA/bin/*.py files (which appear to be meant only for import by tsebra.py) in a ${SP_DIR}/tsebra_mod module.

This proposed braker2 package update was tested on the [TSEBRA example](https://github.com/Gaius-Augustus/TSEBRA/tree/main/example), modifying the run_tsebra_example.sh script to use the fix_gtf_idx.py and tsebra.py scripts in the user's PATH instead of the bin/ directory of the git working tree:
```
diff --git a/example/run_tsebra_example.sh b/example/run_tsebra_example.sh
index b8aab2a..bbb118f 100755
--- a/example/run_tsebra_example.sh
+++ b/example/run_tsebra_example.sh
@@ -22,2 +22,2 @@ new_b2=$d/braker2.gtf
-$c/../bin/fix_gtf_ids.py --gtf $b1 --out $new_b1
-$c/../bin/fix_gtf_ids.py --gtf $b2 --out $new_b2
+fix_gtf_ids.py --gtf $b1 --out $new_b1
+fix_gtf_ids.py --gtf $b2 --out $new_b2
@@ -33 +33 @@ echo "*** Running PrEvCo ***\n"
-$c/../bin/tsebra.py -g $b1,$b2 -c $c/../config/default.cfg -e $h1,$h2 -o $o
+tsebra.py -g $b1,$b2 -c $c/../config/default.cfg -e $h1,$h2 -o $o
```