### PR TITLE
Update: simplesam needs setuptools as run dependency

### DIFF
--- a/recipes/simplesam/meta.yaml
+++ b/recipes/simplesam/meta.yaml
@@ -10,17 +10,18 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: "python -m pip install . --no-deps --ignore-installed -vv"
 
 requirements:
   host:
     - pip
     - python
+    - setuptools-scm
   run:
-    - pip
     - python
     - six
+    - setuptools  # uses pkg_resources
 
 test:
   imports:

--- a/recipes/simplesam/meta.yaml
+++ b/recipes/simplesam/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   noarch: python
-  number: 1
+  number: 0
   script: "python -m pip install . --no-deps --ignore-installed -vv"
 
 requirements:


### PR DESCRIPTION
I've based this change on the work done for https://github.com/bioconda/bioconda-recipes/commit/d32d9d69e304638a09cbc253c648b5554c14b0b3

@daler This update should fix the simplesam build issue described in #35449.
