### PR TITLE
gimmemotifs requires genomepy 0.10 or higher

### DIFF
--- a/recipes/gimmemotifs/meta.yaml
+++ b/recipes/gimmemotifs/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 0b0ff0d791212d8c05d993ef09e817dfcef7f154244ae87be40040436ca92e59
 
 build:
-  number: 0
+  number: 1
   skip: True  # [py2k]
 
 requirements:
@@ -28,7 +28,7 @@ requirements:
     - feather-format
     - future
     - gadem
-    - genomepy >=0.9.0
+    - genomepy >=0.10.0
     - homer
 #    - ipywidgets  # Necessary for progress bar in Jupyter notebook
     - iteround


### PR DESCRIPTION
@simonvh gimmemotifs motif2factors doesn't work with genomepy lower than 0.10 :shrug: 