### PR TITLE
Update ppx dependencies for 1.3.0

### DIFF
--- a/recipes/ppx/meta.yaml
+++ b/recipes/ppx/meta.yaml
@@ -19,11 +19,13 @@ build:
 requirements:
   host:
     - pip
-    - python >=3.6
+    - python >=3.7
+    - setuptools_scm >=6.4.2
   run:
-    - python >=3.6
-    - requests >=2.25.1
+    - python >=3.7
+    - requests >=2.23.0
     - tqdm >=4.60.0
+    - cloudpathlib >=0.7.1
 
 test:
   imports:


### PR DESCRIPTION
This PR updates the dependencies for ppx v1.3.0. Please note that this is a PR against the `bump/ppx` branch generated @BiocondaBot in #34618, not master.

@dpryan79 - can you add me to the Bioconda org? It would be easier to modify the autobump PR directly in the future for this and other other packages I maintain. 