### PR TITLE
Add recipe for scAR

### DIFF
--- a/recipes/scar/conda_build_config.yaml
+++ b/recipes/scar/conda_build_config.yaml
@@ -1,3 +1,0 @@
-build_variant:
-    - cpu
-    - cuda

--- a/recipes/scar/conda_build_config.yaml
+++ b/recipes/scar/conda_build_config.yaml
@@ -1,0 +1,3 @@
+build_variant:
+    - cpu
+    - cuda

--- a/recipes/scar/meta.yaml
+++ b/recipes/scar/meta.yaml
@@ -19,7 +19,7 @@ build:
       - pytorch-mutex
   {% endif %}
   run_exports:
-    - {{ pin_compatible('pytorch-mutex', exact=True) }}
+    - {{ pin_compatible('pytorch-mutex') }}
   script: "{{ PYTHON }} -m pip install . -vv"
 
 requirements:

--- a/recipes/scar/meta.yaml
+++ b/recipes/scar/meta.yaml
@@ -12,40 +12,26 @@ source:
 build:
   noarch: python
   number: 0
-  string: {{ build_variant }}
-  script: "{{ PYTHON }} -m pip install . -vv"
+  script: "{{ PYTHON }} -m pip install . -vv --no-frpd"
 
 requirements:
   host:
-    - conda-forge::python>=3.8.6
-    - nvidia::cudatoolkit>=11.1
-    - pytorch::pytorch>=1.10.0
-    - pytorch::torchvision>=0.9.0
-    - pytorch::torchaudio>=0.8.0
-    - conda-forge::tqdm>=4.62.3
-    - conda-forge::pandas>=1.3.4
-    - conda-forge::seaborn>=0.11.2
-    - conda-forge::tensorboard>=2.2.1
-    - conda-forge::scikit-learn>=1.0.1
-    - conda-forge::anndata
-    - conda-forge::scanpy
-    - conda-forge::pyro-ppl>=1.8.0
-    - conda-forge::pip
+    - python>=3.8.6
+    - pip
   run:
-    - conda-forge::python>=3.8.6
-    - nvidia::cudatoolkit>=11.1
-    - pytorch::pytorch>=1.10.0
-    - pytorch::torchvision>=0.9.0
-    - pytorch::torchaudio>=0.8.0
-    - conda-forge::tqdm>=4.62.3
-    - conda-forge::pandas>=1.3.4
-    - conda-forge::seaborn>=0.11.2
-    - conda-forge::tensorboard>=2.2.1
-    - conda-forge::scikit-learn>=1.0.1
-    - conda-forge::anndata
-    - conda-forge::scanpy
-    - conda-forge::pyro-ppl>=1.8.0
-    - conda-forge::pip
+    - python>=3.8.6
+    - cudatoolkit>=11.1
+    - pytorch>=1.10.0
+    - torchvision>=0.9.0
+    - torchaudio>=0.8.0
+    - tqdm>=4.62.3
+    - pandas>=1.3.4
+    - seaborn>=0.11.2
+    - tensorboard>=2.2.1
+    - scikit-learn>=1.0.1
+    - anndata
+    - scanpy
+    - pyro-ppl>=1.8.0
 
 test:
   commands:

--- a/recipes/scar/meta.yaml
+++ b/recipes/scar/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   noarch: python
   number: 0
-  script: "{{ PYTHON }} -m pip install . -vv --no-frpd"
+  script: "{{ PYTHON }} -m pip install . -vv --no-deps"
 
 requirements:
   host:

--- a/recipes/scar/meta.yaml
+++ b/recipes/scar/meta.yaml
@@ -1,12 +1,12 @@
-{% set version = "0.2.1" %}
-{% set sha256 = "e449d5d4ddd74002315a717d5c36ed8e" %}
+{% set version = "0.2.2" %}
+{% set sha256 = "285d5202fc151fffc6c8f0857b8f894e" %}
 
 package:
   name: scar
   version: "{{ version }}"
 
 source:
-  url: https://github.com/Novartis/scAR/archive/refs/tags/v{{ version }}-beta.tar.gz
+  url: https://github.com/Novartis/scAR/archive/refs/tags/v{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:
@@ -23,7 +23,6 @@ requirements:
     - cudatoolkit>=11.1
     - pytorch>=1.10.0
     - torchvision>=0.9.0
-    - torchaudio>=0.8.0
     - tqdm>=4.62.3
     - pandas>=1.3.4
     - seaborn>=0.11.2

--- a/recipes/scar/meta.yaml
+++ b/recipes/scar/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "0.2.2" %}
-{% set sha256 = "285d5202fc151fffc6c8f0857b8f894e" %}
+{% set sha256 = "c3013ea8c73c536253ba08fa37b0eecae095fe3540f3d1002f102d693ff99418" %}
 
 package:
   name: scar

--- a/recipes/scar/meta.yaml
+++ b/recipes/scar/meta.yaml
@@ -13,10 +13,14 @@ build:
   noarch: python
   number: 0
   string: {{ build_variant }}
+  # also lower cpu priority with track_features
+  {% if build_variant == 'cpu' %}
+  track_features:
+      - pytorch-mutex
+  {% endif %}
   run_exports:
     - {{ pin_subpackage('pytorch-mutex', exact=True) }}
   script: "{{ PYTHON }} -m pip install . -vv"
-
 
 requirements:
   host:
@@ -25,7 +29,7 @@ requirements:
     - pytorch::pytorch>=1.10.0
     - pytorch::torchvision>=0.9.0
     - pytorch::torchaudio>=0.8.0
-    - pytorch::pytorch-mutex=1.0={{ build_variant }}
+    - pytorch::pytorch-mutex
     - conda-forge::tqdm>=4.62.3
     - conda-forge::pandas>=1.3.4
     - conda-forge::seaborn>=0.11.2
@@ -41,7 +45,7 @@ requirements:
     - pytorch::pytorch>=1.10.0
     - pytorch::torchvision>=0.9.0
     - pytorch::torchaudio>=0.8.0
-    - pytorch::pytorch-mutex=1.0={{ build_variant }}
+    - pytorch::pytorch-mutex
     - conda-forge::tqdm>=4.62.3
     - conda-forge::pandas>=1.3.4
     - conda-forge::seaborn>=0.11.2

--- a/recipes/scar/meta.yaml
+++ b/recipes/scar/meta.yaml
@@ -19,7 +19,7 @@ build:
       - pytorch-mutex
   {% endif %}
   run_exports:
-    - {{ pin_subpackage('pytorch-mutex', exact=True) }}
+    - {{ pin_compatible('pytorch-mutex', exact=True) }}
   script: "{{ PYTHON }} -m pip install . -vv"
 
 requirements:

--- a/recipes/scar/meta.yaml
+++ b/recipes/scar/meta.yaml
@@ -13,13 +13,6 @@ build:
   noarch: python
   number: 0
   string: {{ build_variant }}
-  # also lower cpu priority with track_features
-  {% if build_variant == 'cpu' %}
-  track_features:
-      - pytorch-mutex
-  {% endif %}
-  run_exports:
-    - {{ pin_compatible('pytorch-mutex') }}
   script: "{{ PYTHON }} -m pip install . -vv"
 
 requirements:
@@ -29,7 +22,6 @@ requirements:
     - pytorch::pytorch>=1.10.0
     - pytorch::torchvision>=0.9.0
     - pytorch::torchaudio>=0.8.0
-    - pytorch::pytorch-mutex
     - conda-forge::tqdm>=4.62.3
     - conda-forge::pandas>=1.3.4
     - conda-forge::seaborn>=0.11.2
@@ -45,7 +37,6 @@ requirements:
     - pytorch::pytorch>=1.10.0
     - pytorch::torchvision>=0.9.0
     - pytorch::torchaudio>=0.8.0
-    - pytorch::pytorch-mutex
     - conda-forge::tqdm>=4.62.3
     - conda-forge::pandas>=1.3.4
     - conda-forge::seaborn>=0.11.2

--- a/recipes/scar/meta.yaml
+++ b/recipes/scar/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.2.1-beta" %}
+{% set version = "0.2.1\-beta" %}
 {% set sha256 = "e449d5d4ddd74002315a717d5c36ed8e" %}
 
 package:

--- a/recipes/scar/meta.yaml
+++ b/recipes/scar/meta.yaml
@@ -1,0 +1,63 @@
+{% set version = "0.2.1-beta" %}
+{% set sha256 = "e449d5d4ddd74002315a717d5c36ed8e" %}
+
+package:
+  name: scar
+  version: "{{ version }}"
+
+source:
+  url: https://github.com/Novartis/scAR/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  noarch: python
+  number: 0
+  string: {{ build_variant }}
+  run_exports:
+    - {{ pin_subpackage('pytorch-mutex', exact=True) }}
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+
+requirements:
+  host:
+    - conda-forge::python>=3.8.6
+    - nvidia::cudatoolkit>=11.1
+    - pytorch::pytorch>=1.10.0
+    - pytorch::torchvision>=0.9.0
+    - pytorch::torchaudio>=0.8.0
+    - pytorch-mutex=*={{ string }}
+    - conda-forge::tqdm>=4.62.3
+    - conda-forge::pandas>=1.3.4
+    - conda-forge::seaborn>=0.11.2
+    - conda-forge::tensorboard>=2.2.1
+    - conda-forge::scikit-learn>=1.0.1
+    - conda-forge::anndata
+    - conda-forge::scanpy
+    - conda-forge::pyro-ppl>=1.8.0
+    - conda-forge::pip
+  run:
+    - conda-forge::python>=3.8.6
+    - nvidia::cudatoolkit>=11.1
+    - pytorch::pytorch>=1.10.0
+    - pytorch::torchvision>=0.9.0
+    - pytorch::torchaudio>=0.8.0
+    - pytorch-mutex=*={{ string }}
+    - conda-forge::tqdm>=4.62.3
+    - conda-forge::pandas>=1.3.4
+    - conda-forge::seaborn>=0.11.2
+    - conda-forge::tensorboard>=2.2.1
+    - conda-forge::scikit-learn>=1.0.1
+    - conda-forge::anndata
+    - conda-forge::scanpy
+    - conda-forge::pyro-ppl>=1.8.0
+    - conda-forge::pip
+
+test:
+  commands:
+    - scAR -h
+
+about:
+  home: https://github.com/Novartis/scAR
+  license: MIT
+  license_file: LICENSE
+  summary: 'scAR (single cell Ambient Remover) is a package for denoising multiple single cell omics data.'

--- a/recipes/scar/meta.yaml
+++ b/recipes/scar/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.2.1\-beta" %}
+{% set version = "0.2.1" %}
 {% set sha256 = "e449d5d4ddd74002315a717d5c36ed8e" %}
 
 package:
@@ -6,7 +6,7 @@ package:
   version: "{{ version }}"
 
 source:
-  url: https://github.com/Novartis/scAR/archive/refs/tags/v{{ version }}.tar.gz
+  url: https://github.com/Novartis/scAR/archive/refs/tags/v{{ version }}-beta.tar.gz
   sha256: {{ sha256 }}
 
 build:

--- a/recipes/scar/meta.yaml
+++ b/recipes/scar/meta.yaml
@@ -39,5 +39,5 @@ test:
 about:
   home: https://github.com/Novartis/scAR
   license: MIT
-  license_file: LICENSE
+  license_file: LICENSE.txt
   summary: 'scAR (single cell Ambient Remover) is a package for denoising multiple single cell omics data.'

--- a/recipes/scar/meta.yaml
+++ b/recipes/scar/meta.yaml
@@ -54,7 +54,7 @@ requirements:
 
 test:
   commands:
-    - scAR -h
+    - scar -h
 
 about:
   home: https://github.com/Novartis/scAR

--- a/recipes/scar/meta.yaml
+++ b/recipes/scar/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - pytorch::pytorch>=1.10.0
     - pytorch::torchvision>=0.9.0
     - pytorch::torchaudio>=0.8.0
-    - pytorch-mutex=*={{ string }}
+    - pytorch-mutex=1.0={{ string }}
     - conda-forge::tqdm>=4.62.3
     - conda-forge::pandas>=1.3.4
     - conda-forge::seaborn>=0.11.2
@@ -41,7 +41,7 @@ requirements:
     - pytorch::pytorch>=1.10.0
     - pytorch::torchvision>=0.9.0
     - pytorch::torchaudio>=0.8.0
-    - pytorch-mutex=*={{ string }}
+    - pytorch-mutex=1.0={{ string }}
     - conda-forge::tqdm>=4.62.3
     - conda-forge::pandas>=1.3.4
     - conda-forge::seaborn>=0.11.2

--- a/recipes/scar/meta.yaml
+++ b/recipes/scar/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - pytorch::pytorch>=1.10.0
     - pytorch::torchvision>=0.9.0
     - pytorch::torchaudio>=0.8.0
-    - pytorch-mutex=1.0={{ string }}
+    - pytorch::pytorch-mutex=1.0={{ build_variant }}
     - conda-forge::tqdm>=4.62.3
     - conda-forge::pandas>=1.3.4
     - conda-forge::seaborn>=0.11.2
@@ -41,7 +41,7 @@ requirements:
     - pytorch::pytorch>=1.10.0
     - pytorch::torchvision>=0.9.0
     - pytorch::torchaudio>=0.8.0
-    - pytorch-mutex=1.0={{ string }}
+    - pytorch::pytorch-mutex=1.0={{ build_variant }}
     - conda-forge::tqdm>=4.62.3
     - conda-forge::pandas>=1.3.4
     - conda-forge::seaborn>=0.11.2


### PR DESCRIPTION
Add recipe for [scAR](https://github.com/Novartis/scAR). It has two build versions. One for cpu and one for gpu, based on the pytorch-mutex metapackage.