### PR TITLE
Update parse-vcf

### DIFF
--- a/recipes/parse-vcf/meta.yaml
+++ b/recipes/parse-vcf/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 788c5f866c66024f5bd061c797c21ffa9a7b6628d4dfc17583b4ad7566a23bfe
 
 build:
-  number: 0
+  number: 1
   noarch: generic
   script: "{{ PYTHON }} -m pip install . -vv"
 
@@ -18,10 +18,10 @@ requirements:
   host:
     - pip
     - pysam
-    - python
+    - python=3.9
   run:
     - pysam
-    - python
+    - python=3.9
 
 test:
   imports:

--- a/recipes/parse-vcf/meta.yaml
+++ b/recipes/parse-vcf/meta.yaml
@@ -11,17 +11,17 @@ source:
 
 build:
   number: 1
-  noarch: generic
+  noarch: python
   script: "{{ PYTHON }} -m pip install . -vv"
 
 requirements:
   host:
     - pip
     - pysam
-    - python =3.9
+    - python >=3.9
   run:
     - pysam
-    - python =3.9
+    - python >=3.9
 
 test:
   imports:

--- a/recipes/parse-vcf/meta.yaml
+++ b/recipes/parse-vcf/meta.yaml
@@ -18,10 +18,10 @@ requirements:
   host:
     - pip
     - pysam
-    - python=3.9
+    - python =3.9
   run:
     - pysam
-    - python=3.9
+    - python =3.9
 
 test:
   imports:


### PR DESCRIPTION
This pull request pins python to 3.9 for parse-vcf.

Necessary for VASE, which depends on parse-vcf and looks for the parse_vcf module in the python3.9 library.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
