### PR TITLE
bump DROP 1.1.1 -> 1.1.2 and update dependencies

### DIFF
--- a/recipes/drop/meta.yaml
+++ b/recipes/drop/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "drop" %}
-{% set version = "1.1.1" %} 
+{% set version = "1.1.2" %} 
 
 package:
   name: "{{ name|lower }}"
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/gagneurlab/{{ name }}/archive/{{ version }}.tar.gz
-  sha256: 18f2a2eb4fa587d00bb717c9ca7a5d20b397805db1542db68afdd6079a8e43f4
+  sha256: be6f55b7856a7613a40f48fef15575332120d21ced02fe79d89a98e21479d06c
 
 build:
   number: 0
@@ -51,17 +51,14 @@ requirements:
     - r-tidyr
     - r-magrittr
     - r-devtools
-    - r-tmae >=1.0.2
+    - r-tmae >=1.0.4
     # bioconductor packages
     - bioconductor-deseq2
     - bioconductor-GenomicScores
     - bioconductor-outrider >=1.6.1
     - bioconductor-fraser >=1.2.1
     - bioconductor-variantannotation
-      #- bioconductor-bsgenome.hsapiens.ucsc.hg19
-      #- bioconductor-mafdb.gnomad.r2.1.hs37d5
-      #- bioconductor-mafdb.gnomad.r2.1.grch38
-
+    
 test:
   imports:
     - drop
@@ -90,3 +87,4 @@ extra:
   recipe-maintainers:
     - c-mertes
     - mumichae
+    - vyepez88


### PR DESCRIPTION
This is the correct version bump for DROP 1.1.2, since the autobump does not update the dependencies. Fixes #32745