### PR TITLE
Pin ngscheckmate samtools to 1.14. samtools mpileup is removed in 1.15

### DIFF
--- a/recipes/ngscheckmate/meta.yaml
+++ b/recipes/ngscheckmate/meta.yaml
@@ -7,19 +7,19 @@ source:
   md5: 4c4e34abc8c4851d29661f5f0cc13b49
 
 build:
-  number: 2
+  number: 3
   noarch: generic
 
 requirements:
   host:
     - python 2.7.18
     - R 4.1
-    - samtools
+    - samtools 1.14
     - bcftools
   run:
     - python 2.7.18
     - R 4.1
-    - samtools
+    - samtools 1.14
     - bcftools
 
 test:


### PR DESCRIPTION
samtools mpileup is removed from v1.15 so bam mode fails as the python script calls samtools mpileup.
Reverts my previous PR #33444 .