### PR TITLE
update `odgi` to v0.7.0 with the correct `tar.gz` archive

### DIFF
--- a/recipes/odgi/meta.yaml
+++ b/recipes/odgi/meta.yaml
@@ -6,11 +6,11 @@ package:
 
 source:
   url: https://github.com/pangenome/odgi/releases/download/v0.6.3/odgi-v0.6.3.tar.gz
-  sha256: 631f2afd605adfa6b5fe5d7775f49ac62f59f99234c35df8501477ad34a7c6fd
+  sha256: c143613843f3298a04403ba71fcb30cf5c942d042a913c4217373d23500dc8b7
 
 build:
   skip: True  # [osx or py27]
-  number: 1
+  number: 0
 
 requirements:
   build:


### PR DESCRIPTION
This replaces #33887 