### PR TITLE
Add gtftools recipe

### DIFF
--- a/recipes/gtftools/meta.yaml
+++ b/recipes/gtftools/meta.yaml
@@ -30,9 +30,11 @@ test:
     - gtftools --help
 
 about:
+  home: https://github.com/RacconC/gtftools
   license: MIT
   summary: "gtftools provides a set of functions to compute or extract various features of gene models."
-  doc_url: https://pypi.org/project/gtftools/
+  doc_url: https://pypi.org/project/gtftools
+  dev_url: https://github.com/RacconC/gtftools
 
 extra:
   recipe-maintainers:

--- a/recipes/gtftools/meta.yaml
+++ b/recipes/gtftools/meta.yaml
@@ -1,0 +1,39 @@
+{% set name = "gtftools" %}
+{% set version = "0.9.0" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  sha256: 7dfc0f8ecb8c5d34fee26aa3981c2393cee0419dcf3e51a70d7896c8c393f3fd
+
+build:
+  number: 0
+  entry_points:
+    - gtftools = gtftools.gtftools:main
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - pip
+    - python
+  run:
+    - python
+    - numpy
+
+test:
+  imports:
+    - gtftools
+  commands:
+    - gtftools --help
+
+about:
+  license: MIT
+  summary: "gtftools provides a set of functions to compute or extract various features of gene models."
+  doc_url: https://pypi.org/project/gtftools/
+
+extra:
+  recipe-maintainers:
+    - RacconC


### PR DESCRIPTION
I have a package named gtftools that provides a set of functions to compute or extract various features of gene models. I want to upload it to bioconda for everyone to use. 