### PR TITLE
Add 10x bamtofastq tool

### DIFF
--- a/recipes/10x_bamtofastq/build.sh
+++ b/recipes/10x_bamtofastq/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -e
+
+# TODO: Remove the following export when pinning is updated and we use
+#       {{ compiler('rust') }} in the recipe.
+export \
+    CARGO_NET_GIT_FETCH_WITH_CLI=true \
+    CARGO_HOME="${BUILD_PREFIX}/.cargo"
+
+export BINDGEN_EXTRA_CLANG_ARGS="${CFLAGS} ${CPPFLAGS} ${LDFLAGS}"
+
+cargo install --no-track --verbose --root "${PREFIX}" --path .

--- a/recipes/10x_bamtofastq/meta.yaml
+++ b/recipes/10x_bamtofastq/meta.yaml
@@ -1,0 +1,35 @@
+{% set version = "1.4.1" %}
+
+package:
+  name: 10x_bamtofastq
+  version: {{ version }}
+
+build:
+  number: 0
+
+source:
+  url: https://github.com/10XGenomics/bamtofastq/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: cebf968b0eff8911df65102e2be5884e6cd7312f1cb0aba6718bfc2d9407d543
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - rust >=1.60.0
+    - pkg-config
+    - make
+    - cmake
+  host:
+  run:
+
+test:
+  commands:
+    - bamtofastq --help
+
+about:
+  home: https://github.com/10XGenomics/bamtofastq
+  license: MIT
+  summary: |
+    Tool for converting 10x BAMs produced by Cell Ranger, Space Ranger, Cell Ranger ATAC, Cell Ranger DNA, 
+    and Long Ranger back to FASTQ files that can be used as inputs to re-run analysis
+

--- a/recipes/10x_bamtofastq/meta.yaml
+++ b/recipes/10x_bamtofastq/meta.yaml
@@ -29,6 +29,7 @@ test:
 about:
   home: https://github.com/10XGenomics/bamtofastq
   license: MIT
+  license_file: LICENSE
   summary: |
     Tool for converting 10x BAMs produced by Cell Ranger, Space Ranger, Cell Ranger ATAC, Cell Ranger DNA, 
     and Long Ranger back to FASTQ files that can be used as inputs to re-run analysis


### PR DESCRIPTION
A tool to convert Cell Ranger generated BAM files to FASTQ: https://github.com/10XGenomics/bamtofastq
A bedtools based bamtofastq does cannot produce R1 from these special BAM files. Hence we need this tool. Unlike cellranger it comes with MIT license.