### PR TITLE
Update SnpEff java path

### DIFF
--- a/recipes/snpeff/meta.yaml
+++ b/recipes/snpeff/meta.yaml
@@ -14,7 +14,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 2
+  number: 3
   noarch: generic
 
 source:

--- a/recipes/snpeff/snpeff.py
+++ b/recipes/snpeff/snpeff.py
@@ -29,13 +29,18 @@ def real_dirname(path):
 
 def java_executable():
     """Return the executable name of the Java interpreter."""
-    java_home = getenv('JAVA_HOME')
-    java_bin = os.path.join('bin', 'java')
+    # JAVA_HOME is not set in the Conda environment, it points to the system's java install
+    # Since the Conda environment includes open-jdk with the correct version, we can just
+    # use this java executable
 
-    if java_home and access(os.path.join(java_home, java_bin), X_OK):
-        return os.path.join(java_home, java_bin)
-    else:
-        return 'java'
+    # java_home = getenv('JAVA_HOME')
+    # java_bin = os.path.join('bin', 'java')
+
+    # if java_home and access(os.path.join(java_home, java_bin), X_OK):
+    #     return os.path.join(java_home, java_bin)
+    # else:
+    #     return 'java'
+    return 'java'
 
 
 def jvm_opts(argv):


### PR DESCRIPTION
The recipe for SnpEff contains a script used to run it as executable. This script was retrieving the value of JAVA_HOME to build the path to the java executable, but this environment variable was not set, so the system's java executable was used instead of the environment one. Since openjdk is included in the environment with the correct version, I changed the script to point directly to 'java'. If there was a better way to fix that, please tell me!