### PR TITLE
Add r-disprose.

### DIFF
--- a/recipes/r-disprose/build.sh
+++ b/recipes/r-disprose/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-disprose/meta.yaml
+++ b/recipes/r-disprose/meta.yaml
@@ -1,0 +1,43 @@
+{% set version = '0.1.6' %}
+
+package:
+  name: r-disprose
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/disprose_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/disprose/disprose_{{ version }}.tar.gz
+  sha256: 65a4abf261063171e23b29bf5ad2b437617afe44988e5e75866d64c76547b64a
+
+build:
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+  run:
+    - r-base
+
+test:
+  commands:
+    - $R -e "library('disprose')"
+
+about:
+  home: https://CRAN.R-project.org/package=disprose
+  license: GPL-3.0-only
+  summary: "Set of tools for molecular probes selection and design of a microarray, e.g. the
+    assessment of physical and chemical properties, blast performance, selection according
+    to sensitivity and selectivity. Methods used in package are described in: Lorenz
+    R., Stephan H.B., H\xF6ner zu Siederdissen C. et al. (2011) <doi:10.1186/1748-7188-6-26>;
+    Camacho C., Coulouris G., Avagyan V. et al. (2009) <doi:10.1186/1471-2105-10-421>."
+  license_family: GPL3
+  license_file:
+    - {{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3


### PR DESCRIPTION
Adds `r-disprose`; this package depends on a Bioconda package with Bioconductor dependencies, hence I add it here, not on conda-forge.