### PR TITLE
Update metaSNV to 2.0.0

### DIFF
--- a/recipes/metasnv/build.sh
+++ b/recipes/metasnv/build.sh
@@ -5,27 +5,16 @@ export LDFLAGS="-L$PREFIX/lib"
 tag=share/metasnv-${PKG_VERSION}/
 odir=$PREFIX/$tag
 
-# Makefile hardcodes "CC=g++" so we need to comment that out
-# And replace uses of $CC with $CXX
-sed 's/^CC=g++/# CC=g++/' src/snpCaller/Makefile | sed 's/$(CC)/$(CXX)/' > src/snpCaller/Makefile.tmp
-mv src/snpCaller/Makefile.tmp src/snpCaller/Makefile
-
 make
 mkdir -p $odir
 cp -pr src $odir
 cp -pr metaSNV.py $odir
-cp -pr metaSNV_post.py $odir
+cp -pr metaSNV_DistDiv.py $odir
+cp -pr metaSNV_Filtering.py $odir
+cp -pr metaSNV_subpopr.R $odir
 
 # The scripts find their resources relative to themselves so they cannot be
 # installed directly to bin/
-
-cat >$PREFIX/bin/metaSNV_post.py <<EOF
-#!/usr/bin/env bash
-
-BINDIR="\$(cd "\$(dirname "\${0}")" && pwd -P)"
-
-exec python \$BINDIR/../$tag/metaSNV_post.py "\$@"
-EOF
 
 cat >$PREFIX/bin/metaSNV.py <<EOF
 #!/usr/bin/env bash
@@ -35,5 +24,31 @@ BINDIR="\$(cd "\$(dirname "\${0}")" && pwd -P)"
 exec python \$BINDIR/../$tag/metaSNV.py "\$@"
 EOF
 
+cat >$PREFIX/bin/metaSNV_DistDiv.py <<EOF
+#!/usr/bin/env bash
+
+BINDIR="\$(cd "\$(dirname "\${0}")" && pwd -P)"
+
+exec python \$BINDIR/../$tag/metaSNV_DistDiv.py "\$@"
+EOF
+
+cat >$PREFIX/bin/metaSNV_Filtering.py <<EOF
+#!/usr/bin/env bash
+
+BINDIR="\$(cd "\$(dirname "\${0}")" && pwd -P)"
+
+exec python \$BINDIR/../$tag/metaSNV_Filtering.py "\$@"
+EOF
+
+cat >$PREFIX/bin/metaSNV_subpopr.R <<EOF
+#!/usr/bin/env bash
+
+BINDIR="\$(cd "\$(dirname "\${0}")" && pwd -P)"
+
+exec Rscript \$BINDIR/../$tag/metaSNV_subpopr.R "\$@"
+EOF
+
 chmod +x $PREFIX/bin/metaSNV.py
-chmod +x $PREFIX/bin/metaSNV_post.py
+chmod +x $PREFIX/bin/metaSNV_DistDiv.py
+chmod +x $PREFIX/bin/metaSNV_Filtering.py
+chmod +x $PREFIX/bin/metaSNV_subpopr.R

--- a/recipes/metasnv/meta.yaml
+++ b/recipes/metasnv/meta.yaml
@@ -1,16 +1,16 @@
-{% set version = "1.0.3" %}
-{% set sha256 = "41bbff76450cf7ad2cfb30f4ec39bfdb51cbe34200c8ddd9418f3340ce843955" %}
+{% set version = "2.0.0" %}
+{% set sha256 = "cc2f729d596e77e04de5db94ebf607e81c8466de46b1e0a15a7dd0fade9d1af1" %}
 
 package:
   name: metasnv
   version: {{ version }}
 
 source:
-  url: https://git.embl.de/costea/metaSNV/repository/v{{ version }}/archive.tar.gz
+  url: https://github.com/metasnv-tool/metaSNV/archive/refs/tags/v{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:
-  number: 4
+  number: 0
 
 requirements:
   build:
@@ -27,21 +27,48 @@ requirements:
     - zlib
   run:
     - python >3.6
+    - pandoc >=2.1
     - numpy
     - pandas
     - htslib
     - zlib
+    - r-base >=4.0
+    - bioconductor-biocparallel >=1.26
+    - r-ape
+    - r-batchtools
+    - r-cairo
+    - r-cluster
+    - r-data.table
+    - r-dplyr
+    - r-dt
+    - r-forcats
+    - r-fpc
+    - r-futile.logger
+    - r-getopt
+    - r-ggplot2
+    - r-ggrepel
+    - r-gridextra
+    - r-kableextra
+    - r-optparse
+    - r-readr
+    - r-reshape2
+    - r-rmarkdown
+    - r-tidyr
 
 test:
   commands:
-    - metaSNV.py -h
-    - metaSNV_post.py -h
+    - metaSNV.py --help
+    - metaSNV_Filtering.py --help
+    - metaSNV_DistDiv.py --help
+    - metaSNV_subpopr.R --help
 
 about:
   home: http:// metasnv.embl.de
   license: GPLv3
+  license_file: LICENSE
   summary: SNV calling software
 
 extra:
   recipe-maintainers:
     - AlessioMilanese
+    - LucasPaoli

--- a/recipes/metasnv/meta.yaml
+++ b/recipes/metasnv/meta.yaml
@@ -10,6 +10,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
+  skip: True  # [py2k or py36
   number: 0
 
 requirements:
@@ -19,14 +20,14 @@ requirements:
     - pkg-config
     - libtool
   host:
-    - python >3.6
-    - boost
+    - python
+    - libboost
     - htslib
     - numpy
     - pandas
     - zlib
   run:
-    - python >3.6
+    - python
     - pandoc >=2.1
     - numpy
     - pandas

--- a/recipes/metasnv/meta.yaml
+++ b/recipes/metasnv/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  skip: True  # [py2k or py36
+  skip: True  # [py2k or py36]
   number: 0
 
 requirements:


### PR DESCRIPTION
metaSNV 2.0.0 is now available updating from 1.0.3

Tagging the dev team: @theavanrossum @LucasPaoli and the initial bioconda recipe maintainer @AlessioMilanese 

