### PR TITLE
Update r-ichorcna to most recent github version (v0.3.2)

### DIFF
--- a/recipes/r-ichorcna/meta.yaml
+++ b/recipes/r-ichorcna/meta.yaml
@@ -24,14 +24,14 @@ requirements:
     - perl  # for adding in correct path references to scripts
     - 'bioconductor-genomeinfodb >=1.26.7'
     - 'bioconductor-hmmcopy >=1.32.0'
-    - 'bioconductor-genomicranges >= 1.42.0'
+    - 'bioconductor-genomicranges >=1.42.0'
     - r-optparse
     - r-plyr
   run:
     - r-base
     - 'bioconductor-genomeinfodb >=1.26.7'
     - 'bioconductor-hmmcopy >=1.32.0'
-    - 'bioconductor-genomicranges >= 1.42.0'
+    - 'bioconductor-genomicranges >=1.42.0'
     - r-optparse
     - r-plyr
 

--- a/recipes/r-ichorcna/meta.yaml
+++ b/recipes/r-ichorcna/meta.yaml
@@ -1,4 +1,4 @@
-{% set version="0.2.0" %}
+{% set version="0.3.2" %}
 {% set name="ichorCNA" %}
 
 package:
@@ -6,8 +6,10 @@ package:
   version: '{{ version }}'
 
 source:
-  url: https://github.com/broadinstitute/ichorCNA/archive/v{{ version }}.tar.gz
-  sha256: 7730ca4d9ddb5b9e1d10b6ea756144984df59e50f50d143f95103b5467d7b440
+  url: https://github.com/broadinstitute/ichorCNA/commit/5bfc03ed854f0e93fe5b624c97c1290fa0053837.zip
+  md5: c3838aafb8367758bf4102b03a014df5
+  sha1: 10a9467cbed61c8b61ec065f6265f8e0649a875a
+  sha256: 9131dcd6668f127fe8ac56baef675ad87ccf31e29aba6572e792ef506f3594f2
 
 build:
   number: 3

--- a/recipes/r-ichorcna/meta.yaml
+++ b/recipes/r-ichorcna/meta.yaml
@@ -22,14 +22,14 @@ requirements:
   host:
     - r-base
     - perl  # for adding in correct path references to scripts
-    - 'bioconductor-genomeinfodb >=1.8.7'
-    - 'bioconductor-hmmcopy >=1.14.0'
+    - 'bioconductor-genomeinfodb >=1.26.7'
+    - 'bioconductor-hmmcopy >=1.32.0'
     - r-optparse
     - r-plyr
   run:
     - r-base
-    - 'bioconductor-genomeinfodb >=1.8.7'
-    - 'bioconductor-hmmcopy >=1.14.0'
+    - 'bioconductor-genomeinfodb >=1.26.7'
+    - 'bioconductor-hmmcopy >=1.32.0'
     - r-optparse
     - r-plyr
 

--- a/recipes/r-ichorcna/meta.yaml
+++ b/recipes/r-ichorcna/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: '{{ version }}'
 
 source:
-  url: https://github.com/broadinstitute/ichorCNA/commit/5bfc03ed854f0e93fe5b624c97c1290fa0053837.zip
+  url: https://github.com/broadinstitute/ichorCNA/archive/5bfc03ed854f0e93fe5b624c97c1290fa0053837.tar.gz
   md5: c3838aafb8367758bf4102b03a014df5
   sha1: 10a9467cbed61c8b61ec065f6265f8e0649a875a
   sha256: 9131dcd6668f127fe8ac56baef675ad87ccf31e29aba6572e792ef506f3594f2

--- a/recipes/r-ichorcna/meta.yaml
+++ b/recipes/r-ichorcna/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: 9131dcd6668f127fe8ac56baef675ad87ccf31e29aba6572e792ef506f3594f2
 
 build:
-  number: 3
+  number: 0
   noarch: generic
   rpaths:
     - lib/R/lib/

--- a/recipes/r-ichorcna/meta.yaml
+++ b/recipes/r-ichorcna/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: '{{ version }}'
 
 source:
-  url: https://github.com/broadinstitute/ichorCNA/archive/5bfc03ed854f0e93fe5b624c97c1290fa0053837.tar.gz
+  url: https://github.com/broadinstitute/ichorCNA/archive/5bfc03ed854f0e93fe5b624c97c1290fa0053837.zip
   md5: c3838aafb8367758bf4102b03a014df5
   sha1: 10a9467cbed61c8b61ec065f6265f8e0649a875a
   sha256: 9131dcd6668f127fe8ac56baef675ad87ccf31e29aba6572e792ef506f3594f2

--- a/recipes/r-ichorcna/meta.yaml
+++ b/recipes/r-ichorcna/meta.yaml
@@ -24,12 +24,14 @@ requirements:
     - perl  # for adding in correct path references to scripts
     - 'bioconductor-genomeinfodb >=1.26.7'
     - 'bioconductor-hmmcopy >=1.32.0'
+    - 'bioconductor-genomicranges >= 1.42.0'
     - r-optparse
     - r-plyr
   run:
     - r-base
     - 'bioconductor-genomeinfodb >=1.26.7'
     - 'bioconductor-hmmcopy >=1.32.0'
+    - 'bioconductor-genomicranges >= 1.42.0'
     - r-optparse
     - r-plyr
 


### PR DESCRIPTION
The current r-ichorcna package is the most recent github tagged version (May 2019), but there have been changes and a newer script version since then (v0.3.2 - as detailed in the DESCRIPTION file).
