### PR TITLE
Update ucsc-fatovcf from v407 to v426; remove skip.

### DIFF
--- a/build-fail-blacklist
+++ b/build-fail-blacklist
@@ -288,7 +288,6 @@ recipes/seq2hla
 recipes/reaper
 recipes/genie
 recipes/admixture
-recipes/ucsc-fatovcf
 recipes/mace
 recipes/riboseq-rust
 

--- a/recipes/ucsc-fatovcf/build.sh
+++ b/recipes/ucsc-fatovcf/build.sh
@@ -11,6 +11,7 @@ export MACHTYPE=x86_64
 export BINDIR=$(pwd)/bin
 export L="${LDFLAGS}"
 mkdir -p "$BINDIR"
+printenv
 (cd kent/src/lib && make)
 (cd kent/src/htslib && make)
 (cd kent/src/jkOwnLib && make)
@@ -18,4 +19,3 @@ mkdir -p "$BINDIR"
 (cd kent/src/hg/utils/faToVcf && make)
 cp bin/faToVcf "$PREFIX/bin"
 chmod +x "$PREFIX/bin/faToVcf"
-ls -l "$PREFIX/bin/faToVcf"

--- a/recipes/ucsc-fatovcf/build.sh
+++ b/recipes/ucsc-fatovcf/build.sh
@@ -3,6 +3,7 @@
 export CFLAGS="$CFLAGS -I$PREFIX/include"
 export LDFLAGS="$LDFLAGS -L$PREFIX/lib"
 export CPATH=${PREFIX}/include
+export USE_HIC=0
 
 mkdir -p "$PREFIX/bin"
 export MACHTYPE=x86_64

--- a/recipes/ucsc-fatovcf/build.sh
+++ b/recipes/ucsc-fatovcf/build.sh
@@ -11,7 +11,7 @@ export MACHTYPE=x86_64
 export BINDIR=$(pwd)/bin
 export L="${LDFLAGS}"
 mkdir -p "$BINDIR"
-printenv
+ls -R $PREFIX
 (cd kent/src/lib && make)
 (cd kent/src/htslib && make)
 (cd kent/src/jkOwnLib && make)

--- a/recipes/ucsc-fatovcf/build.sh
+++ b/recipes/ucsc-fatovcf/build.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -x
 
 export CFLAGS="$CFLAGS -I$PREFIX/include"
 export LDFLAGS="$LDFLAGS -L$PREFIX/lib"
@@ -17,3 +18,4 @@ mkdir -p "$BINDIR"
 (cd kent/src/hg/utils/faToVcf && make)
 cp bin/faToVcf "$PREFIX/bin"
 chmod +x "$PREFIX/bin/faToVcf"
+ls -l "$PREFIX/bin/faToVcf"

--- a/recipes/ucsc-fatovcf/build.sh
+++ b/recipes/ucsc-fatovcf/build.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -x
 
 export CFLAGS="$CFLAGS -I$PREFIX/include"
 export LDFLAGS="$LDFLAGS -L$PREFIX/lib"
@@ -11,7 +10,6 @@ export MACHTYPE=x86_64
 export BINDIR=$(pwd)/bin
 export L="${LDFLAGS}"
 mkdir -p "$BINDIR"
-ls -R $PREFIX
 patch kent/src/inc/common.mk $RECIPE_DIR/inc.common.mk.v426.patch
 (cd kent/src/lib && make)
 (cd kent/src/htslib && make)

--- a/recipes/ucsc-fatovcf/build.sh
+++ b/recipes/ucsc-fatovcf/build.sh
@@ -12,6 +12,7 @@ export BINDIR=$(pwd)/bin
 export L="${LDFLAGS}"
 mkdir -p "$BINDIR"
 ls -R $PREFIX
+patch kent/src/inc/common.mk $RECIPE_DIR/inc.common.mk.v426.patch
 (cd kent/src/lib && make)
 (cd kent/src/htslib && make)
 (cd kent/src/jkOwnLib && make)

--- a/recipes/ucsc-fatovcf/inc.common.mk.v426.patch
+++ b/recipes/ucsc-fatovcf/inc.common.mk.v426.patch
@@ -1,5 +1,5 @@
 diff --git a/src/inc/common.mk b/src/inc/common.mk
-index 1c6c0e93d9..02aab85a7a 100644
+index 1c6c0e93d9..0c3abb2ac7 100644
 --- a/src/inc/common.mk
 +++ b/src/inc/common.mk
 @@ -34,36 +34,41 @@ else
@@ -18,7 +18,7 @@ index 1c6c0e93d9..02aab85a7a 100644
 +# Skip freetype for conda build; not needed for utils, and the Mac build environment has
 +# freetype installed but we don't want to use the system libraries because they can be
 +# for a newer OSX version than the conda build target, and can be incompatible.
-+ifneq ($CONDA_BUILD,1)
++ifneq (${CONDA_BUILD},1)
 +  FREETYPECFLAGS = $(shell freetype-config --cflags  2> /dev/null)
 +
 +  # we use our static library on dev

--- a/recipes/ucsc-fatovcf/inc.common.mk.v426.patch
+++ b/recipes/ucsc-fatovcf/inc.common.mk.v426.patch
@@ -1,0 +1,121 @@
+diff --git a/src/inc/common.mk b/src/inc/common.mk
+index 1c6c0e93d9..02aab85a7a 100644
+--- a/src/inc/common.mk
++++ b/src/inc/common.mk
+@@ -34,36 +34,41 @@ else
+   IS_HGWDEV = no
+ endif
+ 
+-FREETYPECFLAGS = $(shell freetype-config --cflags  2> /dev/null)
+-
+-# we use our static library on dev
+-ifeq (${IS_HGWDEV},no)
+-  ifeq (${FREETYPELIBS},)
+-    ifeq ($(UNAME_S),Darwin)
+-      ifneq ($(wildcard /usr/local/Cellar/freetype/2.11.0/lib/libfreetype.a),)
+-        ifneq ($(wildcard /usr/local/opt/bzip2/lib/libbz2.a),)
+-          FREETYPELIBS = /usr/local/Cellar/freetype/2.11.0/lib/libfreetype.a /usr/local/opt/bzip2/lib/libbz2.a
++# Skip freetype for conda build; not needed for utils, and the Mac build environment has
++# freetype installed but we don't want to use the system libraries because they can be
++# for a newer OSX version than the conda build target, and can be incompatible.
++ifneq ($CONDA_BUILD,1)
++  FREETYPECFLAGS = $(shell freetype-config --cflags  2> /dev/null)
++
++  # we use our static library on dev
++  ifeq (${IS_HGWDEV},no)
++    ifeq (${FREETYPELIBS},)
++      ifeq ($(UNAME_S),Darwin)
++        ifneq ($(wildcard /usr/local/Cellar/freetype/2.11.0/lib/libfreetype.a),)
++          ifneq ($(wildcard /usr/local/opt/bzip2/lib/libbz2.a),)
++            FREETYPELIBS = /usr/local/Cellar/freetype/2.11.0/lib/libfreetype.a /usr/local/opt/bzip2/lib/libbz2.a
++          else
++            FREETYPELIBS = /usr/local/Cellar/freetype/2.11.0/lib/libfreetype.a -lbz2
++          endif
+         else
+-          FREETYPELIBS = /usr/local/Cellar/freetype/2.11.0/lib/libfreetype.a -lbz2
+-        endif
+-      else
+-        ifneq ($(wildcard /opt/local/lib/libfreetype.a),)
+-          FREETYPELIBS=/opt/local/lib/libfreetype.a /opt/local/lib/libbz2.a /opt/local/lib/libbrotlidec-static.a /opt/local/lib/libbrotlienc-static.a /opt/local/lib/libbrotlicommon-static.a
++          ifneq ($(wildcard /opt/local/lib/libfreetype.a),)
++            FREETYPELIBS=/opt/local/lib/libfreetype.a /opt/local/lib/libbz2.a /opt/local/lib/libbrotlidec-static.a /opt/local/lib/libbrotlienc-static.a /opt/local/lib/libbrotlicommon-static.a
++          endif
+         endif
+       endif
+-    endif
+-    ifeq (${FREETYPELIBS},)
+-      FREETYPELIBS =  $(shell freetype-config --libs 2> /dev/null )
++      ifeq (${FREETYPELIBS},)
++        FREETYPELIBS =  $(shell freetype-config --libs 2> /dev/null )
++      endif
+     endif
+   endif
+-endif
+ 
+-ifneq (${FREETYPECFLAGS},)
+-FREETYPECFLAGS += -DUSE_FREETYPE
+-endif
++  ifneq (${FREETYPECFLAGS},)
++  FREETYPECFLAGS += -DUSE_FREETYPE
++  endif
+ 
+-HG_INC += ${FREETYPECFLAGS}
+-L += ${FREETYPELIBS}
++  HG_INC += ${FREETYPECFLAGS}
++  L += ${FREETYPELIBS}
++endif
+ 
+ ifeq (${IS_HGWDEV},yes)
+   FULLWARN = yes
+@@ -138,28 +143,32 @@ ifeq (${IS_HGWDEV},yes)
+    L+=/hive/groups/browser/freetype/freetype-2.10.0/objs/.libs/libfreetype.a -lbz2
+    L+=/usr/lib64/libssl.a /usr/lib64/libcrypto.a -lkrb5 -lk5crypto -ldl
+ else
+-   ifneq ($(wildcard /opt/local/lib/libssl.a),)
+-       L+=/opt/local/lib/libssl.a
++   ifeq (${CONDA_BUILD},1)
++       L+=${PREFIX}/lib/libssl.a ${PREFIX}/lib/libcrypto.a
+    else
+-     ifneq ($(wildcard /usr/lib/x86_64-linux-gnu/libssl.a),)
+-	L+=/usr/lib/x86_64-linux-gnu/libssl.a
++     ifneq ($(wildcard /opt/local/lib/libssl.a),)
++         L+=/opt/local/lib/libssl.a
+      else
+-        ifneq ($(wildcard /usr/local/opt/openssl/lib/libssl.a),)
+-           L+=/usr/local/opt/openssl/lib/libssl.a
+-        else
+-           L+=-lssl
+-        endif
++       ifneq ($(wildcard /usr/lib/x86_64-linux-gnu/libssl.a),)
++	  L+=/usr/lib/x86_64-linux-gnu/libssl.a
++       else
++          ifneq ($(wildcard /usr/local/opt/openssl/lib/libssl.a),)
++             L+=/usr/local/opt/openssl/lib/libssl.a
++          else
++             L+=-lssl
++          endif
++       endif
+      endif
+-   endif
+-   ifneq ($(wildcard /opt/local/lib/libcrypto.a),)
+-       L+=/opt/local/lib/libcrypto.a
+-   else
+-        ifneq ($(wildcard /usr/local/opt/openssl/lib/libcrypto.a),)
+-           L+=/usr/local/opt/openssl/lib/libcrypto.a
+-        else
+-           L+=-lcrypto
+-        endif
+-   endif
++     ifneq ($(wildcard /opt/local/lib/libcrypto.a),)
++         L+=/opt/local/lib/libcrypto.a
++     else
++          ifneq ($(wildcard /usr/local/opt/openssl/lib/libcrypto.a),)
++             L+=/usr/local/opt/openssl/lib/libcrypto.a
++          else
++             L+=-lcrypto
++          endif
++     endif
++  endif
+ endif
+ 
+ # autodetect where libm is installed

--- a/recipes/ucsc-fatovcf/meta.yaml
+++ b/recipes/ucsc-fatovcf/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: "{{ sha256 }}"
 
 build:
-  number: 1
+  number: 0
 
 requirements:
   build:

--- a/recipes/ucsc-fatovcf/meta.yaml
+++ b/recipes/ucsc-fatovcf/meta.yaml
@@ -24,6 +24,7 @@ requirements:
     - libuuid
     - mysql-connector-c
     - openssl
+    - libopenssl-static
     - zlib
   run:
     - libpng

--- a/recipes/ucsc-fatovcf/meta.yaml
+++ b/recipes/ucsc-fatovcf/meta.yaml
@@ -1,18 +1,17 @@
 {% set package = "ucsc-fatovcf" %}
 {% set program = "faToVcf" %}
-{% set version = "407" %}
-{% set sha256 = "b7b2ed0b2e7a89d8821a9048e2c89a667795bb871b7eb3764d0e219560a95ffb" %}
+{% set version = "426" %}
+{% set sha256 = "b79d057adeac0c1c2997da3975c103d4b4bdf8ecdaf49a9d48ed091fc5ebf74a" %}
 
 package:
   name: "{{ package }}"
   version: "{{ version }}"
 
 source:
-  url: "http://hgdownload.cse.ucsc.edu/admin/exe/userApps.v407.src.tgz"
+  url: "http://hgdownload.cse.ucsc.edu/admin/exe/userApps.archive/userApps.v{{ version }}.src.tgz"
   sha256: "{{ sha256 }}"
 
 build:
-  skip: True  # [osx]
   number: 1
 
 requirements:

--- a/recipes/ucsc-fatovcf/run_test.sh
+++ b/recipes/ucsc-fatovcf/run_test.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -x
-faToVcf
+set +o pipefail
 faToVcf 2> /dev/null || [[ "$?" == 255 ]]

--- a/recipes/ucsc-fatovcf/run_test.sh
+++ b/recipes/ucsc-fatovcf/run_test.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 set -x
-set +o pipefail
-faToVcf 2> /dev/null || [[ "$?" == 255 ]]
+faToVcf 2> /dev/null || [[ "$?" == 1 ]]

--- a/recipes/ucsc-fatovcf/run_test.sh
+++ b/recipes/ucsc-fatovcf/run_test.sh
@@ -1,2 +1,4 @@
 #!/bin/bash
+set -x
+faToVcf
 faToVcf 2> /dev/null || [[ "$?" == 255 ]]

--- a/recipes/ucsc-fatovcf/run_test.sh
+++ b/recipes/ucsc-fatovcf/run_test.sh
@@ -1,3 +1,2 @@
 #!/bin/bash
-set -x
 faToVcf 2> /dev/null || [[ "$?" == 1 ]]


### PR DESCRIPTION
@BiocondaBot please add label

ucsc-fatovcf has not been updated since March 2021, and it has `skip: True # [osx]`.  However, the tool pangolin, used by public health departments worldwide to assign SARS-CoV-2 lineages to new genome sequences, depends on faToVcf when using --usher mode, which is slated to become pangolin's default mode soon.  In June 2021, an important new option was added to faToVcf; pangolin really should be using the latest version of faToVcf with the new option.

This PR updates the version from 407 to the latest stable version, 426, and removes the `skip: True # [osx]`.

I expect there will be some build problems because the `skip` must have been added for a reason, but I'm sure we can work through them.