### PR TITLE
Update seqan3: remove range-v3 reference

### DIFF
--- a/recipes/seqan3/build.sh
+++ b/recipes/seqan3/build.sh
@@ -7,7 +7,7 @@ include (\${SEQAN3_CLONE_DIR}/build_system/seqan3-install.cmake)" > CMakeLists.t
 cmake -DSEQAN3_CLONE_DIR="${SRC_DIR}" \
       -DSEQAN3_INCLUDE_DIR="${SRC_DIR}/include" \
       -DSEQAN3_SUBMODULES_DIR="${SRC_DIR}" \
-      -DSEQAN3_DEPENDENCY_INCLUDE_DIRS="${SRC_DIR}/submodules/range-v3/include;${SRC_DIR}/submodules/sdsl-lite/include;${SRC_DIR}/submodules/cereal/include" \
+      -DSEQAN3_DEPENDENCY_INCLUDE_DIRS="${SRC_DIR}/submodules/sdsl-lite/include;${SRC_DIR}/submodules/cereal/include" \
       -DCMAKE_INSTALL_PREFIX="${PREFIX}" .
 
 make install


### PR DESCRIPTION
Update seqan3: remove range-v3 reference: It is no longer used


----
<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
