### PR TITLE
Add pfp recipe

### DIFF
--- a/recipes/pfp/build.sh
+++ b/recipes/pfp/build.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 
-
 cmake -DCMAKE_INSTALL_PREFIX=${PREFIX} \
 	${SRC_DIR} 
 
-
-make -j${CPU_COUNT} ${VERBOSE_CM}
+make -j${CPU_COUNT} ${VERBOSE_CM} 
 make install -j${CPU_COUNT}

--- a/recipes/pfp/build.sh
+++ b/recipes/pfp/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+
+cmake -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+	${SRC_DIR} 
+
+
+make -j${CPU_COUNT} ${VERBOSE_CM}
+make install -j${CPU_COUNT}

--- a/recipes/pfp/meta.yaml
+++ b/recipes/pfp/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.3.3" %}
+{% set version = "0.3.4" %}
 
 package:
   name: pfp
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/marco-oliva/pfp/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 59b96eb75a6aee254eb19c953220ef16b2edf1cd2244e8bca6ae78e35ac6b671
+  sha256: e9fe9c0fde35450443db1a5163f360723db0c4f7fc2f553c291adb6def83b5a3
 
 build:
   number: 0

--- a/recipes/pfp/meta.yaml
+++ b/recipes/pfp/meta.yaml
@@ -1,0 +1,36 @@
+{% set version = "0.3.3" %}
+
+package:
+  name: pfp
+  version: {{ version }}
+
+source:
+  url: https://github.com/marco-oliva/pfp/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 59b96eb75a6aee254eb19c953220ef16b2edf1cd2244e8bca6ae78e35ac6b671
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - cmake
+    - make
+    - {{ compiler('cxx') }}
+  host:
+    - zlib
+    - htslib
+  run:
+    - zlib
+    - htslib
+
+test:
+  commands: 
+    - pfp++ --help
+
+about:
+  home: https://github.com/marco-oliva/pfp
+  license: MIT
+  summary: Prefix Free Parsing.
+
+recipe-maintainers:
+  - marco-oliva

--- a/recipes/pfp/meta.yaml
+++ b/recipes/pfp/meta.yaml
@@ -19,9 +19,11 @@ requirements:
   host:
     - zlib
     - htslib
+    - llvm-openmp # [osx]
   run:
     - zlib
     - htslib
+    - llvm-openmp # [osx]
 
 test:
   commands: 

--- a/recipes/pfp/meta.yaml
+++ b/recipes/pfp/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.3.4" %}
+{% set version = "0.3.5" %}
 
 package:
   name: pfp
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/marco-oliva/pfp/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: e9fe9c0fde35450443db1a5163f360723db0c4f7fc2f553c291adb6def83b5a3
+  sha256: 5c8d67cfca27504a00bbc1e39532c61bb34465028cc4c99586c210e652c8b5f4
 
 build:
   number: 0


### PR DESCRIPTION
This PR adds a new bioinformatic recipe to bioconda. 

Adding PFP from [https://github.com/marco-oliva/pfp](https://github.com/marco-oliva/pfp). PFP is used to build compressed data structures over pan-genomics datasets.  