### PR TITLE
Add pgscatalog_utils

### DIFF
--- a/recipes/pgscatalog-utils/meta.yaml
+++ b/recipes/pgscatalog-utils/meta.yaml
@@ -1,0 +1,59 @@
+{% set name = "pgscatalog-utils" %}
+{% set version = "0.1.1" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  sha256: 15e48997ca94c53b80f0abadfb0915b50a2cd657c3ac7d7b39d0760bb48db9fa
+
+build:
+  number: 0
+  entry_points:
+    - combine_scorefiles = pgscatalog_utils.scorefile.combine_scorefiles:combine_scorefiles
+    - download_scorefiles = pgscatalog_utils.download.download_scorefile:download_scorefile
+    - match_variants = pgscatalog_utils.match.match_variants:match_variants
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - jq >=1.2.2,<2.0.0
+    - pandas >=1.4.3,<2.0.0
+    - pip
+    - polars >=0.13.59,<0.14.0
+    - pyliftover >=0.4,<0.5
+    - python
+    - requests >=2.28.1,<3.0.0
+  run:
+    - jq >=1.2.2,<2.0.0
+    - pandas >=1.4.3,<2.0.0
+    - polars >=0.13.59,<0.14.0
+    - pyliftover >=0.4,<0.5
+    - python
+    - requests >=2.28.1,<3.0.0
+
+test:
+  imports:
+    - pgscatalog_utils
+    - pgscatalog_utils.download
+    - pgscatalog_utils.match
+    - pgscatalog_utils.scorefile
+  commands:
+    - combine_scorefiles --help
+    - download_scorefiles --help
+    - match_variants --help
+
+about:
+  home: "https://github.com/PGScatalog/pgscatalog_utils"
+  license: Apache Software
+  license_family: APACHE
+  license_file: 
+  summary: "Utilities for working with PGS Catalog API and scoring files"
+  doc_url: 
+  dev_url: 
+
+extra:
+  recipe-maintainers:
+    - nebfield


### PR DESCRIPTION
Add [`pgscatalog_utils`](https://github.com/PGScatalog/pgscatalog_utils), a collection of useful programs for working with polygenic scores in the [PGS Catalog](https://www.pgscatalog.org).

----

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
