### PR TITLE
Remove perl-bio-db-hts from build-fail-blacklist

### DIFF
--- a/build-fail-blacklist
+++ b/build-fail-blacklist
@@ -129,7 +129,6 @@ recipes/repeatmodeler
 recipes/perl-bioperl
 recipes/hla-la
 recipes/feelnc
-recipes/perl-bio-db-hts
 recipes/bttoxin_scanner
 recipes/perl-bio-mlst-check
 recipes/snmf


### PR DESCRIPTION
Allow rebuilding perl-bio-db-hts (in particular: on Linux, which is missing the `_2` build) so it has a package that is installable alongside other packages that use the currently pinned htslib, 1.12.

(We may need to bump the build number again as well, i.e., incorporate #29412.)

----

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
