### PR TITLE
Update and use versioned download urls for SnpEff and SnpSift

### DIFF
--- a/recipes/snpeff/meta.yaml
+++ b/recipes/snpeff/meta.yaml
@@ -1,7 +1,7 @@
-{% set snpeff_ver = "latest" %}
+{% set snpeff_ver = "v5_1d" %}
 # NOTE: if the version contains a trailing letter, use the <d>.<d>.1<l> format
 # Please update recipes/snpsift as well!
-{% set version = "5.1" %}
+{% set version = "5.1d" %}
 {% set sha256 = "919e0595c08e86d1dd82279723c83cb872070244ee4ce0cb3167bde2b272893b" %}
 
 about:
@@ -14,7 +14,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 2
+  number: 0
   noarch: generic
 
 source:

--- a/recipes/snpsift/meta.yaml
+++ b/recipes/snpsift/meta.yaml
@@ -1,7 +1,7 @@
-{% set snpeff_ver = "latest" %}
+{% set snpeff_ver = "v5_1d" %}
 # NOTE: if the version contains a trailing letter, use the <d>.<d>.1<l> format
 # Please update recipes/snpeff as well
-{% set version = "5.1" %}
+{% set version = "5.1d" %}
 {% set sha256 = "919e0595c08e86d1dd82279723c83cb872070244ee4ce0cb3167bde2b272893b" %}
 
 about:


### PR DESCRIPTION
While updating the recipes to v5.0, the urls have been changed to
point to the *latest* version, which can lead to unintended version changes
with new builds.
