### PR TITLE
Update MSMetaEnhancer: add aiocircuitbreaker dependency

### DIFF
--- a/recipes/msmetaenhancer/meta.yaml
+++ b/recipes/msmetaenhancer/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 9016198819cc310b11952ca7ac1d598739ea4bb81fd7c54ca5ad6711cf996722
 
 build:
-  number: 1
+  number: 0
   noarch: python
   script: "{{ PYTHON }} -m pip install . "
 

--- a/recipes/msmetaenhancer/meta.yaml
+++ b/recipes/msmetaenhancer/meta.yaml
@@ -10,16 +10,16 @@ source:
   sha256: 9016198819cc310b11952ca7ac1d598739ea4bb81fd7c54ca5ad6711cf996722
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: "{{ PYTHON }} -m pip install . "
 
 requirements:
   host:
-    - python >=3.8
+    - python >=3.9
     - pip
   run:
-    - python >=3.8
+    - python >=3.9
     - matchms
     - pandas
     - scipy
@@ -30,6 +30,7 @@ requirements:
     - tabulate
     - rdkit
     - multidict
+    - aiocircuitbreaker
 
 test:
   imports:


### PR DESCRIPTION
This PR adds [aiocircuitbreaker](https://anaconda.org/conda-forge/aiocircuitbreaker) dependency to `MSMetaEnhancer` introduced by version `v0.2.4`. This new dependency also requires Python `3.9+`.