### PR TITLE
patch pymummer recipe

### DIFF
--- a/recipes/pymummer/meta.yaml
+++ b/recipes/pymummer/meta.yaml
@@ -9,10 +9,12 @@ package:
 source:
   url: https://pypi.io/packages/source/p/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: {{ sha256 }}
+  patches:
+    - temp_dir_path.patch
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:

--- a/recipes/pymummer/temp_dir_path.patch
+++ b/recipes/pymummer/temp_dir_path.patch
@@ -1,0 +1,13 @@
+diff --git a/pymummer/nucmer.py b/pymummer/nucmer.py
+index 5c7d0b9..88c31c6 100644
+--- a/pymummer/nucmer.py
++++ b/pymummer/nucmer.py
+@@ -136,7 +136,7 @@ def run(self):
+         qry = os.path.abspath(self.qry)
+         ref = os.path.abspath(self.ref)
+         outfile = os.path.abspath(self.outfile)
+-        tmpdir = tempfile.mkdtemp(prefix='tmp.run_nucmer.', dir=os.getcwd())
++        tmpdir = tempfile.mkdtemp(prefix='tmp.run_nucmer.')
+         original_dir = os.getcwd()
+         os.chdir(tmpdir)
+         script = 'run_nucmer.sh'


### PR DESCRIPTION
pymummer makes use of `tempfile.mkdtemp()` but specifies where the temp directory is made. Which does not play well with containers:
```
Traceback (most recent call last):
  File "/usr/local/bin/seroba", line 88, in <module>
    args.func(args)
  File "/usr/local/lib/python3.8/site-packages/seroba/tasks/sero_run.py", line 19, in run
    sero.run()
  File "/usr/local/lib/python3.8/site-packages/seroba/serotyping.py", line 481, in run
    self._prediction(assemblie_file,cluster)
  File "/usr/local/lib/python3.8/site-packages/seroba/serotyping.py", line 452, in _prediction
    self.sero, self.imp = Serotyping._find_serotype(assemblie_file,serogroup_fasta,self.meta_data_dict[serogroup],\
  File "/usr/local/lib/python3.8/site-packages/seroba/serotyping.py", line 261, in _find_serotype
    pymummer.nucmer.Runner(
  File "/usr/local/lib/python3.8/site-packages/pymummer/nucmer.py", line 139, in run
    tmpdir = tempfile.mkdtemp(prefix='tmp.run_nucmer.', dir=os.getcwd())
  File "/usr/local/lib/python3.8/tempfile.py", line 358, in mkdtemp
    _os.mkdir(file, 0o700)
PermissionError: [Errno 13] Permission denied: '/tmp.run_nucmer.727hfrey'
```

This PR allows `tempfile` to figure out where to make the temp dir (see https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir)

```
Python searches a standard list of directories to find one which the calling user can create files in. The list is:

The directory named by the TMPDIR environment variable.
The directory named by the TEMP environment variable.
The directory named by the TMP environment variable.
A platform-specific location:
    - On Windows, the directories C:\TEMP, C:\TMP, \TEMP, and \TMP, in that order
    - On all other platforms, the directories /tmp, /var/tmp, and /usr/tmp, in that order.

As a last resort, the current working directory.
```

An upstream pull request has been submitted to pymummer (https://github.com/sanger-pathogens/pymummer/pull/36), but a timeline of review is not available

This is also related to https://github.com/bioconda/bioconda-recipes/pull/35378

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
