### PR TITLE
`pggb` 0.3.0: fix dependencies

### DIFF
--- a/recipes/pggb/meta.yaml
+++ b/recipes/pggb/meta.yaml
@@ -11,21 +11,22 @@ source:
 
 build:
   noarch: generic
-  number: 0
+  number: 1
 
 requirements:
   run:
     - bc
-    - gfaffix
-    - idna <3,>=2.5
-    - multiqc >=1.11
-    - odgi >=0.6.2
-    - pigz
-    - seqwish
-    - smoothxg 0.6.1
     - time
-    - vg
-    - wfmash
+    - pigz
+    - tabix
+    - idna <3,>=2.5
+    - wfmash 0.8.1
+    - odgi 0.7.0
+    - seqwish 0.7.4
+    - smoothxg 0.6.2
+    - vg 1.39.0
+    - gfaffix 0.1.3
+    - multiqc >=1.11
 
 test:
   commands:


### PR DESCRIPTION
We need the latest versions of the tools for `pggb`.