### PR TITLE
Update Pbipa: pinned requirement versions.

### DIFF
--- a/recipes/pbipa/meta.yaml
+++ b/recipes/pbipa/meta.yaml
@@ -11,27 +11,28 @@ source:
     sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 3
   skip: True # [osx]
 
 extra:
   recipe-maintainers:
     - pb-cdunn
+    - isovic
 
 requirements:
   build: 
     - {{ compiler('c') }}
   host:
     - zlib
-    - htslib
+    - htslib >=1.15
     - pcre
   run:
-    - htslib
+    - htslib >=1.15
     - networkx
-    - snakemake-minimal
+    - snakemake-minimal >=7.0.4
     - racon
     - pb-falconc
-    - samtools
+    - samtools >=1.15
     - minimap2
 
 test:


### PR DESCRIPTION
Pinned the versions of Samtools (>=1.15), Htslib (>=1.15) and Snakemake (>=7.0.4) in recipes/pbipa/meta.yaml. Hopefully this will prevent Samtools issues with wrong OpenSSL/libcrypto, and Snakemake issue with smart_open.