### PR TITLE
Add vapor for classification of influenza sequences

### DIFF
--- a/recipes/vapor/meta.yaml
+++ b/recipes/vapor/meta.yaml
@@ -1,0 +1,33 @@
+{% set version = "1.0.2" %}
+
+package:
+  name: vapor
+  version: {{ version }}
+
+source:
+  url: https://github.com/connor-lab/vapor/archive/refs/tags/VAPOR_{{ version }}.tar.gz
+  sha256: bc1a28b6439ef00e3bab604a3fd2ab74709ca38dfc10466a45b2c66d0e5a330e
+
+build:
+  number: 0
+  noarch: python
+  script: python -m pip install --no-deps --ignore-installed .
+
+requirements:
+  host:
+    - python >=3.7
+    - pip
+  run:
+    - python >=3.7
+    - numpy
+
+test:
+  commands:
+    - vapor.py -h
+
+about:
+  home: https://github.com/connor-lab/vapor
+  license: GPL-3.0-only
+  license_file: COPYING
+  summary: Classification of Influenza samples from raw short read sequence data for downstream bioinformatics analysis
+


### PR DESCRIPTION
Vapor is a tool useful for finding the most closely related reference for influenza sequenced reads without prior mapping/assembly.