### PR TITLE
Update comet-ms to 2021.02.0 and change host to GitHub from SourceForge

### DIFF
--- a/recipes/comet-ms/build.sh
+++ b/recipes/comet-ms/build.sh
@@ -2,7 +2,7 @@
 set -e
 set -x
 
-unzip Comet-"$PKG_VERSION".zip
+unzip comet_source_"$PKG_VERSION".zip
 sed -i.bak "s#gcc#${CC}#;s#g++#${CXX}#" CometSearch/Makefile
 sed -i.bak "s#gcc#${CC}#;s#g++#${CXX}#" MSToolkit/Makefile
 make CXX=${CXX} CXXFLAGS="${CXXFLAGS} -mcmodel=large"

--- a/recipes/comet-ms/build.sh
+++ b/recipes/comet-ms/build.sh
@@ -2,7 +2,7 @@
 set -e
 set -x
 
-unzip *.zip
+unzip v"$PKG_VERSION"*.zip
 sed -i.bak "s#gcc#${CC}#;s#g++#${CXX}#" CometSearch/Makefile
 sed -i.bak "s#gcc#${CC}#;s#g++#${CXX}#" MSToolkit/Makefile
 make CXX=${CXX} CXXFLAGS="${CXXFLAGS} -mcmodel=large"

--- a/recipes/comet-ms/build.sh
+++ b/recipes/comet-ms/build.sh
@@ -2,7 +2,7 @@
 set -e
 set -x
 
-unzip comet_source_"$PKG_VERSION".zip
+unzip v"$PKG_VERSION".zip
 sed -i.bak "s#gcc#${CC}#;s#g++#${CXX}#" CometSearch/Makefile
 sed -i.bak "s#gcc#${CC}#;s#g++#${CXX}#" MSToolkit/Makefile
 make CXX=${CXX} CXXFLAGS="${CXXFLAGS} -mcmodel=large"

--- a/recipes/comet-ms/build.sh
+++ b/recipes/comet-ms/build.sh
@@ -2,7 +2,7 @@
 set -e
 set -x
 
-unzip v"$PKG_VERSION".zip
+unzip *.zip
 sed -i.bak "s#gcc#${CC}#;s#g++#${CXX}#" CometSearch/Makefile
 sed -i.bak "s#gcc#${CC}#;s#g++#${CXX}#" MSToolkit/Makefile
 make CXX=${CXX} CXXFLAGS="${CXXFLAGS} -mcmodel=large"

--- a/recipes/comet-ms/build.sh
+++ b/recipes/comet-ms/build.sh
@@ -2,16 +2,7 @@
 set -e
 set -x
 
-platform="$(uname)"
-unzip comet_source_"$PKG_VERSION".zip
-if [ "$platform" = "Darwin" ]; then
-    sed -i.bak -e 's/ -static//' -e 's/ -o / -headerpad_max_install_names&/' Makefile
-    sed -i.bak -e "s/sha1Report='..'/sha1Report=NULL/" MSToolkit/include/MSReader.h
-    sed -i.bak "s/ off64_t / off_t /g" CometSearch/Common.h
-    sed -i.bak "s/fseeko64/fseeko/g;s/ftello64/ftello/g" MSToolkit/include/mzParser.h
-    sed -i.bak "s/fseeko64/fseeko/g;s/ftello64/ftello/g" CometSearch/Common.h
-    sed -i.bak "s/pthread_yield/sched_yield/g;" CometSearch/ThreadPool.h
-fi
+unzip Comet-"$PKG_VERSION".zip
 sed -i.bak "s#gcc#${CC}#;s#g++#${CXX}#" CometSearch/Makefile
 sed -i.bak "s#gcc#${CC}#;s#g++#${CXX}#" MSToolkit/Makefile
 make CXX=${CXX} CXXFLAGS="${CXXFLAGS} -mcmodel=large"

--- a/recipes/comet-ms/meta.yaml
+++ b/recipes/comet-ms/meta.yaml
@@ -1,18 +1,16 @@
 {% set name = "comet-ms" %}
-{% set version = "2021010" %}
-{% set md5 = "cd77b234bf68ef4bf06bba4f5d66f5d5" %}
+{% set version = "2021.02.0" %}
 
 package:
   name: {{ name }}
   version: {{ version }}
 
 source:
-  url: http://downloads.sourceforge.net/project/{{ name }}/comet_{{ version }}.zip
-  md5: {{ md5 }}
+  url: "https://github.com/UWPR/Comet/archive/refs/tags/v{{ version }}.zip"
+  sha256: c62eab75ee633c0c4e55910d850c1c66e82fbad055d06d7091fb2628463bc031
 
 build:
-  skip: True  # [osx]
-  number: 1
+  number: 0
 
 requirements:
   build:
@@ -27,11 +25,17 @@ test:
     - comet -p && rm comet.params.new
 
 about:
-  home: https://uwpr.github.io/Comet/
+  home: "https://github.com/uwpr/comet"
   license: Apache License 2.0
   summary: 'Comet is a command line tool that does MS/MS database search.'
+  doc_url: "https://uwpr.github.io/Comet/"
+  dev_url: "https://github.com/uwpr/comet"
 
 extra:
   identifiers:
     - doi:10.1007/s13361-015-1179-x
     - doi:10.1002/pmic.201200439
+
+extra:
+  recipe-maintainers:
+    - wfondrie

--- a/recipes/comet-ms/meta.yaml
+++ b/recipes/comet-ms/meta.yaml
@@ -35,7 +35,5 @@ extra:
   identifiers:
     - doi:10.1007/s13361-015-1179-x
     - doi:10.1002/pmic.201200439
-
-extra:
   recipe-maintainers:
     - wfondrie


### PR DESCRIPTION
This PR updates comet-ms to v2021.02.0. The project was recently migrated to GitHub from SourceForge, so this PR also accounts for this. With the latest comet-ms update, we included for the MacOS build, so I modified `build.sh` here  accordingly.

I've also added myself as the maintainer.