### PR TITLE
Add recipe for HAPO-G 1.3.2

### DIFF
--- a/recipes/hapog/build.sh
+++ b/recipes/hapog/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+export C_INCLUDE_PATH=${PREFIX}/include
+export LIBRARY_PATH=${PREFIX}/lib
+echo $PREFIX
+
+python setup.py install --record record.txt
+bash build.sh -l $LIBRARY_PATH
+cp -r hapog_build/hapog ${PREFIX}/bin/hapog_bin

--- a/recipes/hapog/meta.yaml
+++ b/recipes/hapog/meta.yaml
@@ -1,0 +1,38 @@
+package:
+  name: hapog
+  version: 1.3.2
+
+build:
+  number: 0
+
+source:
+  url: https://github.com/institut-de-genomique/HAPO-G/archive/refs/tags/1.3.2.tar.gz
+  sha256: "67d6c055ba2e7c26520ed1e8c41676b7651eea8459da6c43999c3f31cfb9c484"
+
+requirements:
+  build:
+    - gcc
+    - cmake
+    - make
+    - htslib
+  host:
+    - 'python>=3.7'
+    - htslib
+  run:
+    - htslib
+    - 'python>=3.7'
+    - biopython
+    - bwa
+    - samtools
+    - minimap2
+
+test:
+  commands:
+    - hapog -h
+    - hapog_bin -h
+
+about:
+  home: https://github.com/institut-de-genomique/HAPO-G
+  license: OTHER
+  license_file: LICENSE.md
+  summary: Haplotype-Aware Polishing of Genomes


### PR DESCRIPTION
Hello,

I've added the recipe for the HAPO-G tool [link](https://github.com/institut-de-genomique/HAPO-G/tree/1.3.2) the list of available recipes by creating the relevant folder (`hapog`) and conda build files.