### PR TITLE
Update hecatomb to 1.0.0.beta.5

### DIFF
--- a/recipes/hecatomb/meta.yaml
+++ b/recipes/hecatomb/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "Hecatomb" %}
-{% set version = "1.0.0.beta.4" %}
+{% set version = "1.0.0.beta.5" %}
 
 package:
   name: {{ name|lower }}
@@ -11,7 +11,7 @@ build:
 
 source:
   url: https://github.com/shandley/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 98b2eac0c841716cb419ebb75c6b421021c3bf6bebb3981fbfde00026492f9dd
+  sha256: 0334759161fff96c948be3f7bc886c1b59fbb17338beb63962b1ccb5ee137069
 
 requirements:
   run:


### PR DESCRIPTION
Updates Hecatomb to v1.0.0.beta.5
