### PR TITLE
Add eBCSgen recipe

### DIFF
--- a/recipes/ebcsgen/meta.yaml
+++ b/recipes/ebcsgen/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: "https://github.com/sybila/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz"
-  sha256: ddd572d525d5f843f8f729ef8d7beabb6f9c7befbadf753b23c4ab2691ca5bb5
+  sha256: 2c49f6c4d724a00c324e8d21ab487da53b1690125b7e103a6bca37dfb79bf202
 
 build:
   number: 0

--- a/recipes/ebcsgen/meta.yaml
+++ b/recipes/ebcsgen/meta.yaml
@@ -1,0 +1,50 @@
+{% set name = "eBCSgen" %}
+{% set version = "1.2" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: "https://github.com/sybila/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz"
+  sha256: ddd572d525d5f843f8f729ef8d7beabb6f9c7befbadf753b23c4ab2691ca5bb5
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . --ignore-installed --no-deps -vv
+
+requirements:
+  host:
+    - python >=3.9
+    - pip
+  run:
+    - python >=3.9
+    - numpy
+    - pandas
+    - pyparsing
+    - regex
+    - requests
+    - scipy
+    - sortedcontainers
+    - sympy
+    - python-libsbml
+    - lark
+    - lark-parser
+    - pymodelchecking
+
+test:
+  imports:
+    - eBCSgen
+
+about:
+  home: https://github.com/sybila/eBCSgen
+  license: MIT
+  license_file: LICENSE
+  summary: "eBSCgen is a tool for development and analysis of models written in Biochemical Space Language (BCSL)."
+  dev_url: "https://github.com/sybila/eBCSgen"
+  doc_url: "https://ebcsgen.readthedocs.io/"
+
+extra:
+  recipe-maintainers:
+    - xtrojak


### PR DESCRIPTION
This pull request adds a recipe for [eBCSgen](https://github.com/sybila/eBCSgen) to bioconda. The goal is to support an easier installation and to wrap this tool for usage in Galaxy.