### PR TITLE
Specify channel for pbcore to access v1.2.7

### DIFF
--- a/recipes/pbhoover/meta.yaml
+++ b/recipes/pbhoover/meta.yaml
@@ -25,8 +25,8 @@ requirements:
     - htslib
     - bcftools
     - pyvcf
-    - pbcore >=1.2.10
     - numpy
+    - bishemma1::pbcore
 
 test:
   commands:


### PR DESCRIPTION
This version of PBHoover (1.0.7) requires pbcore v1.2.7, which is not available on anaconda. I have built a conda package for it and uploaded it to my own channel.

We want people to be able to conda install pbhoover without having to pip install pbcore 1.2.7.
