### PR TITLE
Patch IRMA v1.0.2 to not abort when it detects output dir not writable

### DIFF
--- a/recipes/irma/irma-check-dir-writable.patch
+++ b/recipes/irma/irma-check-dir-writable.patch
@@ -1,0 +1,11 @@
+--- IRMA	2022-05-09 15:15:26.345377197 -0500
++++ IRMA	2022-05-09 15:19:18.818708355 -0500
+@@ -111,7 +111,7 @@
+ 
+ # make sure output directory is valid
+ if [ ! -w "$destination_directory" ];then 
+-	abort "output directory not writable: $destination_directory"
++  timestamp "WARNING: output directory may not be writable: $destination_directory"
+ fi
+ 
+ # test input files

--- a/recipes/irma/meta.yaml
+++ b/recipes/irma/meta.yaml
@@ -13,9 +13,10 @@ source:
   patches:
     - irma-fix-bin-cmds.patch
     - label-fix-bin-cmds.patch
+    - irma-check-dir-writable.patch
 
 build:
-  number: 1
+  number: 2
   noarch: generic
 
 requirements:


### PR DESCRIPTION
IRMA v1.0.2 performs a Bash check to see if the output directory is writable (`[ ! -w "$output_destination" ]`), however, this check fails in some circumstances (e.g. IRMA executed as part of Nextflow pipeline on a Slurm cluster). This PR adds a patch to warn the user that the output directory may not be writable rather than IRMA aborting analysis due to the failed check. 

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
