### PR TITLE
Update to bedops 2.4.40 and reinstate macOS build

### DIFF
--- a/build-fail-blacklist
+++ b/build-fail-blacklist
@@ -51,9 +51,6 @@ recipes/bcftools/1.3.1
 # fitBeta2.cpp:158:93: error: no matching function for call to 'arma::eGlue<arma::Glue<arma::Glue<arma::Op<arma::Mat<double>, arma::op_htrans>, arma::Mat<double>, arma::glue_times>, arma::Mat<double>, arma::glue_times>, arma::Mat<double>, arma::eglue_plus>::i(bool) const'
 recipes/xtail
 
-# unknown c++ error
-recipes/bedops
-
 # needs patching for compilers
 recipes/logol
 

--- a/recipes/bedops/meta.yaml
+++ b/recipes/bedops/meta.yaml
@@ -1,15 +1,17 @@
+{% set version = "2.4.40" %}
+
 package:
   name: bedops
-  version: 2.4.39
+  version: {{ version }}
 
 build:
-  number: 1
-  # Unknown build error with clang-11
-  skip: True  # [OSX]
+  number: 0
 
 source:
-  url: https://github.com/bedops/bedops/archive/v2.4.39.tar.gz
-  sha256: f8bae10c6e1ccfb873be13446c67fc3a54658515fb5071663883f788fc0e4912
+  url: https://github.com/bedops/bedops/archive/v{{ version }}.tar.gz
+  sha256: 8c01db76669dc58c595e2e1b9bdb6d462f3363fc569b15c460a63a63b8b6bf30
+  patches:
+    - omit-bad-mutable.patch
 
 requirements:
   build:

--- a/recipes/bedops/omit-bad-mutable.patch
+++ b/recipes/bedops/omit-bad-mutable.patch
@@ -1,0 +1,76 @@
+GCC and previous Clang successfully compile const member functions that
+modify non-mutable fields when they are members of a templated class
+that is never instantiated. Recent Clang (v11 onwards) produces errors
+in this case.
+
+The problematic functions are never used, so we work around this by
+omitting them.
+
+diff --git a/applications/bed/bedextract/src/ExtractRows.cpp b/applications/bed/bedextract/src/ExtractRows.cpp
+index c5f81b6a..c15644ca 100644
+--- a/applications/bed/bedextract/src/ExtractRows.cpp
++++ b/applications/bed/bedextract/src/ExtractRows.cpp
+@@ -77,7 +77,6 @@ namespace {
+     }
+ 
+     bool Empty() const { return empty_; }
+-    void Clear() const { empty_ = true; }
+ 
+   private:
+     bool empty_;
+diff --git a/interfaces/general-headers/utility/BitMonitor.hpp b/interfaces/general-headers/utility/BitMonitor.hpp
+index f9fefdda..0eb91810 100644
+--- a/interfaces/general-headers/utility/BitMonitor.hpp
++++ b/interfaces/general-headers/utility/BitMonitor.hpp
+@@ -78,6 +78,7 @@ namespace Ext {
+       _open = 0;
+     }
+ 
++#if 0
+     inline std::size_t next_set(std::size_t start) const {
+       start += 1;
+       std::size_t bin = start/BASE;
+@@ -110,6 +111,7 @@ namespace Ext {
+         _open = 0;
+       return next_set(0);
+     }
++#endif
+ 
+     inline std::size_t next_unset(std::size_t start) {
+       start += 1;
+diff --git a/interfaces/general-headers/utility/CharPooledMemory.hpp b/interfaces/general-headers/utility/CharPooledMemory.hpp
+index 267bb604..7d6793a2 100644
+--- a/interfaces/general-headers/utility/CharPooledMemory.hpp
++++ b/interfaces/general-headers/utility/CharPooledMemory.hpp
+@@ -203,6 +203,7 @@ namespace Ext {
+         }
+ 
+     private:
++#if 0
+       char*
+       find_open(char const* c)
+         {
+@@ -254,6 +255,7 @@ namespace Ext {
+           } // while
+           return nullptr;
+         }
++#endif
+ 
+       friend struct PooledCharMemory2<nelements>;
+ 
+@@ -466,6 +468,7 @@ namespace Ext {
+           return clean(c, sz);
+         }
+ 
++#if 0
+       char*
+       clean(char const* c, std::size_t need)
+         {
+@@ -492,6 +495,7 @@ namespace Ext {
+           _dirty.clear();
+           return nullptr;
+         }
++#endif
+ 
+       friend struct PooledCharMemory<nelements>;
+ 


### PR DESCRIPTION
As described in this PR's _omit-bad-mutable.patch_, bedops contains code that fails to compile with recent versions of Clang. Fortunately none of the problematic code is actually used, so the bioconda build can work around the problem simply by removing it.

Build failure analysis reported upstream as bedops/bedops#267.

----

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
