### PR TITLE
Add deepaccess 

### DIFF
--- a/recipes/deepaccess/meta.yaml
+++ b/recipes/deepaccess/meta.yaml
@@ -11,10 +11,11 @@ source:
 
 build:
   number: 0
+  noarch: python
   entry_points:
     - deepaccess=deepaccess.deepaccess:main
   script: "{{ PYTHON }} -m pip install . -vv"
-
+  
 requirements:
   host:
     - pip
@@ -24,7 +25,10 @@ requirements:
     - bedtools >=2.29.2
     - numpy >=1.19.0
     - matplotlib-base >=3.3.3
-    - scipy >= 1.6.2
+    - scipy >=1.6.2
+    - scikit-learn >=0.24.1
+    - tensorflow >=2.4
+    - keras >=2.4.3
     
 test:
   imports:
@@ -45,5 +49,4 @@ extra:
   recipe-maintainers:
     - jhammelman
   identifiers:
-    - doi:10.1101/2021.02.26.433073
-    - 
+    - "doi:10.1101/2021.02.26.433073"

--- a/recipes/deepaccess/meta.yaml
+++ b/recipes/deepaccess/meta.yaml
@@ -1,0 +1,49 @@
+{% set name = "deepaccess" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  sha256: bc1334042f3ceadbef4ffb0493c11ec9af1a019aec92a8c2c55a48f80faf93ab
+
+build:
+  number: 0
+  entry_points:
+    - deepaccess=deepaccess.deepaccess:main
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - pip
+    - python >=3.6
+  run:
+    - python >=3.6
+    - bedtools >=2.29.2
+    - numpy >=1.19.0
+    - matplotlib-base >=3.3.3
+    - scipy >= 1.6.2
+    
+test:
+  imports:
+    - deepaccess
+    - deepaccess.interpret
+    - deepaccess.train
+  commands:
+    - deepaccess --help
+
+about:
+  home: "https://github.com/gifford-lab/deepaccess-package"
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: "A package for training and interpreting an ensemble of neural networks for chromatin accessibility"
+
+extra:
+  recipe-maintainers:
+    - jhammelman
+  identifiers:
+    - doi:10.1101/2021.02.26.433073
+    - 


### PR DESCRIPTION
Add deepaccess as a bioconda recipe. DeepAccess provides training and interpretation of ensemble of convolutional neural networks for predicting accessibility or other functional epigenomic signal data.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
