### PR TITLE
update plink2 to alpha 3.3, v2.00a3.3

### DIFF
--- a/recipes/plink2/meta.yaml
+++ b/recipes/plink2/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: "2.00a3.3"
 
 build:
-  number: 2
+  number: 0
 
 source:
   url: https://s3.amazonaws.com/plink2-assets/alpha3/plink2_linux_x86_64_20220603.zip # [linux]

--- a/recipes/plink2/meta.yaml
+++ b/recipes/plink2/meta.yaml
@@ -1,17 +1,17 @@
 package:
   name: plink2
-  version: "2.00a2.3"
+  version: "2.00a3.3"
 
 build:
   number: 2
 
 source:
-  url: http://s3.amazonaws.com/plink2-assets/alpha2/plink2_linux_x86_64.zip # [linux]
-  sha256: 3fa20a2058df542e928b11d715cc314c01d7c5961525b55fd17a088e6caa9cc9 # [linux]
-  url: http://s3.amazonaws.com/plink2-assets/alpha2/plink2_mac.zip # [osx]
-  sha256: c53d6301c51ebbec3a923ead5a16ee8b8dea7ec89d5df0861430b1a5fa811970 # [osx]
-  url: http://s3.amazonaws.com/plink2-assets/alpha2/plink2_win64.zip # [osw]
-  sha256: c2a0620f851ac2cf98a37ac84f9dff1ba208d9c86714b91cc3f2d784d0833a42 # [osw]
+  url: https://s3.amazonaws.com/plink2-assets/alpha3/plink2_linux_x86_64_20220603.zip # [linux]
+  sha256: ef0215a20d29ddba9e2c2e1ddb309f3f59ea9a0d28f94cfdf4ac92b804955e85 # [linux]
+  url: https://s3.amazonaws.com/plink2-assets/alpha3/plink2_mac_20220603.zip # [osx]
+  sha256: 920aab254f82eb9a14f4d5a5ab326172252430fd30165f0e25472258e0e5d499 # [osx]
+  url: https://s3.amazonaws.com/plink2-assets/alpha3/plink2_win64_20220603.zip # [osw]
+  sha256: 2b71eaeae958488139f242141dc5c0f6376286b9eaa9678a31193886c3b820cd # [osw]
 
 requirements:
   build:
@@ -23,7 +23,7 @@ requirements:
 
 test:
   commands:
-    - plink2 --help | grep "PLINK v2.00a2.3"
+    - plink2 --help | grep "PLINK v2.00a3.3"
 
 about:
   home: https://www.cog-genomics.org/plink2


### PR DESCRIPTION
plink2 has released a new alpha version, 3.3, at the start of June:

https://www.cog-genomics.org/plink/2.0/
