### PR TITLE
Upgrade & reactivate NGLess

### DIFF
--- a/build-fail-blacklist
+++ b/build-fail-blacklist
@@ -197,7 +197,6 @@ recipes/r-phytools
 recipes/translig
 recipes/lsc
 recipes/rambo-k
-recipes/ngless
 recipes/mobster
 recipes/visceral-evaluatesegmentation
 recipes/hyphy/2.3.11

--- a/recipes/ngless/build.sh
+++ b/recipes/ngless/build.sh
@@ -3,161 +3,22 @@
 set -e -o pipefail -x
 
 if [ "$(uname)" == "Darwin" ]; then
-    # On Mac OS X, we use prebuilt binaries. It's not the best solution, but
-    # the solution below does not work on Mac OS X
-    mkdir -p ${PREFIX}/bin
-    chmod +x bin/ngless
-    cp -pir bin/ngless ${PREFIX}/bin
-
-    mkdir -p ${PREFIX}/share
-    chmod +x share/ngless/bin/* share/ngless/bin/*/*
-    cp -pir share/ngless ${PREFIX}/share
-    exit 0
+    BINARY=ngless
+else
+    BINARY=NGLess-v1.4.0-Linux-static-no-deps
 fi
 
+mkdir -p ${PREFIX}/bin/
+chmod +x ${BINARY}
+cp -pir ${BINARY} ${PREFIX}/bin/ngless-wrapped
+cat >> ${PREFIX}/bin/ngless <<EOF
+#!/usr/bin/env bash
 
-# This tour de force script is mostly copy&pasted from
-# https://github.com/conda-forge/git-annex-feedstock
+export NGLESS_SAMTOOLS_BIN=\${CONDA_PREFIX}/bin/samtools
+export NGLESS_BWA_BIN=\${CONDA_PREFIX}/bin/bwa
+export NGLESS_PRODIGAL_BIN=\${CONDA_PREFIX}/bin/prodigal
+export NGLESS_MEGAHIT_BIN=\${CONDA_PREFIX}/bin/megahit
+export NGLESS_MINIMAP2_BIN=\${CONDA_PREFIX}/bin/minimap2
 
-
-
-#######################################################################################################
-# Set up build environment
-#######################################################################################################
-
-mkdir -p $PREFIX/bin $BUILD_PREFIX/bin $PREFIX/lib $BUILD_PREFIX/lib $PREFIX/share $BUILD_PREFIX/share
-export LIBRARY_PATH="${PREFIX}/lib:${LIBRARY_PATH}"
-export LD_LIBRARY_PATH="${PREFIX}/lib:${LD_LIBRARY_PATH}"
-export LDFLAGS=" -L${PREFIX}/lib ${LDFLAGS} "
-export CPPFLAGS="-I${PREFIX}/include ${CPPFLAGS} "
-export CFLAGS="-I${PREFIX}/include ${CFLAGS} "
-
-export GMP_INCLUDE_DIRS=$PREFIX/include
-export GMP_LIB_DIRS=$PREFIX/lib
-
-#
-# Install shim scripts to ensure that certain flags are always passed to the compiler/linker
-#
-
-echo "#!/bin/bash" > $CC-shim
-echo "set -e -o pipefail -x " >> $CC-shim
-echo "$CC -I$PREFIX/include -L$PREFIX/lib -pthread -fPIC \"\$@\"" >> $CC-shim
-chmod u+x $CC-shim
-export CC=$CC-shim
-
-echo "#!/bin/bash" > $GCC-shim
-echo "set -e -o pipefail -x " >> $GCC-shim
-echo "$GCC -I$PREFIX/include -L$PREFIX/lib -pthread -fPIC \"\$@\"" >> $GCC-shim
-chmod u+x $GCC-shim
-export GCC=$GCC-shim
-
-echo "#!/bin/bash" > $CXX-shim
-echo "set -e -o pipefail -x " >> $CXX-shim
-echo "$CXX -I$PREFIX/include -L$PREFIX/lib -pthread -fPIC \"\$@\"" >> $CXX-shim
-chmod u+x $CXX-shim
-export CXX=$CXX-shim
-
-echo "#!/bin/bash" > $LD-shim
-echo "set -e -o pipefail -x " >> $LD-shim
-echo "$LD -L$PREFIX/lib \"\$@\"" >> $LD-shim
-chmod u+x $LD-shim
-export LD=$LD-shim
-
-echo "#!/bin/bash" > ${LD}.gold
-echo "set -e -o pipefail -x " >> ${LD}.gold
-echo "$LD_GOLD -L$PREFIX/lib \"\$@\"" >> ${LD}.gold
-chmod u+x ${LD}.gold
-export LD_GOLD=${LD}.gold
-
-#
-# Hack: ensure that the correct libpthread is used.
-# This fixes an issue specific to https://github.com/conda-forge/docker-images/tree/master/linux-anvil-comp7
-# which I do not fully understand, but the fix seems to work.
-# See https://github.com/conda/conda/issues/8380
-#
-
-HOST_LIBPTHREAD="${BUILD_PREFIX}/${HOST}/sysroot/usr/lib/libpthread.so"
-
-if [[ -f "${HOST_LIBPTHREAD}" ]]; then
-    rm ${HOST_LIBPTHREAD}
-    ln -s /lib64/libpthread.so.0 ${HOST_LIBPTHREAD}
-fi
-
-
-# Ensure that GHC build platform is x86_64-unknown-linux (which GHC knows how to target),
-# rather than x86_64-conda-linux (which GHC does not know about).
-# Suggested by @isuruf on github; see
-# https://github.com/conda-forge/git-annex-feedstock/pull/96/commits/796678ac2cc106e67c4f1f89fb2e92c2ff153616 and
-# https://github.com/conda-forge/git-annex-feedstock/runs/945996913
-#
-unset host_alias
-unset build_alias
-
-
-#######################################################################################################
-# Install bootstrap ghc
-#######################################################################################################
-
-export GHC_BOOTSTRAP_PREFIX=${SRC_DIR}/ghc_bootstrap_pfx
-mkdir -p $GHC_BOOTSTRAP_PREFIX/bin
-export PATH=$PATH:${GHC_BOOTSTRAP_PREFIX}/bin
-
-pushd ${SRC_DIR}/ghc_bootstrap
-./configure --prefix=${GHC_BOOTSTRAP_PREFIX}
-make install
-ghc-pkg recache
-
-popd
-
-#######################################################################################################
-# Build recent ghc from source
-#######################################################################################################
-
-pushd ${SRC_DIR}/ghc_src
-
-touch mk/build.mk
-echo "BuildFlavour = quick" >> mk/build.mk
-echo "libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-includes=$PREFIX/include" >> mk/build.mk
-echo "libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-gmp-libraries=$PREFIX/lib" >> mk/build.mk
-echo "STRIP_CMD = $STRIP" >> build.mk
-
-./boot
-./configure --prefix=${BUILD_PREFIX}  --with-gmp-includes=$PREFIX/include --with-gmp-libraries=$PREFIX/lib --with-system-libffi
-set +e
-make -j${CPU_COUNT}
-set -e
-make
-make install
-ghc-pkg recache
-ghc --version
-popd
-
-#######################################################################################################
-# Build NGLess
-#######################################################################################################
-
-pushd ${SRC_DIR}/ngless
-
-export STACK_ROOT=${SRC_DIR}/stack_root
-mkdir -p $STACK_ROOT
-(
-    echo "extra-include-dirs:"
-    echo "- ${PREFIX}/include"
-    echo "extra-lib-dirs:"
-    echo "- ${PREFIX}/lib"
-    echo "ghc-options:"
-    echo "  \"\$everything\": -optc-I${PREFIX}/include -optl-L${PREFIX}/lib"
-    echo "apply-ghc-options: everything"
-    echo "system-ghc: true"
-) > "${STACK_ROOT}/config.yaml"
-
-stack setup
-stack update
-make NGLess/Dependencies/Versions.hs
-make external-deps CC=$CC CXX=$GCC
-stack build --extra-include-dirs ${PREFIX}/include --extra-lib-dirs ${PREFIX}/lib --local-bin-path ${PREFIX}/bin
-
-make install WGET="wget --no-check-certificate" prefix=$PREFIX CC=$CC
-
-rm -r .stack-work
-popd
+exec \${CONDA_PREFIX}/bin/ngless-wrapped "\$@"
+EOF

--- a/recipes/ngless/meta.yaml
+++ b/recipes/ngless/meta.yaml
@@ -1,69 +1,34 @@
 {% set name = "ngless" %}
-{% set version = "1.3.0" %}
-{% set sha256 = "b0a114ed901b378189b09d091308e5ad554fdbbd7d3722c935d26c0ddd7328d6" %}
-{% set osx_binaries_sha256 = "e72fa4bc5d1666432d4a86c417ec7f80fa21cb4c1f4b3ba5c6490fe8c7f140f9" %}
+{% set version = "1.4.0" %}
+{% set linux_sha256 = "f83f727965c1230eaac0bc1c8a6c6951293da99b589862ba8c5d8a0ff4dbddd3" %}
+{% set osx_sha256 = "a2195c811358b891c84392ebe5f21167b6efbdeaa086891ab4c35f4667d858bd" %}
 
-{% set ghc_src_version = "8.6.5" %}
-{% set ghc_src_sha256 = "4d4aa1e96f4001b934ac6193ab09af5d6172f41f5a5d39d8e43393b9aafee361" %}
-{% set ghc_bootstrap_version = "8.4.2" %}
-{% set ghc_bootstrap_linux_sha256 = "28c31489ed9a83af4400685ec8bc72a6d43d08958d75b2dc35d29a894a5c9d93" %}
 
 package:
   name: {{ name }}
   version: {{ version }}
 
 source:
-  - url: https://github.com/ngless-toolkit/ngless/archive/v{{ version }}.tar.gz # [linux]
-    sha256: {{ sha256 }} # [linux]
-    folder: ngless # [linux]
-  - url: https://downloads.haskell.org/~ghc/{{ ghc_bootstrap_version }}/ghc-{{ ghc_bootstrap_version }}-x86_64-centos67-linux.tar.xz  # [linux]
-    sha256: {{ ghc_bootstrap_linux_sha256 }}  # [linux]
-    folder: ghc_bootstrap # [linux]
-
-  - url: https://downloads.haskell.org/~ghc/{{ ghc_src_version }}/ghc-{{ ghc_src_version }}-src.tar.xz # [linux]
-    sha256: {{ ghc_src_sha256 }} # [linux]
-    folder: ghc_src # [linux]
-
-  - url: https://github.com/ngless-toolkit/ngless/releases/download/v{{ version }}/NGLess-{{ version }}-osx.zip # [osx]
-    sha256: {{ osx_binaries_sha256 }} # [osx]
-
+  - url: https://github.com/ngless-toolkit/ngless/releases/download/v{{ version }}/NGLess-v{{ version }}-Linux-static-no-deps # [linux]
+    sha256: {{ linux_sha256 }} # [linux]
+  - url: https://github.com/ngless-toolkit/ngless/releases/download/v{{ version }}/NGLess-v{{ version }}-MacOSX.zip # [osx]
+    sha256: {{ osx_sha256 }} # [osx]
 
 build:
-  number: 1
-
+  number: 0
 
 requirements:
-  build:
-    - make
-    - {{ compiler('c') }} # [linux]
-    - {{ compiler('cxx') }} # [linux]
-    - make # [linux]
-    - perl # [linux]
-    - coreutils # [linux]
-    - binutils # [linux]
-    - pkg-config # [linux]
-    - automake # [linux]
-    - autoconf # [linux]
-    - libtool # [linux]
-    - stack >=1.9.3 # [linux]
-  host:
-    - gmp
-    - xz
-    - zlib
-    - bzip2
-    - backports.lzma
-    - libiconv
-    - openssh
-    - wget # [linux]
-    - libffi # [linux]
   run:
-    - libffi # [linux]
-
+    - bwa
+    - prodigal
+    - megahit
+    - samtools
+    - minimap2
 
 test:
   commands:
     - ngless --version
-    - ngless --check-install
+    - ngless --check-install --verbose
 
 about:
   home: https://ngless.embl.de
@@ -71,10 +36,9 @@ about:
   summary: A tool for short-read processing with a focus on metagenomics
 
 extra:
-  container:
-    # For GHC
-    extended-base: true
   recipe-maintainers:
     - luispedro
   identifiers:
     - "doi:10.1186/s40168-019-0684-8" # Publication
+  skip-lints:
+    - should_be_noarch_generic


### PR DESCRIPTION
- Install prebuilt binaries: not ideal, but working
- Use a wrapper script to point NGLess to the right dependencies
- More verbose checks


I tested locally (`bioconda-utils build --mulled-test` with and without `--docker`) and it worked well

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
