### PR TITLE
Update augustus: Bump to rebuild against newer gsl

### DIFF
--- a/recipes/augustus/meta.yaml
+++ b/recipes/augustus/meta.yaml
@@ -22,7 +22,7 @@ source:
     - patches/src.makefile.patch
 
 build:
-  number: 5
+  number: 6
 
 requirements:
   build:


### PR DESCRIPTION
Augustus is currently linked against libgsl.so.25.0 so won't happily co-exist with more recent packages which are linked against libgsl.so.27
----

