### PR TITLE
Update BioPhi dependencies, release 1.0.4

### DIFF
--- a/recipes/biophi/meta.yaml
+++ b/recipes/biophi/meta.yaml
@@ -42,15 +42,10 @@ requirements:
 test:
   imports:
     - biophi
-  requires:
-    - pytest
-  source_files:
-    - tests
   commands:
     - biophi --help
     - biophi sapiens --help
     - biophi oasis --help
-    - pytest tests
 
 about:
   home: https://github.com/Merck/BioPhi

--- a/recipes/biophi/meta.yaml
+++ b/recipes/biophi/meta.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/Merck/BioPhi/archive/v{{ version }}.tar.gz
-  sha256: '11f6758b99bf23dfc64c312082cd5cdd2080eb24'
+  sha256: '06d97af0fee9637807a8574b8364b0d776155e60b1bc3faaf422ff36da97e813'
 
 build:
   noarch: python

--- a/recipes/biophi/meta.yaml
+++ b/recipes/biophi/meta.yaml
@@ -57,3 +57,4 @@ about:
   license: MIT
   license_family: MIT
   summary: BioPhi open-source antibody design platform
+

--- a/recipes/biophi/meta.yaml
+++ b/recipes/biophi/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.0.3" %} # Remember to update sha256 below
+{% set version = "1.0.4" %} # Remember to update sha256 below
 
 package:
   name: biophi
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/Merck/BioPhi/archive/v{{ version }}.tar.gz
-  sha256: '556bacca15ca20ffd32fe8c22a08ca2f3df2332952a1cf08051331ca6cea35bd'
+  sha256: '11f6758b99bf23dfc64c312082cd5cdd2080eb24'
 
 build:
   noarch: python
@@ -24,6 +24,8 @@ requirements:
   run:
     - python >=3.8
     - abnumber ==0.2.7
+    - anarci ==2020.04.23
+    - hmmer >=3.1
     - click >=7
     - pandas
     - sqlalchemy
@@ -35,15 +37,20 @@ requirements:
     - tqdm
     - xlsxwriter
     - humanize
-    - fairseq ==0.10.2  
+    - sapiens
 
 test:
   imports:
     - biophi
+  requires:
+    - pytest
+  source_files:
+    - tests
   commands:
     - biophi --help
     - biophi sapiens --help
     - biophi oasis --help
+    - pytest tests
 
 about:
   home: https://github.com/Merck/BioPhi


### PR DESCRIPTION
Update BioPhi dependencies, release 1.0.4

- Add `sapiens` dependency
- Add `anarci` and `hmmer` dependencies
- Run pytest tests