### PR TITLE
Rebuild perl-bio-db-hts with current pinned htslib

### DIFF
--- a/build-fail-blacklist
+++ b/build-fail-blacklist
@@ -129,7 +129,6 @@ recipes/repeatmodeler
 recipes/perl-bioperl
 recipes/hla-la
 recipes/feelnc
-recipes/perl-bio-db-hts
 recipes/bttoxin_scanner
 recipes/perl-bio-mlst-check
 recipes/snmf

--- a/recipes/perl-bio-db-hts/meta.yaml
+++ b/recipes/perl-bio-db-hts/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 12a6bc1f579513cac8b9167cce4e363655cc8eba26b7d9fe1170dfe95e044f42
 
 build:
-  number: 2
+  number: 3
 
 requirements:
   build:


### PR DESCRIPTION
Bump perl-bio-db-hts so it has a package that is installable alongside other packages that use the currently pinned htslib, 1.12.

Fixes #29193.

----

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
