### PR TITLE
Update antiSMASH-lite to 6.1.1

### DIFF
--- a/recipes/antismash-lite/meta.yaml
+++ b/recipes/antismash-lite/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "antiSMASH-lite" %}
-{% set version = "6.1.0" %}
-{% set sha256 = "90a4f0502e8948d333118e92141bd350bb32b91c7ef1bd534e6ab4cbf21fc67f" %}
+{% set version = "6.1.1" %}
+{% set sha256 = "38c9fa8d34dea2552d3b21e3cb2ca293864f2f53d381764de9dd3d5f0b40139e" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
Updating the meta.yml to fetch now antiSMASH v6.1.1 (according to #34688 of the antiSMASH package) .