### PR TITLE
Add GeoMxWorkflows (1.2.0)

### DIFF
--- a/recipes/bioconductor-geomxworkflows/build.sh
+++ b/recipes/bioconductor-geomxworkflows/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+mv DESCRIPTION DESCRIPTION.old
+grep -v '^Priority: ' DESCRIPTION.old > DESCRIPTION
+mkdir -p ~/.R
+echo -e "CC=$CC
+FC=$FC
+CXX=$CXX
+CXX98=$CXX
+CXX11=$CXX
+CXX14=$CXX" > ~/.R/Makevars
+$R CMD INSTALL --build .

--- a/recipes/bioconductor-geomxworkflows/meta.yaml
+++ b/recipes/bioconductor-geomxworkflows/meta.yaml
@@ -1,0 +1,76 @@
+{% set version = "1.2.0" %}
+{% set name = "GeoMxWorkflows" %}
+{% set bioc = "3.15" %}
+
+package:
+  name: 'bioconductor-{{ name|lower }}'
+  version: '{{ version }}'
+source:
+  url:
+    - 'https://bioconductor.org/packages/release/workflows/src/contrib/{{ name }}_{{ version }}.tar.gz'
+  md5: 9655a523bd31ff368301d5a282a0c46d
+build:
+  number: 0
+  rpaths:
+    - lib/R/lib/
+    - lib/
+  noarch: generic
+# Suggests: rmarkdown, knitr
+requirements:
+  host:
+    - 'bioconductor-biobase >=2.54.0,<2.55.0'
+    - 'bioconductor-biocgenerics >=0.40.0,<0.41.0'
+    - 'bioconductor-nanostringnctools >=1.2.0,<1.3.0'
+    - 'bioconductor-s4vectors >=0.32.0,<0.33.0'
+    - 'bioconductor-biocstyle'
+    - 'bioconductor-geomxtools'
+    - r-base
+    - r-data.table
+    - r-dplyr
+    - r-envstats
+    - r-lmertest
+    - r-outliers
+    - r-readxl
+    - r-reshape2
+    - r-rjson
+    - r-rtsne
+    - r-pheatmap
+    - r-umap
+    - r-scales
+    - r-ggrepel
+    - r-cowplot
+    - r-ggforce
+    - r-outliers
+  run:
+    - 'bioconductor-biobase >=2.54.0,<2.55.0'
+    - 'bioconductor-biocgenerics >=0.40.0,<0.41.0'
+    - 'bioconductor-nanostringnctools >=1.2.0,<1.3.0'
+    - 'bioconductor-s4vectors >=0.32.0,<0.33.0'
+    - 'bioconductor-biocstyle'
+    - 'bioconductor-geomxtools'
+    - r-base
+    - r-data.table
+    - r-dplyr
+    - r-envstats
+    - r-lmertest
+    - r-outliers
+    - r-readxl
+    - r-reshape2
+    - r-rjson
+    - r-rtsne
+    - r-pheatmap
+    - r-umap
+    - r-scales
+    - r-ggrepel
+    - r-cowplot
+    - r-ggforce
+    - r-outliers
+test:
+  commands:
+    - '$R -e "library(''{{ name }}'')"'
+about:
+  home: 'https://bioconductor.org/packages/release/workflows/html/{{name}}.html'
+  license: MIT
+  summary: 'Workflows for use with NanoString Technologies GeoMx Technology.'
+  description: 'Package provides bioconductor focused workflows for leveraging existing packages (e.g. GeomxTools) to process, QC, and analyze the data.'
+


### PR DESCRIPTION
[This package](https://bioconductor.org/packages/release/workflows/html/GeoMxWorkflows.html) is part of the 3.15 Bioconductor release (though it's backwards compatibile with R>=4.0).
Perhaps this shouldn't be merged until after the pending bulk branch updating to 3.15.
