### PR TITLE
Update antismash-lite recipe: specify jinja2 version

### DIFF
--- a/recipes/antismash-lite/meta.yaml
+++ b/recipes/antismash-lite/meta.yaml
@@ -7,7 +7,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 0
+  number: 1
   noarch: python
 
 source:

--- a/recipes/antismash-lite/meta.yaml
+++ b/recipes/antismash-lite/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - numpy
     - biopython 1.78
     - helperlibs >=0.2.0
-    - jinja2
+    - jinja2 ==3.0.3
     - joblib
     - jsonschema
     - pysvg-py3


### PR DESCRIPTION
The recent [Jinja2](https://anaconda.org/conda-forge/jinja2) python module update from version 3.0.3 to 3.1.0 caused the antiSMASH `download-antismash-databases` script to fail. Specifically, it fails on `Markup` which was removed in this Jinja2 version, causing an `ImportError: cannot import name 'Markup' from 'jinja2'` (see also the [Jinja changelog](https://jinja.palletsprojects.com/en/3.1.x/changes/#version-3-1-0)).
I now specified the previously used and working Jinja2 version explicitly in the bioconda recipe.