### PR TITLE
Update Dependencies for scanpy-scripts

### DIFF
--- a/recipes/scanpy-scripts/meta.yaml
+++ b/recipes/scanpy-scripts/meta.yaml
@@ -35,23 +35,23 @@ requirements:
     - python>=3.6
   run:
     - anndata
+    - bbknn>=1.5.0
     - click<8
+    - h5py<3.0.0
+    - harmonypy>=0.0.5
     - leidenalg
     - loompy
     - louvain
-    - multicore-tsne
     - matplotlib-base
-    - pandas
-    - h5py<3.0.0
+    - mnnpy>=0.1.9.5
+    - multicore-tsne
     - packaging
+    - pandas
     - python>=3.6
     - scanpy>=1.8.0
     - scipy 
     - scrublet
     - umap-learn<0.4.0
-    - mnnpy>=0.1.9.5
-    - harmonypy>=0.0.5
-    - bbknn>=1.5.0
 
 test:
   imports:

--- a/recipes/scanpy-scripts/meta.yaml
+++ b/recipes/scanpy-scripts/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: f0863e1c743dda5aee84d14ee787ce4c887e310c2e80196e33c87200e1551c71
 
 build:
-  number: 0
+  number: 1
   noarch: python
   entry_points:
     - scanpy-cli=scanpy_scripts.cli:cli
@@ -42,17 +42,16 @@ requirements:
     - multicore-tsne
     - matplotlib-base
     - pandas
-    - h5py<3.0.0 
+    - h5py<3.0.0
     - packaging
     - python>=3.6
-    - scanpy>=1.6.0
+    - scanpy>=1.8.0
     - scipy 
+    - scrublet
     - umap-learn<0.4.0
     - mnnpy>=0.1.9.5
     - harmonypy>=0.0.5
-    - bbknn>=1.3.12,<1.5.0
-    - fa2
-    - numpy<1.19.5
+    - bbknn>=1.5.0
 
 test:
   imports:


### PR DESCRIPTION
The dependencies in the receipt were not up-to-date with the dependencies in the Git repo ([setup.py](https://github.com/ebi-gene-expression-group/scanpy-scripts/blob/v1.0.0/setup.py)).

## Changed:
  - `scanpy>=1.6.0`              --> `scanpy>=1.8.0`
  - `bbknn>=1.3.12,<1.5.0`  -->  `bbknn>=1.5.0`

## Added:
  - `scrublet`

## Removed:
  - `fa2`
  - `numpy<1.19.5`
