### PR TITLE
Update pbhoover dependency versions

### DIFF
--- a/recipes/pbhoover/meta.yaml
+++ b/recipes/pbhoover/meta.yaml
@@ -14,6 +14,7 @@ build:
   noarch: python
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv"
   number: 5
+  skip: True  # [osx]
 
 requirements:
   host:

--- a/recipes/pbhoover/meta.yaml
+++ b/recipes/pbhoover/meta.yaml
@@ -13,7 +13,7 @@ source:
 build:
   noarch: python
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv"
-  number: 4
+  number: 5
 
 requirements:
   host:

--- a/recipes/pbhoover/meta.yaml
+++ b/recipes/pbhoover/meta.yaml
@@ -14,7 +14,6 @@ build:
   noarch: python
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv"
   number: 5
-  skip: True  # [osx]
 
 requirements:
   host:

--- a/recipes/pbhoover/meta.yaml
+++ b/recipes/pbhoover/meta.yaml
@@ -21,12 +21,10 @@ requirements:
     - setuptools
   run:
     - python <3
-    - pbh5tools
-    - htslib
-    - bcftools
-    - pyvcf
-    - pbcore >=1.2.10
-    - numpy
+    - pbh5tools <=0.8.0
+    - bcftools <=1.3.1
+    - pyvcf <=0.6.7
+    - pbcore <=1.2.7
 
 test:
   commands:


### PR DESCRIPTION
As described in the commit, we discovered that PBHoover was buggy unless using these versions of:
pbh5tools <=0.8.0
bcftools <=1.3.1
pyvcf <=0.6.7
pbcore <=1.2.7

So I updated the meta.yaml to fix this.