### PR TITLE
Add parse-vcf

### DIFF
--- a/recipes/parse-vcf/meta.yaml
+++ b/recipes/parse-vcf/meta.yaml
@@ -11,6 +11,7 @@ source:
 
 build:
   number: 0
+  noarch: generic
   script: "{{ PYTHON }} -m pip install . -vv"
 
 requirements:

--- a/recipes/parse-vcf/meta.yaml
+++ b/recipes/parse-vcf/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: "{{ version }}"
 
 source:
-  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  url: "https://files.pythonhosted.org/packages/b8/e0/e8ed80a314c9cadf8e36bd9656d2f48bd81603c414dfe1730db48793b057/parse_vcf-0.2.8.tar.gz"
   sha256: 788c5f866c66024f5bd061c797c21ffa9a7b6628d4dfc17583b4ad7566a23bfe
 
 build:

--- a/recipes/parse-vcf/meta.yaml
+++ b/recipes/parse-vcf/meta.yaml
@@ -1,0 +1,42 @@
+{% set name = "parse-vcf" %}
+{% set version = "0.2.8" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  sha256: 788c5f866c66024f5bd061c797c21ffa9a7b6628d4dfc17583b4ad7566a23bfe
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - pip
+    - pysam
+    - python
+  run:
+    - pysam
+    - python
+
+test:
+  imports:
+    - 
+  requires:
+    - nose
+
+about:
+  home: "https://github.com/david-a-parry/parse_vcf.py"
+  license: MIT
+  license_family: MIT
+  license_file: 
+  summary: "Variant Call Format parser and convenience methods"
+  doc_url: 
+  dev_url: 
+
+extra:
+  recipe-maintainers:
+    - mptrsen

--- a/recipes/parse-vcf/meta.yaml
+++ b/recipes/parse-vcf/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: "{{ version }}"
 
 source:
-  url: "https://files.pythonhosted.org/packages/b8/e0/e8ed80a314c9cadf8e36bd9656d2f48bd81603c414dfe1730db48793b057/parse_vcf-0.2.8.tar.gz"
+  url: "https://files.pythonhosted.org/packages/b8/e0/e8ed80a314c9cadf8e36bd9656d2f48bd81603c414dfe1730db48793b057/parse_vcf-{{ version }}.tar.gz"
   sha256: 788c5f866c66024f5bd061c797c21ffa9a7b6628d4dfc17583b4ad7566a23bfe
 
 build:
@@ -31,10 +31,7 @@ about:
   home: "https://github.com/david-a-parry/parse_vcf.py"
   license: MIT
   license_family: MIT
-  license_file: 
   summary: "Variant Call Format parser and convenience methods"
-  doc_url: 
-  dev_url: 
 
 extra:
   recipe-maintainers:

--- a/recipes/parse-vcf/meta.yaml
+++ b/recipes/parse-vcf/meta.yaml
@@ -25,9 +25,7 @@ requirements:
 
 test:
   imports:
-    - 
-  requires:
-    - nose
+    - parse_vcf
 
 about:
   home: "https://github.com/david-a-parry/parse_vcf.py"


### PR DESCRIPTION
Add parse-vcf, a dependency of VASE (#37138)

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
