### PR TITLE
Fix the Link Time Optimization compile error

### DIFF
--- a/recipes/btllib/build.sh
+++ b/recipes/btllib/build.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 
-export AR=gcc-ar
+if command -v gcc-ar &> /dev/null; then
+  export AR=gcc-ar
+elif command -v llvm-ar &> /dev/null; then
+  export AR=llvm-ar
+fi
+
 ./compile
 
 mkdir -p ${PREFIX}/bin/

--- a/recipes/btllib/build.sh
+++ b/recipes/btllib/build.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+export AR=gcc-ar
 ./compile
 
 mkdir -p ${PREFIX}/bin/

--- a/recipes/btllib/meta.yaml
+++ b/recipes/btllib/meta.yaml
@@ -16,6 +16,7 @@ build:
 requirements:
   build:
     - {{ compiler('cxx') }}
+    - binutils
   host:
     - python
     - pip

--- a/recipes/btllib/meta.yaml
+++ b/recipes/btllib/meta.yaml
@@ -17,7 +17,6 @@ requirements:
   build:
     - {{ compiler('cxx') }}
   host:
-    - gcc          # for gcc-ar
     - python
     - pip
     - wheel

--- a/recipes/btllib/meta.yaml
+++ b/recipes/btllib/meta.yaml
@@ -16,8 +16,8 @@ build:
 requirements:
   build:
     - {{ compiler('cxx') }}
-    - binutils
   host:
+    - gcc          # for gcc-ar
     - python
     - pip
     - wheel


### PR DESCRIPTION
The latest btllib enables Link Time Optimization (LTO), but it looks like default `ar` doesn't support it. This PR tells the build to use `gcc-ar` that has LTO enabled.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
