### PR TITLE
Update seqwish to v0.7.1

### DIFF
--- a/recipes/seqwish/meta.yaml
+++ b/recipes/seqwish/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.4.1" %}
+{% set version = "0.7.1" %}
 
 package:
   name: seqwish
@@ -22,6 +22,7 @@ requirements:
     - make
   host:
     - zlib
+    - jemalloc
   run:
     - llvm-openmp  # [osx]
     - python >=3.6

--- a/recipes/seqwish/meta.yaml
+++ b/recipes/seqwish/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   skip: True  # [osx]
-  number: 1
+  number: 0
 
 requirements:
   build:


### PR DESCRIPTION
This updates the seqwish recipe to v0.7.1. The source includes a buildable tarball now too.