### PR TITLE
Update gotree: Correction of package version in gotree build

### DIFF
--- a/recipes/gotree/build.sh
+++ b/recipes/gotree/build.sh
@@ -7,7 +7,7 @@ export GOCACHE=$PWD/.cache/
 mkdir -p $GOCACHE
 cd src/github.com/evolbioinfo/${PKG_NAME}
 go get .
-go build -o ${PREFIX}/bin/${PKG_NAME} -ldflags "-X github.com/evolbioinfo/${PKG_NAME}/version.Version=${PKG_VERSION}" github.com/evolbioinfo/${PKG_NAME}
+go build -o ${PREFIX}/bin/${PKG_NAME} -ldflags "-X github.com/evolbioinfo/${PKG_NAME}/cmd.Version=${PKG_VERSION}" github.com/evolbioinfo/${PKG_NAME}
 go test github.com/evolbioinfo/${PKG_NAME}/...
 
 # Gotree test data

--- a/recipes/gotree/meta.yaml
+++ b/recipes/gotree/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 1
+  number: 2
   binary_relocation: false
 
 source:


### PR DESCRIPTION
This PR solves an issue in gotree build, where the package version was not properly taken into account.
