### PR TITLE
Add py_fasta_validator

### DIFF
--- a/recipes/py_fasta_validator/meta.yaml
+++ b/recipes/py_fasta_validator/meta.yaml
@@ -44,4 +44,4 @@ extra:
   recipe-maintainers:
     - linsalrob
   identifiers:
-    - doi: 10.5281/zenodo.5006657
+    - doi:10.5281/zenodo.5006657

--- a/recipes/py_fasta_validator/meta.yaml
+++ b/recipes/py_fasta_validator/meta.yaml
@@ -27,7 +27,6 @@ requirements:
 
 test:
   imports:
-    - FastaValidator
     - PyFastaValidator
   commands:
     - py_fasta_validator -v

--- a/recipes/py_fasta_validator/meta.yaml
+++ b/recipes/py_fasta_validator/meta.yaml
@@ -1,0 +1,47 @@
+{% set name = "py_fasta_validator" %}
+{% set version = "0.5" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  sha256: "1f22c832bbc76b7d12e4f137224b5f19f0d0e61b30709455ef66a8deefcdeade"
+
+build:
+  number: 0
+  skip: True  # [py27]
+  script: "{{ PYTHON }} -m pip install --ignore-installed --no-cache-dir -vvv ." 
+
+requirements:
+  build:
+    - {{ compiler('cxx') }}
+  host:
+    - python >=3.6
+    - pip
+    - setuptools >=38.6.0
+    - setuptools_scm
+  run:
+    - python >=3.6
+
+test:
+  imports:
+    - FastaValidator
+    - PyFastaValidator
+  commands:
+    - py_fasta_validator -v
+
+about:
+  home: "https://github.com/linsalrob/py_fasta_validator"
+  license: MIT
+  license_family: MIT
+  summary: "Simply and quickly validate a fasta file. Invalid files return non-zero exit codes"
+  doc_url: "https://github.com/linsalrob/py_fasta_validator"
+  dev_url: "https://github.com/linsalrob/py_fasta_validator"
+
+extra:
+  recipe-maintainers:
+    - linsalrob
+  identifiers:
+    - doi: 10.5281/zenodo.5006657

--- a/recipes/py_fasta_validator/meta.yaml
+++ b/recipes/py_fasta_validator/meta.yaml
@@ -24,6 +24,8 @@ requirements:
     - setuptools_scm
   run:
     - python >=3.6
+    - setuptools >=38.6.0
+    - setuptools_scm
 
 test:
   imports:

--- a/recipes/py_fasta_validator/meta.yaml
+++ b/recipes/py_fasta_validator/meta.yaml
@@ -29,6 +29,7 @@ requirements:
 
 test:
   imports:
+    - FastaValidator
     - PyFastaValidator
   commands:
     - py_fasta_validator -v


### PR DESCRIPTION
py_fasta_validator is a simple, lightweight, python wrapper around a C-based fasta validator. It checks for common errors in a fast file and reports them via the `stderr` or the exit code.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
