### PR TITLE
Fix openssl dep for bioc-rhdf5 and bioc-hdf5array

### DIFF
--- a/recipes/bioconductor-hdf5array/meta.yaml
+++ b/recipes/bioconductor-hdf5array/meta.yaml
@@ -12,13 +12,16 @@ source:
     - 'https://depot.galaxyproject.org/software/bioconductor-{{ name|lower }}/bioconductor-{{ name|lower }}_{{ version }}_src_all.tar.gz'
   md5: 92f1968f6d70442bb1cf260b481ace51
 build:
-  number: 0
+  number: 1
   rpaths:
     - lib/R/lib/
     - lib/
 # Suggests: BiocParallel, GenomicRanges, SummarizedExperiment (>= 1.15.1), h5vcData, ExperimentHub, TENxBrainData, zellkonverter, GenomicFeatures, RUnit, SingleCellExperiment
 # SystemRequirements: GNU make
 requirements:
+  build:
+    - {{ compiler('c') }}
+    - make
   host:
     - 'bioconductor-biocgenerics >=0.38.0,<0.39.0'
     - 'bioconductor-delayedarray >=0.18.0,<0.19.0'
@@ -31,6 +34,7 @@ requirements:
     - r-matrix
     - libblas
     - liblapack
+    - openssl
   run:
     - 'bioconductor-biocgenerics >=0.38.0,<0.39.0'
     - 'bioconductor-delayedarray >=0.18.0,<0.19.0'
@@ -41,9 +45,6 @@ requirements:
     - 'bioconductor-s4vectors >=0.30.0,<0.31.0'
     - r-base
     - r-matrix
-  build:
-    - {{ compiler('c') }}
-    - make
 test:
   commands:
     - '$R -e "library(''{{ name }}'')"'

--- a/recipes/bioconductor-rhdf5/meta.yaml
+++ b/recipes/bioconductor-rhdf5/meta.yaml
@@ -12,30 +12,29 @@ source:
     - 'https://depot.galaxyproject.org/software/bioconductor-{{ name }}/bioconductor-{{ name }}_{{ version }}_src_all.tar.gz'
   md5: 05cfc23c6275c019e9aba5ba37325adc
 build:
-  number: 1
+  number: 2
   rpaths:
     - lib/R/lib/
     - lib/
 # Suggests: bit64, BiocStyle, knitr, rmarkdown, testthat, microbenchmark, dplyr, ggplot2
 # SystemRequirements: GNU make
 requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - automake
+    - make
   host:
     - 'bioconductor-rhdf5filters >=1.4.0,<1.5.0'
     - 'bioconductor-rhdf5lib >=1.14.0,<1.15.0'
     - r-base
     - libblas
     - liblapack
+    - openssl
   run:
     - 'bioconductor-rhdf5filters >=1.4.0,<1.5.0'
     - 'bioconductor-rhdf5lib >=1.14.0,<1.15.0'
     - r-base
-    - openssl
-  build:
-    - {{ compiler('c') }}
-    - {{ compiler('cxx') }}
-    - automake
-    - make
-    - openssl
 test:
   commands:
     - '$R -e "library(''{{ name }}'')"'


### PR DESCRIPTION
This fixes the openssl dependency for bioconductor-rhdf5 and bioconductor-hdf5array.

This PR is needed for #31069

@mbargull: This is the new PR as discussed in the comments of #31069.

fixes gh-31072