### PR TITLE
metaSNV: add missing dependency

### DIFF
--- a/recipes/metasnv/meta.yaml
+++ b/recipes/metasnv/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   skip: True  # [py2k or py36]
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -32,6 +32,7 @@ requirements:
     - numpy
     - pandas
     - htslib
+    - samtools
     - zlib
     - r-base >=4.0
     - bioconductor-biocparallel >=1.26


### PR DESCRIPTION
We need to have samtools in the installed environment.
We missed it in #29996 as it was installed system-wide.
This PR adds it.