### PR TITLE
Add jvarkit-bamstats04

### DIFF
--- a/recipes/jvarkit-bamstats04/bamstats04.sh
+++ b/recipes/jvarkit-bamstats04/bamstats04.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# Wraps bam2wig.jar
+#
+# This is copied from https://github.com/chapmanb/gatk
+#
+set -o pipefail
+
+# Find original directory of bash script, resovling symlinks
+# http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in/246128#246128
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+    DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+    SOURCE="$(readlink "$SOURCE")"
+    [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+
+JAR_DIR=$DIR
+java=java
+if [ -e "$JAVA_HOME/bin/java" ]
+then
+java="$JAVA_HOME/bin/java"
+fi
+
+# extract memory and system property Java arguments from the list of provided arguments
+# http://java.dzone.com/articles/better-java-shell-script
+default_jvm_mem_opts="-Xms512m -Xmx1g"
+jvm_mem_opts=""
+jvm_prop_opts=""
+pass_args=""
+for arg in "$@"; do
+    case $arg in
+        '-D'*)
+            jvm_prop_opts="$jvm_prop_opts $arg"
+            ;;
+        '-XX'*)
+            jvm_prop_opts="$jvm_prop_opts $arg"
+            ;;
+         '-Xm'*)
+            jvm_mem_opts="$jvm_mem_opts $arg"
+            ;;
+         *)
+            pass_args="$pass_args $arg"
+            ;;
+    esac
+done
+
+if [ "$jvm_mem_opts" == "" ]; then
+    jvm_mem_opts="$default_jvm_mem_opts"
+fi
+
+pass_arr=($pass_args)
+if [[ ${pass_arr[0]} == org* ]]
+then
+    eval "$java" $jvm_mem_opts $jvm_prop_opts -cp "$JAR_DIR/bam2wig.jar" $pass_args
+else
+    eval "$java" $jvm_mem_opts $jvm_prop_opts -jar "$JAR_DIR/bam2wig.jar" $pass_args
+fi
+exit

--- a/recipes/jvarkit-bamstats04/build.sh
+++ b/recipes/jvarkit-bamstats04/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+./gradlew bam2wig
+
+OUT="$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM"
+mkdir -p $OUT
+mkdir -p $PREFIX/bin
+cp dist/bamstats04.jar $OUT/
+
+cp $RECIPE_DIR/bamstats04.sh $OUT/bamstats04.sh
+chmod +x $OUT/bamstats04.sh
+ln -s $OUT/bamstats04.sh $PREFIX/bin

--- a/recipes/jvarkit-bamstats04/meta.yaml
+++ b/recipes/jvarkit-bamstats04/meta.yaml
@@ -1,0 +1,29 @@
+{% set version = "201904251722" %}
+  
+package:
+  name: jvarkit-bamstats04
+  version: '{{ version }}'
+  
+source:
+  url: 'https://github.com/lindenb/jvarkit/archive/{{ version }}.tar.gz'
+  sha256: 4b1daa895b504f865e03bf10cd1be2dc3b2517b99b1f5f1caacb8b7999fc6866
+
+build:
+  noarch: generic
+  number: 2
+
+requirements:
+  build:
+    - openjdk >=11
+  run:
+    - openjdk >=11
+
+test:
+  commands:
+    - bamstats04.sh -h
+
+about:
+  home: http://lindenb.github.io/jvarkit/BamStats04.html
+  license: MIT
+  summary: Coverage statistics for a BED file.
+


### PR DESCRIPTION
Included jvarkit-bamstats04 package!
This tool is useful for bam coverage statistics given a bed file with regions.