### PR TITLE
Update repodating patching, loosen curl pinnings in some cases

### DIFF
--- a/recipes/bioconda-repodata-patches/gen_patch_json.py
+++ b/recipes/bioconda-repodata-patches/gen_patch_json.py
@@ -127,7 +127,7 @@ def _gen_new_index(repodata, subdir):
         if subdir == "noarch" and record_name.startswith('bioconductor-') and has_dep(record, "curl"):
             for i, dep in enumerate(deps):
                 if dep.startswith('curl >=7.'):
-                    deps[i] = 'curl >=7,<8.0a0'
+                    deps[i] = 'curl'
                     break
 
     return index

--- a/recipes/bioconda-repodata-patches/gen_patch_json.py
+++ b/recipes/bioconda-repodata-patches/gen_patch_json.py
@@ -123,6 +123,13 @@ def _gen_new_index(repodata, subdir):
                     deps[i] = 'r-base >={},<{}'.format(minVersion, maxVersion)
                     break
 
+        # Bioconductor data packages are noarch: generic and incorrectly pin curl to >=7.38.1,<8, rather than >=7,<8
+        if subdir == "noarch" and record_name.startswith('bioconductor-') and has_dep(record, "curl"):
+            for i, dep in enumerate(deps):
+                if dep.startswith('curl >=7.'):
+                    deps[i] = 'curl >=7,<8.0a0'
+                    break
+
     return index
 
 

--- a/recipes/bioconda-repodata-patches/meta.yaml
+++ b/recipes/bioconda-repodata-patches/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: bioconda-repodata-patches
-  version: 20220803
+  version: 20220921
 
 source:
   path: .
@@ -15,6 +15,8 @@ requirements:
     - setuptools
     - requests
     - tqdm
+  host:
+  run:
 
 test:
   commands:


### PR DESCRIPTION
The curl restriction in bioconductor data packages (i.e., those that are noarch with a curl run-time dependency) is now loosened to >=7,<8.0a0.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
