### PR TITLE
Update shapeit4 to v4.2.1

### DIFF
--- a/recipes/shapeit4/build.sh
+++ b/recipes/shapeit4/build.sh
@@ -3,7 +3,7 @@
 sed -i'.bak' 's/CXX=/CXX?=/g' makefile
 sed -i'.bak' 's/CXXFLAG=/CXXFLAG=\$(CXXFLAGS)/g' makefile
 sed -i'.bak' 's/LDFLAG=/LDFLAG=\$(LDFLAGS) \${LIBPATH}/g' makefile
-sed -i'.bak' 's,HTSLIB_LIB=\$(HOME)/Tools/htslib-1.9/libhts.a,HTSLIB_LIB=-lhts,' makefile
+sed -i'.bak' 's,HTSLIB_LIB=\$(HOME)/Tools/htslib-1.11/libhts.a,HTSLIB_LIB=-lhts,' makefile
 sed -i'.bak' 's,BOOST_LIB_IO=/usr/lib/x86_64-linux-gnu/libboost_iostreams.a,BOOST_LIB_IO=-lboost_iostreams,' makefile
 sed -i'.bak' 's,BOOST_LIB_PO=/usr/lib/x86_64-linux-gnu/libboost_program_options.a,BOOST_LIB_PO=-lboost_program_options,' makefile
 

--- a/recipes/shapeit4/build.sh
+++ b/recipes/shapeit4/build.sh
@@ -3,7 +3,7 @@
 sed -i'.bak' 's/CXX=/CXX?=/g' makefile
 sed -i'.bak' 's/CXXFLAG=/CXXFLAG=\$(CXXFLAGS)/g' makefile
 sed -i'.bak' 's/LDFLAG=/LDFLAG=\$(LDFLAGS) \${LIBPATH}/g' makefile
-sed -i'.bak' 's,HTSLIB_LIB=\$(HOME)/Tools/htslib-1.11/libhts.a,HTSLIB_LIB=-lhts,' makefile
+sed -i'.bak' 's,HTSLIB_LIB=\$(HOME)/Tools/htslib-1.12/libhts.a,HTSLIB_LIB=-lhts,' makefile
 sed -i'.bak' 's,BOOST_LIB_IO=/usr/lib/x86_64-linux-gnu/libboost_iostreams.a,BOOST_LIB_IO=-lboost_iostreams,' makefile
 sed -i'.bak' 's,BOOST_LIB_PO=/usr/lib/x86_64-linux-gnu/libboost_program_options.a,BOOST_LIB_PO=-lboost_program_options,' makefile
 

--- a/recipes/shapeit4/build.sh
+++ b/recipes/shapeit4/build.sh
@@ -3,7 +3,7 @@
 sed -i'.bak' 's/CXX=/CXX?=/g' makefile
 sed -i'.bak' 's/CXXFLAG=/CXXFLAG=\$(CXXFLAGS)/g' makefile
 sed -i'.bak' 's/LDFLAG=/LDFLAG=\$(LDFLAGS) \${LIBPATH}/g' makefile
-sed -i'.bak' 's,HTSLIB_LIB=\$(HOME)/Tools/htslib-1.12/libhts.a,HTSLIB_LIB=-lhts,' makefile
+sed -i'.bak' 's,HTSLIB_LIB=\$(HOME)/Tools/htslib-1.11/libhts.a,HTSLIB_LIB=-lhts,' makefile
 sed -i'.bak' 's,BOOST_LIB_IO=/usr/lib/x86_64-linux-gnu/libboost_iostreams.a,BOOST_LIB_IO=-lboost_iostreams,' makefile
 sed -i'.bak' 's,BOOST_LIB_PO=/usr/lib/x86_64-linux-gnu/libboost_program_options.a,BOOST_LIB_PO=-lboost_program_options,' makefile
 

--- a/recipes/shapeit4/meta.yaml
+++ b/recipes/shapeit4/meta.yaml
@@ -19,11 +19,11 @@ requirements:
   host:
     - boost-cpp
     - bzip2
-    - htslib
+    - htslib=1.11
   run:
     - boost-cpp
     - bzip2
-    - htslib
+    - htslib=1.11
 
 test:
   commands:


### PR DESCRIPTION
Recommended by developer to resolve `invalid pointer` error when using shapeit4 through conda (see odelaneau/shapeit4#54 (comment))