### PR TITLE
Update hAMRonization recipe

### DIFF
--- a/recipes/hamronization/meta.yaml
+++ b/recipes/hamronization/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "hAMRonization" %}
-{% set version = "1.0.3" %}
+{% set version = "1.1.0" %}
 
 package:
   name: "{{ name|lower }}"

--- a/recipes/hamronization/meta.yaml
+++ b/recipes/hamronization/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
-  sha256: 33a86f1287d4c259e1d0dd1e27ab8a4e05ff8b993feb7d77da90635054862240
+  sha256: 13d6122e57b7c8108ac126580349ba2d6e981e4cb974f395e97c2ed004372d90
 
 build:
   noarch: python


### PR DESCRIPTION
 Trivial version bump to the hAMRonization recipe. Now matches latest release on main tool [repository](github.com/pha4ge/hAMRonization) and on PyPI.