### PR TITLE
Pin perl version in VADR recipe

### DIFF
--- a/recipes/vadr/meta.yaml
+++ b/recipes/vadr/meta.yaml
@@ -21,7 +21,7 @@ requirements:
   build:
     - wget
   host:
-    - perl
+    - perl <5.32
     - sequip >=0.08
   run:
     - blast >=2.11.0
@@ -29,7 +29,7 @@ requirements:
     - fasta3 >=36.3.8
     - hmmer >=3.3.2
     - infernal >=1.1.4
-    - perl
+    - perl <5.32
     - perl-bio-easel >=0.15
     - perl-lwp-simple
     - perl-lwp-protocol-https >=6.07

--- a/recipes/vadr/meta.yaml
+++ b/recipes/vadr/meta.yaml
@@ -15,13 +15,13 @@ source:
 
 build:
   noarch: generic
-  number: 1
+  number: 2
 
 requirements:
   build:
     - wget
   host:
-    - perl <5.32
+    - perl =5.26
     - sequip >=0.08
   run:
     - blast >=2.11.0
@@ -29,7 +29,7 @@ requirements:
     - fasta3 >=36.3.8
     - hmmer >=3.3.2
     - infernal >=1.1.4
-    - perl <5.32
+    - perl =5.26
     - perl-bio-easel >=0.15
     - perl-lwp-simple
     - perl-lwp-protocol-https >=6.07


### PR DESCRIPTION
The VADR recipe does not work with Perl 5.32, but works fine with 5.26. This PR pins the Perl version to less 5.26


Here is a related issue: https://github.com/ncbi/vadr/issues/59

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
