### PR TITLE
Add deepsignal-plant recipe

### DIFF
--- a/recipes/deepsignal-plant/meta.yaml
+++ b/recipes/deepsignal-plant/meta.yaml
@@ -14,16 +14,16 @@ build:
   number: 0
   entry_points:
     - deepsignal_plant=deepsignal_plant.deepsignal_plant:main
-  skip: False  # [not sure here]
+  skip: True  # [not sure here]
   script: "{{ PYTHON }} -m pip install . -vv"
 
 requirements:
   host:
     - pip
-    - python
+    - python >=3.6
     - setuptools  # [not sure here]
   run:
-    - python
+    - python >=3.6
     - setuptools  # [not sure here]
     - h5py >=2.8.0
     - numpy >=1.15.3

--- a/recipes/deepsignal-plant/meta.yaml
+++ b/recipes/deepsignal-plant/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "deepsignal-plant" %}
 {% set version = "0.1.2" %}
-{% set hash = "362e012553c1cbe6ed814c480dae805dfbe6f966584ea634c52113b4ee872ccf" %}
+{% set hash = "9c6782a56db0308ac1f5c2e7617dfecd2a646a844f6a132412b0874d571ec726" %}
 
 package:
   name: "{{ name|lower }}"

--- a/recipes/deepsignal-plant/meta.yaml
+++ b/recipes/deepsignal-plant/meta.yaml
@@ -15,7 +15,6 @@ build:
   noarch: python
   entry_points:
     - deepsignal_plant=deepsignal_plant.deepsignal_plant:main
-  skip: False
   script: "{{ PYTHON }} -m pip install . -vv"
 
 requirements:
@@ -42,7 +41,6 @@ about:
   license_family: GPL3
   license_file: LICENSE
   summary: A deep-learning method for detecting DNA methylation state from Oxford Nanopore sequencing reads of plants
-  doc_url: 
   dev_url: https://github.com/PengNi/deepsignal-plant
 
 extra:

--- a/recipes/deepsignal-plant/meta.yaml
+++ b/recipes/deepsignal-plant/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - numpy >=1.15.3
     - scikit-learn >=0.20.1
     - statsmodels >=0.9.0
-    - torch >=1.2.0,<=1.6.0
+    - pytorch >=1.2.0,<=1.6.0
 
 test:
   imports:

--- a/recipes/deepsignal-plant/meta.yaml
+++ b/recipes/deepsignal-plant/meta.yaml
@@ -12,6 +12,7 @@ source:
 
 build:
   number: 0
+  noarch: python
   entry_points:
     - deepsignal_plant=deepsignal_plant.deepsignal_plant:main
   skip: True  # [not sure here]
@@ -24,7 +25,6 @@ requirements:
     - setuptools  # [not sure here]
   run:
     - python >=3.6
-    - setuptools  # [not sure here]
     - h5py >=2.8.0
     - numpy >=1.15.3
     - scikit-learn >=0.20.1
@@ -41,7 +41,7 @@ about:
   home: https://github.com/PengNi/deepsignal-plant
   license: GNU General Public v3 (GPLv3)
   license_family: GPL3
-  license_file: 
+  license_file: LICENSE
   summary: A deep-learning method for detecting DNA methylation state from Oxford Nanopore sequencing reads of plants
   doc_url: 
   dev_url: https://github.com/PengNi/deepsignal-plant

--- a/recipes/deepsignal-plant/meta.yaml
+++ b/recipes/deepsignal-plant/meta.yaml
@@ -1,0 +1,51 @@
+{% set name = "deepsignal-plant" %}
+{% set version = "0.1.2" %}
+{% set hash = "362e012553c1cbe6ed814c480dae805dfbe6f966584ea634c52113b4ee872ccf" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: https://github.com/PengNi/{{ name }}/archive/{{ version }}.tar.gz
+  sha256: {{ hash }}
+
+build:
+  number: 0
+  entry_points:
+    - deepsignal_plant=deepsignal_plant.deepsignal_plant:main
+  skip: False  # [not sure here]
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - pip
+    - python
+    - setuptools  # [not sure here]
+  run:
+    - python
+    - setuptools  # [not sure here]
+    - h5py >=2.8.0
+    - numpy >=1.15.3
+    - scikit-learn >=0.20.1
+    - statsmodels >=0.9.0
+    - torch >=1.2.0,<=1.6.0
+
+test:
+  imports:
+    - deepsignal_plant
+  commands:
+    - deepsignal_plant --help
+
+about:
+  home: https://github.com/PengNi/deepsignal-plant
+  license: GNU General Public v3 (GPLv3)
+  license_family: GPL3
+  license_file: 
+  summary: A deep-learning method for detecting DNA methylation state from Oxford Nanopore sequencing reads of plants
+  doc_url: 
+  dev_url: https://github.com/PengNi/deepsignal-plant
+
+extra:
+  recipe-maintainers:
+    - PengNi

--- a/recipes/deepsignal-plant/meta.yaml
+++ b/recipes/deepsignal-plant/meta.yaml
@@ -15,7 +15,6 @@ build:
   noarch: python
   entry_points:
     - deepsignal_plant=deepsignal_plant.deepsignal_plant:main
-  skip: True  # [not sure here]
   script: "{{ PYTHON }} -m pip install . -vv"
 
 requirements:

--- a/recipes/deepsignal-plant/meta.yaml
+++ b/recipes/deepsignal-plant/meta.yaml
@@ -15,13 +15,13 @@ build:
   noarch: python
   entry_points:
     - deepsignal_plant=deepsignal_plant.deepsignal_plant:main
+  skip: False
   script: "{{ PYTHON }} -m pip install . -vv"
 
 requirements:
   host:
-    - pip
     - python >=3.6
-    - setuptools  # [not sure here]
+    - pip
   run:
     - python >=3.6
     - h5py >=2.8.0


### PR DESCRIPTION
The PR adds a recipe for [deepsignal-plant](https://github.com/PengNi/deepsignal-plant), a deep-learning method for detecting methylation state from Oxford Nanopore sequencing reads of plants.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
