### PR TITLE
Rebuild fsnviz to pull in latest release of 'crimson'

### DIFF
--- a/recipes/fsnviz/meta.yaml
+++ b/recipes/fsnviz/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   noarch: python
-  number: 4
+  number: 5
   script: {{ PYTHON }} -m pip install . --ignore-installed --no-deps -vv
   entry_points:
     - fsnviz=fsnviz.cli:main


### PR DESCRIPTION
A dependency of fsnviz (crimson) has a new bugfix release, see https://github.com/bow/crimson/pull/14 for details