### PR TITLE
Update insilicoseq requirements: bipython <= 1.78

### DIFF
--- a/recipes/insilicoseq/meta.yaml
+++ b/recipes/insilicoseq/meta.yaml
@@ -14,14 +14,14 @@ build:
   entry_points:
     - iss = iss.app:main
   script: python -m pip install --no-deps --ignore-installed .
-  number: 0
+  number: 1
 
 requirements:
   host:
     - python
     - pip
   run:
-    - biopython
+    - biopython <=1.78
     - future
     - joblib
     - numpy


### PR DESCRIPTION
Biopython 1.79 is incompatible with InSilicoSeq for the moment, this pr updates the requirements to biopython <= 1.78

---

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
