### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/AutoMerge.yml.bak
+++ b/.github/workflows/AutoMerge.yml.bak
@@ -36,8 +36,13 @@ concurrency: >-
      )
   }}
 
+permissions:
+  contents: read
+
 jobs:
   automerge:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     name: bioconda-bot automerge
     if: >-

--- a/.github/workflows/AutoMergeTrigger.yml.bak
+++ b/.github/workflows/AutoMergeTrigger.yml.bak
@@ -9,8 +9,13 @@ on:
     - submitted
     - dismissed
 
+permissions:
+  contents: read
+
 jobs:
   automerge-trigger:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     if: >-
       (

--- a/.github/workflows/CommentResponder.yml
+++ b/.github/workflows/CommentResponder.yml
@@ -15,6 +15,8 @@ on:
 #      ) ||
 jobs:
   comment:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     name: bioconda-bot comment
     if: >-
@@ -43,6 +45,8 @@ jobs:
       run: bioconda-bot comment
 
   repost:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     name: bioconda-bot repost
     if: >-
@@ -65,6 +69,8 @@ jobs:
       run: bioconda-bot comment
 
   merge:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     name: bioconda-bot merge
     if: >-


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
