### PR TITLE
Simplify BioPhi requirements

### DIFF
--- a/recipes/biophi/meta.yaml
+++ b/recipes/biophi/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   entry_points:
     - biophi = biophi.common.cli.main:main
   script: {{ PYTHON }} -m pip install . --ignore-installed --no-deps -vv
@@ -27,13 +27,10 @@ requirements:
     - anarci ==2020.04.23
     - hmmer >=3.1
     - click >=7
-    - pandas
     - sqlalchemy
-    - flask
-    - redis
+    - flask >=2.1
+    - redis-py
     - celery
-    - biopython
-    - requests
     - tqdm
     - xlsxwriter
     - humanize

--- a/recipes/biophi/meta.yaml
+++ b/recipes/biophi/meta.yaml
@@ -31,6 +31,7 @@ requirements:
     - flask >=2.1
     - redis-py
     - celery
+    - requests
     - tqdm
     - xlsxwriter
     - humanize


### PR DESCRIPTION
- Use redis-py instead of redis to use the conda-forge channel
- Remove dependencies that are already included by other dependencies