### PR TITLE
Updated Entrez Direct to version 16.2

### DIFF
--- a/recipes/entrez-direct/build.sh
+++ b/recipes/entrez-direct/build.sh
@@ -17,3 +17,6 @@ sh install.sh
 rm -rf eutils cmd help   
 rm -rf *.log *.go *.yaml setup.sh install.sh *.gz *.pdf 
 rm -rf idx-* index-*  pm-*  custom* xy-* CA.pm cacert.pem
+
+# Copy the help files to be accessible
+cp -r help ${PREFIX}/bin

--- a/recipes/entrez-direct/build.sh
+++ b/recipes/entrez-direct/build.sh
@@ -14,7 +14,7 @@ cd ${PREFIX}/bin
 sh install.sh
 
 # clean up
-rm -rf eutils cmd help   
+rm -rf eutils cmd 
 rm -rf *.log *.go *.yaml setup.sh install.sh *.gz *.pdf 
 rm -rf idx-* index-*  pm-*  custom* xy-* CA.pm cacert.pem
 

--- a/recipes/entrez-direct/build.sh
+++ b/recipes/entrez-direct/build.sh
@@ -18,5 +18,3 @@ rm -rf eutils cmd
 rm -rf *.log *.go *.yaml setup.sh install.sh *.gz *.pdf 
 rm -rf idx-* index-*  pm-*  custom* xy-* CA.pm cacert.pem
 
-# Copy the help files to be accessible
-cp -r help ${PREFIX}/bin

--- a/recipes/entrez-direct/meta.yaml
+++ b/recipes/entrez-direct/meta.yaml
@@ -10,7 +10,7 @@ build:
   number: 0
 
 source:
-  url: https://raw.githubusercontent.com/biostars/conda-ready-entrez-direct/main/dist/edirect-15.6.20210906.tar.gz
+  url: https://raw.githubusercontent.com/biostars/conda-ready-entrez-direct/main/dist/edirect-16.2.20211103.tar.gz
   sha256: {{ sha256 }}
 
 requirements:

--- a/recipes/entrez-direct/meta.yaml
+++ b/recipes/entrez-direct/meta.yaml
@@ -1,13 +1,13 @@
-{% set version = "15.6" %}
-{% set date = "20210906" %}
-{% set sha256 = "dba444c9a7754936b0a3ef3ebe68be0bec3f6d52e8970ccf4aea590be64cec38" %}
+{% set version = "16.2" %}
+{% set date = "20211103" %}
+{% set sha256 = "42124ac5aa9aed2bb399b064ad4dfe418b9facb6f61eef95ac7e92e7cc410dd3" %}
 
 package:
   name: entrez-direct
   version: {{ version }}
 
 build:
-  number: 1
+  number: 0
 
 source:
   url: https://raw.githubusercontent.com/biostars/conda-ready-entrez-direct/main/dist/edirect-15.6.20210906.tar.gz


### PR DESCRIPTION
Updated Entrez Direct to version 16.2

Also adding the help files that need to be located in the `$PREFIX/bin/help` folder
