### PR TITLE
Add antismash-lite

### DIFF
--- a/recipes/antismash-lite/build.sh
+++ b/recipes/antismash-lite/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+echo "include antismash/detection/genefinding/data/train_crypto" >> MANIFEST.in
+
+$PYTHON -m pip install . --ignore-installed --no-deps -vv

--- a/recipes/antismash-lite/meta.yaml
+++ b/recipes/antismash-lite/meta.yaml
@@ -1,4 +1,4 @@
-{% set name = "antiSMASH" %}
+{% set name = "antiSMASH-lite" %}
 {% set version = "6.0.1" %}
 {% set sha256 = "be867726e41cd194ba0dfd01654a6674041f97a3517c5aff16a1918fab2bcf44" %}
 

--- a/recipes/antismash-lite/meta.yaml
+++ b/recipes/antismash-lite/meta.yaml
@@ -1,0 +1,74 @@
+{% set name = "antiSMASH" %}
+{% set version = "6.0.1" %}
+{% set sha256 = "be867726e41cd194ba0dfd01654a6674041f97a3517c5aff16a1918fab2bcf44" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+build:
+  number: 0
+  noarch: python
+
+source:
+  url: https://dl.secondarymetabolites.org/releases/{{ version }}/antismash-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+requirements:
+  host:
+    - python >=3.7
+    - pip
+  run:
+    - python >=3.7
+    - numpy
+    - biopython 1.78
+    - helperlibs >=0.2.0
+    - jinja2
+    - joblib
+    - jsonschema
+    - pysvg-py3
+    - bcbio-gff
+    - pyscss
+    - matplotlib-base
+    - scipy
+    - openjdk
+    - scikit-learn >=0.19
+    - diamond 0.9.*
+    - fasttree 2.1.*
+    - glimmerhmm ==3.0.*
+    - hmmer2
+    - hmmer ==3.1b2
+    - meme <=4.11.2
+    - muscle 3.8.*
+    - blast
+    - prodigal
+
+test:
+  commands:
+    - antismash -h
+    - blastp -help
+    - fasttree -help
+    - diamond --help 2>&1 > /dev/null
+
+about:
+  home: https://docs.antismash.secondarymetabolites.org/intro/
+  license: AGPL-3.0
+  license_family: AGPL
+  license_file: LICENSE.txt
+  summary: antiSMASH - the antibiotics and Secondary Metabolite Analysis SHell
+  description: |
+        antiSMASH allows the rapid genome-wide identification,
+        annotation and analysis of secondary metabolite biosynthesis gene clusters.
+  dev_url: https://github.com/antismash/antismash
+  doc_url: https://docs.antismash.secondarymetabolites.org
+
+extra:
+  identifiers:
+    - biotools:antismash
+    - doi:10.1093/nar/gkr466
+    - doi:10.1093/nar/gkt449
+    - doi:10.1093/nar/gkv437
+    - doi:10.1093/nar/gkx319
+    - doi:10.1093/nar/gkz310
+    - doi:10.1093/nar/gkab335
+    - usegalaxy-eu:antismash


### PR DESCRIPTION
As described in [#418](https://github.com/antismash/antismash/issues/418) of the AntiSMASH GitHub, it would be useful to have an AntiSMASH package without automatic database download available on conda.
The name `antismash-lite` is analogous to the provided Docker image without database download (see AntiSMASH [documentation](https://docs.antismash.secondarymetabolites.org/install/#antismash-standalone-lite)).

----

Ping @jfy133 @kblin 