### PR TITLE
Update mokapot dependencies

### DIFF
--- a/recipes/mokapot/meta.yaml
+++ b/recipes/mokapot/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 929e31437434b9231e7685fb41ec3841a19a8f7c7df250fd0b35192749fe54e7
 
 build:
-  number: 1
+  number: 2
   noarch: python
   entry_points:
     - mokapot = mokapot.mokapot:main
@@ -20,6 +20,7 @@ requirements:
   host:
     - pip
     - python >=3.6
+    - setuptools-scm >=6.4.2
   run:
     - matplotlib-base >=3.1.3
     - numba >=0.48.0

--- a/recipes/mokapot/meta.yaml
+++ b/recipes/mokapot/meta.yaml
@@ -20,7 +20,7 @@ requirements:
   host:
     - pip
     - python >=3.6
-    - setuptools-scm >=6.4.2
+    - setuptools_scm >=6.4.2
   run:
     - matplotlib-base >=3.1.3
     - numba >=0.48.0


### PR DESCRIPTION
This PR adds `setuptools_scm` to the host requirements, so that the version is captured correctly.