### PR TITLE
update pggb to v0.3.1 and its dependencies

### DIFF
--- a/recipes/pggb/meta.yaml
+++ b/recipes/pggb/meta.yaml
@@ -7,11 +7,11 @@ package:
 
 source:
   url: https://github.com/pangenome/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 1623554455887a2aae90196131a4a8f4a1449cf04b0c81d28b77d3597cdc4192
+  sha256: 93d6a4f83cf43e752cb3aacb22ab91edb11737d7b5cfc22a5c28152830d6fff6
 
 build:
   noarch: generic
-  number: 1
+  number: 0
 
 requirements:
   run:
@@ -20,13 +20,13 @@ requirements:
     - gfaffix 0.1.3
     - idna <3,>=2.5
     - multiqc >=1.11
-    - odgi 0.7.0
+    - odgi 0.7.1
     - pigz
-    - seqwish 0.7.4
-    - smoothxg 0.6.2
+    - seqwish 0.7.5
+    - smoothxg 0.6.4
     - time
     - vg 1.39.0
-    - wfmash 0.8.1
+    - wfmash 0.8.2
 
 test:
   commands:

--- a/recipes/pggb/meta.yaml
+++ b/recipes/pggb/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pggb" %}
-{% set version = "0.3.0" %}
+{% set version = "0.3.1" %}
 
 package:
   name: "{{ name }}"


### PR DESCRIPTION
This replaces https://github.com/bioconda/bioconda-recipes/pull/34408.