### PR TITLE
Add recipe for LISI

### DIFF
--- a/recipes/r-lisi/meta.yaml
+++ b/recipes/r-lisi/meta.yaml
@@ -1,0 +1,58 @@
+{% set version = '1.0' %}
+{% set name = "lisi" %}
+{% set sha256 = '19cf8bd33b28887f2a63738bcd23d19b2e13db2a0c7a86919d46a20469fe41c4' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-{{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/immunogenomics/LISI/archive/v{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{posix}}filesystem        # [win]
+    - {{posix}}zip               # [win]
+
+  host:
+    - r-base
+    - r-rcpparmadillo
+    - r-rann
+
+  run:
+    - r-base
+    - r-testthat
+    - r-dplyr
+    - r-tidyr
+    - r-magrittr
+    - r-ggplot2
+    - r-rann
+    
+test:
+  commands:
+    - $R -e "library(\"{{ name }}\")"           # [not win]
+    - "\"%R%\" -e \"library(\"{{ name }}\")\""  # [win]
+
+about:
+  home: https://github.com/immunogenomics/LISI
+  license: GPL-3
+  license_family: GPL3
+  summary: This method was designed to assess how well mixed cells with
+    different labels are in single cell RNAseq. This method uses the Inverse
+    Simpson's Index to compute diversity of each cell's local neighborhood.
+  license_file:
+    - LICENSE
+
+extra:
+  recipe-maintainers:
+    - tdido


### PR DESCRIPTION
This recipe adds LISI, a method to assess how well mixed cells with different labels are in single cell RNAseq. This method uses the Inverse Simpson's Index to compute diversity of each cell's local neighborhood.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
