### PR TITLE
Update to v2.2 and add tests

### DIFF
--- a/recipes/canu/build.sh
+++ b/recipes/canu/build.sh
@@ -4,10 +4,9 @@
 set -e
 
 mkdir -p "$PREFIX/bin"
+mkdir -p "$PREFIX/lib"
+mkdir -p "$PREFIX/share"
 
-pushd src
-make clean TARGET_DIR=$PREFIX CC=$CC CXX=$CXX
-make TARGET_DIR=$PREFIX CC=$CC CXX=$CXX
-
-# This installs all of the object files as well, remove that
-rm -rf $PREFIX/*amd64
+cp -r bin/* $PREFIX/bin/
+cp -r lib/* $PREFIX/lib/
+cp -r share/* $PREFIX/share/

--- a/recipes/canu/meta.yaml
+++ b/recipes/canu/meta.yaml
@@ -1,44 +1,36 @@
-{% set version = "2.1.1" %}
+{% set name = "canu" %}
+{% set version = "2.2" %}
 
 package:
-  name: canu
-  version: '{{version}}'
+  name: {{ name|lower }}
+  version: {{ version }}
 
 source:
-  git_url: https://github.com/marbl/canu.git
-  git_rev: 5638f7d9a5379373310ab62c28aa0cdbd864722d
+  url: https://github.com/marbl/{{ name }}/releases/download/v{{ version }}/{{ name }}-{{ version }}.Darwin-amd64.tar.xz # [osx]
+  md5: 6bd937d31bb9f5f46bf0f9839889c00f # [osx]
+  url: https://github.com/marbl/{{ name }}/releases/download/v{{ version }}/{{ name }}-{{ version }}.Linux-amd64.tar.xz # [linux]
+  md5: 63219165fc45b3dbbeb73ed920a23db5 # [linux]
 
 build:
-  number: 2
-  skip: true  # [osx]
+  number: 3
+  skip: true  # [win]
 
 requirements:
-  build:
-    - make
-    - '{{ compiler("c") }}'
-    - '{{ compiler("cxx") }}'
-    - {{ cdt('mesa-libgl-devel') }}  # [linux]
-    - {{ cdt('mesa-dri-drivers') }}  # [linux]
-    - {{ cdt('libselinux') }}  # [linux]
-    - {{ cdt('libxdamage') }}  # [linux]
-    - {{ cdt('libxxf86vm') }}  # [linux]
-    - {{ cdt('libxext') }}     # [linux]
   host:
     - gnuplot >=5.2
     - xorg-libxfixes  # [linux]
   run:
     - perl
     - perl-filesys-df
-    - openjdk
+    - java-jdk  >=8
     - minimap2
     - gnuplot >=5.2
-
 test:
+  requires:
+    - curl
   commands:
-    - canu --version
-    # needed internally
-    - getconf --help
-    ##- gnuplot --help
+     - canu --version
+     - sqStoreDumpFASTQ --version
 
 about:
   home: http://canu.readthedocs.org/

--- a/recipes/canu/run_test.sh
+++ b/recipes/canu/run_test.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# stop on error
+set -eu -o pipefail
+
+# download and run a small assembly
+
+rm -f ./lamba_ont.fasta.gz
+curl -L https://obj.umiacs.umd.edu/sergek/shared/lambda_ont.fasta.gz -o lambda_ont.fasta.gz
+canu -p asm -d asm useGrid=false genomeSize=21k -fast maxMemory=8 maxThreads=4 -nanopore lambda_ont.fasta.gz
+
+if [ ! -s asm/asm.contigs.fasta ] || [ ! -s asm/asm.report ]; then
+   echo "Error: canu assembly test failed!"
+   exit 1
+fi
+
+echo "Finished canu assembly test!"
+exit 0


### PR DESCRIPTION
Update canu to latest release. Switch to using git packages which allows support of OS X and Linux. Switch jvm from openjdk which often fails due to memory over-allocation. Lastly, download/run a small assembly to ensure the installation is working as intended.