### PR TITLE
Update Parascopy to v1.6.1

### DIFF
--- a/recipes/parascopy/meta.yaml
+++ b/recipes/parascopy/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "parascopy" %}
-{% set version = "1.5.0" %}
+{% set version = "1.6.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/tprodanov/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: 70b00627169160e7c5587c260c92098ec910404de9bbe5c3ac0808ae19a380dc
+  sha256: 28dec39f160c8f83243220e2e14eedf7f4198e4ecfa69366a5b825cda8babe8b
 
 build:
   noarch: python


### PR DESCRIPTION
Update [parascopy](https://github.com/tprodanov/parascopy) to version 1.6.1