### PR TITLE
update wfmash to v0.6.1

### DIFF
--- a/recipes/seqwish/build.sh
+++ b/recipes/seqwish/build.sh
@@ -4,4 +4,4 @@ export C_INCLUDE_PATH=${PREFIX}/include
 cmake -H. -Bbuild
 cmake --build build
 mkdir -p $PREFIX/bin
-mv bin/* $PREFIX/bin
+mv build/bin/* $PREFIX/bin

--- a/recipes/seqwish/build.sh
+++ b/recipes/seqwish/build.sh
@@ -4,4 +4,4 @@ export C_INCLUDE_PATH=${PREFIX}/include
 cmake -H. -Bbuild
 cmake --build build
 mkdir -p $PREFIX/bin
-mv build/bin/* $PREFIX/bin
+mv bin/* $PREFIX/bin

--- a/recipes/wfmash/build.sh
+++ b/recipes/wfmash/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+export LIBRARY_PATH=${PREFIX}/lib
+export C_INCLUDE_PATH=${PREFIX}/include
+cmake -H. -Bbuild
+cmake --build build
+mkdir -p $PREFIX/bin
+mv bin/* $PREFIX/bin

--- a/recipes/wfmash/build.sh
+++ b/recipes/wfmash/build.sh
@@ -4,4 +4,4 @@ export C_INCLUDE_PATH=${PREFIX}/include
 cmake -H. -Bbuild
 cmake --build build
 mkdir -p $PREFIX/bin
-mv bin/* $PREFIX/bin
+mv build/bin/* $PREFIX/bin

--- a/recipes/wfmash/meta.yaml
+++ b/recipes/wfmash/meta.yaml
@@ -2,11 +2,11 @@
 {% set version = "0.6.1" %}
 
 package:
-  name: {{ name|lower }}
-  version: '{{ version }}'
+  name: "{{ name }}"
+  version: "{{ version }}"
 
 source:
-  url: https://github.com/ekg/{{ name }}/releases/download/v{{ version }}/wfmash-v{{ version }}.tar.gz
+  url: https://github.com/ekg/{{ name }}/releases/download/v{{ version }}/{{ name }}-v{{ version }}.tar.gz
   sha256: 972ff149df638aceff07ee09dbbfdf2dd6ee64e09eb728df490d68f0fe1070f3
 
 build:

--- a/recipes/wfmash/meta.yaml
+++ b/recipes/wfmash/meta.yaml
@@ -1,0 +1,41 @@
+{% set version = "0.6" %}
+
+package:
+  name: wfmash
+  version: '{{ version }}'
+
+source:
+  git_url: https://github.com/ekg/wfmash
+  git_tag: v{{ version }}
+  sha256: unused
+
+build:
+  skip: True  # [osx or py27]
+  number: 0
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - llvm-openmp  # [osx]
+    - cmake
+    - make
+  host:
+    - zlib
+    - jemalloc
+  run:
+    - llvm-openmp  # [osx]
+
+test:
+  commands:
+    - wfmash --help
+
+about:
+  home: https://github.com/ekg/wfmash
+  license: MIT
+  license_file: LICENSE
+  summary: A DNA sequence aligner based on mash distances and the wavefront alignment algorithm
+
+extra:
+  skip-lints:
+    - uses_vcs_url

--- a/recipes/wfmash/meta.yaml
+++ b/recipes/wfmash/meta.yaml
@@ -1,13 +1,12 @@
-{% set version = "0.6" %}
+{% set version = "0.6.1" %}
 
 package:
   name: wfmash
   version: '{{ version }}'
 
 source:
-  git_url: https://github.com/ekg/wfmash
-  git_tag: v{{ version }}
-  sha256: unused
+  url: https://github.com/ekg/wfmash/releases/download/v0.6.1/wfmash-v0.6.1.tar.gz
+  sha256: 972ff149df638aceff07ee09dbbfdf2dd6ee64e09eb728df490d68f0fe1070f3
 
 build:
   skip: True  # [osx or py27]

--- a/recipes/wfmash/meta.yaml
+++ b/recipes/wfmash/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/ekg/{{ name }}/releases/download/v{{ version }}/{{ name }}-v{{ version }}.tar.gz
-  sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+  sha256: 972ff149df638aceff07ee09dbbfdf2dd6ee64e09eb728df490d68f0fe1070f3
 
 build:
   skip: True  # [osx or py27]

--- a/recipes/wfmash/meta.yaml
+++ b/recipes/wfmash/meta.yaml
@@ -1,11 +1,12 @@
+{% set name = "wfmash" %}
 {% set version = "0.6.1" %}
 
 package:
-  name: wfmash
+  name: {{ name|lower }}
   version: '{{ version }}'
 
 source:
-  url: https://github.com/ekg/wfmash/releases/download/v0.6.1/wfmash-v0.6.1.tar.gz
+  url: https://github.com/ekg/{{ name }}/releases/download/v{{ version }}/wfmash-v{{ version }}.tar.gz
   sha256: 972ff149df638aceff07ee09dbbfdf2dd6ee64e09eb728df490d68f0fe1070f3
 
 build:

--- a/recipes/wfmash/meta.yaml
+++ b/recipes/wfmash/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   skip: True  # [osx or py27]
-  number: 1
+  number: 0
 
 requirements:
   build:

--- a/recipes/wfmash/meta.yaml
+++ b/recipes/wfmash/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/ekg/{{ name }}/releases/download/v{{ version }}/{{ name }}-v{{ version }}.tar.gz
-  sha256: 972ff149df638aceff07ee09dbbfdf2dd6ee64e09eb728df490d68f0fe1070f3
+  sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 
 build:
   skip: True  # [osx or py27]
@@ -21,6 +21,7 @@ requirements:
     - cmake
     - make
   host:
+    - gsl
     - zlib
     - jemalloc
   run:

--- a/recipes/wfmash/meta.yaml
+++ b/recipes/wfmash/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   skip: True  # [osx or py27]
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipes/wfmash/meta.yaml
+++ b/recipes/wfmash/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 972ff149df638aceff07ee09dbbfdf2dd6ee64e09eb728df490d68f0fe1070f3
 
 build:
-  skip: True  # [osx or py27]
+  skip: True  # [osx]
   number: 0
 
 requirements:


### PR DESCRIPTION
To allow users to install more easily wfmash (https://github.com/ekg/wfmash/issues/87, https://github.com/pangenome/pggb/issues/112).