### PR TITLE
add fishtaco to build-fail-blacklist

### DIFF
--- a/build-fail-blacklist
+++ b/build-fail-blacklist
@@ -1258,3 +1258,7 @@ recipes/ucsc-wigtobigwig
 recipes/ucsc-wordline
 recipes/ucsc-xmlcat
 recipes/ucsc-xmltosql
+
+# Above v1.0.5 there are licensing restrictions and it cannot be distributed
+# via bioconda. See https://github.com/bioconda/bioconda-recipes/pull/23476.
+recipes/fishtaco


### PR DESCRIPTION
Adds `fishtaco` to the blacklist.

(not to be confused with (and notably less delicious than) blackened fish tacos).

This is because versions >1.0.5 cannot be redistributed via bioconda, see https://github.com/bioconda/bioconda-recipes/pull/23476.

Since the autobump code will ignore recipes in `build-fail-blacklist`, hopefully this will prevent future `fishtaco` updates from triggering autobump-created PRs.