### PR TITLE
Add psims

### DIFF
--- a/recipes/psims/meta.yaml
+++ b/recipes/psims/meta.yaml
@@ -1,0 +1,42 @@
+{% set version = "0.1.45" %}
+{% set sha256 = "bf237731d4b99ee0f90cc85f0586e9ba0680920e64dcc1c0cac5eee9d9f7d5f1" %}
+
+package:
+  name: "psims"
+  version: "{{ version }}"
+
+source:
+  url: https://pypi.io/packages/source/p/psims/psims-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv "
+  noarch: python
+
+requirements:
+  host:
+    - pip
+    - python
+  run:
+    - lxml
+    - six
+    - sqlalchemy
+    - numpy
+
+test:
+  imports:
+    - psims
+
+about:
+  home: https://github.com/mobiusklein/psims
+  license: Apache-2.0
+  license_file: LICENSE
+  license_family: APACHE
+  summary: "Writers and controlled vocabulary manager for PSI-MS's mzML and mzIdentML standards"
+  doc_url: https://mobiusklein.github.io/psims/docs/build/html/
+  dev_url: https://github.com/mobiusklein/psims
+
+extra:
+  recipe-maintainers:
+    - mobiusklein


### PR DESCRIPTION
Add recipe for the `psims` Python package: 
>A declarative API for writing XML documents for HUPO PSI-MS mzML and mzIdentML
>https://github.com/mobiusklein/psims

Fixes https://github.com/mobiusklein/psims/issues/13

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
