### PR TITLE
Update macrel version (to 1.0.1) & DOI reference

### DIFF
--- a/recipes/macrel/meta.yaml
+++ b/recipes/macrel/meta.yaml
@@ -55,4 +55,4 @@ extra:
   recipe-maintainers:
     - luispedro
   identifiers:
-    - "doi:10.1101/2019.12.17.880385" # bioRxiv preprint
+    - "doi:10.7717/peerj.10555" # Paper

--- a/recipes/macrel/meta.yaml
+++ b/recipes/macrel/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "macrel" %}
-{% set version = "1.0.0" %}
-{% set sha256 = "f92bc19e61aaba22a8afd49652012259c1bbc374ce3af11b3038adf90640e4e8" %}
+{% set version = "1.0.1" %}
+{% set sha256 = "055040b1f311a0dd4f833e444ebe97c85a48a2cc8db42a5247ead819ead73309" %}
 
 package:
   name: {{ name }}
@@ -11,7 +11,7 @@ source:
  sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 0
   skip: True # [py2k]
   entry_points:
     - macrel= macrel.main:main


### PR DESCRIPTION
Piggy-backs on updating macrel (#30365) to also update the DOI to the published paper (instead of the preprint)
----

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
