### PR TITLE
Rebuild calib

### DIFF
--- a/recipes/calib/meta.yaml
+++ b/recipes/calib/meta.yaml
@@ -20,7 +20,7 @@ source:
     folder: consensus/spoa_v1.1.3/vendor/googletest
 
 build:
-  number: 2
+  number: 3
 
 requirements:
   build:


### PR DESCRIPTION
Current packaged version gives an "invalid instruction" error. Indicating that it must use some architecture specific instructions in the build.

Current plan: 
- Rebuild
- Use `@BiocondaBot please fetch artifacts` to fetch and test artifacts. If the invalid instruction is gone, problem solved.
- If not solved -> debug the issue.