### PR TITLE
Patch ngmlr to avoid producing an invalid MAPQ value

### DIFF
--- a/recipes/ngmlr/mapq.patch
+++ b/recipes/ngmlr/mapq.patch
@@ -1,0 +1,15 @@
+Avoid MAPQ = -2147483648, which causes samtools >= 1.10 to fail.
+Applies https://github.com/philres/ngmlr/pull/96
+
+diff --git a/src/AlignmentBuffer.cpp b/src/AlignmentBuffer.cpp
+index 26130d1..33597ec 100644
+--- a/src/AlignmentBuffer.cpp
++++ b/src/AlignmentBuffer.cpp
+@@ -1888,6 +1888,7 @@ int AlignmentBuffer::computeMappingQuality(Align const & alignment, int readLeng
+ 		mqSum += results[j].value;
+ 		mqCount += 1;
+ 	}
++	if (mqCount == 0) return 0;
+ //	verbose(1, true, "");
+ 	verbose(1, true, "%d / %d = %d", mqSum, mqCount, (int) (mqSum * 1.0f / mqCount));
+ 	return (int) (mqSum * 1.0f / mqCount);

--- a/recipes/ngmlr/meta.yaml
+++ b/recipes/ngmlr/meta.yaml
@@ -9,10 +9,11 @@ source:
   sha256: '{{sha256}}'
   url: "https://github.com/philres/ngmlr/archive/v{{ version }}.tar.gz"
   patches:
+    - mapq.patch
     - ngmlr-aarch64.patch # [linux and aarch64]
 
 build:
-  number: 8
+  number: 9
   run_exports:
     - {{ pin_subpackage('ngmlr', max_pin="x") }}
 


### PR DESCRIPTION
Add a patch that applies a version of PR philres/ngmlr#96. This bug has been known for ~18 months and prevents use with samtools >= 1.10, which rejects negative values for MAPQ (which are invalid in SAM). The upstream patch has been available for a couple of months and has been applied in e.g. Debian's packaging but not yet by the upstream project.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
