### PR TITLE
Add recipe for vafator

### DIFF
--- a/recipes/vafator/meta.yaml
+++ b/recipes/vafator/meta.yaml
@@ -11,6 +11,7 @@ source:
 
 build:
   number: 0
+  noarch: python
   entry_points:
     - vafator=vafator.command_line:annotator
     - multiallelics-filter=vafator.command_line:multiallelics_filter
@@ -18,16 +19,16 @@ build:
 
 requirements:
   host:
-    - cyvcf2 ==0.30.11
-    - pandas ==1.3.3
+    - cyvcf2==0.30.11
+    - pandas==1.3.3
     - pip
-    - pysam ==0.17.0
-    - python
+    - pysam==0.17.0
+    - python==3.7.*
   run:
-    - cyvcf2 ==0.30.11
-    - pandas ==1.3.3
-    - pysam ==0.17.0
-    - python
+    - cyvcf2==0.30.11
+    - pandas==1.3.3
+    - pysam==0.17.0
+    - python==3.7.*
 
 test:
   imports:


### PR DESCRIPTION
This PR adds a recipe for vafator. 

Vafator annotates variants in a VCF file with information about allele frequency and depth of coverage from multiple BAM files from tumor and or normal samples. Even though the functionality of vafator is simple this is useful to homogenise technical annotations like VAF across different variant callers. 