### PR TITLE
Update spatyper 

### DIFF
--- a/recipes/spatyper/build.sh
+++ b/recipes/spatyper/build.sh
@@ -8,6 +8,7 @@ mkdir -p ${SPATYPER_SHARE}
 chmod 755 ${RECIPE_DIR}/download-spatypes.sh
 bash ${RECIPE_DIR}/download-spatypes.sh ${SPATYPER_SHARE}
 mv ${RECIPE_DIR}/download-spatypes.sh ${PREFIX}/bin
+sed -i "s/BIOCONDA_SED_REPLACE/${SPATYPER_SHARE}/" ${PREFIX}/bin/spaTyper
 
 # Setup the spaTyper env variables
 mkdir -p ${PREFIX}/etc/conda/activate.d ${PREFIX}/etc/conda/deactivate.d

--- a/recipes/spatyper/build.sh
+++ b/recipes/spatyper/build.sh
@@ -1,14 +1,15 @@
 #! /bin/bash
 
+SPATYPER_SHARE="${PREFIX}/share/${PKG_NAME}-${PKG_VERSION}"
+sed -i "s/BIOCONDA_SED_REPLACE/$SPATYPER_SHARE/" main/spaTyper
 $PYTHON -m pip install . --ignore-installed --no-deps -vv
 
 # Add default databases
-SPATYPER_SHARE="${PREFIX}/share/${PKG_NAME}-${PKG_VERSION}"
 mkdir -p ${SPATYPER_SHARE}
 chmod 755 ${RECIPE_DIR}/download-spatypes.sh
 bash ${RECIPE_DIR}/download-spatypes.sh ${SPATYPER_SHARE}
 mv ${RECIPE_DIR}/download-spatypes.sh ${PREFIX}/bin
-sed -i "s/BIOCONDA_SED_REPLACE/${SPATYPER_SHARE}/" ${PREFIX}/bin/spaTyper
+
 
 # Setup the spaTyper env variables
 mkdir -p ${PREFIX}/etc/conda/activate.d ${PREFIX}/etc/conda/deactivate.d

--- a/recipes/spatyper/build.sh
+++ b/recipes/spatyper/build.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 
 SPATYPER_SHARE="${PREFIX}/share/${PKG_NAME}-${PKG_VERSION}"
-sed -i "s/BIOCONDA_SED_REPLACE/$SPATYPER_SHARE/" main/spaTyper
+sed -i "s=BIOCONDA_SED_REPLACE=$SPATYPER_SHARE=" main/spaTyper
 $PYTHON -m pip install . --ignore-installed --no-deps -vv
 
 # Add default databases

--- a/recipes/spatyper/meta.yaml
+++ b/recipes/spatyper/meta.yaml
@@ -12,7 +12,7 @@ source:
     - spatyper.patch
 
 build:
-  number: 2
+  number: 3
   noarch: python
 
 requirements:

--- a/recipes/spatyper/spatyper.patch
+++ b/recipes/spatyper/spatyper.patch
@@ -22,7 +22,7 @@ index 4aeee87..fddeb51 100755
 +parser.add_argument('-r', '--repeat_file', action='store', help='List of spa repeats (http://spa.ridom.de/dynamic/sparepeats.fasta)',
 +                    default=f'{SPATYPER_SHARE}/sparepeats.fasta')
 +parser.add_argument('-o', '--repeat_order_file', action='store', help='List spa types and order of repeats (http://spa.ridom.de/dynamic/spatypes.txt)', 
-+                    default=f'{SPATYPER_SHARE}/spatypes.txt)
++                    default=f'{SPATYPER_SHARE}/spatypes.txt')
  parser.add_argument('-d', '--folder', action='store', help='Folder to save downloaded files from Ridom/Spa server')
  parser.add_argument('-f', '--fasta', action='store', nargs='+', help='List of one or more fasta files.')
  parser.add_argument('-g', '--glob', action='store', 

--- a/recipes/spatyper/spatyper.patch
+++ b/recipes/spatyper/spatyper.patch
@@ -1,8 +1,17 @@
 diff --git a/main/spaTyper b/main/spaTyper
-index 4aeee87..1eeafc2 100755
+index 4aeee87..fddeb51 100755
 --- a/main/spaTyper
 +++ b/main/spaTyper
-@@ -25,10 +25,10 @@ module. Python 3 version only.
+@@ -7,6 +7,8 @@ import sys
+ import spaTyper.spa_typing
+ import spaTyper.utils
+ 
++SPATYPER_SHARE="BIOCONDA_SED_REPLACE"
++
+ #####################################################
+ parser = argparse.ArgumentParser(prog='spaTyper', formatter_class=argparse.RawDescriptionHelpFormatter, 
+                                  description='''
+@@ -25,10 +27,10 @@ module. Python 3 version only.
  ''', epilog="Original code: mjsull. Modified by: JFSanchezHerrero")
  
  #####################################################
@@ -11,9 +20,9 @@ index 4aeee87..1eeafc2 100755
 -parser.add_argument('-o', '--repeat_order_file', action='store', 
 -                    help='List spa types and order of repeats (http://spa.ridom.de/dynamic/spatypes.txt)')
 +parser.add_argument('-r', '--repeat_file', action='store', help='List of spa repeats (http://spa.ridom.de/dynamic/sparepeats.fasta)',
-+                    default=f'{os.environ.get("SPATYPER_SHARE")}/sparepeats.fasta')
++                    default=f'{SPATYPER_SHARE}/sparepeats.fasta')
 +parser.add_argument('-o', '--repeat_order_file', action='store', help='List spa types and order of repeats (http://spa.ridom.de/dynamic/spatypes.txt)', 
-+                    default=f'{os.environ.get("SPATYPER_SHARE")}/spatypes.txt')
++                    default=f'{SPATYPER_SHARE}/spatypes.txt)
  parser.add_argument('-d', '--folder', action='store', help='Folder to save downloaded files from Ridom/Spa server')
  parser.add_argument('-f', '--fasta', action='store', nargs='+', help='List of one or more fasta files.')
  parser.add_argument('-g', '--glob', action='store', 


### PR DESCRIPTION
I thought I had it figured out in https://github.com/bioconda/bioconda-recipes/pull/30622 but it fails when `--entrypoint` is used due to loss of ENV variables.

This PR adds default DB location to spaTyper script

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
