### PR TITLE
Update scar to 0.2.3

### DIFF
--- a/recipes/scar/meta.yaml
+++ b/recipes/scar/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - pip
   run:
     - python>=3.8.6
-    - setuptools<61.0.0   
+    - setuptools<60.0.0   
     - cudatoolkit>=11.1
     - pytorch>=1.10.0
     - torchvision>=0.9.0

--- a/recipes/scar/meta.yaml
+++ b/recipes/scar/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - pip
   run:
     - python>=3.8.6
-    - setuptools<=59.8.0   
+    - setuptools<=59.5.0   
     - cudatoolkit>=11.1
     - pytorch>=1.10.0
     - torchvision>=0.9.0

--- a/recipes/scar/meta.yaml
+++ b/recipes/scar/meta.yaml
@@ -18,9 +18,9 @@ requirements:
   host:
     - python>=3.8.6
     - pip
-    - setuptools<61.0.0
   run:
     - python>=3.8.6
+    - setuptools<61.0.0   
     - cudatoolkit>=11.1
     - pytorch>=1.10.0
     - torchvision>=0.9.0

--- a/recipes/scar/meta.yaml
+++ b/recipes/scar/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - pip
   run:
     - python>=3.8.6
-    - setuptools<60.0.0   
+    - setuptools<=59.8.0   
     - cudatoolkit>=11.1
     - pytorch>=1.10.0
     - torchvision>=0.9.0

--- a/recipes/scar/meta.yaml
+++ b/recipes/scar/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "0.2.2" %}
-{% set sha256 = "c3013ea8c73c536253ba08fa37b0eecae095fe3540f3d1002f102d693ff99418" %}
+{% set version = "0.2.3" %}
+{% set sha256 = "130c61fdd1bcd552b4ddcaf1d551eb71dea7da440014c05f29fdb7c2b0c0c006" %}
 
 package:
   name: scar
@@ -18,6 +18,7 @@ requirements:
   host:
     - python>=3.8.6
     - pip
+    - setuptools<61.0.0
   run:
     - python>=3.8.6
     - cudatoolkit>=11.1


### PR DESCRIPTION
Update scar to 0.2.3. Restrict setuptools version.
It should replace: https://github.com/bioconda/bioconda-recipes/pull/34403