### PR TITLE
Bump scanpy-scripts version

### DIFF
--- a/recipes/scanpy-scripts/meta.yaml
+++ b/recipes/scanpy-scripts/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "scanpy-scripts" %}
-{% set version = "1.1.3" %}
+{% set version = "1.1.5" %}
 
 package:
   name: "{{ name|lower }}"
@@ -7,7 +7,7 @@ package:
 
 source:
   - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-    sha256: 96eb39bedb5cd075509247d770cfd951e57f2834248bf1e6896c55e7fe2c524f
+    sha256: 7c99554f240be1cd1a57a797cc47faec74858230d70b88f58509d715b0ffccad
     folder: scanpy-scripts
   - url: https://pypi.io/packages/source/s/scanpy/scanpy-1.8.1.tar.gz 
     sha256: 1b8603a868d783bd6c18c8db763a450153feefc8daed862c440749790d47c654


### PR DESCRIPTION
Just a bump necessary due the multiple sources preventing autobump.

FAO Bioconda overlords: I do intend to remove this hack once the upstream Scanpy releases include the requisite Scrublet fixes. 

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
