### PR TITLE
Remove version pinning for ngscheckmate

### DIFF
--- a/recipes/ngscheckmate/meta.yaml
+++ b/recipes/ngscheckmate/meta.yaml
@@ -7,20 +7,20 @@ source:
   md5: 4c4e34abc8c4851d29661f5f0cc13b49
 
 build:
-  number: 1
+  number: 2
   noarch: generic
 
 requirements:
   host:
     - python 2.7.18
     - R 4.1
-    - samtools 1.14
-    - bcftools 1.3.1
+    - samtools
+    - bcftools
   run:
     - python 2.7.18
     - R 4.1
-    - samtools 1.14
-    - bcftools 1.3.1
+    - samtools
+    - bcftools
 
 test:
   commands:


### PR DESCRIPTION
Remove the version pinning for bcftools and samtools in ngscheckmate as discussed after #33443 was merged.