### PR TITLE
Update antismash-lite to 6.1.0

### DIFF
--- a/recipes/antismash-lite/build.sh
+++ b/recipes/antismash-lite/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 echo "include antismash/detection/genefinding/data/train_crypto" >> MANIFEST.in
-
+df -h 
 $PYTHON -m pip install . --ignore-installed --no-deps -vv

--- a/recipes/antismash-lite/meta.yaml
+++ b/recipes/antismash-lite/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "antiSMASH-lite" %}
-{% set version = "6.0.1" %}
-{% set sha256 = "be867726e41cd194ba0dfd01654a6674041f97a3517c5aff16a1918fab2bcf44" %}
+{% set version = "6.1.0" %}
+{% set sha256 = "90a4f0502e8948d333118e92141bd350bb32b91c7ef1bd534e6ab4cbf21fc67f" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 build:
-  number: 1
+  number: 0
   noarch: python
 
 source:
@@ -23,9 +23,10 @@ requirements:
     - numpy
     - biopython 1.78
     - helperlibs >=0.2.0
-    - jinja2 ==3.0.3
+    - jinja2
     - joblib
     - jsonschema
+    - markupsafe >=2.0
     - pysvg-py3
     - bcbio-gff
     - pyscss


### PR DESCRIPTION
Adopting the changes of antismash 6.1.0 (#34096) to the antismash-lite recipe.
