### PR TITLE
[Update]: add make argument

### DIFF
--- a/recipes/meta-apo/build.sh
+++ b/recipes/meta-apo/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 mkdir -p ${PREFIX}/bin
 
-make 
+make CC=$CXX
 
 cp -r bin/* ${PREFIX}/bin
 

--- a/recipes/meta-apo/meta.yaml
+++ b/recipes/meta-apo/meta.yaml
@@ -14,7 +14,7 @@ source:
     sha256: 4ab5753da65b5a31c9808f8301d26c3f9629fd710ea3e931a71c8bcb37708339
 
 build:
-  number: 2
+  number: 3
 
 requirements:
   build:


### PR DESCRIPTION
Missing `make CC=$CXX` lead to a segment fault. This time we fixed it.