### PR TITLE
Update nextstrain-cli to include dep changes from 4.1.1 → 4.2.0

### DIFF
--- a/recipes/nextstrain-cli/meta.yaml
+++ b/recipes/nextstrain-cli/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: c64274cee6409ca7b9da253629e9f752bc11d965e1f6114c4f9408b2258a4a21
 
 build:
-  number: 0
+  number: 1
   noarch: python
   entry_points:
     - nextstrain = nextstrain.cli.__main__:main
@@ -24,6 +24,8 @@ requirements:
     - python >=3.6
     - docutils
     - fasteners
+    - importlib_metadata # [py<38]
+    - packaging
     - pyjwt >=2.0.0
     - cryptography # Required for pyjwt digital signature support. Replicates "pip install pyjwt[crypto]".
     - requests
@@ -37,7 +39,6 @@ requirements:
     - fsspec
     - boto3
     - s3fs
-    - setuptools >=8.0.3
 
 test:
   requires:


### PR DESCRIPTION
Missed by the auto-bump in <https://github.com/bioconda/bioconda-recipes/pull/36154>.