### PR TITLE
Update jgoslin to version 2.0.2 and JDK 17

### DIFF
--- a/recipes/jgoslin/meta.yaml
+++ b/recipes/jgoslin/meta.yaml
@@ -1,6 +1,6 @@
 # Do not forget to update the version string in the jgoslin.py file
 {% set name = "jgoslin" %}
-{% set version = "1.1.2" %}
+{% set version = "2.0.2" %}
 
 package:
   name: jgoslin
@@ -11,12 +11,12 @@ build:
   noarch: generic
 
 source:
-  url: https://bintray.com/lifs/maven/download_file?file_path=de%2Fisas%2Flipidomics%2F{{ name }}-cli%2F{{ version }}%2F{{ name }}-cli-{{ version }}-bin.zip
-  sha256: 65c6439f69382bd3318ac66ea430c64b58f07592511548209b2346595af632ea
+  url: https://repo1.maven.org/maven2/org/lifs-tools/jgoslin-cli/2.0.2/{{ name }}-cli-{{ version }}-bin.zip
+  sha256: cb6950bbcb68074acf65cfd875807684a9fd818811a7b1c8e4acbab1ae947751
 
 requirements:
   run:
-    - openjdk >=11
+    - openjdk >=17
     - python
 
 test:
@@ -45,4 +45,4 @@ extra:
     For example run it with "jgoslin -Xms512m -Xmx1g"
   identifiers:
     - biotools:jgoslin
-    - doi:10.5281/zenodo.3842332
+    - doi:10.5281/zenodo.7018207

--- a/recipes/jgoslin/meta.yaml
+++ b/recipes/jgoslin/meta.yaml
@@ -7,7 +7,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 1
+  number: 0 
   noarch: generic
 
 source:


### PR DESCRIPTION
This PR updates the jgoslin library to version 2.0.2 and JDK17. Updates to versions 2.0.0 and 2.0.1 were blocked due to the requirement of JDK17 not being available at the time.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
