### PR TITLE
Add recipe for pbcore v1.2.7

### DIFF
--- a/recipes/pbcore/1.2.7/meta.yaml
+++ b/recipes/pbcore/1.2.7/meta.yaml
@@ -1,0 +1,55 @@
+{% set name = "pbcore" %}
+{% set version = "1.2.7" %}
+
+package:
+  name: pbcore
+  version: "{{ version }}"
+
+source:
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  sha256: b3f5feb55007848bd5589b1b48bf586268d1a246dc874cc9759a8dc1b6322a46
+
+build:
+  number: 0
+  entry_points:
+    - .open = pbcore.io.opener:entryPoint
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - cython
+    - h5py >=2.0.1
+    - numpy >=1.7.1
+    - pip
+    - pysam >=0.8.4
+    - python
+  run:
+    - cython
+    - h5py >=2.0.1
+    - numpy >=1.7.1
+    - pysam >=0.8.4
+    - python
+
+test:
+  imports:
+    - pbcore
+    - pbcore.chemistry
+    - pbcore.data
+    - pbcore.data.datasets
+    - pbcore.io
+    - pbcore.io.align
+    - pbcore.io.dataset
+    - pbcore.model
+    - pbcore.util
+  requires:
+    - nose
+    - sphinx
+
+about:
+  home: https://github.com/PacificBiosciences/pbcore
+  license: BSD-3-Clause-Clear
+  summary: "A Python library for reading and writing PacBio® data files"
+
+extra:
+  recipe-maintainers:
+    - bishemma1

--- a/recipes/pbcore/1.2.7/meta.yaml
+++ b/recipes/pbcore/1.2.7/meta.yaml
@@ -10,6 +10,7 @@ source:
   sha256: b3f5feb55007848bd5589b1b48bf586268d1a246dc874cc9759a8dc1b6322a46
 
 build:
+  noarch: python
   number: 0
   entry_points:
     - .open = pbcore.io.opener:entryPoint
@@ -24,7 +25,6 @@ requirements:
     - pysam >=0.8.4
     - python
   run:
-    - cython
     - h5py >=2.0.1
     - numpy >=1.7.1
     - pysam >=0.8.4

--- a/recipes/pbcore/1.2.7/meta.yaml
+++ b/recipes/pbcore/1.2.7/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: <3
   entry_points:
     - .open = pbcore.io.opener:entryPoint
   script: "{{ PYTHON }} -m pip install . -vv"

--- a/recipes/pbcore/1.2.7/meta.yaml
+++ b/recipes/pbcore/1.2.7/meta.yaml
@@ -20,9 +20,9 @@ requirements:
     - pip
     - python <3
   run:
-    - h5py
-    - numpy
-    - pysam
+    - h5py <=2.7.0
+    - numpy <=1.10.0
+    - pysam <=0.8.3
     - python <3
 
 test:

--- a/recipes/pbcore/1.2.7/meta.yaml
+++ b/recipes/pbcore/1.2.7/meta.yaml
@@ -12,8 +12,6 @@ source:
 build:
   noarch: python
   number: 0
-  entry_points:
-    - .open = pbcore.io.opener:entryPoint
   script: "{{ PYTHON }} -m pip install . -vv"
 
 requirements:

--- a/recipes/pbcore/1.2.7/meta.yaml
+++ b/recipes/pbcore/1.2.7/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: <3
+  number: 0
   entry_points:
     - .open = pbcore.io.opener:entryPoint
   script: "{{ PYTHON }} -m pip install . -vv"
@@ -19,16 +19,13 @@ build:
 requirements:
   host:
     - cython
-    - h5py >=2.0.1
-    - numpy >=1.7.1
     - pip
-    - pysam >=0.8.4
-    - python
+    - python <3
   run:
-    - h5py >=2.0.1
-    - numpy >=1.7.1
-    - pysam >=0.8.4
-    - python
+    - h5py
+    - numpy
+    - pysam
+    - python <3
 
 test:
   imports:


### PR DESCRIPTION
This is related to pull request  #30651. I was able to build a working package of pbcore v1.2.7 using the recipe I've added here (my package is at https://anaconda.org/bishemma1/pbcore). This package needs to be under the bioconda channel so that I can specify this version in the PBHoover recipe (https://github.com/bioconda/bioconda-recipes/blob/master/recipes/pbhoover/meta.yaml). PBHoover v1.0.7 needs pbcore v1.2.7 specifically, and we want to avoid requiring users to pip install that version of pbcore.

@simonbray 