### PR TITLE
MaxQuant 1.6.17.0 use dotnet instead of mono

### DIFF
--- a/recipes/maxquant/1.6.17.0/maxquant
+++ b/recipes/maxquant/1.6.17.0/maxquant
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+dotnet $DIR/MaxQuantCmd.exe $@

--- a/recipes/maxquant/1.6.17.0/meta.yaml
+++ b/recipes/maxquant/1.6.17.0/meta.yaml
@@ -1,0 +1,46 @@
+{% set version = "1.6.17.0" %}
+{% set sha256 = "6cc000f2b4ea84b9d856d46824c86bd3407c7d144cd0c8cb50f78f1232a9f539" %}
+
+package:
+  name: maxquant
+  version: '{{ version }}'
+
+source:
+  url: http://share.gruenings.eu/MaxQuant_{{ version }}.zip
+  sha256: '{{ sha256 }}'
+
+build:
+  noarch: generic
+  number: 3
+
+  script:
+    - cp -r * $PREFIX
+    - cp $RECIPE_DIR/maxquant $PREFIX/bin/maxquant
+    - chmod +x $PREFIX/bin/maxquant
+    - chmod +x $PREFIX/bin/MaxQuantCmd.exe
+    - chmod +x $PREFIX/bin/MaxQuantGui.exe
+    - chmod +x $RECIPE_DIR/xmlcombine.py
+    - $RECIPE_DIR/xmlcombine.py $PREFIX/bin/conf/modifications.xml $RECIPE_DIR/mod_*.xml > $PREFIX/bin/conf/modifications_temp.xml
+    - mv $PREFIX/bin/conf/modifications_temp.xml $PREFIX/bin/conf/modifications.xml
+
+requirements:
+  host:
+    - python >=3.6
+  run:
+    - dotnet =2.1
+
+test:
+  commands:
+    - maxquant --version 2>&1 | grep 1.6.5.0 # Bug in v. 1.6.17.0 use 1.6.5.0 instead of {{ version }}
+
+about:
+  home: http://www.coxdocs.org/doku.php?id=maxquant:start
+  license: http://www.coxdocs.org/lib/exe/fetch.php?media=license_agreement.pdf
+  summary: MaxQuant is a quantitative proteomics software package designed for analyzing large mass-spectrometric data sets. License restricted.
+
+extra:
+  identifiers:
+    - biotools:MaxQuant
+    - biotools:maxquant
+    - doi:10.1038/s41592-018-0018-y
+    - usegalaxy-eu:maxquant

--- a/recipes/maxquant/1.6.17.0/mod_propionamide.xml
+++ b/recipes/maxquant/1.6.17.0/mod_propionamide.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<modifications xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modification title="Propionamide (C)" description="Acrylamide adduct" create_date="2021-06-20T14:26:00.00000-05:00" last_modified_date="2021-06-20T14:26:00.00000-05:00" user="npinter" reporterCorrectionM2="0" reporterCorrectionM1="0" reporterCorrectionP1="0" reporterCorrectionP2="0" reporterCorrectionType="false" composition="H(5) C(3) N O">
+      <position>anywhere</position>
+      <modification_site site="C">
+         <neutralloss_collection />
+         <diagnostic_collection />
+      </modification_site>
+      <type>Standard</type>
+      <terminus_type>none</terminus_type>
+    </modification>
+        <modification title="Propionamide (K)" description="Acrylamide adduct" create_date="2021-06-20T14:26:00.00000-05:00" last_modified_date="2021-06-20T14:26:00.00000-05:00" user="npinter" reporterCorrectionM2="0" reporterCorrectionM1="0" reporterCorrectionP1="0" reporterCorrectionP2="0" reporterCorrectionType="false" composition="H(5) C(3) N O">
+      <position>anywhere</position>
+      <modification_site site="K">
+         <neutralloss_collection />
+         <diagnostic_collection />
+      </modification_site>
+      <type>Standard</type>
+      <terminus_type>none</terminus_type>
+    </modification>
+    <modification title="Propionamide (N-term)" description="Acrylamide adduct" create_date="2021-06-20T14:26:00.00000-05:00" last_modified_date="2021-06-20T14:26:00.00000-05:00" user="npinter" reporterCorrectionM2="0" reporterCorrectionM1="0" reporterCorrectionP1="0" reporterCorrectionP2="0" reporterCorrectionType="false" composition="H(5) C(3) N O">
+      <position>anyNterm</position>
+      <modification_site site="-">
+         <neutralloss_collection />
+         <diagnostic_collection />
+      </modification_site>
+      <type>Standard</type>
+      <terminus_type>none</terminus_type>
+   </modification>
+</modifications>

--- a/recipes/maxquant/1.6.17.0/mod_tmtpro16plex.xml
+++ b/recipes/maxquant/1.6.17.0/mod_tmtpro16plex.xml
@@ -1,0 +1,355 @@
+<?xml version="1.0" encoding="utf-8"?>
+<modifications xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modification title="TMTpro16plex-Nter126C" description="N-terminal TMTpro16plex126C" create_date="2019-08-27T19:59:56.0854233+02:00" last_modified_date="2019-08-27T20:28:20.6265375+02:00" user="Ed" reporterCorrectionM2="0" reporterCorrectionM1="0" reporterCorrectionP1="0" reporterCorrectionP2="0" reporterCorrectionType="false" composition="H(25) C(8) Cx(7) N O(3) Nx(2)">
+        <position>anyNterm</position>
+        <modification_site site="-">
+            <neutralloss_collection />
+            <diagnostic_collection>
+                <diagnostic name="126C" shortname="126C" composition="H(15) C(8) N" />
+            </diagnostic_collection>
+        </modification_site>
+        <type>IsobaricLabel</type>
+        <terminus_type>none</terminus_type>
+    </modification>
+    <modification title="TMTpro16plex-Nter127N" description="N-terminal TMTpro16plex127N" create_date="2019-08-27T20:28:27.3220014+02:00" last_modified_date="2019-08-27T20:30:24.8104686+02:00" user="Ed" reporterCorrectionM2="0" reporterCorrectionM1="0" reporterCorrectionP1="0" reporterCorrectionP2="0" reporterCorrectionType="false" composition="H(25) C(8) Cx(7) N O(3) Nx(2)">
+        <position>anyNterm</position>
+        <modification_site site="-">
+            <neutralloss_collection />
+            <diagnostic_collection>
+                <diagnostic name="127N" shortname="127N" composition="H(15) C(8) Nx" />
+            </diagnostic_collection>
+        </modification_site>
+        <type>IsobaricLabel</type>
+        <terminus_type>none</terminus_type>
+    </modification>
+    <modification title="TMTpro16plex-Nter127C" description="N-terminal TMTpro16plex127C" create_date="2019-08-27T20:30:38.2417931+02:00" last_modified_date="2019-08-27T20:32:06.890274+02:00" user="Ed" reporterCorrectionM2="0" reporterCorrectionM1="0" reporterCorrectionP1="0" reporterCorrectionP2="0" reporterCorrectionType="false" composition="H(25) C(8) Cx(7) N O(3) Nx(2)">
+        <position>anyNterm</position>
+        <modification_site site="-">
+            <neutralloss_collection />
+            <diagnostic_collection>
+                <diagnostic name="127C" shortname="127C" composition="H(15) C(7) Cx N" />
+            </diagnostic_collection>
+        </modification_site>
+        <type>IsobaricLabel</type>
+        <terminus_type>none</terminus_type>
+    </modification>
+    <modification title="TMTpro16plex-Nter128N" description="N-terminal TMTpro16plex128N" create_date="2019-08-27T20:32:23.3619825+02:00" last_modified_date="2019-08-27T22:12:56.8887575+02:00" user="Ed" reporterCorrectionM2="0" reporterCorrectionM1="0" reporterCorrectionP1="0" reporterCorrectionP2="0" reporterCorrectionType="false" composition="H(25) C(8) Cx(7) N O(3) Nx(2)">
+        <position>anyNterm</position>
+        <modification_site site="-">
+            <neutralloss_collection />
+            <diagnostic_collection>
+                <diagnostic name="128N" shortname="128N" composition="H(15) C(7) Cx Nx" />
+            </diagnostic_collection>
+        </modification_site>
+        <type>IsobaricLabel</type>
+        <terminus_type>none</terminus_type>
+    </modification>
+    <modification title="TMTpro16plex-Nter128C" description="N-terminal TMTpro16plex128C" create_date="2019-08-27T20:33:50.3227494+02:00" last_modified_date="2019-08-27T20:36:33.1226102+02:00" user="Ed" reporterCorrectionM2="0" reporterCorrectionM1="0" reporterCorrectionP1="0" reporterCorrectionP2="0" reporterCorrectionType="false" composition="H(25) C(8) Cx(7) N O(3) Nx(2)">
+        <position>anyNterm</position>
+        <modification_site site="-">
+            <neutralloss_collection />
+            <diagnostic_collection>
+                <diagnostic name="128C" shortname="128C" composition="H(15) C(6) Cx(2) N" />
+            </diagnostic_collection>
+        </modification_site>
+        <type>IsobaricLabel</type>
+        <terminus_type>none</terminus_type>
+    </modification>
+    <modification title="TMTpro16plex-Nter129N" description="N-terminal TMTpro16plex129N" create_date="2019-08-27T20:35:15.7223533+02:00" last_modified_date="2019-08-27T20:36:42.2823079+02:00" user="Ed" reporterCorrectionM2="0" reporterCorrectionM1="0" reporterCorrectionP1="0" reporterCorrectionP2="0" reporterCorrectionType="false" composition="H(25) C(8) Cx(7) N O(3) Nx(2)">
+        <position>anyNterm</position>
+        <modification_site site="-">
+            <neutralloss_collection />
+            <diagnostic_collection>
+                <diagnostic name="129N" shortname="129N" composition="H(15) C(6) Cx(2) Nx" />
+            </diagnostic_collection>
+        </modification_site>
+        <type>IsobaricLabel</type>
+        <terminus_type>none</terminus_type>
+    </modification>
+    <modification title="TMTpro16plex-Nter129C" description="N-terminal TMTpro16plex129C" create_date="2019-08-27T20:36:57.9810485+02:00" last_modified_date="2019-08-27T20:38:01.0927111+02:00" user="Ed" reporterCorrectionM2="0" reporterCorrectionM1="0" reporterCorrectionP1="0" reporterCorrectionP2="0" reporterCorrectionType="false" composition="H(25) C(8) Cx(7) N O(3) Nx(2)">
+        <position>anyNterm</position>
+        <modification_site site="-">
+            <neutralloss_collection />
+            <diagnostic_collection>
+                <diagnostic name="129C" shortname="129C" composition="H(15) C(5) Cx(3) N" />
+            </diagnostic_collection>
+        </modification_site>
+        <type>IsobaricLabel</type>
+        <terminus_type>none</terminus_type>
+    </modification>
+    <modification title="TMTpro16plex-Nter130N" description="N-terminal TMTpro16plex130N" create_date="2019-08-27T20:38:13.2185206+02:00" last_modified_date="2019-08-27T20:39:03.1726144+02:00" user="Ed" reporterCorrectionM2="0" reporterCorrectionM1="0" reporterCorrectionP1="0" reporterCorrectionP2="0" reporterCorrectionType="false" composition="H(25) C(8) Cx(7) N O(3) Nx(2)">
+        <position>anyNterm</position>
+        <modification_site site="-">
+            <neutralloss_collection />
+            <diagnostic_collection>
+                <diagnostic name="130N" shortname="130N" composition="H(15) C(5) Cx(3) Nx" />
+            </diagnostic_collection>
+        </modification_site>
+        <type>IsobaricLabel</type>
+        <terminus_type>none</terminus_type>
+    </modification>
+    <modification title="TMTpro16plex-Nter130C" description="N-terminal TMTpro16plex130C" create_date="2019-08-27T20:39:26.3227397+02:00" last_modified_date="2019-08-27T20:40:26.0830255+02:00" user="Ed" reporterCorrectionM2="0" reporterCorrectionM1="0" reporterCorrectionP1="0" reporterCorrectionP2="0" reporterCorrectionType="false" composition="H(25) C(8) Cx(7) N O(3) Nx(2)">
+        <position>anyNterm</position>
+        <modification_site site="-">
+            <neutralloss_collection />
+            <diagnostic_collection>
+                <diagnostic name="130C" shortname="130C" composition="H(15) C(4) Cx(4) N" />
+            </diagnostic_collection>
+        </modification_site>
+        <type>IsobaricLabel</type>
+        <terminus_type>none</terminus_type>
+    </modification>
+    <modification title="TMTpro16plex-Nter131N" description="N-terminal TMTpro16plex131N" create_date="2019-08-27T20:42:05.8749695+02:00" last_modified_date="2019-08-27T20:43:42.7637206+02:00" user="Ed" reporterCorrectionM2="0" reporterCorrectionM1="0" reporterCorrectionP1="0" reporterCorrectionP2="0" reporterCorrectionType="false" composition="H(25) C(8) Cx(7) N O(3) Nx(2)">
+        <position>anyNterm</position>
+        <modification_site site="-">
+            <neutralloss_collection />
+            <diagnostic_collection>
+                <diagnostic name="131N" shortname="131N" composition="H(15) C(4) Cx(4) Nx" />
+            </diagnostic_collection>
+        </modification_site>
+        <type>IsobaricLabel</type>
+        <terminus_type>none</terminus_type>
+    </modification>
+    <modification title="TMTpro16plex-Nter131C" description="N-terminal TMTpro16plex131C" create_date="2019-08-27T20:43:44.6993284+02:00" last_modified_date="2019-08-27T20:44:39.6230927+02:00" user="Ed" reporterCorrectionM2="0" reporterCorrectionM1="0" reporterCorrectionP1="0" reporterCorrectionP2="0" reporterCorrectionType="false" composition="H(25) C(8) Cx(7) N O(3) Nx(2)">
+        <position>anyNterm</position>
+        <modification_site site="-">
+            <neutralloss_collection />
+            <diagnostic_collection>
+                <diagnostic name="131C" shortname="131C" composition="H(15) C(3) Cx(5) N" />
+            </diagnostic_collection>
+        </modification_site>
+        <type>IsobaricLabel</type>
+        <terminus_type>none</terminus_type>
+    </modification>
+    <modification title="TMTpro16plex-Nter132N" description="N-terminal TMTpro16plex132N" create_date="2019-08-27T20:44:48.4029914+02:00" last_modified_date="2019-08-27T20:45:36.5397225+02:00" user="Ed" reporterCorrectionM2="0" reporterCorrectionM1="0" reporterCorrectionP1="0" reporterCorrectionP2="0" reporterCorrectionType="false" composition="H(25) C(8) Cx(7) N O(3) Nx(2)">
+        <position>anyNterm</position>
+        <modification_site site="-">
+            <neutralloss_collection />
+            <diagnostic_collection>
+                <diagnostic name="132N" shortname="132N" composition="H(15) C(3) Cx(5) Nx" />
+            </diagnostic_collection>
+        </modification_site>
+        <type>IsobaricLabel</type>
+        <terminus_type>none</terminus_type>
+    </modification>
+    <modification title="TMTpro16plex-Nter132C" description="N-terminal TMTpro16plex132C" create_date="2019-08-27T20:45:42.467698+02:00" last_modified_date="2019-08-27T20:46:37.9474816+02:00" user="Ed" reporterCorrectionM2="0" reporterCorrectionM1="0" reporterCorrectionP1="0" reporterCorrectionP2="0" reporterCorrectionType="false" composition="H(25) C(8) Cx(7) N O(3) Nx(2)">
+        <position>anyNterm</position>
+        <modification_site site="-">
+            <neutralloss_collection />
+            <diagnostic_collection>
+                <diagnostic name="132C" shortname="132C" composition="H(15) C(2) Cx(6) N" />
+            </diagnostic_collection>
+        </modification_site>
+        <type>IsobaricLabel</type>
+        <terminus_type>none</terminus_type>
+    </modification>
+    <modification title="TMTpro16plex-Nter133N" description="N-terminal TMTpro16plex133N" create_date="2019-08-27T20:46:41.8532372+02:00" last_modified_date="2019-08-27T20:47:22.1135142+02:00" user="Ed" reporterCorrectionM2="0" reporterCorrectionM1="0" reporterCorrectionP1="0" reporterCorrectionP2="0" reporterCorrectionType="false" composition="H(25) C(8) Cx(7) N O(3) Nx(2)">
+        <position>anyNterm</position>
+        <modification_site site="-">
+            <neutralloss_collection />
+            <diagnostic_collection>
+                <diagnostic name="133N" shortname="133N" composition="H(15) C(2) Cx(6) Nx" />
+            </diagnostic_collection>
+        </modification_site>
+        <type>IsobaricLabel</type>
+        <terminus_type>none</terminus_type>
+    </modification>
+    <modification title="TMTpro16plex-Nter133C" description="N-terminal TMTpro16plex133C" create_date="2019-08-27T20:47:29.2129789+02:00" last_modified_date="2019-08-27T20:48:22.9933179+02:00" user="Ed" reporterCorrectionM2="0" reporterCorrectionM1="0" reporterCorrectionP1="0" reporterCorrectionP2="0" reporterCorrectionType="false" composition="H(25) C(8) Cx(7) N O(3) Nx(2)">
+        <position>anyNterm</position>
+        <modification_site site="-">
+            <neutralloss_collection />
+            <diagnostic_collection>
+                <diagnostic name="133C" shortname="133C" composition="H(15) C Cx(7) N" />
+            </diagnostic_collection>
+        </modification_site>
+        <type>IsobaricLabel</type>
+        <terminus_type>none</terminus_type>
+    </modification>
+    <modification title="TMTpro16plex-Nter134N" description="N-terminal TMTpro16plex134N" create_date="2019-08-27T20:48:41.0849929+02:00" last_modified_date="2019-08-27T20:49:38.1934775+02:00" user="Ed" reporterCorrectionM2="0" reporterCorrectionM1="0" reporterCorrectionP1="0" reporterCorrectionP2="0" reporterCorrectionType="false" composition="H(25) C(8) Cx(7) N O(3) Nx(2)">
+        <position>anyNterm</position>
+        <modification_site site="-">
+            <neutralloss_collection />
+            <diagnostic_collection>
+                <diagnostic name="134N" shortname="134N" composition="H(15) C Cx(7) Nx" />
+            </diagnostic_collection>
+        </modification_site>
+        <type>IsobaricLabel</type>
+        <terminus_type>none</terminus_type>
+    </modification>
+    <modification title="TMTpro16plex-Lys126C" description="Lys TMTpro16plex126C" create_date="2019-08-27T20:55:09.2937767+02:00" last_modified_date="2019-08-27T22:15:28.7592547+02:00" user="Ed" reporterCorrectionM2="0" reporterCorrectionM1="0" reporterCorrectionP1="0" reporterCorrectionP2="0" reporterCorrectionType="false" composition="H(25) C(8) Cx(7) N O(3) Nx(2)">
+        <position>anywhere</position>
+        <modification_site site="K">
+            <neutralloss_collection />
+            <diagnostic_collection>
+                <diagnostic name="126C" shortname="126C" composition="H(15) C(8) N" />
+            </diagnostic_collection>
+        </modification_site>
+        <type>IsobaricLabel</type>
+        <terminus_type>none</terminus_type>
+    </modification>
+    <modification title="TMTpro16plex-Lys127N" description="Lys TMTpro16plex127N" create_date="2019-08-27T22:06:25.2783474+02:00" last_modified_date="2019-08-27T22:15:34.8689443+02:00" user="Ed" reporterCorrectionM2="0" reporterCorrectionM1="0" reporterCorrectionP1="0" reporterCorrectionP2="0" reporterCorrectionType="false" composition="H(25) C(8) Cx(7) N O(3) Nx(2)">
+        <position>anywhere</position>
+        <modification_site site="K">
+            <neutralloss_collection />
+            <diagnostic_collection>
+                <diagnostic name="127N" shortname="127N" composition="H(15) C(8) Nx" />
+            </diagnostic_collection>
+        </modification_site>
+        <type>IsobaricLabel</type>
+        <terminus_type>none</terminus_type>
+    </modification>
+    <modification title="TMTpro16plex-Lys127C" description="Lys TMTpro16plex127C" create_date="2019-08-27T22:07:14.1681983+02:00" last_modified_date="2019-08-27T22:15:41.1890417+02:00" user="Ed" reporterCorrectionM2="0" reporterCorrectionM1="0" reporterCorrectionP1="0" reporterCorrectionP2="0" reporterCorrectionType="false" composition="H(25) C(8) Cx(7) N O(3) Nx(2)">
+        <position>anywhere</position>
+        <modification_site site="K">
+            <neutralloss_collection />
+            <diagnostic_collection>
+                <diagnostic name="127C" shortname="127C" composition="H(15) C(7) N Cx" />
+            </diagnostic_collection>
+        </modification_site>
+        <type>IsobaricLabel</type>
+        <terminus_type>none</terminus_type>
+    </modification>
+    <modification title="TMTpro16plex-Lys128N" description="Lys TMTpro16plex128N" create_date="2019-08-27T22:08:05.6383658+02:00" last_modified_date="2019-08-27T22:15:47.681672+02:00" user="Ed" reporterCorrectionM2="0" reporterCorrectionM1="0" reporterCorrectionP1="0" reporterCorrectionP2="0" reporterCorrectionType="false" composition="H(25) C(8) Cx(7) N O(3) Nx(2)">
+        <position>anywhere</position>
+        <modification_site site="K">
+            <neutralloss_collection />
+            <diagnostic_collection>
+                <diagnostic name="128N" shortname="128N" composition="H(15) C(7) Cx Nx" />
+            </diagnostic_collection>
+        </modification_site>
+        <type>IsobaricLabel</type>
+        <terminus_type>none</terminus_type>
+    </modification>
+    <modification title="TMTpro16plex-Lys128C" description="Lys TMTpro16plex128C" create_date="2019-08-27T22:09:06.7087671+02:00" last_modified_date="2019-08-27T22:15:54.0286881+02:00" user="Ed" reporterCorrectionM2="0" reporterCorrectionM1="0" reporterCorrectionP1="0" reporterCorrectionP2="0" reporterCorrectionType="false" composition="H(25) C(8) Cx(7) N O(3) Nx(2)">
+        <position>anywhere</position>
+        <modification_site site="K">
+            <neutralloss_collection />
+            <diagnostic_collection>
+                <diagnostic name="128C" shortname="128C" composition="H(15) C(6) Cx(2) N" />
+            </diagnostic_collection>
+        </modification_site>
+        <type>IsobaricLabel</type>
+        <terminus_type>none</terminus_type>
+    </modification>
+    <modification title="TMTpro16plex-Lys129N" description="Lys TMTpro16plex129N" create_date="2019-08-27T22:10:11.7761054+02:00" last_modified_date="2019-08-27T22:16:01.5376107+02:00" user="Ed" reporterCorrectionM2="0" reporterCorrectionM1="0" reporterCorrectionP1="0" reporterCorrectionP2="0" reporterCorrectionType="false" composition="H(25) C(8) Cx(7) N O(3) Nx(2)">
+        <position>anywhere</position>
+        <modification_site site="K">
+            <neutralloss_collection />
+            <diagnostic_collection>
+                <diagnostic name="129N" shortname="129N" composition="H(15) C(6) Cx(2) Nx" />
+            </diagnostic_collection>
+        </modification_site>
+        <type>IsobaricLabel</type>
+        <terminus_type>none</terminus_type>
+    </modification>
+    <modification title="TMTpro16plex-Lys129C" description="Lys TMTpro16plex129C" create_date="2019-08-27T22:10:53.0568997+02:00" last_modified_date="2019-08-27T22:16:07.2389663+02:00" user="Ed" reporterCorrectionM2="0" reporterCorrectionM1="0" reporterCorrectionP1="0" reporterCorrectionP2="0" reporterCorrectionType="false" composition="H(25) C(8) Cx(7) N O(3) Nx(2)">
+        <position>anywhere</position>
+        <modification_site site="K">
+            <neutralloss_collection />
+            <diagnostic_collection>
+                <diagnostic name="129C" shortname="129C" composition="H(15) C(5) Cx(3) N" />
+            </diagnostic_collection>
+        </modification_site>
+        <type>IsobaricLabel</type>
+        <terminus_type>none</terminus_type>
+    </modification>
+    <modification title="TMTpro16plex-Lys130N" description="Lys TMTpro16plex130N" create_date="2019-08-27T22:11:42.888705+02:00" last_modified_date="2019-08-27T22:16:12.3090372+02:00" user="Ed" reporterCorrectionM2="0" reporterCorrectionM1="0" reporterCorrectionP1="0" reporterCorrectionP2="0" reporterCorrectionType="false" composition="H(25) C(8) Cx(7) N O(3) Nx(2)">
+        <position>anywhere</position>
+        <modification_site site="K">
+            <neutralloss_collection />
+            <diagnostic_collection>
+                <diagnostic name="130N" shortname="130N" composition="H(15) C(5) Cx(3) Nx" />
+            </diagnostic_collection>
+        </modification_site>
+        <type>IsobaricLabel</type>
+        <terminus_type>none</terminus_type>
+    </modification>
+    <modification title="TMTpro16plex-Lys130C" description="Lys TMTpro16plex130C" create_date="2019-08-27T22:13:30.6085273+02:00" last_modified_date="2019-08-27T22:16:19.1589126+02:00" user="Ed" reporterCorrectionM2="0" reporterCorrectionM1="0" reporterCorrectionP1="0" reporterCorrectionP2="0" reporterCorrectionType="false" composition="H(25) C(8) Cx(7) N O(3) Nx(2)">
+        <position>anywhere</position>
+        <modification_site site="K">
+            <neutralloss_collection />
+            <diagnostic_collection>
+                <diagnostic name="130C" shortname="130C" composition="H(15) C(4) Cx(4) N" />
+            </diagnostic_collection>
+        </modification_site>
+        <type>IsobaricLabel</type>
+        <terminus_type>none</terminus_type>
+    </modification>
+    <modification title="TMTpro16plex-Lys131N" description="Lys TMTpro16plex131N" create_date="2019-08-27T22:14:34.8007599+02:00" last_modified_date="2019-08-27T22:16:27.2888726+02:00" user="Ed" reporterCorrectionM2="0" reporterCorrectionM1="0" reporterCorrectionP1="0" reporterCorrectionP2="0" reporterCorrectionType="false" composition="H(25) C(8) Cx(7) N O(3) Nx(2)">
+        <position>anywhere</position>
+        <modification_site site="K">
+            <neutralloss_collection />
+            <diagnostic_collection>
+                <diagnostic name="131N" shortname="131N" composition="H(15) C(4) Cx(4) Nx" />
+            </diagnostic_collection>
+        </modification_site>
+        <type>IsobaricLabel</type>
+        <terminus_type>none</terminus_type>
+    </modification>
+    <modification title="TMTpro16plex-Lys131C" description="Lys TMTpro16plex131C" create_date="2019-08-27T22:16:31.8190129+02:00" last_modified_date="2019-08-27T22:17:15.2391319+02:00" user="Ed" reporterCorrectionM2="0" reporterCorrectionM1="0" reporterCorrectionP1="0" reporterCorrectionP2="0" reporterCorrectionType="false" composition="H(25) C(8) Cx(7) N O(3) Nx(2)">
+        <position>anywhere</position>
+        <modification_site site="K">
+            <neutralloss_collection />
+            <diagnostic_collection>
+                <diagnostic name="131C" shortname="131C" composition="H(15) C(3) Cx(5) N" />
+            </diagnostic_collection>
+        </modification_site>
+        <type>IsobaricLabel</type>
+        <terminus_type>none</terminus_type>
+    </modification>
+    <modification title="TMTpro16plex-Lys132N" description="Lys TMTpro16plex132N" create_date="2019-08-27T22:17:20.4252847+02:00" last_modified_date="2019-08-27T22:17:59.5691812+02:00" user="Ed" reporterCorrectionM2="0" reporterCorrectionM1="0" reporterCorrectionP1="0" reporterCorrectionP2="0" reporterCorrectionType="false" composition="H(25) C(8) Cx(7) N O(3) Nx(2)">
+        <position>anywhere</position>
+        <modification_site site="K">
+            <neutralloss_collection />
+            <diagnostic_collection>
+                <diagnostic name="132N" shortname="132N" composition="H(15) C(3) Cx(5) Nx" />
+            </diagnostic_collection>
+        </modification_site>
+        <type>IsobaricLabel</type>
+        <terminus_type>none</terminus_type>
+    </modification>
+    <modification title="TMTpro16plex-Lys132C" description="Lys TMTpro16plex132C" create_date="2019-08-27T22:18:05.0140618+02:00" last_modified_date="2019-08-27T22:18:49.1492579+02:00" user="Ed" reporterCorrectionM2="0" reporterCorrectionM1="0" reporterCorrectionP1="0" reporterCorrectionP2="0" reporterCorrectionType="false" composition="H(25) C(8) Cx(7) N O(3) Nx(2)">
+        <position>anywhere</position>
+        <modification_site site="K">
+            <neutralloss_collection />
+            <diagnostic_collection>
+                <diagnostic name="132C" shortname="132C" composition="H(15) C(2) Cx(6) N" />
+            </diagnostic_collection>
+        </modification_site>
+        <type>IsobaricLabel</type>
+        <terminus_type>none</terminus_type>
+    </modification>
+    <modification title="TMTpro16plex-Lys133N" description="Lys TMTpro16plex133N" create_date="2019-08-27T22:18:53.6194828+02:00" last_modified_date="2019-08-27T22:19:35.5492651+02:00" user="Ed" reporterCorrectionM2="0" reporterCorrectionM1="0" reporterCorrectionP1="0" reporterCorrectionP2="0" reporterCorrectionType="false" composition="H(25) C(8) Cx(7) N O(3) Nx(2)">
+        <position>anywhere</position>
+        <modification_site site="K">
+            <neutralloss_collection />
+            <diagnostic_collection>
+                <diagnostic name="133N" shortname="133N" composition="H(15) C(2) Cx(6) Nx" />
+            </diagnostic_collection>
+        </modification_site>
+        <type>IsobaricLabel</type>
+        <terminus_type>none</terminus_type>
+    </modification>
+    <modification title="TMTpro16plex-Lys133C" description="Lys TMTpro16plex133C" create_date="2019-08-27T22:19:41.6498824+02:00" last_modified_date="2019-08-27T22:20:17.7495157+02:00" user="Ed" reporterCorrectionM2="0" reporterCorrectionM1="0" reporterCorrectionP1="0" reporterCorrectionP2="0" reporterCorrectionType="false" composition="H(25) C(8) Cx(7) N O(3) Nx(2)">
+        <position>anywhere</position>
+        <modification_site site="K">
+            <neutralloss_collection />
+            <diagnostic_collection>
+                <diagnostic name="133C" shortname="133C" composition="H(15) C Cx(7) N" />
+            </diagnostic_collection>
+        </modification_site>
+        <type>IsobaricLabel</type>
+        <terminus_type>none</terminus_type>
+    </modification>
+    <modification title="TMTpro16plex-Lys134N" description="Lys TMTpro16plex134N" create_date="2019-08-27T22:20:26.5619944+02:00" last_modified_date="2019-08-27T22:21:08.4889746+02:00" user="Ed" reporterCorrectionM2="0" reporterCorrectionM1="0" reporterCorrectionP1="0" reporterCorrectionP2="0" reporterCorrectionType="false" composition="H(25) C(8) Cx(7) N O(3) Nx(2)">
+        <position>anywhere</position>
+        <modification_site site="K">
+            <neutralloss_collection />
+            <diagnostic_collection>
+                <diagnostic name="134N" shortname="134N" composition="H(15) C Cx(7) Nx" />
+            </diagnostic_collection>
+        </modification_site>
+        <type>IsobaricLabel</type>
+        <terminus_type>none</terminus_type>
+    </modification>
+</modifications>

--- a/recipes/maxquant/1.6.17.0/xmlcombine.py
+++ b/recipes/maxquant/1.6.17.0/xmlcombine.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+# Script to extend modifications/enzymes/databases/crosslinks/annotation_config.xml
+# with custom xml files in the recipe dir
+
+import sys
+from xml.etree.ElementTree import parse, tostring
+
+
+def combine(files):
+	first = None
+	for file in files:
+		xml_data = parse(file).getroot()
+		if first is None:
+			first = xml_data
+		else:
+			first.extend(xml_data)
+	if first is not None:
+		print(tostring(first, encoding="unicode"))
+
+
+if __name__ == "__main__":
+	combine(sys.argv[1:])


### PR DESCRIPTION
In some instances newer MaxQuant versions complaining about not using .NET. It depends on the useDotNetCore parameter in the mqpar file, which by default is set to True in version >=1.6.17.0. In older versions the paramater is set to False (f.e. in 1.6.10.43). To avoid any further incompatibilities I would suggest to switch to dotnet.

**Moved files of MaxQuant 1.6.17.0 tool wrapper into versioned subdir.**