### PR TITLE
Change requirements in abnumber

### DIFF
--- a/recipes/abnumber/meta.yaml
+++ b/recipes/abnumber/meta.yaml
@@ -10,20 +10,18 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --ignore-installed --no-deps -vv
 
 requirements:
   host:
     - python >=3.6
     - pip
-    - pandas
-    - anarci >=2020.04.23
   run:
     - python >=3.6
     - biopython
     - pandas
-    - anarci >=2020.04.23
+    - anarci ==2020.04.23
 
 test:
   imports:


### PR DESCRIPTION
Due to bug in ANARCI dependency, we will now require a fixed version in abnumber package