### PR TITLE
Add mummer2circos

### DIFF
--- a/recipes/mummer2circos/meta.yaml
+++ b/recipes/mummer2circos/meta.yaml
@@ -1,5 +1,5 @@
 
-{% set version = "1.4.1" %}
+{% set version = "1.4.2" %}
 
 package:
   name: mummer2circos
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/metagenlab/mummer2circos/archive/refs/tags/{{ version }}.tar.gz
-  sha256: 8fc31524e11038416fe4aab189d4748819f85e67bf1633578fb0b5a75512af5a
+  sha256: d540fcc7f0d128c72397cbaf9ad61c40eef3229d705bb2df55ceb48b7b26185f
 
 build:
   number: 0

--- a/recipes/mummer2circos/meta.yaml
+++ b/recipes/mummer2circos/meta.yaml
@@ -1,0 +1,48 @@
+
+{% set version = "1.4.1" %}
+
+package:
+  name: mummer2circos
+  version: {{ version }}
+
+source:
+  url: https://github.com/metagenlab/mummer2circos/archive/refs/tags/{{ version }}.tar.gz
+  sha256: 8fc31524e11038416fe4aab189d4748819f85e67bf1633578fb0b5a75512af5a
+
+build:
+  number: 0
+  entry_points:
+    - mummer2circos=mummer2circos:main
+  noarch: python
+  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+
+requirements:
+  host:
+    - python =3.8
+    - pip
+  run:
+    - biopython=1.72
+    - circos=0.69.8=0
+    - libiconv
+    - perl-math-bezier=0.01=pl526_1
+    - perl-math-round=0.07=pl526_1
+    - perl-math-vecstat=0.08=pl526_1
+    - perl-set-intspan=1.19=pl526_1
+    - perl-statistics-basic=1.6611=pl526_2
+    - mummer
+    - blast
+    - matplotlib
+    - libwebp=0.5
+    - pandas
+    
+ 
+test:
+  commands:
+    - "mummer2circos -h"
+
+about:
+  home: https://github.com/metagenlab/mummer2circos
+  dev_url: https://github.com/metagenlab/mummer2circos
+  license: MIT
+  license_filte: LICENSE
+  summary: Circular bacterial genome plots based on BLAST or NUCMER/PROMER alignments

--- a/recipes/mummer2circos/meta.yaml
+++ b/recipes/mummer2circos/meta.yaml
@@ -21,18 +21,18 @@ requirements:
     - python =3.8
     - pip
   run:
-    - biopython=1.72
-    - circos=0.69.8=0
+    - biopython =1.72
+    - circos =0.69.8=0
     - libiconv
-    - perl-math-bezier=0.01=pl526_1
-    - perl-math-round=0.07=pl526_1
-    - perl-math-vecstat=0.08=pl526_1
-    - perl-set-intspan=1.19=pl526_1
-    - perl-statistics-basic=1.6611=pl526_2
+    - perl-math-bezier =0.01=pl526_1
+    - perl-math-round =0.07=pl526_1
+    - perl-math-vecstat =0.08=pl526_1
+    - perl-set-intspan =1.19=pl526_1
+    - perl-statistics-basic =1.6611=pl526_2
     - mummer
     - blast
-    - matplotlib
-    - libwebp=0.5
+    - matplotlib-base
+    - libwebp =0.5
     - pandas
     
  


### PR DESCRIPTION

This pull request adds a recipe for mummer2circos, a tool to generate circos plots based on mummer or blast alignments.
https://github.com/metagenlab/mummer2circos