### PR TITLE
Update recipe to deepaccess version 0.1.1 - missing important data files for package functionality

### DIFF
--- a/recipes/deepaccess/meta.yaml
+++ b/recipes/deepaccess/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "deepaccess" %}
-{% set version = "0.1.0" %}
+{% set version = "0.1.1" %}
 
 package:
   name: "{{ name|lower }}"
@@ -7,8 +7,8 @@ package:
 
 source:
   url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
-  sha256: bc1334042f3ceadbef4ffb0493c11ec9af1a019aec92a8c2c55a48f80faf93ab
-
+  sha256: be7505f1e52f92c2249259e5b0e8130884f9b3fa962b60fca6e1c1994f9c06de
+  
 build:
   number: 0
   noarch: python
@@ -37,7 +37,9 @@ test:
     - deepaccess.train
   commands:
     - deepaccess --help
-
+    - deepaccess train -h
+    - deepaccess interpret -h
+    
 about:
   home: "https://github.com/gifford-lab/deepaccess-package"
   license: MIT


### PR DESCRIPTION
Update recipe to deepaccess version 0.1.1 - missing important package data files for base functionality

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
