### PR TITLE
Update longshot

### DIFF
--- a/recipes/longshot/meta.yaml
+++ b/recipes/longshot/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.4.1" %}
+{% set version = "0.4.4" %}
 
 package:
   name: longshot
@@ -9,7 +9,7 @@ build:
 
 source:
   url: https://github.com/pjedge/longshot/archive/v{{ version }}.tar.gz
-  sha256: 062529eb47fafc2ef4a1a12ea30a565a0df922b310b6fc5705a1605ce4f495f3
+  sha256: d3a3e284b6f907a984444b870379759e1498497fcd4ad86d746c4794126c7300
 
 requirements:
   build:


### PR DESCRIPTION
Update [longshot](https://github.com/pjedge/longshot/) to version 0.4.4.