### PR TITLE
Create r-breakaway v.4.7.9 recipe

### DIFF
--- a/recipes/r-breakaway/build.sh
+++ b/recipes/r-breakaway/build.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# 'Autobrew' is being used by more and more packages these days
+# to grab static libraries from Homebrew bottles. These bottles
+# are fetched via Homebrew's --force-bottle option which grabs
+# a bottle for the build machine which may not be macOS 10.9.
+# Also, we want to use conda packages (and shared libraries) for
+# these 'system' dependencies. See:
+# https://github.com/jeroen/autobrew/issues/3
+export DISABLE_AUTOBREW=1
+
+# R refuses to build packages that mark themselves as Priority: Recommended
+mv DESCRIPTION DESCRIPTION.old
+grep -va '^Priority: ' DESCRIPTION.old > DESCRIPTION
+# shellcheck disable=SC2086
+${R} CMD INSTALL --build . ${R_ARGS}
+
+# Add more build steps here, if they are necessary.
+
+# See
+# https://docs.conda.io/projects/conda-build
+# for a list of environment variables that are set during the build process.

--- a/recipes/r-breakaway/meta.yaml
+++ b/recipes/r-breakaway/meta.yaml
@@ -48,6 +48,7 @@ test:
     - $R -e "library('breakaway')"           # [not win]
     - "\"%R%\" -e \"library('breakaway')\""  # [win]
 
+
 about:
   home: https://adw96.github.io/breakaway/
   license: GPL-2

--- a/recipes/r-breakaway/meta.yaml
+++ b/recipes/r-breakaway/meta.yaml
@@ -1,0 +1,107 @@
+{% set version = '4.7.9' %}
+
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-breakaway
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/breakaway_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/breakaway/breakaway_{{ version }}.tar.gz
+  sha256: 11019e462415619fa56af60c92d574e2d29e57cfcaf554afc209fad929183691
+
+build:
+  merge_build_host: True  # [win]
+  # If this is a new build for the same version, increment the build number.
+  number: 0
+  # no skip
+
+  # This is required to make R link correctly on Linux.
+  rpaths:
+    - lib/R/lib/
+    - lib/
+    
+  noarch: generic
+
+# Suggests: corncob, covr, devtools, dplyr, DT, knitr, openxlsx, plyr, RCurl, reshape2, R.rsp, remotes, rmarkdown, testthat, tidyverse
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+
+  host:
+    - r-base
+    - r-mass
+    - r-ggplot2
+    - r-lme4
+    - r-magrittr
+    - bioconductor-phyloseq
+    - r-tibble
+
+  run:
+    - r-base
+    - r-mass
+    - r-ggplot2
+    - r-lme4
+    - r-magrittr
+    - bioconductor-phyloseq
+    - r-tibble
+
+test:
+  commands:
+    # You can put additional test commands to be run here.
+    - $R -e "library('breakaway')"           # [not win]
+    - "\"%R%\" -e \"library('breakaway')\""  # [win]
+
+  # You can also put a file called run_test.py, run_test.sh, or run_test.bat
+  # in the recipe that will be run at test time.
+
+  # requires:
+    # Put any additional test requirements here.
+
+about:
+  home: https://adw96.github.io/breakaway/
+  license: GPL-2
+  description: Understanding the drivers of microbial diversity is an important frontier of microbial
+    ecology, and investigating the diversity of samples from microbial ecosystems is
+    a common step in any microbiome analysis. 'breakaway' is the premier package for
+    statistical analysis of microbial diversity. 'breakaway' implements the latest and
+    greatest estimates of species richness, as well as the most commonly used estimates.
+    Methods uniquely available in this package include objective Bayes estimators described
+    in Barger and Bunge (2010) <doi:10.1214/10-BA527>, frequency-ratio-based estimators
+    described in Willis and Bunge (2015) <doi:10.1111/biom.12332>, and as described
+    in Willis, Whitman, and Bunge (2016) <doi:10.1111/rssc.12206>, a linear modeling
+    approach for detecting changes in diversity.
+  license_family: GPL2
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2'
+
+# The original CRAN metadata for this package was:
+
+# Package: breakaway
+# Title: Species Richness Estimation and Modeling
+# Version: 4.7.9
+# Date: 2022-02-09
+# Authors@R: c( person('Amy', 'Willis', email = 'adwillis@uw.edu', role = c('aut', 'cre'), comment = c(ORCID = '0000-0002-2802-4317')), person('Bryan D', 'Martin', role = 'aut', comment = c(ORCID = '0000-0002-8002-5296')), person('Pauline', 'Trinh', role = 'aut'), person('Sarah', 'Teichman', role = 'aut'), person('David', 'Clausen', role = 'aut'), person('Kathryn', 'Barger', role =  'aut'), person('John', 'Bunge', role = 'aut') )
+# Description: Understanding the drivers of microbial diversity is an important frontier of microbial ecology, and investigating the diversity of samples from microbial ecosystems is a common step in any microbiome analysis. 'breakaway' is the premier package for statistical analysis of microbial diversity. 'breakaway' implements the latest and greatest estimates of species richness, as well as the most commonly used estimates. Methods uniquely available in this package include objective Bayes estimators described in Barger and Bunge (2010) <doi:10.1214/10-BA527>, frequency-ratio-based estimators described in Willis and Bunge (2015) <doi:10.1111/biom.12332>, and as described in Willis, Whitman, and Bunge (2016) <doi:10.1111/rssc.12206>, a linear modeling approach for detecting changes in diversity.
+# License: GPL-2
+# BugReports: https://github.com/adw96/breakaway/issues
+# LazyData: true
+# RoxygenNote: 7.1.2
+# Depends: R (>= 3.5.0)
+# Imports: ggplot2, graphics, lme4, magrittr, MASS, phyloseq, stats, tibble, utils
+# Suggests: corncob, covr, devtools, dplyr, DT, knitr, openxlsx, plyr, RCurl, reshape2, R.rsp, remotes, rmarkdown, testthat, tidyverse
+# VignetteBuilder: knitr
+# URL: https://adw96.github.io/breakaway/
+# NeedsCompilation: no
+# Packaged: 2022-03-06 23:44:55 UTC; davidclausen
+# Author: Amy Willis [aut, cre] (<https://orcid.org/0000-0002-2802-4317>), Bryan D Martin [aut] (<https://orcid.org/0000-0002-8002-5296>), Pauline Trinh [aut], Sarah Teichman [aut], David Clausen [aut], Kathryn Barger [aut], John Bunge [aut]
+# Maintainer: Amy Willis <adwillis@uw.edu>
+# Repository: CRAN
+# Date/Publication: 2022-03-09 08:00:09 UTC
+
+# See
+# https://docs.conda.io/projects/conda-build for
+# more information about meta.yaml

--- a/recipes/r-breakaway/meta.yaml
+++ b/recipes/r-breakaway/meta.yaml
@@ -1,8 +1,5 @@
 {% set version = '4.7.9' %}
 
-{% set posix = 'm2-' if win else '' %}
-{% set native = 'm2w64-' if win else '' %}
-
 package:
   name: r-breakaway
   version: {{ version|replace("-", "_") }}
@@ -14,7 +11,6 @@ source:
   sha256: 11019e462415619fa56af60c92d574e2d29e57cfcaf554afc209fad929183691
 
 build:
-  merge_build_host: True  # [win]
   number: 0
   noarch: generic
   rpaths:
@@ -22,9 +18,6 @@ build:
     - lib/
 
 requirements:
-  build:
-    - {{ posix }}zip               # [win]
-
   host:
     - r-base
     - r-mass
@@ -33,7 +26,6 @@ requirements:
     - r-magrittr
     - bioconductor-phyloseq
     - r-tibble
-
   run:
     - r-base
     - r-mass
@@ -45,9 +37,7 @@ requirements:
 
 test:
   commands:
-    - $R -e "library('breakaway')"           # [not win]
-    - "\"%R%\" -e \"library('breakaway')\""  # [win]
-
+    - $R -e "library('breakaway')"
 
 about:
   home: https://adw96.github.io/breakaway/
@@ -66,24 +56,6 @@ about:
   license_file:
     - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2'
 
-# Package: breakaway
-# Title: Species Richness Estimation and Modeling
-# Version: 4.7.9
-# Date: 2022-02-09
-# Authors@R: c( person('Amy', 'Willis', email = 'adwillis@uw.edu', role = c('aut', 'cre'), comment = c(ORCID = '0000-0002-2802-4317')), person('Bryan D', 'Martin', role = 'aut', comment = c(ORCID = '0000-0002-8002-5296')), person('Pauline', 'Trinh', role = 'aut'), person('Sarah', 'Teichman', role = 'aut'), person('David', 'Clausen', role = 'aut'), person('Kathryn', 'Barger', role =  'aut'), person('John', 'Bunge', role = 'aut') )
-# Description: Understanding the drivers of microbial diversity is an important frontier of microbial ecology, and investigating the diversity of samples from microbial ecosystems is a common step in any microbiome analysis. 'breakaway' is the premier package for statistical analysis of microbial diversity. 'breakaway' implements the latest and greatest estimates of species richness, as well as the most commonly used estimates. Methods uniquely available in this package include objective Bayes estimators described in Barger and Bunge (2010) <doi:10.1214/10-BA527>, frequency-ratio-based estimators described in Willis and Bunge (2015) <doi:10.1111/biom.12332>, and as described in Willis, Whitman, and Bunge (2016) <doi:10.1111/rssc.12206>, a linear modeling approach for detecting changes in diversity.
-# License: GPL-2
-# BugReports: https://github.com/adw96/breakaway/issues
-# LazyData: true
-# RoxygenNote: 7.1.2
-# Depends: R (>= 3.5.0)
-# Imports: ggplot2, graphics, lme4, magrittr, MASS, phyloseq, stats, tibble, utils
-# Suggests: corncob, covr, devtools, dplyr, DT, knitr, openxlsx, plyr, RCurl, reshape2, R.rsp, remotes, rmarkdown, testthat, tidyverse
-# VignetteBuilder: knitr
-# URL: https://adw96.github.io/breakaway/
-# NeedsCompilation: no
-# Packaged: 2022-03-06 23:44:55 UTC; davidclausen
-# Author: Amy Willis [aut, cre] (<https://orcid.org/0000-0002-2802-4317>), Bryan D Martin [aut] (<https://orcid.org/0000-0002-8002-5296>), Pauline Trinh [aut], Sarah Teichman [aut], David Clausen [aut], Kathryn Barger [aut], John Bunge [aut]
-# Maintainer: Amy Willis <adwillis@uw.edu>
-# Repository: CRAN
-# Date/Publication: 2022-03-09 08:00:09 UTC
+extra:
+  skip-lints:
+    - in_other_channels

--- a/recipes/r-breakaway/meta.yaml
+++ b/recipes/r-breakaway/meta.yaml
@@ -15,18 +15,12 @@ source:
 
 build:
   merge_build_host: True  # [win]
-  # If this is a new build for the same version, increment the build number.
   number: 0
-  # no skip
-
-  # This is required to make R link correctly on Linux.
+  noarch: generic
   rpaths:
     - lib/R/lib/
     - lib/
-    
-  noarch: generic
 
-# Suggests: corncob, covr, devtools, dplyr, DT, knitr, openxlsx, plyr, RCurl, reshape2, R.rsp, remotes, rmarkdown, testthat, tidyverse
 requirements:
   build:
     - {{ posix }}zip               # [win]
@@ -51,15 +45,8 @@ requirements:
 
 test:
   commands:
-    # You can put additional test commands to be run here.
     - $R -e "library('breakaway')"           # [not win]
     - "\"%R%\" -e \"library('breakaway')\""  # [win]
-
-  # You can also put a file called run_test.py, run_test.sh, or run_test.bat
-  # in the recipe that will be run at test time.
-
-  # requires:
-    # Put any additional test requirements here.
 
 about:
   home: https://adw96.github.io/breakaway/
@@ -77,8 +64,6 @@ about:
   license_family: GPL2
   license_file:
     - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2'
-
-# The original CRAN metadata for this package was:
 
 # Package: breakaway
 # Title: Species Richness Estimation and Modeling
@@ -101,7 +86,3 @@ about:
 # Maintainer: Amy Willis <adwillis@uw.edu>
 # Repository: CRAN
 # Date/Publication: 2022-03-09 08:00:09 UTC
-
-# See
-# https://docs.conda.io/projects/conda-build for
-# more information about meta.yaml

--- a/recipes/r-breakaway/meta.yaml
+++ b/recipes/r-breakaway/meta.yaml
@@ -51,7 +51,7 @@ test:
 about:
   home: https://adw96.github.io/breakaway/
   license: GPL-2
-  description: Understanding the drivers of microbial diversity is an important frontier of microbial
+  summary: Understanding the drivers of microbial diversity is an important frontier of microbial
     ecology, and investigating the diversity of samples from microbial ecosystems is
     a common step in any microbiome analysis. 'breakaway' is the premier package for
     statistical analysis of microbial diversity. 'breakaway' implements the latest and


### PR DESCRIPTION
This is a PR to create a recipe for r-breakaway (v.4.7.9). There was a previous version (v.3.0) of this package on bioconda that was ported over to conda. Unfortunately, because `breakaway` has a bioconductor dependency (`bioconductor-phyloseq`) it is not possible to update the recipe on conda. 

See: https://github.com/conda-forge/r-breakaway-feedstock/pull/4#issuecomment-1112406403

please review & merge @bioconda/team
