### PR TITLE
split gimmemotifs recipe

### DIFF
--- a/recipes/gimmemotifs/conda_build_config.yaml
+++ b/recipes/gimmemotifs/conda_build_config.yaml
@@ -9,16 +9,16 @@
 #            https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/main/recipe/conda_build_config.yaml
 python:
   - 3.9.*  *_cpython
-  - 3.8.*  *_cpython
+#   - 3.8.*  *_cpython
 #   - 3.7.*  *_cpython
 #   - 3.6.*  *_cpython
 python_impl:
   - cpython
-  - cpython
+#   - cpython
 #   - cpython
 #   - cpython
 numpy:
   - 1.19.*
-  - 1.17.*
+#   - 1.17.*
 #   - 1.17.*
 #   - 1.17.*

--- a/recipes/gimmemotifs/meta.yaml
+++ b/recipes/gimmemotifs/meta.yaml
@@ -62,10 +62,10 @@ outputs:
         - homer >=4.11  # [not osx]
         - meme >=5.4.1
         - prosampler >=1.0
-        - trawler >=2.0
-        - weeder >=2.0
+#         - trawler >=2.0                # removed to save RAM on Bioconda's tests
+#         - weeder >=2.0                 # removed to save RAM on Bioconda's tests
         - xxmotif >=1.6
-        - yamda >=0.1.00e9c9d
+#         - yamda >=0.1.00e9c9d          # removed to save RAM on Bioconda's tests
 
 test:
   imports:

--- a/recipes/gimmemotifs/meta.yaml
+++ b/recipes/gimmemotifs/meta.yaml
@@ -52,9 +52,9 @@ outputs:
         - xgboost >=1.0.2
 
   - name: gimmemotifs
-
-    build:
-      noarch: python
+# 
+#     build:
+#       noarch: python
 
     requirements:
       run:

--- a/recipes/gimmemotifs/meta.yaml
+++ b/recipes/gimmemotifs/meta.yaml
@@ -9,59 +9,70 @@ source:
   sha256: 4d73d4b1df0ef765414dac952bf1d26609e74e97f9a2ee2d3d65a09078e1ad4c
 
 build:
-  number: 1
-  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv"
+  number: 2
 
-requirements:
-  build:
-    - {{ compiler('c') }}
-    - {{ compiler('cxx') }}
-  host:
-    - pip
-    - python                        # pinned in conda_build_config.yaml
-  run:
-    - biofluff >=3.0.4              # Necessary for coverage_table()
-    - configparser
-    - diskcache
-    - feather-format
-    - genomepy >=0.13.0
-#     - ipywidgets                  # Necessary for progress bar in Jupyter notebook. removed to save RAM on Bioconda's tests
-    - iteround
-    - jinja2
-    - logomaker
-    - loguru
-    - matplotlib-base >=3.3         # https://matplotlib.org/stable/devel/min_dep_policy.html#list-of-dependency-versions
-    - numpy >=0.18                  # https://numpy.org/neps/nep-0029-deprecation_policy.html#support-table
-    - pandas >=1.0.3, <=1.1.5       # 1.3.5/1.4.2 are bugged
-    - pyarrow                       # can be removed next release.
-    - pybedtools >=0.9.0
-    - pysam >=0.16
-    - python                        # pinned in conda_build_config.yaml
-    - python-xxhash
-    - qnorm  >=0.8.1
-    - scikit-learn >=0.23.2         # https://scikit-learn.org/stable/install.html#installing-the-latest-release
-    - scipy >=1.5                   # https://docs.scipy.org/doc/scipy/dev/toolchain.html#numpy
-    - seaborn >=0.10.1
-    - statsmodels
-    - tqdm >=4.46.1
-    - xdg
-    - xgboost >=1.0.2
-    # motif discovery tools
-    - dinamo >=1.0  # [not osx]
-    - gadem >=1.3.1
-    - homer >=4.11  # [not osx]
-    - meme >=5.4.1
-    - cudatoolkit =9.0              # MEME dependency (smallest conda version)
-    - prosampler >=1.0
-#     - trawler >=2.0                # removed to save RAM on Bioconda's tests
-#     - weeder >=2.0                 # removed to save RAM on Bioconda's tests
-    - xxmotif >=1.6
-#     - yamda >=0.1.00e9c9d          # removed to save RAM on Bioconda's tests
-          
+outputs:
+  - name: gimmemotifs-minimal
+
+    build:
+      script: python -m pip install . --no-deps --ignore-installed -vvv
+
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+      host:
+        - pip
+        - python                        # pinned in conda_build_config.yaml
+      run:
+        - biofluff >=3.0.4              # Necessary for coverage_table()
+        - configparser
+        - diskcache
+        - feather-format
+        - genomepy >=0.13.0
+        - iteround
+        - jinja2
+        - logomaker
+        - loguru
+        - matplotlib-base >=3.3         # https://matplotlib.org/stable/devel/min_dep_policy.html#list-of-dependency-versions
+        - numpy >=0.18                  # https://numpy.org/neps/nep-0029-deprecation_policy.html#support-table
+        - pandas >=1.0.3, <=1.1.5       # 1.3.5/1.4.2 are bugged
+        - pyarrow                       # can be removed next release.
+        - pybedtools >=0.9.0
+        - pysam >=0.16
+        - python                        # pinned in conda_build_config.yaml
+        - python-xxhash
+        - qnorm  >=0.8.1
+        - scikit-learn >=0.23.2         # https://scikit-learn.org/stable/install.html#installing-the-latest-release
+        - scipy >=1.5                   # https://docs.scipy.org/doc/scipy/dev/toolchain.html#numpy
+        - seaborn >=0.10.1
+        - statsmodels
+        - tqdm >=4.46.1
+        - xdg
+        - xgboost >=1.0.2
+
+  - name: gimmemotifs
+
+    build:
+      noarch: python
+
+    requirements:
+      run:
+        - gimmemotifs-minimal ={{ version }}
+        - ipywidgets                    # Necessary for progress bar in Jupyter notebook.
+        - dinamo >=1.0  # [not osx]
+        - gadem >=1.3.1
+        - homer >=4.11  # [not osx]
+        - meme >=5.4.1
+        - prosampler >=1.0
+        - trawler >=2.0
+        - weeder >=2.0
+        - xxmotif >=1.6
+        - yamda >=0.1.00e9c9d
+
 test:
   imports:
     - gimmemotifs
-
   commands:
     - gimme --help
 
@@ -69,9 +80,11 @@ about:
   home: https://github.com/vanheeringen-lab/gimmemotifs
   license: MIT
   summary: Motif prediction pipeline and various motif-related tools
+  description: Motif prediction pipeline and various motif-related tools
 
 extra:
   recipe-maintainers:
     - simonvh
+    - siebrenf
   identifiers:
     - biotools:gimmemotifs

--- a/recipes/gimmemotifs/meta.yaml
+++ b/recipes/gimmemotifs/meta.yaml
@@ -52,9 +52,6 @@ outputs:
         - xgboost >=1.0.2
 
   - name: gimmemotifs
-# 
-#     build:
-#       noarch: python
 
     requirements:
       run:

--- a/recipes/gimmemotifs/meta.yaml
+++ b/recipes/gimmemotifs/meta.yaml
@@ -56,7 +56,7 @@ outputs:
     requirements:
       run:
         - gimmemotifs-minimal ={{ version }}
-        - ipywidgets                    # Necessary for progress bar in Jupyter notebook.
+#         - ipywidgets                   # Necessary for progress bar in Jupyter notebook. removed to save RAM on Bioconda's tests
         - dinamo >=1.0  # [not osx]
         - gadem >=1.3.1
         - homer >=4.11  # [not osx]


### PR DESCRIPTION
`Gimmemotifs` contains several motif discovery tools which are (or depend on) some very large packages. 
These tools are required for _de novo_ motif discovery by `gimme motifs` and `gimme location`. Together they add around 150 packages, worth ~1.5 GB of space.

The Bioconda's Azure container is running out of memory. I do now know if this is caused by the solver, or by the package when it's loading into memory. In this PR, I'm attempting to split the load on the solver, by separating `gimmemotifs` into `gimmemotifs-minimal` and `gimmemotifs`, similar to `matplotlib` and `snakemake`. The added benefit is that packages using gimme can save a lot if _de novo_ motif discovery is not required (e.g. `ANANSE`).