### PR TITLE
Add HORmon (attempt 2)

### DIFF
--- a/recipes/hormon/meta.yaml
+++ b/recipes/hormon/meta.yaml
@@ -1,0 +1,43 @@
+{% set version="1.0.0" %}
+
+package:
+  name: hormon
+  version: {{ version }}
+
+source:
+  url: https://github.com/ablab/HORmon/archive/v{{ version }}.tar.gz
+  sha256: 0d5850a573fe33281256b0705a367bc1442f4faa30d476dc43cd1f3dd4ab76c0
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build: 
+    - python >=3.6
+  host:
+    - python >=3.6
+  run:
+    - python >=3.6
+    - biopython
+    - python-edlib
+    - clustalo
+    - joblib
+    - setuptools
+    - networkx
+    - pygraphviz
+    - stringdecomposer
+ 
+test:
+  commands:
+    - monomer_inference --help | grep -q "Monomer Inference Problem"
+    - HORmon --help | grep -q "updating monomers to make it consistent with CE postulate"
+
+about:
+  home: https://github.com/ablab/HORmon
+  license: GPLv2
+  license_family: GPL
+  license_file: LICENSE
+  summary: A tool for annotation of alpha satellite arrays in centromeres of a newly assembled human genome.
+  description: HORmon infer human monomers based on the given alpha-satellite consensus template and centromeric sequence, extract HORs and decompose centromeric sequence into HORs.


### PR DESCRIPTION
Adding HORmon attempt 2 after [attempt 1](https://github.com/bioconda/bioconda-recipes/pull/30964) stalled with message "bioconda-test Expected — Waiting for status to be reported" for 10 hours.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
