### PR TITLE
Add recipe for popcast

### DIFF
--- a/recipes/popcast/meta.yaml
+++ b/recipes/popcast/meta.yaml
@@ -1,0 +1,44 @@
+{% set version = "1.0.0" %}
+
+package:
+  name: popcast
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/p/popcast/popcast-{{ version }}.tar.gz
+  sha256: 085bc9ff68484257f8595cfacd653d0bba782579f26d317766dd78e3b2ff6f49
+
+build:
+  number: 0
+  noarch: python
+  entry_points:
+    - popcast = popcast.cli:main
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv"
+
+requirements:
+  host:
+    - python >=3.6
+    - pip
+  run:
+    - python >=3.6
+    - jellyfish >=0.8.2,<0.9
+    - opencv-python >=4.5,<5
+    - pandas >=1.2.0,<1.3.0
+    - scipy >=1.5.4,<1.6.0
+
+test:
+  imports:
+    - popcast
+  commands:
+    - popcast --help
+
+about:
+  home: https://github.com/blab/popcast
+  license: MIT
+  summary: 'Long-term forecasts for pathogen populations'
+  license_family: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - huddlej


### PR DESCRIPTION
Adds a recipe for popcast, a tool for long-term forecasting of pathogen populations such as seasonal influenza. See Huddleston et al. 2020 (https://doi.org/10.7554/eLife.60067) for more details on the methods.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
