### PR TITLE
Update r-ramclustr 1.2.3 dependencies

### DIFF
--- a/recipes/r-ramclustr/meta.yaml
+++ b/recipes/r-ramclustr/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = '1.2.2' %}
+{% set version = '1.2.3' %}
 
 package:
   name: r-ramclustr
@@ -8,7 +8,7 @@ source:
   url:
     - {{ cran_mirror }}/src/contrib/RAMClustR_{{ version }}.tar.gz
     - {{ cran_mirror }}/src/contrib/Archive/RAMClustR/RAMClustR_{{ version }}.tar.gz
-  sha256: 1cdfc6ce620be2791498852fff2da0ced90024307f2fff0797cbaf60796fe56c
+  sha256: 9dc09c9cc1ac09ed6d6c6abeedffa4a6645a4eb49476a95ad6170d1865b24827
 
 build:
   number: 0
@@ -19,10 +19,11 @@ build:
 
 requirements:
   host:
-    - r-base
+    - r-base >=4.0
     - r-biocmanager
     - r-interpretmsspectrum
     - bioconductor-msnbase
+    - r-readxl
     - r-rcurl
     - r-dynamictreecut
     - r-e1071
@@ -39,10 +40,11 @@ requirements:
     - r-webchem
     - r-xml2
   run:
-    - r-base
+    - r-base >=4.0
     - r-biocmanager
     - r-interpretmsspectrum
     - bioconductor-msnbase
+    - r-readxl
     - r-rcurl
     - r-dynamictreecut
     - r-e1071


### PR DESCRIPTION
Updating dependencies of `r-ramclustr` version `1.2.3`, currently in [PR](https://github.com/bioconda/bioconda-recipes./pull/34015).