### PR TITLE
Updated masurca to 4.0.5

### DIFF
--- a/recipes/masurca/build.sh
+++ b/recipes/masurca/build.sh
@@ -1,15 +1,12 @@
 #!/usr/bin/env bash
 
 set -x -e
-
 export BOOST_ROOT=${PREFIX}
 export DEST=${PREFIX}
 export PERL_EXT_CPPFLAGS="-D_REENTRANT -D_GNU_SOURCE -fwrapv -fno-strict-aliasing -pipe -fstack-protector"
 export PERL_EXT_LDFLAGS="-shared -O2 -fstack-protector"
 export LDFLAGS="-L${PREFIX}/lib"
 export CPATH=${PREFIX}/include
-# C++17 breaks the Celera Assembler build, so force C++11 by adding the flag last
-export CXXFLAGS="$CXXFLAGS -std=c++11"
-sed -i.bak "s#-lz#-L${PREFIX}/lib -lz#g" Flye/lib/minimap2/Makefile
+export CXXFLAGS="-Ofast -fPIC"
 
 ./install.sh

--- a/recipes/masurca/conda_build_config.yaml
+++ b/recipes/masurca/conda_build_config.yaml
@@ -1,0 +1,12 @@
+c_compiler:
+        - gcc
+cxx_compiler:
+        - gxx
+fortran_compiler:
+        - gfortran
+c_compiler_version:
+        - 10
+cxx_compiler_version:
+        - 10
+fortran_compiler_version:
+        - 10

--- a/recipes/masurca/conda_build_config.yaml
+++ b/recipes/masurca/conda_build_config.yaml
@@ -2,11 +2,7 @@ c_compiler:
         - gcc
 cxx_compiler:
         - gxx
-fortran_compiler:
-        - gfortran
 c_compiler_version:
         - 10
 cxx_compiler_version:
-        - 10
-fortran_compiler_version:
         - 10

--- a/recipes/masurca/meta.yaml
+++ b/recipes/masurca/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: db525c26f2b09d6b359a2830fcbd4a3fdc65068e9a116c91076240fd1f5924ed
 
 build:
-  number: 1
+  number: 0
   skip: True  # [osx]
 
 requirements:

--- a/recipes/masurca/meta.yaml
+++ b/recipes/masurca/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "masurca" %}
-{% set version = "3.4.2" %}
+{% set version = "4.0.5" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/alekseyzimin/masurca/releases/download/v{{ version }}/MaSuRCA-{{ version }}.tar.gz
-  sha256: ab97cfdce4167349542aac300c27f128361a80d1999e79fb9e0e41a3bf02c0f1
+  sha256: db525c26f2b09d6b359a2830fcbd4a3fdc65068e9a116c91076240fd1f5924ed
 
 build:
   number: 1


### PR DESCRIPTION
Update to recipe/masurca
* The masurca recipe was stuck on 3.4.2 and the latest version is now 4.0.5.
* It was necessary to pin the compiler to version 10 of gcc as version 11 failed to handle pointer integer comparison in global-1/CA8/src/AS_GKP/fastqAnalyze.C line 73.

@BiocondaBot please update
