### PR TITLE
Update Hapo-G to 1.3.3

### DIFF
--- a/recipes/hapog/meta.yaml
+++ b/recipes/hapog/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.3.2" %}
+{% set version = "1.3.3" %}
 
 package:
   name: hapog
@@ -9,7 +9,7 @@ build:
 
 source:
   url: https://github.com/institut-de-genomique/HAPO-G/archive/refs/tags/{{ version }}.tar.gz
-  sha256: "46e0d102467276d0aee5c493e5e678c76120760f0dbe57caf4d880d366dcb285"
+  sha256: "cc70b0b2948180cb898d488be077df1f2210d078a7e1f443b1429f6cd5694fcd"
 
 requirements:
   build:


### PR DESCRIPTION
Hello,

this is an update to the Hapo-G recipe which fixes a bug. This bump in version is necessary for the tool to be integrated into Galaxy as it fixes a bug when launched with 1 thread.
