### PR TITLE
Enable homer on conda environement with @

### DIFF
--- a/recipes/homer/build.sh
+++ b/recipes/homer/build.sh
@@ -10,7 +10,7 @@ cp configureHomer.pl $outdir/
 ln -s ${CC} $BUILD_PREFIX/bin/gcc
 ln -s ${CXX} $BUILD_PREFIX/bin/g++
 
-( cd $outdir && perl configureHomer.pl -install )
+( cd $outdir && perl configureHomer.pl -keepScript -install )
 
 ls -1 $outdir/bin/ | grep -v old | sed -e "s/\*/ \\\/g" | while read id;
 do

--- a/recipes/homer/configureHomer.patch
+++ b/recipes/homer/configureHomer.patch
@@ -1,0 +1,32 @@
+--- configureHomer.pl.ori	2021-07-05 16:37:13.648245955 +0200
++++ configureHomer.pl	2021-07-05 16:35:05.770994077 +0200
+@@ -166,7 +166,7 @@
+ 	my $url = $baseURL . "homer.misc.v1.0.zip";
+ 	`wget -O homer.package.zip "$url"`;
+ 	print STDERR "\t\tUnzipping...\n";
+-	`unzip -o -d "$homeDir" homer.package.zip`;
++	`unzip -o -d "$homeDir" homer.package.zip -x configureHomer.pl`;
+ 	`rm homer.package.zip`;
+ }
+ my $configFile = $homeDir . "/" . "config.txt";
+@@ -432,7 +432,7 @@
+ 					next;
+ 				}
+ 				print STDERR "\t\tUnzipping...\n";
+-				`unzip -o -d "$homeDir" homer.package.zip`;
++				`unzip -o -d "$homeDir" homer.package.zip -x configureHomer.pl`;
+ 				`rm homer.package.zip`;
+ 				$config->{$mode}->{$package} = $update->{$mode}->{$package};
+ 				if ($wantedVersion ne '') {
+@@ -862,9 +862,9 @@
+ 			} elsif ($count == 2) {
+ 				print OUT "use warnings;\n";
+ 			} elsif ($count == 3) {
+-				print OUT "use lib \"$homeDir/bin\";\n";
++				print OUT "use lib \'$homeDir/bin\';\n";
+ 			} elsif ($count == 4) {
+-				print OUT 'my $homeDir = "' . $homeDir . "\";\n";
++				print OUT 'my $homeDir = \'' . $homeDir . "\';\n";
+ 			} else {
+ 				print OUT $_;
+ 			}

--- a/recipes/homer/meta.yaml
+++ b/recipes/homer/meta.yaml
@@ -12,9 +12,11 @@ package:
 source:
   - url: http://homer.ucsd.edu/homer/configureHomer.pl
     sha256: 37e36fb10387a90050251683d35fe568657941b863b2088dcb0d09d9b1b59477
+    patches:
+      - configureHomer.patch
 
 build:
-  number: 4
+  number: 5
   # Ships pre-built binaries that install_name_tool isn't able to fix.
   skip: True  # [osx]
 


### PR DESCRIPTION
Hi,
Currently if the conda environment contains a @ in the name (like in galaxy), `annotatePeaks.pl` raise an error.
For the moment, this PR is not working but I don't know how to do it.
I would like the patch to be applied before running the `build.sh`. Is it the case like this?

Thanks
