### PR TITLE
Update - 1.2.2 version bump

### DIFF
--- a/recipes/artic/meta.yaml
+++ b/recipes/artic/meta.yaml
@@ -35,23 +35,22 @@ requirements:
     - artic-porechop =0.3.2pre
     - artic-tools =0.2.6
     - bcftools =1.10.2
-    - biopython >=1.76
+    - biopython =1.76
     - bwa =0.7.17
     - clint
     - htslib =1.10.2
-    - longshot >=0.4.1
-    - medaka >=1.0.3
+    - longshot =0.4.1
+    - medaka =1.0.3
     - minimap2 =2.17
     - multiqc
     - muscle =3.8
-    - nanopolish >=0.13.2
-    - pandas <1
+    - nanopolish =0.13.2
+    - pandas =0.23.0
     - pip
-    - pysam >=0.16.0.1
+    - pysam =0.16.0.1
     - pytest
-    - python >=3
-    - pysam >=0.15.3
-    - pyvcf >=0.6.8
+    - python =3.6.13
+    - pyvcf =0.6.8
     - requests
     - samtools =1.10
     - tqdm

--- a/recipes/artic/meta.yaml
+++ b/recipes/artic/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "artic" %}
-{% set version = "1.2.1" %}
-{% set sha256 = "74b5fdb18dca57e73fbe872c5c4e25c110e7826fac7a062f0eb0a5453e4e7b20" %}
+{% set version = "1.2.2" %}
+{% set sha256 = "4f8ea1ef98d01329ef60e9f3159db6b753bb7151ec405577c8719e1d23ca2942" %}
 
 package:
   name: {{ name|lower }}
@@ -43,7 +43,7 @@ requirements:
     - medaka >=1.0.3
     - minimap2 =2.17
     - multiqc
-    - muscle >=3.8
+    - muscle =3.8
     - nanopolish >=0.13.2
     - pandas <1
     - pip


### PR DESCRIPTION
Muscle pinned to version 3.8 for compatibility, also reimplemented the scheme downloader in python to avoid a bug with artic-tools where the latest scheme (V4.1) was processed as a float.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
