### PR TITLE
Add MetaNovo recipe

### DIFF
--- a/recipes/metanovo/build.sh
+++ b/recipes/metanovo/build.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# Copy executable scripts
+declare -a metanovo_scripts=(
+    bin/bash/metanovo.sh
+    bin/bash/compomics.sh
+    bin/python/bp_export_tags.py
+    bin/python/bp_mapped_tags.py
+    bin/python/bp_export_proteins.py
+    bin/python/bp_fasta_prepare.py
+    bin/python/bp_parse_tags.py
+)
+
+for script in "${metanovo_scripts[@]}"; do
+    cp $script "$PREFIX/bin"
+done
+
+# Copy python libraries.
+cp lib/tagmatch.py "$PREFIX/lib/python3.9/site-packages"
+
+# Create source file. This sets paths for MetaNovo dependencies.
+mkdir -p "$PREFIX/etc/conda/activate.d"
+cp "$RECIPE_DIR/metanovo_activate.sh" "$PREFIX/etc/conda/activate.d/${PKG_NAME}_activate.sh"
+
+# Create bio/ directory for MetaNovo dependencies.
+METANOVO_DEPENDENCIES="$PREFIX/bio"
+mkdir "$METANOVO_DEPENDENCIES"
+
+# Install downloaded dependencies
+declare -A dependency_urls
+
+dependency_urls['PeptideShaker']='http://genesis.ugent.be/maven2/eu/isas/peptideshaker/PeptideShaker/1.16.2/PeptideShaker-1.16.2.zip'
+dependency_urls['SearchGUI']='http://genesis.ugent.be/maven2/eu/isas/searchgui/SearchGUI/3.2.20/SearchGUI-3.2.20-mac_and_linux.tar.gz'
+dependency_urls['DeNovoGUI']='http://genesis.ugent.be/maven2/com/compomics/denovogui/DeNovoGUI/1.15.11/DeNovoGUI-1.15.11-mac_and_linux.tar.gz'
+dependency_urls['utilities']='http://genesis.ugent.be/maven2/com/compomics/utilities/4.12.0/utilities-4.12.0.zip'
+
+for dependency in "${!dependency_urls[@]}"; do
+    mkdir $METANOVO_DEPENDENCIES/$dependency
+    cd $METANOVO_DEPENDENCIES/$dependency
+    url=${dependency_urls[$dependency]}
+    extension="${url##*.}"
+    wget $url
+    if [[ $extension == "gz" ]]; then
+        tar -zxvf *.tar.gz && rm -rf *.tar.gz
+    elif [[ $extension == "zip" ]]; then
+        unzip *.zip && rm -rf *.zip
+    else
+        echo "File download failed" >&2
+        exit 1
+    fi
+done

--- a/recipes/metanovo/meta.yaml
+++ b/recipes/metanovo/meta.yaml
@@ -1,0 +1,72 @@
+{% set name = "metanovo" %}
+{% set version = "1.9.4" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/uct-cbio/proteomics-pipelines/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 009acafadd49e7da9d09697a919764aeed09570aeddc26619b618b4ce8245c01
+
+requirements:
+  build:
+    - python=3.9.9
+    - setuptools=59.8.0
+    - pip=22.0.4
+    - unzip=6.0
+    - wget=1.20.1
+  run:
+    - python=3.9.9
+    - parallel=20220222
+    - biopython==1.79
+    - numpy==1.22.1
+    - pandas==1.3.5
+
+build:
+  skip: True # [not linux64]
+  number: 0
+  missing_dso_whitelist:
+    - /lib64/ld-linux-x86-64.so.2
+    - /lib64/libbz2.so.1
+    - /lib64/libc.so.6
+    - /lib64/libdl.so.2
+    - /lib64/libm.so.6
+    - /lib64/libnsl.so.1
+    - /lib64/libpthread.so.0
+    - /lib64/librt.so.1
+    - /lib64/libstdc++.so.6
+    - lib/libgcc_s.so.1
+    - lib/libz.so.1
+    - $RPATH/ld-linux.so.2
+    - $RPATH/libbz2.so.1
+    - $RPATH/libc.so.6
+    - $RPATH/libdl.so.2
+    - $RPATH/libm.so.6
+    - $RPATH/libnsl.so.1
+    - $RPATH/libpthread.so.0
+    - $RPATH/librt.so.1
+    - $RPATH/libstdc++.so.6
+
+test:
+  commands:
+    - test -f $PREFIX/bin/metanovo.sh
+    - test -f $PREFIX/bin/compomics.sh
+    - test -f $PREFIX/bin/bp_export_tags.py
+    - test -f $PREFIX/bin/bp_mapped_tags.py
+    - test -f $PREFIX/bin/bp_export_proteins.py
+    - test -f $PREFIX/bin/bp_fasta_prepare.py
+    - test -f $PREFIX/bin/bp_parse_tags.py
+    - test -d $PREFIX/bio/DeNovoGUI
+    - test -d $PREFIX/bio/PeptideShaker
+    - test -d $PREFIX/bio/SearchGUI
+    - test -d $PREFIX/bio/utilities
+
+about:
+  home: https://github.com/uct-cbio/proteomics-pipelines
+  license: MIT
+  summary: Produce targeted databases for mass spectrometry analysis.
+
+extra:
+  skip-lints:
+    - should_be_noarch_python

--- a/recipes/metanovo/metanovo_activate.sh
+++ b/recipes/metanovo/metanovo_activate.sh
@@ -1,0 +1,4 @@
+export SG_PATH=${CONDA_PREFIX}/bio/SearchGUI/SearchGUI-3.2.20
+export DG_PATH=${CONDA_PREFIX}/bio/DeNovoGUI/DeNovoGUI-1.15.11
+export CU_PATH=${CONDA_PREFIX}/bio/utilities/utilities-4.12.0
+export MZIDLIB_PATH=${CONDA_PREFIX}/bio/ProteoAnnotator/ProteoAnnotator-1.7.86/mzidlib-1.7


### PR DESCRIPTION
This adds a new recipe for the MetaNovo tool.

A few notes:
- I added `- should_be_noarch_python` to `skip-lints` because this does target specifically `linux-64`.  Other architectures are skipped with `skip: True`. I'm not sure why the linter expects `noarch: python`, but I used the precedent in #16556 to skip the check.
- I added some DSOs to the list of allowable missing DSOs. I expect that the user's Linux system should have these available for the packaged native dependency. In fact, these specific dependencies are not yet used (they may be at a later time) by the tool, but are included in the larger distribution that is used by MetaNovo, e.g. PepNovo in DeNovoGUI.