### PR TITLE
Update odgi to v0.6

### DIFF
--- a/recipes/odgi/meta.yaml
+++ b/recipes/odgi/meta.yaml
@@ -26,7 +26,6 @@ requirements:
   run: 
     - llvm-openmp  # [osx]
     - python
-    - zlib
 
 test:
   commands:
@@ -36,9 +35,6 @@ test:
 
 about:
   home: https://github.com/vgteam/odgi
-  license: https://github.com/pangenome/odgi/blob/master/LICENSE
+  license: MIT
+  license_file: LICENSE
   summary: An optimized dynamic genome/graph implementation
-
-extra:
-  skip-lints:
-    - uses_vcs_url

--- a/recipes/odgi/meta.yaml
+++ b/recipes/odgi/meta.yaml
@@ -19,7 +19,6 @@ requirements:
     - llvm-openmp  # [osx]
     - cmake
     - make
-    - jemalloc
   host:
     - zlib
     - python
@@ -37,7 +36,7 @@ test:
 
 about:
   home: https://github.com/vgteam/odgi
-  license: MIT
+  license: https://github.com/pangenome/odgi/blob/master/LICENSE
   summary: An optimized dynamic genome/graph implementation
 
 extra:

--- a/recipes/odgi/meta.yaml
+++ b/recipes/odgi/meta.yaml
@@ -1,13 +1,12 @@
-{% set version = "0.4.1" %}
+{% set version = "0.6" %}
 
 package:
   name: odgi
   version: '{{version}}'
 
 source:
-  git_url: https://github.com/vgteam/odgi/
-  git_tag: v{{ version }}
-  sha256: unused
+  url: https://github.com/pangenome/odgi/releases/download/0.6/odgi-0.6.tar.gz
+  sha256: 1fafc9b961c1f38758316a5cd13ea9b3b35b3b0b2f58884f7e96f7f84b81b9ec
 
 build:
   skip: True  # [osx or py27]
@@ -20,6 +19,7 @@ requirements:
     - llvm-openmp  # [osx]
     - cmake
     - make
+    - jemalloc
   host:
     - zlib
     - python
@@ -37,7 +37,7 @@ test:
 about:
   home: https://github.com/vgteam/odgi
   license: MIT
-  summary: An optimized dynamic genome graph implementation
+  summary: An optimized dynamic genome/graph implementation
 
 extra:
   skip-lints:

--- a/recipes/odgi/meta.yaml
+++ b/recipes/odgi/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   skip: True  # [osx or py27]
-  number: 1
+  number: 0
 
 requirements:
   build:

--- a/recipes/odgi/meta.yaml
+++ b/recipes/odgi/meta.yaml
@@ -23,6 +23,7 @@ requirements:
   host:
     - zlib
     - python
+    - jemalloc
   run: 
     - llvm-openmp  # [osx]
     - python


### PR DESCRIPTION
This updates the `odgi` recipe to v0.6. The source is now a buildable tarball. The SHA256 sum was added, too.
`odgi` has a new build dependency, `jemalloc`. I hope I did everything correctly.
Since `Conda` was updated to GCC9.3 recently, this is not a blocker for `odgi` on `Bioconda` anymore. However, we still have the custom build script. I don't have enough experience with `Bioconda`, but maybe someone experienced can judge, if we can get rid of this.
Please take a look @apeltzer @dpryan79. Thanks!