### PR TITLE
`pggb 0.3.0`: update the dependencies

### DIFF
--- a/recipes/pggb/meta.yaml
+++ b/recipes/pggb/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: generic
-  number: 1
+  number: 0
 
 requirements:
   run:

--- a/recipes/pggb/meta.yaml
+++ b/recipes/pggb/meta.yaml
@@ -30,7 +30,7 @@ requirements:
 
 test:
   commands:
-    - pggb -h
+    - pggb --help
 
 about:
   home: https://github.com/pangenome/pggb

--- a/recipes/pggb/meta.yaml
+++ b/recipes/pggb/meta.yaml
@@ -11,21 +11,22 @@ source:
 
 build:
   noarch: generic
-  number: 0
+  number: 1
 
 requirements:
   run:
     - bc
-    - gfaffix
+    - tabix
+    - gfaffix 0.1.3
     - idna <3,>=2.5
     - multiqc >=1.11
-    - odgi >=0.6.2
+    - odgi 0.7.0
     - pigz
-    - seqwish
-    - smoothxg 0.6.1
+    - seqwish 0.7.4
+    - smoothxg 0.6.2
     - time
-    - vg
-    - wfmash
+    - vg 1.39.0
+    - wfmash 0.8.1
 
 test:
   commands:

--- a/recipes/pggb/meta.yaml
+++ b/recipes/pggb/meta.yaml
@@ -30,7 +30,7 @@ requirements:
 
 test:
   commands:
-    - pggb --help
+    - pggb -h
 
 about:
   home: https://github.com/pangenome/pggb

--- a/recipes/pggb/meta.yaml
+++ b/recipes/pggb/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: generic
-  number: 0
+  number: 1
 
 requirements:
   run:


### PR DESCRIPTION
We need the latest versions of the tools for `pggb`.