### PR TITLE
Update quast for python 3.8+

### DIFF
--- a/recipes/quast/meta.yaml
+++ b/recipes/quast/meta.yaml
@@ -6,11 +6,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 0
-  # Needs to adjust cgi.escape to be html.escape for Python 3.8.
-  # (cgi.escape is deprecated since 3.2)
-  # AttributeError: module 'cgi' has no attribute 'escape'
-  skip: True  # [py>=38]
+  number: 1
 
 source:
   url:


### PR DESCRIPTION
The latest release of `quast` appears to have corrected the issue indicated in the recipe: https://github.com/ablab/quast/commit/bc4af762a7f53176d66bd5e6c5b7d28376d28e11. I expect that Python 3.8+ builds will work successfully now.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
