### PR TITLE
Fix deepbgc protobuf dependency

### DIFF
--- a/recipes/deepbgc/meta.yaml
+++ b/recipes/deepbgc/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   entry_points:
     - deepbgc = deepbgc.main:main
   script: python setup.py install --single-version-externally-managed --record=record.txt
@@ -35,6 +35,7 @@ requirements:
     - scipy ==1.2.0
     - hmmer >=3.1b2 # needed for antiSMASH compatibility
     - prodigal
+    - protobuf <4 # needed to load old model pickle files
 
 test:
   imports:


### PR DESCRIPTION
Make sure we use `protobuf < 4` for DeepBGC for compatibility reasons