### PR TITLE
Remove R dependencies

### DIFF
--- a/recipes/fgbio/meta.yaml
+++ b/recipes/fgbio/meta.yaml
@@ -16,9 +16,6 @@ requirements:
   run:
     - openjdk >=8
     - python
-    - r-base
-    - r-ggplot2
-    - r-scales
 
 test:
   commands:


### PR DESCRIPTION
Remove R as a dependency.  It's not strictly required, and inflates the environment significantly.  

For the maintainers, is there any way to make an optional features for this recipe?