### PR TITLE
Nextclade: add run_test.sh

### DIFF
--- a/recipes/nextclade/meta.yaml
+++ b/recipes/nextclade/meta.yaml
@@ -14,7 +14,7 @@ source:
     sha256: 5017669852d5d624e9f677036470a3cb9a7225c644b5e357fc27c49a9b602d71                             # [arm64]
 
 build:
-  number: 0
+  number: 1
   binary_relocation: False
 
 requirements:

--- a/recipes/nextclade/run_test.sh
+++ b/recipes/nextclade/run_test.sh
@@ -4,7 +4,7 @@ nextclade dataset get --name 'sars-cov-2' --output-dir 'data/sars-cov-2'
 
 nextclade run \
 --input-dataset 'data/sars-cov-2' \
---input-fasta 'my_sequences.fasta' \
+--input-fasta 'data/sars-cov-2/sequences.fasta' \
 --output-tsv 'output/nextclade.tsv' \
 --output-tree 'output/tree.json' \
 --output-dir 'output/'

--- a/recipes/nextclade/run_test.sh
+++ b/recipes/nextclade/run_test.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+nextclade dataset get --name 'sars-cov-2' --output-dir 'data/sars-cov-2'
+
+nextclade run \
+--input-dataset 'data/sars-cov-2' \
+--input-fasta 'my_sequences.fasta' \
+--output-tsv 'output/nextclade.tsv' \
+--output-tree 'output/tree.json' \
+--output-dir 'output/'

--- a/recipes/nextclade/run_test.sh
+++ b/recipes/nextclade/run_test.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+set -x
+set -e
+
 nextclade dataset get --name 'sars-cov-2' --output-dir 'data/sars-cov-2'
 
 nextclade run \


### PR DESCRIPTION
Add run_test.sh to catch more bugs before pushing out new version

@pvanheus do you have experience with tests and bioconda?

It appears as though our release 1.8.0 is broken for macOS and this wasn't noticed because the test is currently too simple

Hence, I'm trying to add a more sophisticated test than `nextclade --help` through `run_test.sh` but I've never added such a test to a bioconda recipe so I'm not sure I'm doing it right.