### PR TITLE
update hecatomb to 1.0.0.beta.3

### DIFF
--- a/recipes/hecatomb/meta.yaml
+++ b/recipes/hecatomb/meta.yaml
@@ -1,21 +1,21 @@
 {% set name = "Hecatomb" %}
-{% set version = "1.0.0.beta.2" %}
+{% set version = "1.0.0.beta.3" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 build:
-  number: 1
+  number: 0
   noarch: generic
 
 source:
   url: https://github.com/shandley/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: a27e5c1ebd0906dfc4b3bb4e6f8c2e6d94965f12bebf6023f338c5555f75648d
+  sha256: bea306ba5c3e6bfddd32970727419e3310d18d52845874f617c45bcd85ca3bdf
 
 requirements:
   run:
-    - python=3
+    - python>=3
     - snakemake-minimal>=6.10.0
     - jinja2>=3.0.2
     - networkx>=2.6.3


### PR DESCRIPTION
Update Hecatomb to version 1.0.0.beta.3

I'm not sure why the bot didn't automatically generate the PR.