### PR TITLE
Update igblast to 1.19.0

### DIFF
--- a/recipes/igblast/meta.yaml
+++ b/recipes/igblast/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.17.1" %}
+{% set version = "1.19.0" %}
 
 package:
   name: igblast
@@ -8,7 +8,6 @@ about:
   home: http://www.ncbi.nlm.nih.gov/projects/igblast/
   license: Public Domain and others
   license_file:
-    - c++/include/misc/jsonwrapp/rapidjson10/license.txt  # [linux]
     - c++/include/misc/jsonwrapp/rapidjson11/license.txt  # [linux]
     - c++/include/util/bitset/license.txt                 # [linux]
     - c++/scripts/projects/blast/LICENSE                  # [linux]
@@ -21,14 +20,14 @@ about:
 
 source:
   url: ftp://ftp.ncbi.nih.gov/blast/executables/igblast/release/{{ version }}/ncbi-igblast-{{ version }}-src.tar.gz  # [linux]
-  sha256: 4320a8ff4518230daf36818f3809d4d85e204759f3fb22081c9504bc9c24a74a  # [linux]
+  sha256: 3506f6510f5bee95c42cc524de368ab68052645bc294be22c0bcc279d1bbd86e  # [linux]
   url: ftp://ftp.ncbi.nih.gov/blast/executables/igblast/release/{{ version }}/ncbi-igblast-{{ version }}-x64-macosx.tar.gz  # [osx]
-  sha256: b9a56aae680c0e344d9e4f7fa1fac4888764a8225eaa48fab6ae1397056dbf39 # [osx]
+  sha256: 56a132160b9697590c1528847f2450492d211d6c706e88a2aae57d81107fa263 # [osx]
   patches:
     - shared_vdb.patch  # [linux]
 
 build:
-  number: 1
+  number: 0
 
 requirements:
   build:


### PR DESCRIPTION
Updates igblast from 1.17.1 to 1.19.0.

I don't think anything major changed as far as packaging goes so I've just updated the basics (version, build, URLs, and hashes) and removed one no-longer-existent license file.