### PR TITLE
Update Triqler dependencies for 0.6.2

### DIFF
--- a/recipes/triqler/meta.yaml
+++ b/recipes/triqler/meta.yaml
@@ -24,6 +24,7 @@ requirements:
     - numpy >=1.12
     - python
     - scipy >=0.17
+    - threadpoolctl >=1.0
 
 test:
   imports:


### PR DESCRIPTION
This PR adds a missing dependency for the latest version of Triqler.