### PR TITLE
Fix gsl version needed for fastANI

### DIFF
--- a/recipes/fastani/meta.yaml
+++ b/recipes/fastani/meta.yaml
@@ -7,7 +7,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 0
+  number: 1
 
 source:
   url: https://github.com/ParBLiSS/{{ name }}/archive/v{{ version }}.tar.gz
@@ -21,7 +21,7 @@ requirements:
     - automake
   host:
     - zlib
-    - gsl
+    - gsl >=2.6, <2.7.1
     - openmp
     - clangdev  # [osx]
     - libcxx >=4.0  # [osx]


### PR DESCRIPTION
Describe your pull request here

fastANI needs `libgsl.so.25`, while the lastest `gsl` 2.7.1 provides `libgsl.so.27`. So the `gsl` version needed to be restricted to be >=2.6, <2.7.1.

```
gsl-2.7.1 => lib/libgsl.so.27
gsl-2.7   => lib/libgsl.so.25
gsl-2.6   => lib/libgsl.so.25
gsl-2.5   => lib/libgsl.so.23
```

A workaround solution:

```
mamba install gsl==2.7.0
mamba install fastani
```

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
