### PR TITLE
split gimmemotifs

### DIFF
--- a/recipes/gimmemotifs/meta.yaml
+++ b/recipes/gimmemotifs/meta.yaml
@@ -1,7 +1,7 @@
 {% set version = "0.17.1" %}
 
 package:
-  name: gimmemotifs-suite
+  name: gimmemotifs
   version: {{ version }}
 
 source:
@@ -10,10 +10,54 @@ source:
 
 build:
   number: 2
-  
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv"
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+  host:
+    - pip
+    - python                        # pinned in conda_build_config.yaml
+  run:
+    - python                        # pinned in conda_build_config.yaml
+    - gimmemotifs-minimal ={{ version }}
+    # motif discovery tools
+    - dinamo >=1.0  # [not osx]
+    - gadem >=1.3.1
+    - homer >=4.11  # [not osx]
+    - meme >=5.4.1
+#        - cudatoolkit =9.0            # MEME dependency (smallest conda version)
+    - prosampler >=1.0
+#        - trawler >=2.0               # removed to save RAM on Bioconda's tests
+#        - weeder >=2.0                # removed to save RAM on Bioconda's tests
+    - xxmotif >=1.6
+#        - yamda >=0.1.00e9c9d         # removed to save RAM on Bioconda's tests  
+
+test:
+#   imports:
+#     - gimmemotifs
+  commands:
+    - gimme --help
+
+about:
+  home: https://github.com/vanheeringen-lab/gimmemotifs
+  license: MIT
+  summary: Motif prediction pipeline and various motif-related tools
+  description: Motif prediction pipeline and various motif-related tools
+
+extra:
+  recipe-maintainers:
+    - simonvh
+  identifiers:
+    - biotools:gimmemotifs
+
 outputs:
-  - name: gimmemotifs-base
-    script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv"
+  - name: gimmemotifs-minimal
+    
+    build:
+      script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv"
+    
     requirements:
       build:
         - {{ compiler('c') }}
@@ -48,48 +92,15 @@ outputs:
         - tqdm >=4.46.1
         - xdg
         - xgboost >=1.0.2   
+    
     test:
       imports:
         - gimmemotifs
       commands:
         - gimme --help
-    
-  - name: gimmemotifs
-    script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv"
-    requirements:
-      build:
-        - {{ compiler('c') }}
-        - {{ compiler('cxx') }}
-      host:
-        - pip
-        - python                        # pinned in conda_build_config.yaml
-      run:
-        - python                        # pinned in conda_build_config.yaml
-        - {{ pin_subpackage('gimmemotifs-base', max_pin="x.x.x") }}
-        # motif discovery tools
-        - dinamo >=1.0  # [not osx]
-        - gadem >=1.3.1
-        - homer >=4.11  # [not osx]
-        - meme >=5.4.1
-#        - cudatoolkit =9.0              # MEME dependency (smallest conda version)
-        - prosampler >=1.0
-#        - trawler >=2.0               # removed to save RAM on Bioconda's tests
-#        - weeder >=2.0                # removed to save RAM on Bioconda's tests
-        - xxmotif >=1.6
-#        - yamda >=0.1.00e9c9d         # removed to save RAM on Bioconda's tests  
-    test:
-#       imports:
-#         - gimmemotifs
-      commands:
-        - gimme --help
 
-about:
-  home: https://github.com/vanheeringen-lab/gimmemotifs
-  license: MIT
-  summary: Motif prediction pipeline and various motif-related tools
-
-extra:
-  recipe-maintainers:
-    - simonvh
-  identifiers:
-    - biotools:gimmemotifs
+    about:
+      home: https://github.com/vanheeringen-lab/gimmemotifs
+      license: MIT
+      summary: Motif prediction pipeline and various motif-related tools
+      description: Gimmemotifs, but without motif discovery tools

--- a/recipes/gimmemotifs/meta.yaml
+++ b/recipes/gimmemotifs/meta.yaml
@@ -10,17 +10,17 @@ source:
 
 build:
   number: 2
-  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv"
+#   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv"
 
 requirements:
-  build:
-    - {{ compiler('c') }}
-    - {{ compiler('cxx') }}
-  host:
-    - pip
-    - python                        # pinned in conda_build_config.yaml
+#   build:
+#     - {{ compiler('c') }}
+#     - {{ compiler('cxx') }}
+#   host:
+#     - pip
+#     - python                        # pinned in conda_build_config.yaml
   run:
-    - python                        # pinned in conda_build_config.yaml
+#     - python                        # pinned in conda_build_config.yaml
     - gimmemotifs-minimal ={{ version }}
     # motif discovery tools
     - dinamo >=1.0  # [not osx]
@@ -93,11 +93,11 @@ outputs:
         - xdg
         - xgboost >=1.0.2   
 
-    test:
-      imports:
-        - gimmemotifs
-      commands:
-        - gimme --help
+#     test:
+#       imports:
+#         - gimmemotifs
+#       commands:
+#         - gimme --help
 
     about:
       home: https://github.com/vanheeringen-lab/gimmemotifs

--- a/recipes/gimmemotifs/meta.yaml
+++ b/recipes/gimmemotifs/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   number: 2
-  script: python -m pip install . --no-deps --ignore-installed
+  script: python -m pip install . --no-deps --ignore-installed -vvv
 
 requirements:
   build:
@@ -56,7 +56,9 @@ outputs:
   - name: gimmemotifs-minimal
     
     build:
-      script: python -m pip install . --no-deps --ignore-installed
+      script: python -m pip install . --no-deps --ignore-installed -vvv
+      entry_points: 
+        - gimmemotifs = gimmemotifs.cli:cli
     
     requirements:
       build:

--- a/recipes/gimmemotifs/meta.yaml
+++ b/recipes/gimmemotifs/meta.yaml
@@ -15,6 +15,7 @@ build:
 requirements:
   run:
     - gimmemotifs-minimal ={{ version }}
+    - ipywidgets                        # Necessary for progress bar in Jupyter notebook.
     - dinamo >=1.0  # [not osx]
     - gadem >=1.3.1
     - homer >=4.11  # [not osx]
@@ -40,6 +41,7 @@ about:
 extra:
   recipe-maintainers:
     - simonvh
+    - siebrenf
   identifiers:
     - biotools:gimmemotifs
   skip-lints:
@@ -64,7 +66,6 @@ outputs:
         - diskcache
         - feather-format
         - genomepy >=0.13.0
-#         - ipywidgets                  # Necessary for progress bar in Jupyter notebook. removed to save RAM on Bioconda's tests
         - iteround
         - jinja2
         - logomaker
@@ -84,13 +85,7 @@ outputs:
         - statsmodels
         - tqdm >=4.46.1
         - xdg
-        - xgboost >=1.0.2   
-
-    test:
-      imports:
-        - gimmemotifs
-      commands:
-        - gimme --help
+        - xgboost >=1.0.2
 
     about:
       home: https://github.com/vanheeringen-lab/gimmemotifs

--- a/recipes/gimmemotifs/meta.yaml
+++ b/recipes/gimmemotifs/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   number: 2
-  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv"
+  script: python -m pip install . --no-deps --ignore-installed
 
 requirements:
   build:
@@ -35,8 +35,8 @@ requirements:
 #        - yamda >=0.1.00e9c9d         # removed to save RAM on Bioconda's tests  
 
 test:
-#   imports:
-#     - gimmemotifs
+  imports:
+    - gimmemotifs
   commands:
     - gimme --help
 
@@ -56,7 +56,7 @@ outputs:
   - name: gimmemotifs-minimal
     
     build:
-      script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv"
+      script: python -m pip install . --no-deps --ignore-installed
     
     requirements:
       build:

--- a/recipes/gimmemotifs/meta.yaml
+++ b/recipes/gimmemotifs/meta.yaml
@@ -11,29 +11,19 @@ source:
 build:
   number: 2
   noarch: python
-#   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv"
 
 requirements:
-#   build:
-#     - {{ compiler('c') }}
-#     - {{ compiler('cxx') }}
-#   host:
-#     - pip
-#     - python                        # pinned in conda_build_config.yaml
   run:
-#     - python                        # pinned in conda_build_config.yaml
     - gimmemotifs-minimal ={{ version }}
-    # motif discovery tools
     - dinamo >=1.0  # [not osx]
     - gadem >=1.3.1
     - homer >=4.11  # [not osx]
     - meme >=5.4.1
-#        - cudatoolkit =9.0            # MEME dependency (smallest conda version)
     - prosampler >=1.0
-#        - trawler >=2.0               # removed to save RAM on Bioconda's tests
-#        - weeder >=2.0                # removed to save RAM on Bioconda's tests
+    - trawler >=2.0
+    - weeder >=2.0
     - xxmotif >=1.6
-#        - yamda >=0.1.00e9c9d         # removed to save RAM on Bioconda's tests  
+    - yamda >=0.1.00e9c9d
 
 test:
   imports:
@@ -96,11 +86,11 @@ outputs:
         - xdg
         - xgboost >=1.0.2   
 
-#     test:
-#       imports:
-#         - gimmemotifs
-#       commands:
-#         - gimme --help
+    test:
+      imports:
+        - gimmemotifs
+      commands:
+        - gimme --help
 
     about:
       home: https://github.com/vanheeringen-lab/gimmemotifs

--- a/recipes/gimmemotifs/meta.yaml
+++ b/recipes/gimmemotifs/meta.yaml
@@ -59,7 +59,7 @@ outputs:
   - name: gimmemotifs-minimal
 
     build:
-      script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv"
+      script: python -m pip install . --no-deps --ignore-installed -vvv
 
     requirements:
       build:

--- a/recipes/gimmemotifs/meta.yaml
+++ b/recipes/gimmemotifs/meta.yaml
@@ -10,6 +10,7 @@ source:
 
 build:
   number: 2
+  noarch: python
 #   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv"
 
 requirements:
@@ -51,6 +52,8 @@ extra:
     - simonvh
   identifiers:
     - biotools:gimmemotifs
+  skip-lints:
+    - should_not_be_noarch_compiler  # toplevel package is noarch
 
 outputs:
   - name: gimmemotifs-minimal

--- a/recipes/gimmemotifs/meta.yaml
+++ b/recipes/gimmemotifs/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   number: 2
-  script: python -m pip install . --no-deps --ignore-installed -vvv
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv"
 
 requirements:
   build:
@@ -56,7 +56,7 @@ outputs:
   - name: gimmemotifs-minimal
 
     build:
-      script: python -m pip install . --no-deps --ignore-installed -vvv
+      script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv"
 
     requirements:
       build:
@@ -93,11 +93,11 @@ outputs:
         - xdg
         - xgboost >=1.0.2   
 
-#     test:
-#       imports:
-#         - gimmemotifs
-#       commands:
-#         - gimme --help
+    test:
+      imports:
+        - gimmemotifs
+      commands:
+        - gimme --help
 
     about:
       home: https://github.com/vanheeringen-lab/gimmemotifs

--- a/recipes/gimmemotifs/meta.yaml
+++ b/recipes/gimmemotifs/meta.yaml
@@ -54,12 +54,10 @@ extra:
 
 outputs:
   - name: gimmemotifs-minimal
-    
+
     build:
       script: python -m pip install . --no-deps --ignore-installed -vvv
-      entry_points: 
-        - gimmemotifs = gimmemotifs.cli:cli
-    
+
     requirements:
       build:
         - {{ compiler('c') }}
@@ -73,7 +71,7 @@ outputs:
         - diskcache
         - feather-format
         - genomepy >=0.13.0
-    #     - ipywidgets                  # Necessary for progress bar in Jupyter notebook. removed to save RAM on Bioconda's tests
+#         - ipywidgets                  # Necessary for progress bar in Jupyter notebook. removed to save RAM on Bioconda's tests
         - iteround
         - jinja2
         - logomaker
@@ -94,12 +92,12 @@ outputs:
         - tqdm >=4.46.1
         - xdg
         - xgboost >=1.0.2   
-    
-    test:
-      imports:
-        - gimmemotifs
-      commands:
-        - gimme --help
+
+#     test:
+#       imports:
+#         - gimmemotifs
+#       commands:
+#         - gimme --help
 
     about:
       home: https://github.com/vanheeringen-lab/gimmemotifs

--- a/recipes/gimmemotifs/meta.yaml
+++ b/recipes/gimmemotifs/meta.yaml
@@ -1,7 +1,7 @@
 {% set version = "0.17.1" %}
 
 package:
-  name: gimmemotifs
+  name: gimmemotifs-suite
   version: {{ version }}
 
 source:
@@ -71,15 +71,15 @@ outputs:
         - gadem >=1.3.1
         - homer >=4.11  # [not osx]
         - meme >=5.4.1
-#         - cudatoolkit =9.0              # MEME dependency (smallest conda version)
+#        - cudatoolkit =9.0              # MEME dependency (smallest conda version)
         - prosampler >=1.0
-    #     - trawler >=2.0               # removed to save RAM on Bioconda's tests
-    #     - weeder >=2.0                # removed to save RAM on Bioconda's tests
+#        - trawler >=2.0               # removed to save RAM on Bioconda's tests
+#        - weeder >=2.0                # removed to save RAM on Bioconda's tests
         - xxmotif >=1.6
-    #     - yamda >=0.1.00e9c9d         # removed to save RAM on Bioconda's tests  
+#        - yamda >=0.1.00e9c9d         # removed to save RAM on Bioconda's tests  
     test:
-      imports:
-        - gimmemotifs
+#       imports:
+#         - gimmemotifs
       commands:
         - gimme --help
 

--- a/recipes/gimmemotifs/meta.yaml
+++ b/recipes/gimmemotifs/meta.yaml
@@ -9,61 +9,79 @@ source:
   sha256: 4d73d4b1df0ef765414dac952bf1d26609e74e97f9a2ee2d3d65a09078e1ad4c
 
 build:
-  number: 1
-  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv"
-
-requirements:
-  build:
-    - {{ compiler('c') }}
-    - {{ compiler('cxx') }}
-  host:
-    - pip
-    - python                        # pinned in conda_build_config.yaml
-  run:
-    - biofluff >=3.0.4              # Necessary for coverage_table()
-    - configparser
-    - diskcache
-    - feather-format
-    - genomepy >=0.13.0
-#     - ipywidgets                  # Necessary for progress bar in Jupyter notebook. removed to save RAM on Bioconda's tests
-    - iteround
-    - jinja2
-    - logomaker
-    - loguru
-    - matplotlib-base >=3.3         # https://matplotlib.org/stable/devel/min_dep_policy.html#list-of-dependency-versions
-    - numpy >=0.18                  # https://numpy.org/neps/nep-0029-deprecation_policy.html#support-table
-    - pandas >=1.0.3, <=1.1.5       # 1.3.5/1.4.2 are bugged
-    - pyarrow                       # can be removed next release.
-    - pybedtools >=0.9.0
-    - pysam >=0.16
-    - python                        # pinned in conda_build_config.yaml
-    - python-xxhash
-    - qnorm  >=0.8.1
-    - scikit-learn >=0.23.2         # https://scikit-learn.org/stable/install.html#installing-the-latest-release
-    - scipy >=1.5                   # https://docs.scipy.org/doc/scipy/dev/toolchain.html#numpy
-    - seaborn >=0.10.1
-    - statsmodels
-    - tqdm >=4.46.1
-    - xdg
-    - xgboost >=1.0.2
-    # motif discovery tools
-    - dinamo >=1.0  # [not osx]
-    - gadem >=1.3.1
-    - homer >=4.11  # [not osx]
-    - meme >=5.4.1
-    - cudatoolkit =9.0              # MEME dependency (smallest conda version)
-    - prosampler >=1.0
-#     - trawler >=2.0                # removed to save RAM on Bioconda's tests
-#     - weeder >=2.0                 # removed to save RAM on Bioconda's tests
-    - xxmotif >=1.6
-#     - yamda >=0.1.00e9c9d          # removed to save RAM on Bioconda's tests
-          
-test:
-  imports:
-    - gimmemotifs
-
-  commands:
-    - gimme --help
+  number: 2
+  
+outputs:
+  - name: gimmemotifs-base
+    script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv"
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+      host:
+        - pip
+        - python                        # pinned in conda_build_config.yaml
+      run:
+        - biofluff >=3.0.4              # Necessary for coverage_table()
+        - configparser
+        - diskcache
+        - feather-format
+        - genomepy >=0.13.0
+    #     - ipywidgets                  # Necessary for progress bar in Jupyter notebook. removed to save RAM on Bioconda's tests
+        - iteround
+        - jinja2
+        - logomaker
+        - loguru
+        - matplotlib-base >=3.3         # https://matplotlib.org/stable/devel/min_dep_policy.html#list-of-dependency-versions
+        - numpy >=0.18                  # https://numpy.org/neps/nep-0029-deprecation_policy.html#support-table
+        - pandas >=1.0.3, <=1.1.5       # 1.3.5/1.4.2 are bugged
+        - pyarrow                       # can be removed next release.
+        - pybedtools >=0.9.0
+        - pysam >=0.16
+        - python                        # pinned in conda_build_config.yaml
+        - python-xxhash
+        - qnorm  >=0.8.1
+        - scikit-learn >=0.23.2         # https://scikit-learn.org/stable/install.html#installing-the-latest-release
+        - scipy >=1.5                   # https://docs.scipy.org/doc/scipy/dev/toolchain.html#numpy
+        - seaborn >=0.10.1
+        - statsmodels
+        - tqdm >=4.46.1
+        - xdg
+        - xgboost >=1.0.2   
+    test:
+      imports:
+        - gimmemotifs
+      commands:
+        - gimme --help
+    
+  - name: gimmemotifs
+    script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv"
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+      host:
+        - pip
+        - python                        # pinned in conda_build_config.yaml
+      run:
+        - python                        # pinned in conda_build_config.yaml
+        - {{ pin_subpackage('gimmemotifs-base', max_pin="x.x.x") }}
+        # motif discovery tools
+        - dinamo >=1.0  # [not osx]
+        - gadem >=1.3.1
+        - homer >=4.11  # [not osx]
+        - meme >=5.4.1
+#         - cudatoolkit =9.0              # MEME dependency (smallest conda version)
+        - prosampler >=1.0
+    #     - trawler >=2.0               # removed to save RAM on Bioconda's tests
+    #     - weeder >=2.0                # removed to save RAM on Bioconda's tests
+        - xxmotif >=1.6
+    #     - yamda >=0.1.00e9c9d         # removed to save RAM on Bioconda's tests  
+    test:
+      imports:
+        - gimmemotifs
+      commands:
+        - gimme --help
 
 about:
   home: https://github.com/vanheeringen-lab/gimmemotifs


### PR DESCRIPTION
`Gimmemotifs` contains several motif discovery tools which are (or depend on) some very large packages. 
These tools are required for _de novo_ motif discovery by `gimme motifs` and `gimme location`. Together they add around 150 packages, worth ~1.5 GB of space.

The Bioconda's Azure container is running out of memory. I do now know if this is caused by the solver, or by the package when it's loading into memory. In this PR, I'm attempting to split the load on the solver, by separating `gimmemotifs` into `gimmemotifs-minimal` and `gimmemotifs`, similar to `matplotlib` and `snakemake`. The added benefit is that packages using gimme can save a lot if _de novo_ motif discovery is not required (e.g. `ANANSE`).