### PR TITLE
Update virchip

### DIFF
--- a/recipes/virchip/build.sh
+++ b/recipes/virchip/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$PYTHON -m pip install -vv --disable-pip-version-check --no-deps --no-cache-dir --ignore-installed . 

--- a/recipes/virchip/build.sh
+++ b/recipes/virchip/build.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-$PYTHON -m pip install -vv --disable-pip-version-check --no-deps --no-cache-dir --ignore-installed . 

--- a/recipes/virchip/meta.yaml
+++ b/recipes/virchip/meta.yaml
@@ -1,36 +1,35 @@
 {% set version = "1.2.2" %}
 
 package:
-    name: virchip
-    version: {{ version }}
+  name: virchip
+  version: {{ version }}
 
 source:
     url: https://bitbucket.org/hoffmanlab/virchip/get/v{{ version }}.tar.gz
-    md5sum: 38c90df8f2e504bb0824f939bc4558d5
     sha256: f7afc7c8edc0e4a880af7cdf04b75d566e06245a8f68f0610449e28ff40bcd85
 
 build:
-    noarch: python
-    number: 0
-
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . --ignore-installed --no-deps -vv
 
 requirements:
-    build:
-        - python
-        - setuptools
-    run:
-        - python 2.7.*
-        - pandas 0.23.*
-        - numpy >=1.4.15
-        - scikit-learn >=0.18.1
-        - scipy 1.1.0
-        - r-base *
+  host:
+    - python <3
+    - pip
+  run:
+    - python <3
+    - pandas 0.23.*
+    - numpy >=1.4.15
+    - scikit-learn >=0.18.1
+    - scipy 1.1.0
+    - r-base
 
 test:
-    imports:
+  imports:
     - virchip
 
 about:
-    home: https://virchip.hoffmanlab.org
-    license: General Public License version 3
-    summary: "Virtual ChIP-seq predicts transcription factor binding in any cell type with chromatin accessibility and transcriptome data. Manuscript DOI: https://doi.org/10.1101/168419"
+  home: https://virchip.hoffmanlab.org
+  license: General Public License version 3
+  summary: "Virtual ChIP-seq predicts transcription factor binding in any cell type with chromatin accessibility and transcriptome data. Manuscript DOI: https://doi.org/10.1101/168419"

--- a/recipes/virchip/meta.yaml
+++ b/recipes/virchip/meta.yaml
@@ -10,6 +10,7 @@ source:
     sha256: ed79afc85d81df2cc487bc23bcfd335b86845ef5e7d71ac306ac24e5460c1bb4
 
 build:
+    noarch: python
     number: 0
 
 
@@ -25,9 +26,9 @@ requirements:
         - scipy 1.1.0
         - r-base *
 
-    test:
-        commands:
-            - bash test_run.sh $PWD
+test:
+    commands:
+        - bash test_run.sh $PWD
 
 about:
     home: https://virchip.hoffmanlab.org

--- a/recipes/virchip/meta.yaml
+++ b/recipes/virchip/meta.yaml
@@ -1,13 +1,13 @@
-{% set version = "1.2.0" %}
+{% set version = "1.2.2" %}
 
 package:
     name: virchip
     version: {{ version }}
 
 source:
-    url: https://bitbucket.org/hoffmanlab/virchip/get/V{{ version }}.tar.gz
-    md5sum: 9804872c89ac40bbdf7b2b15c4e61ba5
-    sha256: ed79afc85d81df2cc487bc23bcfd335b86845ef5e7d71ac306ac24e5460c1bb4
+    url: https://bitbucket.org/hoffmanlab/virchip/get/v{{ version }}.tar.gz
+    md5sum: 38c90df8f2e504bb0824f939bc4558d5
+    sha256: f7afc7c8edc0e4a880af7cdf04b75d566e06245a8f68f0610449e28ff40bcd85
 
 build:
     noarch: python
@@ -27,8 +27,8 @@ requirements:
         - r-base *
 
 test:
-    commands:
-        - bash test_run.sh $PWD
+    imports:
+    - virchip
 
 about:
     home: https://virchip.hoffmanlab.org

--- a/recipes/virchip/meta.yaml
+++ b/recipes/virchip/meta.yaml
@@ -5,8 +5,8 @@ package:
   version: {{ version }}
 
 source:
-    url: https://bitbucket.org/hoffmanlab/virchip/get/v{{ version }}.tar.gz
-    sha256: f7afc7c8edc0e4a880af7cdf04b75d566e06245a8f68f0610449e28ff40bcd85
+  url: https://bitbucket.org/hoffmanlab/virchip/get/v{{ version }}.tar.gz
+  sha256: f7afc7c8edc0e4a880af7cdf04b75d566e06245a8f68f0610449e28ff40bcd85
 
 build:
   noarch: python

--- a/recipes/virchip/meta.yaml
+++ b/recipes/virchip/meta.yaml
@@ -29,7 +29,7 @@ requirements:
         commands:
             - bash test_run.sh $PWD
 
-    about:
-        home: https://virchip.hoffmanlab.org
-        license: General Public License version 3
-        summary: "Virtual ChIP-seq predicts transcription factor binding in any cell type with chromatin accessibility and transcriptome data. Manuscript DOI: https://doi.org/10.1101/168419"
+about:
+    home: https://virchip.hoffmanlab.org
+    license: General Public License version 3
+    summary: "Virtual ChIP-seq predicts transcription factor binding in any cell type with chromatin accessibility and transcriptome data. Manuscript DOI: https://doi.org/10.1101/168419"

--- a/recipes/virchip/meta.yaml
+++ b/recipes/virchip/meta.yaml
@@ -1,0 +1,35 @@
+{% set version = "1.2.0" %}
+
+package:
+    name: virchip
+    version: {{ version }}
+
+source:
+    url: https://bitbucket.org/hoffmanlab/virchip/get/V{{ version }}.tar.gz
+    md5sum: 9804872c89ac40bbdf7b2b15c4e61ba5
+    sha256: ed79afc85d81df2cc487bc23bcfd335b86845ef5e7d71ac306ac24e5460c1bb4
+
+build:
+    number: 0
+
+
+requirements:
+    build:
+        - python
+        - setuptools
+    run:
+        - python 2.7.*
+        - pandas 0.23.*
+        - numpy >=1.4.15
+        - scikit-learn >=0.18.1
+        - scipy 1.1.0
+        - r-base *
+
+    test:
+        commands:
+            - bash test_run.sh $PWD
+
+    about:
+        home: https://virchip.hoffmanlab.org
+        license: General Public License version 3
+        summary: "Virtual ChIP-seq predicts transcription factor binding in any cell type with chromatin accessibility and transcriptome data. Manuscript DOI: https://doi.org/10.1101/168419"

--- a/recipes/virchip/meta.yaml
+++ b/recipes/virchip/meta.yaml
@@ -5,8 +5,8 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/hoffmangroup/virchip/blob/master/get/virchip_v{{ version }}.tar.gz
-  sha256: 0ddda1064ce7254fa9f6d5f68e24c434191b641ce295142b3f66364ab487f701
+  url: https://github.com/hoffmangroup/virchip/releases/download/v1.2.2/virchip_v{{ version }}.tar.gz
+  sha256: f0a81244b6edc45ac0917b97acbeca27b2bea1ae6fa6e78e8ba9049c09c490aa
 
 build:
   noarch: python

--- a/recipes/virchip/meta.yaml
+++ b/recipes/virchip/meta.yaml
@@ -5,12 +5,12 @@ package:
   version: {{ version }}
 
 source:
-  url: https://bitbucket.org/hoffmanlab/virchip/get/v{{ version }}.tar.gz
-  sha256: f7afc7c8edc0e4a880af7cdf04b75d566e06245a8f68f0610449e28ff40bcd85
+  url: https://github.com/hoffmangroup/virchip/blob/master/get/virchip_v{{ version }}.tar.gz
+  sha256: 0ddda1064ce7254fa9f6d5f68e24c434191b641ce295142b3f66364ab487f701
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --ignore-installed --no-deps -vv
 
 requirements:


### PR DESCRIPTION
URL changed from deprecated bitbucket repo to GitHub releases and updated the sha256sum
Increased build number from 0 to 1

