### PR TITLE
Update MaxQuant 1.6.17.0

### DIFF
--- a/recipes/maxquant/maxquant
+++ b/recipes/maxquant/maxquant
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 DIR="$(cd "$(dirname "$0")" && pwd)"
-dotnet $DIR/MaxQuantCmd.exe $@
+mono $DIR/MaxQuantCmd.exe $@

--- a/recipes/maxquant/meta.yaml
+++ b/recipes/maxquant/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: generic
-  number: 1
+  number: 2
   script:
     - cp -r * $PREFIX
     - cp $RECIPE_DIR/maxquant $PREFIX/bin/maxquant

--- a/recipes/maxquant/meta.yaml
+++ b/recipes/maxquant/meta.yaml
@@ -26,7 +26,7 @@ requirements:
   host:
     - python >=3.6
   run:
-    - dotnet =2.1
+    - mono =5.14.0.177 # dotnet=2.1 and mono>=6.12 do have incompatibilities with soft links and Thermo RAW files
 
 test:
   commands:


### PR DESCRIPTION
MaxQuant in combination with dotnet=2.1 or mono>=6.12 do have incompatibilities with symbolic/soft links and Thermo RAW files (run crashes at `Assemble_run_info`). The last conda package of mono=5 does not have those issues.
