### PR TITLE
Update stringdecomposer to 1.1.0 (manual)

### DIFF
--- a/recipes/stringdecomposer/meta.yaml
+++ b/recipes/stringdecomposer/meta.yaml
@@ -11,7 +11,7 @@ source:
 build:
   skip: True  # [py27 or osx or py == 39]
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv --ignore-installed --no-deps
+  # script: {{ PYTHON }} -m pip install . -vv --ignore-installed --no-deps
 
 requirements:
   build:
@@ -32,6 +32,7 @@ requirements:
  
 test:
   commands:
+    - cd $SRC_DIR
     - make test_launch
     - make test_launch_install
 

--- a/recipes/stringdecomposer/meta.yaml
+++ b/recipes/stringdecomposer/meta.yaml
@@ -24,16 +24,15 @@ requirements:
     - pip
   run:
     - python
-    - biopython <1.78
-    - joblib
-    - numpy
+    - biopython
     - pandas
     - python-edlib
-    - scikit-learn <0.22
+    - setuptools
  
 test:
   commands:
-    - run_decomposer -h | grep Decomposes
+    - make test_launch
+    - make test_launch_install
 
 about:
   home: https://github.com/ablab/stringdecomposer

--- a/recipes/stringdecomposer/meta.yaml
+++ b/recipes/stringdecomposer/meta.yaml
@@ -18,23 +18,19 @@ requirements:
     - {{ compiler('cxx') }}
     - llvm-openmp  # [osx]
     - libgomp  # [linux]
-    - make
+    - make install
   host:
     - python
     - pip
   run:
-    - make
     - python
     - biopython
     - pandas
     - python-edlib
-    - setuptools
  
 test:
   commands:
-    - cd $SRC_DIR
-    - make test_launch
-    - make test_launch_install
+    - stringdecomposer -h | grep -q "Decomposes string into blocks alphabet"
 
 about:
   home: https://github.com/ablab/stringdecomposer

--- a/recipes/stringdecomposer/meta.yaml
+++ b/recipes/stringdecomposer/meta.yaml
@@ -23,6 +23,7 @@ requirements:
     - python
     - pip
   run:
+    - make
     - python
     - biopython
     - pandas

--- a/recipes/stringdecomposer/meta.yaml
+++ b/recipes/stringdecomposer/meta.yaml
@@ -1,4 +1,4 @@
-{% set version="1.0.0" %}
+{% set version="1.1.0" %}
 
 package:
   name: stringdecomposer
@@ -6,11 +6,11 @@ package:
 
 source:
   url: https://github.com/ablab/stringdecomposer/archive/v{{ version }}.tar.gz
-  sha256: 561deea67808bc4d0bab04b2167ef47f918f2080f8ea1d8cc1e92e045f00aa84
+  sha256: 644070c448a9436c093c2d9e83175a3f7c1cbf04debbf9b8f2ea822040eba6b6
 
 build:
   skip: True  # [py27 or osx or py == 39]
-  number: 1
+  number: 0
   script: {{ PYTHON }} -m pip install . -vv --ignore-installed --no-deps
 
 requirements:

--- a/recipes/stringdecomposer/meta.yaml
+++ b/recipes/stringdecomposer/meta.yaml
@@ -12,13 +12,14 @@ build:
   skip: True  # [py27 or osx or py == 39]
   number: 0
   # script: {{ PYTHON }} -m pip install . -vv --ignore-installed --no-deps
+  script: make install
 
 requirements:
   build:
     - {{ compiler('cxx') }}
     - llvm-openmp  # [osx]
     - libgomp  # [linux]
-    - make install
+    - make
   host:
     - python
     - pip

--- a/recipes/stringdecomposer/meta.yaml
+++ b/recipes/stringdecomposer/meta.yaml
@@ -12,7 +12,7 @@ build:
   skip: True  # [py27 or osx or py == 39]
   number: 0
   # script: {{ PYTHON }} -m pip install . -vv --ignore-installed --no-deps
-  script: make install
+  script: make install PREFIX=${PREFIX}
 
 requirements:
   build:
@@ -23,6 +23,7 @@ requirements:
   host:
     - python
     - pip
+    - setuptools
   run:
     - python
     - biopython

--- a/recipes/stringdecomposer/meta.yaml
+++ b/recipes/stringdecomposer/meta.yaml
@@ -11,8 +11,8 @@ source:
 build:
   skip: True  # [py27 or osx or py == 39]
   number: 0
-  # script: {{ PYTHON }} -m pip install . -vv --ignore-installed --no-deps
-  script: make install PREFIX=${PREFIX}
+  script: {{ PYTHON }} -m pip install . -vv --ignore-installed --no-deps
+  # script: make install PREFIX=${PREFIX}
 
 requirements:
   build:
@@ -23,7 +23,6 @@ requirements:
   host:
     - python
     - pip
-    - setuptools
   run:
     - python
     - biopython


### PR DESCRIPTION
Update [stringdecomposer](https://bioconda.github.io/recipes/stringdecomposer/README.html): 1.0.0 → 1.1.0.
Fix to the recipe to account for the changed interface of the tool.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
