### PR TITLE
Update DeepSig Python dependency

### DIFF
--- a/recipes/deepsig/meta.yaml
+++ b/recipes/deepsig/meta.yaml
@@ -19,7 +19,7 @@ requirements:
     - python >=3
     - pip
   run:
-    - python >=3
+    - python =3.6|3.7|3.8
     - biopython >=1.78
     - keras =2.4.3
     - tensorflow =2.2.0

--- a/recipes/deepsig/meta.yaml
+++ b/recipes/deepsig/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   entry_points:
     - deepsig = deepsig.deepsig:main
 


### PR DESCRIPTION
Due to a dep collision, Python needs to be of version `<3.9`.
Therefore, I downgraded python to version `3.6|3.7|3.8`