### PR TITLE
Add rusty_axe

### DIFF
--- a/recipes/rusty-axe-bbrener1/meta.yaml
+++ b/recipes/rusty-axe-bbrener1/meta.yaml
@@ -1,0 +1,39 @@
+{% set name = "rusty-axe-bbrener1" %}
+{% set version = "0.68" %}
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+source:
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  sha256: 5033b5c987af3c670db853161e2ff0fd47f3bba31fef28466d8adeac2c82ec90
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+requirements:
+  host:
+    - leidenalg
+    - matplotlib >=3.4.2
+    - pip
+    - python
+    - scikit-learn
+    - umap-learn
+  run:
+    - leidenalg
+    - matplotlib >=3.4.2
+    - python
+    - scikit-learn
+    - umap-learn
+test:
+  imports:
+    - rusty_axe
+about:
+  home: "https://github.com/bbrener1/rf_5"
+  license: MIT
+  license_family: MIT
+  license_file:
+  summary: "Random Forest Latent Structure (Biology)"
+  doc_url:
+  dev_url:
+extra:
+  recipe-maintainers:
+    - bbrener1@jhu.edu


### PR DESCRIPTION
This pull request adds a recipe for the rusty axe single cell analysis package to bioconda (as can be seen at https://github.com/bbrener1/rusty_axe) . It is a first attempt and I am hoping it builds successfully. The effort is in support of easier installation but also to wrap this tool for usage in Galaxy. 
