### PR TITLE
Update TRUST4 v1.0.6

### DIFF
--- a/recipes/trust4/build.sh
+++ b/recipes/trust4/build.sh
@@ -7,6 +7,6 @@ make \
     LINKPATH="${LDFLAGS} -I./samtools-0.1.19"
 install -d "${PREFIX}/bin"
 install trust4 fastq-extractor bam-extractor annotator run-trust4 \
-    trust-simplerep.pl trust-barcoderep.pl trust-smartseq.pl \
+    trust-simplerep.pl trust-barcoderep.pl trust-smartseq.pl trust-airr.pl \
     BuildDatabaseFa.pl BuildImgtAnnot.pl \
     "${PREFIX}/bin/"

--- a/recipes/trust4/meta.yaml
+++ b/recipes/trust4/meta.yaml
@@ -31,6 +31,7 @@ test:
     - which trust-simplerep.pl
     - which trust-barcoderep.pl
     - which trust-smartseq.pl
+    - which trust-airr.pl
     - which BuildDatabaseFa.pl
     - which BuildImgtAnnot.pl
     - which run-trust4

--- a/recipes/trust4/meta.yaml
+++ b/recipes/trust4/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: '{{ version }}'
 
 build:
-  number: 0
+  number: 1
 
 source:
   url: https://github.com/liulab-dfci/TRUST4/archive/v{{ version }}.tar.gz


### PR DESCRIPTION
TRUST4 v1.0.6 adds a new postprocessing script trust-airr.pl, and needs to add to the bioconda install list. Thank you!