### PR TITLE
Add pathogentrack recipes

### DIFF
--- a/recipes/pathogentrack/meta.yaml
+++ b/recipes/pathogentrack/meta.yaml
@@ -6,14 +6,15 @@ package:
   version: "{{ version }}"
 
 source:
-  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  url: "https://files.pythonhosted.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
   sha256: 6a86a79c11e56f82f01510d2b309d7f6d84c1729e3358ec6390b18e02615d4eb
 
 build:
-  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . --ignore-installed --no-deps -vv
   entry_points:
     - PathogenTrack=PathogenTrack.PathogenTrack:main
-  noarch: python
+  number: 1
 
 requirements:
   host:

--- a/recipes/pathogentrack/meta.yaml
+++ b/recipes/pathogentrack/meta.yaml
@@ -10,6 +10,7 @@ source:
   sha256: 64d08f02320fd25977736e78bcf75262f8cfb7b469f321837fa7d90cc1c608b8
 
 build:
+  noarch: python
   number: 0
   entry_points:
     - PathogenTrack=PathogenTrack.PathogenTrack:main

--- a/recipes/pathogentrack/meta.yaml
+++ b/recipes/pathogentrack/meta.yaml
@@ -14,7 +14,7 @@ build:
   script: {{ PYTHON }} -m pip install . --ignore-installed --no-deps -vv
   entry_points:
     - PathogenTrack=PathogenTrack.PathogenTrack:main
-  number: 1
+  number: 0
 
 requirements:
   host:

--- a/recipes/pathogentrack/meta.yaml
+++ b/recipes/pathogentrack/meta.yaml
@@ -1,0 +1,42 @@
+{% set name = "pathogentrack" %}
+{% set version = "0.2.1" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  sha256: 6a86a79c11e56f82f01510d2b309d7f6d84c1729e3358ec6390b18e02615d4eb
+
+build:
+  number: 0
+  entry_points:
+    - PathogenTrack=PathogenTrack.PathogenTrack:main
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - biopython >=1.78
+    - pip
+    - python
+  run:
+    - biopython >=1.78
+    - python
+
+test:
+  commands:
+    - PathogenTrack --help
+
+about:
+  home: "https://github.com/ncrna/PathogenTrack"
+  license: MIT
+  license_family: MIT
+  license_file: 
+  summary: "A pipeline to identify pathogenic microorganisms from scRNA-seq raw data"
+  doc_url: 
+  dev_url: 
+
+extra:
+  recipe-maintainers:
+    - ncrna

--- a/recipes/pathogentrack/meta.yaml
+++ b/recipes/pathogentrack/meta.yaml
@@ -13,7 +13,7 @@ build:
   number: 0
   entry_points:
     - PathogenTrack=PathogenTrack.PathogenTrack:main
-  noarch: general
+  noarch: python
 
 requirements:
   host:

--- a/recipes/pathogentrack/meta.yaml
+++ b/recipes/pathogentrack/meta.yaml
@@ -1,20 +1,19 @@
 {% set name = "pathogentrack" %}
-{% set version = "0.2.1" %}
+{% set version = "0.2.2" %}
 
 package:
   name: "{{ name|lower }}"
   version: "{{ version }}"
 
 source:
-  url: "https://files.pythonhosted.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
-  sha256: 6a86a79c11e56f82f01510d2b309d7f6d84c1729e3358ec6390b18e02615d4eb
+  url: "https://files.pythonhosted.org/packages/c4/89/0bae1709372b9d5ef814942a67f34ef82247d4a6409571ddc84d78227e71/PathogenTrack-0.2.2.tar.gz"
+  sha256: 64d08f02320fd25977736e78bcf75262f8cfb7b469f321837fa7d90cc1c608b8
 
 build:
-  noarch: python
-  script: {{ PYTHON }} -m pip install . --ignore-installed --no-deps -vv
+  number: 0
   entry_points:
     - PathogenTrack=PathogenTrack.PathogenTrack:main
-  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
 
 requirements:
   host:
@@ -26,6 +25,8 @@ requirements:
     - python
 
 test:
+  imports:
+    - PathogenTrack
   commands:
     - PathogenTrack --help
 
@@ -40,4 +41,4 @@ about:
 
 extra:
   recipe-maintainers:
-    - ncrna
+    - your-github-id-here

--- a/recipes/pathogentrack/meta.yaml
+++ b/recipes/pathogentrack/meta.yaml
@@ -13,7 +13,7 @@ build:
   number: 0
   entry_points:
     - PathogenTrack=PathogenTrack.PathogenTrack:main
-  script: "{{ PYTHON }} -m pip install . -vv"
+  noarch: general
 
 requirements:
   host:


### PR DESCRIPTION
PathogenTrack is an unsupervised computational software that uses unmapped single-cell RNAseq reads to characterize intracellular pathogens (viruses and bacteria) at the single-cell level.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
