### PR TITLE
Jc add peregrine 2021

### DIFF
--- a/recipes/peregrine-2021/build.sh
+++ b/recipes/peregrine-2021/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -euo
+
+# Add workaround for SSH-based Git connections from Rust/cargo.  See https://github.com/rust-lang/cargo/issues/2078 for details.
+# We set CARGO_HOME because we don't pass on HOME to conda-build, thus rendering the default "${HOME}/.cargo" defunct.
+export CARGO_NET_GIT_FETCH_WITH_CLI=true CARGO_HOME="$(pwd)/.cargo"
+
+# build statically linked binary with Rust
+RUST_BACKTRACE=1 cargo install --verbose --path . --root $PREFIX

--- a/recipes/peregrine-2021/meta.yaml
+++ b/recipes/peregrine-2021/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.4.1" %}
+{% set version = "0.4.11" %}
 
 package:
   name: peregrine-2021
@@ -9,29 +9,16 @@ build:
 
 source:
   url: https://github.com/cschin/peregrine-2021/archive/refs/tags/v{{version}}.tar.gz
-  sha256: 5b260b10243e2d7cdc3f0b0c94020b50b034e378544146f453115703c5e3de6d
+  sha256: 79e2e07d0c0801b2d78888a3de2c6863858fef233f1da667777d62b4e421d0e9
 
 requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - rust >=1.58.0
-    - clangdev
-    - pkg-config
-    - make
-    - cmake
   host:
-    - gsl
-    - libcblas
-    - openssl
   run:
-    - jq
-    - exonerate
     - parallel
-    - pigz
-    - samtools
-    - tzdata
-    - wget
 
 test:
   commands:

--- a/recipes/peregrine-2021/meta.yaml
+++ b/recipes/peregrine-2021/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.4.11" %}
+{% set version = "0.4.12" %}
 
 package:
   name: peregrine-2021
@@ -9,7 +9,7 @@ build:
 
 source:
   url: https://github.com/cschin/peregrine-2021/archive/refs/tags/v{{version}}.tar.gz
-  sha256: 79e2e07d0c0801b2d78888a3de2c6863858fef233f1da667777d62b4e421d0e9
+  sha256: 727ecd3633fc57e2123275dfc3a3b56567bac67e368eff7c2da7e2382aa36bfe
 
 requirements:
   build:

--- a/recipes/peregrine-2021/meta.yaml
+++ b/recipes/peregrine-2021/meta.yaml
@@ -1,0 +1,48 @@
+{% set version = "0.4.1" %}
+
+package:
+  name: peregrine-2021
+  version: {{ version }}
+
+build:
+  number: 0
+
+source:
+  url: https://github.com/cschin/peregrine-2021/archive/refs/tags/v{{version}}.tar.gz
+  sha256: 5b260b10243e2d7cdc3f0b0c94020b50b034e378544146f453115703c5e3de6d
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - rust >=1.58.0
+    - clangdev
+    - pkg-config
+    - make
+    - cmake
+  host:
+    - gsl
+    - libcblas
+    - openssl
+  run:
+    - jq
+    - exonerate
+    - parallel
+    - pigz
+    - samtools
+    - tzdata
+    - wget
+
+test:
+  commands:
+    - pg_asm --help
+
+about:
+  home: https://github.com/cschin/peregrine-2021
+  license: CC BY-NC-SA 4.0
+  license_family: CC
+  license_file: LICENSE
+  summary: A genome assembler designed for long-reads that have good enough accuracy
+extra:
+  recipe-maintainers:
+    - rpetit3


### PR DESCRIPTION
This PR adds [peregrine-2021](https://github.com/cschin/peregrine-2021) which is a long-read assembler written in Rust.

