### PR TITLE
Update mokapot's dependencies

### DIFF
--- a/recipes/mokapot/meta.yaml
+++ b/recipes/mokapot/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 929e31437434b9231e7685fb41ec3841a19a8f7c7df250fd0b35192749fe54e7
 
 build:
-  number: 0
+  number: 1
   noarch: python
   entry_points:
     - mokapot = mokapot.mokapot:main

--- a/recipes/mokapot/meta.yaml
+++ b/recipes/mokapot/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - pandas >=1.0.3
     - python >=3.6
     - scikit-learn >=0.22.1
-    - triqler >=0.3.0
+    - triqler >=0.6.2
     - lxml >=4.6.2
 
 test:


### PR DESCRIPTION
This PR bumps the minimum version of Triqler required from v0.3.0 to v0.6.2. 

@dpryan79 --- can you add me as a Bioconda member? Thanks!
