### PR TITLE
Add pprodigal 1.0.1

### DIFF
--- a/recipes/pprodigal/meta.yaml
+++ b/recipes/pprodigal/meta.yaml
@@ -1,0 +1,55 @@
+<<<<<<< HEAD
+{% set version = "1.0.1" %}
+=======
+{% set version = "1.0" %}
+>>>>>>> 6df5f2d7c3... add pprodigal recipe
+
+package:
+  name: pprodigal
+  version: '{{ version }}'
+
+source:
+  url: https://github.com/sjaenick/pprodigal/archive/v{{ version }}.tar.gz
+<<<<<<< HEAD
+  sha256: '0fd0e8a847a4aa72ee2704d58b251c33225c5dd46825e932180b8c403c7502a6'
+=======
+  sha256: '4bd05c9e319144e806de2b1f00e9a0e388b2c1e039e3685a2bd0c44dd29628bf'
+>>>>>>> 6df5f2d7c3... add pprodigal recipe
+
+build:
+  noarch: python
+  number: 0
+  script: python -m pip install --no-deps --ignore-installed .
+  entry_points:
+<<<<<<< HEAD
+    - pprodigal = pprodigal.pprodigal:main
+=======
+    - pprodigal = pprodigal.main:main
+>>>>>>> 6df5f2d7c3... add pprodigal recipe
+
+requirements:
+  host:
+    - python >=3
+    - pip
+  run:
+    - python >=3
+    - prodigal >=2.6.3
+
+<<<<<<< HEAD
+test:
+  commands:
+    - pprodigal --help
+
+=======
+>>>>>>> 6df5f2d7c3... add pprodigal recipe
+about:
+  home: https://github.com/sjaenick/pprodigal
+  license: MIT
+  license_file: LICENSE
+<<<<<<< HEAD
+  summary: PProdigal - Parallelized gene prediction based on Prodigal.
+=======
+  summary: PProdigal: Parallelized gene prediction based on Prodigal.
+>>>>>>> 6df5f2d7c3... add pprodigal recipe
+  dev_url: https://github.com/sjaenick/pprodigal
+

--- a/recipes/pprodigal/meta.yaml
+++ b/recipes/pprodigal/meta.yaml
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
 {% set version = "1.0.1" %}
-=======
-{% set version = "1.0" %}
->>>>>>> 6df5f2d7c3... add pprodigal recipe
 
 package:
   name: pprodigal
@@ -10,22 +6,14 @@ package:
 
 source:
   url: https://github.com/sjaenick/pprodigal/archive/v{{ version }}.tar.gz
-<<<<<<< HEAD
   sha256: '0fd0e8a847a4aa72ee2704d58b251c33225c5dd46825e932180b8c403c7502a6'
-=======
-  sha256: '4bd05c9e319144e806de2b1f00e9a0e388b2c1e039e3685a2bd0c44dd29628bf'
->>>>>>> 6df5f2d7c3... add pprodigal recipe
 
 build:
   noarch: python
   number: 0
   script: python -m pip install --no-deps --ignore-installed .
   entry_points:
-<<<<<<< HEAD
     - pprodigal = pprodigal.pprodigal:main
-=======
-    - pprodigal = pprodigal.main:main
->>>>>>> 6df5f2d7c3... add pprodigal recipe
 
 requirements:
   host:
@@ -35,21 +23,14 @@ requirements:
     - python >=3
     - prodigal >=2.6.3
 
-<<<<<<< HEAD
 test:
   commands:
     - pprodigal --help
 
-=======
->>>>>>> 6df5f2d7c3... add pprodigal recipe
 about:
   home: https://github.com/sjaenick/pprodigal
   license: MIT
   license_file: LICENSE
-<<<<<<< HEAD
   summary: PProdigal - Parallelized gene prediction based on Prodigal.
-=======
-  summary: PProdigal: Parallelized gene prediction based on Prodigal.
->>>>>>> 6df5f2d7c3... add pprodigal recipe
   dev_url: https://github.com/sjaenick/pprodigal
 


### PR DESCRIPTION
Add recipe for pprodigal, a simple python3-based wrapper to parallelize gene prediction
with the popular prodigal tool by splitting the input into chunks.
