### PR TITLE
Update pharokka to v 1.0.0

### DIFF
--- a/recipes/pharokka/meta.yaml
+++ b/recipes/pharokka/meta.yaml
@@ -12,7 +12,7 @@ build:
   noarch: python
 
 source:
-  git_url: https://github.com/{{ user }}/{{ name }}/releases/tag/v{{ version }}.tar.gz
+  url: https://github.com/{{ user }}/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 requirements:

--- a/recipes/pharokka/meta.yaml
+++ b/recipes/pharokka/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "1.0.0" %}
 {% set name = "pharokka" %}
-{% set sha256 = "78994a4c0cda5b2c03256642f028e09880eeeca84d04ecb29fb014d9f5359f93" %}
+{% set sha256 = "0cd539173c22af8f911b1faf6e7ab09c1bf3d102738181c0bad08e33f237f3b2" %}
 {% set user = "gbouras13" %}
 
 package:

--- a/recipes/pharokka/meta.yaml
+++ b/recipes/pharokka/meta.yaml
@@ -1,6 +1,6 @@
-{% set version = "0.1.11" %}
+{% set version = "1.0.0" %}
 {% set name = "pharokka" %}
-{% set sha256 = "be26e9c0262806da5ac83296b4cd7c30b19d533ba77f7840a941d98cd112a393" %}
+{% set sha256 = "78994a4c0cda5b2c03256642f028e09880eeeca84d04ecb29fb014d9f5359f93" %}
 {% set user = "gbouras13" %}
 
 package:
@@ -12,21 +12,20 @@ build:
   noarch: python
 
 source:
-  url: https://github.com/{{ user }}/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  git_url: https://github.com/{{ user }}/{{ name }}/releases/tag/v{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 requirements:
  run:
-  - biopython>1.78
+  - bcbio-gff
+  - biopython>=1.78
   - phanotate>=1.5.0
   - mmseqs2>=13.45111
   - trnascan-se>=2.0.9
-  - hhsuite>=3.3.0
-  - emboss>=6.6.0
   - prodigal>=2.6.3
   - minced>=0.4.2
   - aragorn>=1.2.41
-  - bcbio-gff
+
 
 test:
   commands:
@@ -40,3 +39,7 @@ about:
   summary: "Fast Phage Annotation Program"
   dev_url: https://github.com/gbouras13/pharokka
   doc_url: https://pharokka.readthedocs.io
+
+extra:
+  recipe-maintainers:
+    - gbouras13


### PR DESCRIPTION
Describe your pull request here

This PR updates the pharokka recipe to remove 2 large dependencies (emboss and hhsuite) that are no longer required in pharokka v1.0.0

Please ignore the autobump #36980

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
