### PR TITLE
restrict numpy version in cellprofiler

### DIFF
--- a/recipes/cellprofiler/meta.yaml
+++ b/recipes/cellprofiler/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: "4b315864ac492a8042a626b130c89d86d1fe891902f4316f1f7a91a468e29d2a"
 
 build:
-  number: 0
+  number: 1
   script: "{{ PYTHON }} -m pip install --no-deps --ignore-installed . -vv"
   #skip: True  # this is using for some reason up to 3GB of memory and crashes CCI, build and push locally
   #skip: True  # [win or osx or py3k]

--- a/recipes/cellprofiler/meta.yaml
+++ b/recipes/cellprofiler/meta.yaml
@@ -38,7 +38,7 @@ requirements:
     - sentry-sdk
     - matplotlib-base
     - mysqlclient
-    - numpy  >=1.18.2
+    - numpy  >=1.18.2,<=1.20.0
     - prokaryote
     - python-bioformats
     - requests


### PR DESCRIPTION
restrict the numpy version <1.20 for cellprofiler 4 to work correctly