### PR TITLE
Update r-ramclustr 1.2.3 dependencies

### DIFF
--- a/recipes/r-ramclustr/meta.yaml
+++ b/recipes/r-ramclustr/meta.yaml
@@ -19,10 +19,11 @@ build:
 
 requirements:
   host:
-    - r-base
+    - r-base >=4.0
     - r-biocmanager
     - r-interpretmsspectrum
     - bioconductor-msnbase
+    - r-readxl 
     - r-rcurl
     - r-dynamictreecut
     - r-e1071
@@ -39,10 +40,11 @@ requirements:
     - r-webchem
     - r-xml2
   run:
-    - r-base
+    - r-base >=4.0
     - r-biocmanager
     - r-interpretmsspectrum
     - bioconductor-msnbase
+    - r-readxl 
     - r-rcurl
     - r-dynamictreecut
     - r-e1071


### PR DESCRIPTION
Update dependencies for `RAMClustR` version `1.2.3`, currently in [PR](https://github.com/bioconda/bioconda-recipes/pull/34015).