### PR TITLE
Update nextalign to 1.7.0

### DIFF
--- a/recipes/nextalign/meta.yaml
+++ b/recipes/nextalign/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "nextalign" %}
-{% set version = "1.6.0" %}
+{% set version = "1.7.0" %}
 
 package:
   name: "{{ name|lower }}"
@@ -7,11 +7,11 @@ package:
 
 source:
   - url: https://github.com/nextstrain/nextclade/releases/download/{{ version }}/{{ name }}-Linux-x86_64 # [linux64]
-    sha256: ab177b4e7da43b4966143fc2838b0d1e02214aa6d5ec30ce3c5a48ba8a60a44d                             # [linux64]
+    sha256: a6fc8ae57d8843e69448cc43ff3b859032c193df9a77f8500c7bcd558eb8be6e                             # [linux64]
   - url: https://github.com/nextstrain/nextclade/releases/download/{{ version }}/{{ name }}-MacOS-x86_64 # [osx and x86_64]
-    sha256: 071708bfc264c80ed1526108728b42e83804617a6372957c289da72f00d1050a                             # [osx and x86_64]
+    sha256: 74c0abd86301a7d58b7ed0a36066ccd3b843f5e665ee685b1bc3f7aa48b621d4                             # [osx and x86_64]
   - url: https://github.com/nextstrain/nextclade/releases/download/{{ version }}/{{ name }}-MacOS-arm64  # [arm64]
-    sha256: 795ea112504eb74c3555c715419c96e3f04c5ba81e369b0b42e59ad7370cf742                             # [arm64]
+    sha256: 4e057dd2c179aff4d2683fabeedb4a635ab7e5808e2cdb0040419dedf3f4ac6f                             # [arm64]
 
 build:
   number: 0


### PR DESCRIPTION
Update nextalign to 1.7.0
According to the author:
* Nextalign is up to 6x times faster! (now aligns and translates 100k sequences in 51 seconds, down from 5 minutes, on AWS EC2 c5.24xlarge)


----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
