### PR TITLE
Add python-crypt4gh recipe

### DIFF
--- a/recipes/python-crypt4gh/build.sh
+++ b/recipes/python-crypt4gh/build.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+pip install . --no-deps --ignore-installed --no-cache-dir

--- a/recipes/python-crypt4gh/meta.yaml
+++ b/recipes/python-crypt4gh/meta.yaml
@@ -1,0 +1,51 @@
+{% set name = "crypt4gh" %}
+{% set version = "1.5" %}
+{% set sha256_any = "4d68da51952f8ed46b2e5e4df912b6aa7d977da59c1d0c8febcc891e3602a344" %}
+
+package:
+  name: python-{{ name }}
+  version: {{ version }}
+
+source:
+  url:  https://github.com/EGA-archive/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: {{ sha256_any }}
+
+build:
+  number: 0
+  noarch: python
+
+requirements:
+  host:
+    - python >=3
+    - pip
+  run:
+    - python >=3
+    - pyyaml
+    - docopt
+    - cryptography
+    - pynacl
+    - bcrypt
+
+test:
+  imports:
+    - crypt4gh
+    - crypt4gh.lib
+    - crypt4gh.keys.kdf
+    - crypt4gh.keys.c4gh
+  
+  commands:
+    - crypt4gh -h > testfile-help.txt
+    - crypt4gh-keygen --sk alice.key --pk alice.pub -C 'bioconda Alice test' --nocrypt
+    - crypt4gh-keygen --sk bob.key --pk bob.pub -C 'bioconda Bob test' --nocrypt
+    - crypt4gh encrypt --sk bob.key --recipient_pk bob.pub --recipient_pk alice.pub < testfile-help.txt > message.c4gh
+    - crypt4gh decrypt --sk alice.key < message.c4gh > message.alice.received
+    - diff testfile-help.txt message.alice.received
+    - crypt4gh decrypt --sk bob.key < message.c4gh > message.bob.received
+    - diff testfile-help.txt message.bob.received
+
+about:
+  home: https://github.com/EGA-archive/crypt4gh
+  license: Apache Software License
+  license_family: APACHE
+  license_file: LICENSE
+  summary: GA4GH cryptographic tools

--- a/recipes/python-crypt4gh/meta.yaml
+++ b/recipes/python-crypt4gh/meta.yaml
@@ -45,7 +45,7 @@ test:
 
 about:
   home: https://github.com/EGA-archive/crypt4gh
-  license: Apache Software License
+  license: Apache-2.0
   license_family: APACHE
   license_file: LICENSE
   summary: GA4GH cryptographic tools


### PR DESCRIPTION
This pull requests adds a new recipe for python crypt4gh 1.5 package (https://github.com/EGA-archive/crypt4gh).

The package is one of the reference implementations of [GA4GH encryption standard](https://www.ga4gh.org/news/crypt4gh-a-secure-method-for-sharing-human-genetic-data/), which is adopted by EGA.

The package is currently being maintained by both @silverdaz and @blankdots , I'm a mere user of it.