### PR TITLE
Update pangolin recipe's usher version

### DIFF
--- a/recipes/pangolin/meta.yaml
+++ b/recipes/pangolin/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 7fd6fd715b74550f56abf46b42940931082d3fdcbdd92bd4924890cda6f14028
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: python -m pip install --no-deps --ignore-installed .
 

--- a/recipes/pangolin/meta.yaml
+++ b/recipes/pangolin/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - minimap2 >=2.16
     - snakemake-minimal >=5.13,<=6.8.0
     - gofasta
-    - usher >=0.5.2
+    - usher >=0.5.4
     - ucsc-fatovcf >=426
     - git-lfs
     - scorpio >=0.3.12


### PR DESCRIPTION
Require usher >=0.5.4 to get a recent bugfix.
