### PR TITLE
Update Du Novo: Initial version of 3.0 support.

### DIFF
--- a/recipes/dunovo/build.sh
+++ b/recipes/dunovo/build.sh
@@ -5,7 +5,7 @@ cat > submodules.txt <<EOF
 kalign  0.3.0       makovalab-psu kalign-dunovo c0ef2de4a958aed47311ea86591debb3bada871143a6923bc6338ab2f99f2d5b
 utillib 0.1.1-alpha NickSto       utillib       961f5a3481d1c0dbe00c258b9df2de541e5605f3de4ff25bcc3cec22922e7c06
 ET      0.3         NickSto       ET            6b757b3ab3634b949f78692ac0db72e9264a1dceaf7449e921091d3ad0012eea
-bfx     0.5.0       NickSto       bfx           f5cc5c9c8a627a082f8b505135aec10b47c09647269ad92abe3a1fa2f2059048
+bfx     0.5.1       NickSto       bfx           03a251d64f6da5908a5e2502881000fa4154f9d81a667bb4f94f4a86367faac6
 EOF
 
 while read name version owner repo hash; do
@@ -23,8 +23,6 @@ while read name version owner repo hash; do
 done < submodules.txt
 
 # Compile binaries and move them to lib.
-sed -i.bak "s#gcc#${CC}#g" Makefile
-sed -i.bak "s#gcc#${CC}#g" bfx/Makefile
 make
 mkdir -p "$PREFIX/lib"
 mv *.so "$PREFIX/lib"

--- a/recipes/dunovo/build.sh
+++ b/recipes/dunovo/build.sh
@@ -1,11 +1,16 @@
+SubModules="bfx kalign utillib ET"
 
 # Compile binaries and move them to lib.
-make "CC=$CC"
+if [[ "$CC" ]]; then
+  make "CC=$CC"
+else
+  make
+fi
 mkdir -p "$PREFIX/lib"
 mv *.so "$PREFIX/lib"
-while read name rest; do
-  mv "$name" "$PREFIX/lib/$name"
-done < submodules.txt
+for submodule in $SubModules; do
+  mv "$submodule" "$PREFIX/lib/$submodule"
+done
 
 # Move scripts to lib and link to them from bin.
 mkdir -p "$PREFIX/bin"

--- a/recipes/dunovo/build.sh
+++ b/recipes/dunovo/build.sh
@@ -1,27 +1,4 @@
 
-# Download submodules and move them to lib.
-
-cat > submodules.txt <<EOF
-kalign  0.3.0       makovalab-psu kalign-dunovo c0ef2de4a958aed47311ea86591debb3bada871143a6923bc6338ab2f99f2d5b
-utillib 0.1.1-alpha NickSto       utillib       961f5a3481d1c0dbe00c258b9df2de541e5605f3de4ff25bcc3cec22922e7c06
-ET      0.3         NickSto       ET            6b757b3ab3634b949f78692ac0db72e9264a1dceaf7449e921091d3ad0012eea
-bfx     0.5.1       NickSto       bfx           03a251d64f6da5908a5e2502881000fa4154f9d81a667bb4f94f4a86367faac6
-EOF
-
-while read name version owner repo hash; do
-  echo "Downloading $name v$version from $owner/$repo"
-  wget --no-check-certificate "https://github.com/$owner/$repo/archive/v$version.tar.gz"
-  downloaded_hash=`sha256sum "v$version.tar.gz" | tr -s ' ' | cut -d ' ' -f 1`
-  if ! [ "$hash" == "$downloaded_hash" ]; then
-    echo "Error: Hash does not match!" >&2
-    return 1
-  fi
-  tar -zxvpf "v$version.tar.gz"
-  rm -rf "$name"
-  mv "$repo-$version" "$name"
-  rm "v$version.tar.gz"
-done < submodules.txt
-
 # Compile binaries and move them to lib.
 make
 mkdir -p "$PREFIX/lib"

--- a/recipes/dunovo/build.sh
+++ b/recipes/dunovo/build.sh
@@ -1,6 +1,6 @@
 
 # Compile binaries and move them to lib.
-make
+make "CC=$CC"
 mkdir -p "$PREFIX/lib"
 mv *.so "$PREFIX/lib"
 while read name rest; do

--- a/recipes/dunovo/build.sh
+++ b/recipes/dunovo/build.sh
@@ -1,10 +1,10 @@
 SubModules="bfx kalign utillib ET"
 
 # Compile binaries and move them to lib.
-if [[ "$CC" ]]; then
-  make "CC=$CC"
-else
+if [ "x$CC" = x ]; then
   make
+else
+  make "CC=$CC"
 fi
 mkdir -p "$PREFIX/lib"
 mv *.so "$PREFIX/lib"

--- a/recipes/dunovo/build.sh
+++ b/recipes/dunovo/build.sh
@@ -1,8 +1,15 @@
-#!/bin/bash
 
 # Download submodules and move them to lib.
-get_submodule () {
-  read name version owner repo hash <<< "$@"
+
+cat > submodules.txt <<EOF
+kalign  0.3.0       makovalab-psu kalign-dunovo c0ef2de4a958aed47311ea86591debb3bada871143a6923bc6338ab2f99f2d5b
+utillib 0.1.1-alpha NickSto       utillib       961f5a3481d1c0dbe00c258b9df2de541e5605f3de4ff25bcc3cec22922e7c06
+ET      0.3         NickSto       ET            6b757b3ab3634b949f78692ac0db72e9264a1dceaf7449e921091d3ad0012eea
+bfx     0.5.0       NickSto       bfx           f5cc5c9c8a627a082f8b505135aec10b47c09647269ad92abe3a1fa2f2059048
+EOF
+
+while read name version owner repo hash; do
+  echo "Downloading $name v$version from $owner/$repo"
   wget --no-check-certificate "https://github.com/$owner/$repo/archive/v$version.tar.gz"
   downloaded_hash=`sha256sum "v$version.tar.gz" | tr -s ' ' | cut -d ' ' -f 1`
   if ! [ "$hash" == "$downloaded_hash" ]; then
@@ -11,32 +18,24 @@ get_submodule () {
   fi
   tar -zxvpf "v$version.tar.gz"
   rm -rf "$name"
-  if [ "$name" == kalign ]; then
-    mv "$repo-$version" "$name"
-  else
-    mv "$repo-$version" "$PREFIX/lib/$name"
-  fi
+  mv "$repo-$version" "$name"
   rm "v$version.tar.gz"
-}
-get_submodule kalign  0.2.0 makovalab-psu kalign-dunovo 473dd562f520a218df2dd147c89940422344adad6d8824141bffe6466c6d40e7
-get_submodule utillib 0.1.0 NickSto       utillib       bffe515f7bd98661657c26003c41c1224f405c3a36ddabf5bf961fab86f9651a
-get_submodule ET      0.2.2 NickSto       ET            11dc5cb02521a2260e6c88a83d489c72f819bd759aeff31d66aa40ca2f1358a6
-get_submodule bfx     0.2.0 NickSto       bfx           252d31dc260882f203d04624945c8abb4940f3ae4b03a5050182d23854488ef8
-
-# Inject compilers
-sed -i.bak 's#gcc#${CC}#g' Makefile
+done < submodules.txt
 
 # Compile binaries and move them to lib.
-make CC=$CC
+make
+mkdir -p "$PREFIX/lib"
 mv *.so "$PREFIX/lib"
-mv kalign "$PREFIX/lib"
+while read name rest; do
+  mv "$name" "$PREFIX/lib/$name"
+done < submodules.txt
 
 # Move scripts to lib and link to them from bin.
+mkdir -p "$PREFIX/bin"
 for script in *.awk *.sh *.py; do
   mv "$script" "$PREFIX/lib"
-  ln -s "../lib/$script" "$PREFIX/bin"
+  ln -s "../lib/$script" "$PREFIX/bin/$script"
 done
-
 # Handle special cases.
 mv utils/precheck.py "$PREFIX/lib"
 ln -s ../lib/precheck.py "$PREFIX/bin"

--- a/recipes/dunovo/build.sh
+++ b/recipes/dunovo/build.sh
@@ -23,7 +23,7 @@ while read name version owner repo hash; do
 done < submodules.txt
 
 # Compile binaries and move them to lib.
-make
+make CC=$CC
 mkdir -p "$PREFIX/lib"
 mv *.so "$PREFIX/lib"
 while read name rest; do

--- a/recipes/dunovo/build.sh
+++ b/recipes/dunovo/build.sh
@@ -23,7 +23,8 @@ while read name version owner repo hash; do
 done < submodules.txt
 
 # Compile binaries and move them to lib.
-make CC=$CC
+sed -i.bak "s#gcc#${CC}#g" Makefile
+make
 mkdir -p "$PREFIX/lib"
 mv *.so "$PREFIX/lib"
 while read name rest; do

--- a/recipes/dunovo/build.sh
+++ b/recipes/dunovo/build.sh
@@ -24,6 +24,7 @@ done < submodules.txt
 
 # Compile binaries and move them to lib.
 sed -i.bak "s#gcc#${CC}#g" Makefile
+sed -i.bak "s#gcc#${CC}#g" bfx/Makefile
 make
 mkdir -p "$PREFIX/lib"
 mv *.so "$PREFIX/lib"

--- a/recipes/dunovo/meta.yaml
+++ b/recipes/dunovo/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.0.1" %}
+{% set version = "3.0.2" %}
 {% set stage = "" %}
 
 package:
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/galaxyproject/dunovo/archive/v{{ version }}{{ stage }}.tar.gz
-  sha256: 0f399a424503d4ea1587eafd0874335997695590039b2513a34da79a8eed686f
+  sha256: f6b545782559490802bb5a96e302a59e007910478e13590a7b75f357ec2a3d82
 
 build:
   number: 0

--- a/recipes/dunovo/meta.yaml
+++ b/recipes/dunovo/meta.yaml
@@ -6,8 +6,8 @@ package:
   version: "{{ version }}"
 
 source:
-  url: https://github.com/galaxyproject/dunovo/archive/v{{ version }}{{ stage }}.tar.gz
-  sha256: f6b545782559490802bb5a96e302a59e007910478e13590a7b75f357ec2a3d82
+  url: https://github.com/galaxyproject/dunovo/releases/download/v{{ version }}{{ stage }}/dunovo.tar.gz
+  sha256: 79f6469bdf6752c3a2555feefc26038ae793dac4acb0136355287aed6cb791e0
 
 build:
   number: 0

--- a/recipes/dunovo/meta.yaml
+++ b/recipes/dunovo/meta.yaml
@@ -21,12 +21,12 @@ requirements:
     - tar
 
   run:
-    - libgcc
-    - tbb 2018.0.3
+    #- libgcc
+    #- tbb 2018.0.3
     - python >=3.6
     - bash >=4.0.0
     - mafft 7.221
-    - bowtie >=1.2.0,<1.3.0
+    - bowtie >=1.3.0
     - networkx 2.4
     - biopython 1.78
     - samtools 1.9

--- a/recipes/dunovo/meta.yaml
+++ b/recipes/dunovo/meta.yaml
@@ -6,7 +6,6 @@ package:
   version: "{{ version }}"
 
 source:
-  fn: v{{ version }}{{ stage }}.tar.gz
   url: https://github.com/galaxyproject/dunovo/archive/v{{ version }}{{ stage }}.tar.gz
   sha256: 0f399a424503d4ea1587eafd0874335997695590039b2513a34da79a8eed686f
 
@@ -53,3 +52,7 @@ about:
   license: GPL2
   license_file: COPYING
   summary: "Du Novo: A pipeline for processing duplex sequencing data."
+
+extra:
+  skip-lints:
+    - should_use_compilers

--- a/recipes/dunovo/meta.yaml
+++ b/recipes/dunovo/meta.yaml
@@ -1,35 +1,44 @@
-{% set version = "2.16" %}
+{% set version = "3.0.1" %}
+{% set stage = "" %}
 
 package:
   name: dunovo
-  version: {{ version }}
+  version: "{{ version }}"
 
 source:
-  url: https://github.com/galaxyproject/dunovo/archive/v{{ version }}.tar.gz
-  sha256: e2594064fbc20a395a12a5f2d48bf9e5105947878477aa304e4b4c127b7818de
+  fn: v{{ version }}{{ stage }}.tar.gz
+  url: https://github.com/galaxyproject/dunovo/archive/v{{ version }}{{ stage }}.tar.gz
+  sha256: 0f399a424503d4ea1587eafd0874335997695590039b2513a34da79a8eed686f
 
 build:
   number: 0
-  skip: True  # [py2k or osx]
+  skip: True  # [osx]
 
 requirements:
   build:
     - make
     - {{ compiler('c') }}
     - wget
-  host:
-    - python
-    - pip
+    - tar
+
   run:
-    - python
+    - libgcc
+    - tbb 2018.0.3
+    - python >=3.6
+    - bash >=4.0.0
     - mafft 7.221
-    - bowtie >=1.2.1.1
-    - networkx >=2.4
-    - paste
+    - bowtie >=1.2.0,<1.3.0
+    - networkx 2.4
+    - biopython 1.78
+    - samtools 1.9
     - gawk
+    - gzip
+    - file
+    - coreutils
 
 test:
   commands:
+    - 'baralign.sh -v > /dev/null'
     - 'correct.py --version > /dev/null'
     - 'align-families.py --version > /dev/null'
     - 'make-consensi.py --version > /dev/null'
@@ -37,9 +46,10 @@ test:
     - 'trimmer.py --help > /dev/null'
   imports:
     - networkx
+    - Bio.Align
 
 about:
   home: https://github.com/galaxyproject/dunovo
-  license: GPLv2
-  license_file: LICENSE.txt
+  license: GPL2
+  license_file: COPYING
   summary: "Du Novo: A pipeline for processing duplex sequencing data."


### PR DESCRIPTION
I'm trying to make a package for Du Novo 3.0. The new tool version has a new dependency: BioPython.

I've also added a few other dependencies which it always depended on but weren't specified before, like samtools, bash, and a number of unix utilities.

I've had a lot of trouble getting this to build and run. I logged one problem in #32718. Based on @bgruening's suggestion, I pinned `tbb`, but even then, it still doesn't run properly unless I first manually install an old version of `tbb` in the conda environment (so far I've only tried 2018.0.3). But it sounds like this might just be my machine?