### PR TITLE
Add TMTpro18plex modifications to MaxQuant 1.6.17.0 & 2.0.1.0

### DIFF
--- a/recipes/maxquant/1.6.17.0/meta.yaml
+++ b/recipes/maxquant/1.6.17.0/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: generic
-  number: 3
+  number: 4
 
   script:
     - cp -r * $PREFIX

--- a/recipes/maxquant/1.6.17.0/mod_tmtpro18plex.xml
+++ b/recipes/maxquant/1.6.17.0/mod_tmtpro18plex.xml
@@ -1,0 +1,62 @@
+<modifications>   
+    <modification title="TMTpro18plex-Nter134C" description="N-terminal TMTpro18plex134C"
+                  create_date="2021-07-26T23:24:00.4170436+02:00" last_modified_date="2021-07-26T23:58:37.6771226+02:00"
+                  user="npinter"
+                  reporterCorrectionM2="0" reporterCorrectionM1="0" reporterCorrectionP1="0" reporterCorrectionP2="0"
+                  reporterCorrectionType="false" composition="H(25) C(8) Cx(7) N O(3) Nx(2)">
+      <position>anyNterm</position>
+      <modification_site site="-">
+         <neutralloss_collection />
+         <diagnostic_collection>
+            <diagnostic name="134C" shortname="134C" composition="H(15) Cx(8) N" />
+         </diagnostic_collection>
+      </modification_site>
+      <type>IsobaricLabel</type>
+      <terminus_type>none</terminus_type>
+   </modification>
+   <modification title="TMTpro18plex-Nter135N" description="N-terminal TMTpro18plex135N"
+                 create_date="2021-07-26T23:24:03.5470957+02:00" last_modified_date="2021-07-26T23:59:47.9761617+02:00"
+                 user="npinter"
+                 reporterCorrectionM2="0" reporterCorrectionM1="0" reporterCorrectionP1="0" reporterCorrectionP2="0"
+                 reporterCorrectionType="false" composition="H(25) C(8) Cx(7) N O(3) Nx(2)">
+      <position>anyNterm</position>
+      <modification_site site="-">
+         <neutralloss_collection />
+         <diagnostic_collection>
+            <diagnostic name="135N" shortname="135N" composition="H(15) Cx(8) Nx" />
+         </diagnostic_collection>
+      </modification_site>
+      <type>IsobaricLabel</type>
+      <terminus_type>none</terminus_type>
+   </modification>
+   <modification title="TMTpro18plex-Lys134C" description="Lys TMTpro18plex134C"
+                 create_date="2021-07-26T23:24:07.5950469+02:00" last_modified_date="2021-07-27T00:01:21.3402067+02:00"
+                 user="npinter"
+                 reporterCorrectionM2="0" reporterCorrectionM1="0" reporterCorrectionP1="0" reporterCorrectionP2="0"
+                 reporterCorrectionType="false" composition="H(25) C(8) Cx(7) N O(3) Nx(2)">
+      <position>anywhere</position>
+      <modification_site site="K">
+         <neutralloss_collection />
+         <diagnostic_collection>
+            <diagnostic name="134C" shortname="134C" composition="H(15) Cx(8) N" />
+         </diagnostic_collection>
+      </modification_site>
+      <type>IsobaricLabel</type>
+      <terminus_type>none</terminus_type>
+   </modification>
+   <modification title="TMTpro18plex-Lys135N" description="Lys TMTpro18plex135N"
+                 create_date="2021-07-26T23:24:08.7281005+02:00" last_modified_date="2021-07-27T00:02:06.52923+02:00"
+                 user="npinter"
+                 reporterCorrectionM2="0" reporterCorrectionM1="0" reporterCorrectionP1="0" reporterCorrectionP2="0"
+                 reporterCorrectionType="false" composition="H(25) C(8) Cx(7) N O(3) Nx(2)">
+      <position>anywhere</position>
+      <modification_site site="K">
+         <neutralloss_collection />
+         <diagnostic_collection>
+            <diagnostic name="135N" shortname="135N" composition="H(15) Cx(8) Nx" />
+         </diagnostic_collection>
+      </modification_site>
+      <type>IsobaricLabel</type>
+      <terminus_type>none</terminus_type>
+   </modification>
+</modifications>

--- a/recipes/maxquant/meta.yaml
+++ b/recipes/maxquant/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: generic
-  number: 1
+  number: 2
 
   script:
     - cp -r * $PREFIX

--- a/recipes/maxquant/mod_tmtpro18plex.xml
+++ b/recipes/maxquant/mod_tmtpro18plex.xml
@@ -1,0 +1,62 @@
+<modifications>   
+    <modification title="TMTpro18plex-Nter134C" description="N-terminal TMTpro18plex134C"
+                  create_date="2021-07-26T23:24:00.4170436+02:00" last_modified_date="2021-07-26T23:58:37.6771226+02:00"
+                  user="npinter"
+                  reporterCorrectionM2="0" reporterCorrectionM1="0" reporterCorrectionP1="0" reporterCorrectionP2="0"
+                  reporterCorrectionType="false" composition="H(25) C(8) Cx(7) N O(3) Nx(2)">
+      <position>anyNterm</position>
+      <modification_site site="-">
+         <neutralloss_collection />
+         <diagnostic_collection>
+            <diagnostic name="134C" shortname="134C" composition="H(15) Cx(8) N" />
+         </diagnostic_collection>
+      </modification_site>
+      <type>IsobaricLabel</type>
+      <terminus_type>none</terminus_type>
+   </modification>
+   <modification title="TMTpro18plex-Nter135N" description="N-terminal TMTpro18plex135N"
+                 create_date="2021-07-26T23:24:03.5470957+02:00" last_modified_date="2021-07-26T23:59:47.9761617+02:00"
+                 user="npinter"
+                 reporterCorrectionM2="0" reporterCorrectionM1="0" reporterCorrectionP1="0" reporterCorrectionP2="0"
+                 reporterCorrectionType="false" composition="H(25) C(8) Cx(7) N O(3) Nx(2)">
+      <position>anyNterm</position>
+      <modification_site site="-">
+         <neutralloss_collection />
+         <diagnostic_collection>
+            <diagnostic name="135N" shortname="135N" composition="H(15) Cx(8) Nx" />
+         </diagnostic_collection>
+      </modification_site>
+      <type>IsobaricLabel</type>
+      <terminus_type>none</terminus_type>
+   </modification>
+   <modification title="TMTpro18plex-Lys134C" description="Lys TMTpro18plex134C"
+                 create_date="2021-07-26T23:24:07.5950469+02:00" last_modified_date="2021-07-27T00:01:21.3402067+02:00"
+                 user="npinter"
+                 reporterCorrectionM2="0" reporterCorrectionM1="0" reporterCorrectionP1="0" reporterCorrectionP2="0"
+                 reporterCorrectionType="false" composition="H(25) C(8) Cx(7) N O(3) Nx(2)">
+      <position>anywhere</position>
+      <modification_site site="K">
+         <neutralloss_collection />
+         <diagnostic_collection>
+            <diagnostic name="134C" shortname="134C" composition="H(15) Cx(8) N" />
+         </diagnostic_collection>
+      </modification_site>
+      <type>IsobaricLabel</type>
+      <terminus_type>none</terminus_type>
+   </modification>
+   <modification title="TMTpro18plex-Lys135N" description="Lys TMTpro18plex135N"
+                 create_date="2021-07-26T23:24:08.7281005+02:00" last_modified_date="2021-07-27T00:02:06.52923+02:00"
+                 user="npinter"
+                 reporterCorrectionM2="0" reporterCorrectionM1="0" reporterCorrectionP1="0" reporterCorrectionP2="0"
+                 reporterCorrectionType="false" composition="H(25) C(8) Cx(7) N O(3) Nx(2)">
+      <position>anywhere</position>
+      <modification_site site="K">
+         <neutralloss_collection />
+         <diagnostic_collection>
+            <diagnostic name="135N" shortname="135N" composition="H(15) Cx(8) Nx" />
+         </diagnostic_collection>
+      </modification_site>
+      <type>IsobaricLabel</type>
+      <terminus_type>none</terminus_type>
+   </modification>
+</modifications>


### PR DESCRIPTION
This PR adds TMTpro18plex modifications (`mod_tmtpro18plex.xml`) to MaxQuant version 1.6.17.0 and 2.0.1.0.