### PR TITLE
Rebuild libdeflate-using packages with current conda-forge libdeflate

### DIFF
--- a/recipes/fastp/meta.yaml
+++ b/recipes/fastp/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 185bd58732e57474fa08aae90e154fbc05f3e437ee2b434386dd2266d60d8ef6
 
 build:
-  number: 2
+  number: 3
 
 requirements:
   build:

--- a/recipes/htslib/meta.yaml
+++ b/recipes/htslib/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage('htslib', max_pin='x.x') }}
 

--- a/recipes/pysam/meta.yaml
+++ b/recipes/pysam/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: c33a51324fc4191bbfb135e93bf0c9b85ac9dad1320fb852a8af47c38626e37a
 
 build:
-  number: 0
+  number: 1
   binary_relocation: False # [linux]
 
 requirements:

--- a/recipes/rustybam/meta.yaml
+++ b/recipes/rustybam/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 1
+  number: 2
 
 source:
   url: https://github.com/mrvollger/rustybam/archive/v{{ version }}.tar.gz

--- a/recipes/staden_io_lib/meta.yaml
+++ b/recipes/staden_io_lib/meta.yaml
@@ -11,8 +11,7 @@ source:
   sha256: {{ hash }}
 
 build:
-  number: 3
-  skip: True # [osx]
+  number: 4
 
 requirements:
   build:


### PR DESCRIPTION
Bump all of bioconda's directly-libdeflate-using packages to ensure there remains a current package of each that is installable using only data from the channels' _current_repodata.json_ files. The current versions of these bioconda packages are built again libdeflate 1.10. Fortunately 1.10 is still present in conda-forge's _current_repodata.json_ (for now), but their 1.12 migration completed about a month ago.

Enable macOS staden_io_lib build — there was never a reason to disable this.



----

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
