### PR TITLE
Add pprodigal recipe

### DIFF
--- a/recipes/pprodigal/meta.yaml
+++ b/recipes/pprodigal/meta.yaml
@@ -1,0 +1,32 @@
+{% set version = "1.0" %}
+
+package:
+  name: pprodigal
+  version: '{{ version }}'
+
+source:
+  url: https://github.com/sjaenick/pprodigal/archive/v{{ version }}.tar.gz
+  sha256: '4bd05c9e319144e806de2b1f00e9a0e388b2c1e039e3685a2bd0c44dd29628bf'
+
+build:
+  noarch: python
+  number: 0
+  script: python -m pip install --no-deps --ignore-installed .
+  entry_points:
+    - pprodigal = pprodigal.main:main
+
+requirements:
+  host:
+    - python >=3
+    - pip
+  run:
+    - python >=3
+    - prodigal >=2.6.3
+
+about:
+  home: https://github.com/sjaenick/pprodigal
+  license: MIT
+  license_file: LICENSE
+  summary: PProdigal: Parallelized gene prediction based on Prodigal.
+  dev_url: https://github.com/sjaenick/pprodigal
+


### PR DESCRIPTION
Add recipe for pprodigal, a simple python3-based wrapper to parallelize gene prediction
with the popular prodigal tool by splitting the input into chunks.
