### PR TITLE
Update to release 0.018

### DIFF
--- a/recipes/rfplasmid/meta.yaml
+++ b/recipes/rfplasmid/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "rfplasmid" %}
-{% set version = "0.0.17" %}
-{% set blake2_sha256 = "79a90a1262a2fe72736c5d43fb75f34d3cf4b25343fe87acc8bc9636600e092d" %}
+{% set version = "0.0.18" %}
+{% set blake2_sha256 = "94c0f87aa1a4be2bdd34846922c5a2e53241fd384868bfd8469d3f83a94bf8b1" %}
 
 package:
   name:  {{ name }}
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://files.pythonhosted.org/packages/{{ blake2_sha256[0:2] }}/{{ blake2_sha256[2:4] }}/{{ blake2_sha256[4:] }}/{{ name }}-{{ version }}-py3-none-any.whl
-  sha256: b1fe37e6ae3bb78222bcecf3ad94a94d41a0fe054a2d0eb68123538447861521
+  sha256: 45f2e380a82d75b1eb31ee27007197a55013b40d9b4cb6bd28457f9acce30b2e
 
 build:
   noarch: python


### PR DESCRIPTION
Update to release 0.018
1. Automated sampsize selection for training.
2. Renaming the taxa agnostic Bacteria model to "Generic"
3. TOC in the Readme
4. Google Colab notebook

Describe your pull request here

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
