### PR TITLE
MaxQuant 1.6.17.0 use dotnet instead of mono

### DIFF
--- a/recipes/maxquant/maxquant
+++ b/recipes/maxquant/maxquant
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 DIR="$(cd "$(dirname "$0")" && pwd)"
-mono $DIR/MaxQuantCmd.exe $@
+dotnet $DIR/MaxQuantCmd.exe $@

--- a/recipes/maxquant/meta.yaml
+++ b/recipes/maxquant/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "2.0.1.0" %}
-{% set sha256 = "8c98b62634aab5d60c5db47c63e44960c73bcc001959f280a59d1b24b8b46887" %}
+{% set version = "1.6.17.0" %}
+{% set sha256 = "6cc000f2b4ea84b9d856d46824c86bd3407c7d144cd0c8cb50f78f1232a9f539" %}
 
 package:
   name: maxquant
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: generic
-  number: 0
+  number: 3
 
   script:
     - cp -r * $PREFIX
@@ -27,11 +27,11 @@ requirements:
   host:
     - python >=3.6
   run:
-    - mono =5.14.0.177 # dotnet=2.1 and mono>=6.12 do have incompatibilities with soft links and Thermo RAW files
+    - dotnet =2.1
 
 test:
   commands:
-    - maxquant --version 2>&1 | grep {{ version }}
+    - maxquant --version 2>&1 | grep 1.6.5.0 # Bug in v. 1.6.17.0 use 1.6.5.0 instead of {{ version }}
 
 about:
   home: http://www.coxdocs.org/doku.php?id=maxquant:start


### PR DESCRIPTION
In some instances newer MaxQuant versions complaining about not using .NET. It depends on the useDotNetCore parameter in the mqpar file, which by default is set to `True` in version >=1.6.17.0. In older versions the paramater is set to `False` (f.e. in 1.6.10.43). To avoid any further incompatibilities I would suggest to switch to `dotnet`.