### PR TITLE
minimum genomepy version

### DIFF
--- a/recipes/genomepy/meta.yaml
+++ b/recipes/genomepy/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - diskcache
     - click
     - colorama
-    - filelock
+    - filelock >=3.5
     - loguru
     - mygene
     - mysql-connector-python

--- a/recipes/genomepy/meta.yaml
+++ b/recipes/genomepy/meta.yaml
@@ -9,13 +9,13 @@ source:
   sha256: f90810c9b9d1b099b547efa321f5fdda04e565146ec6217c6b40cb0ab28d3e0a
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv
   
 requirements:
   host:
-    - python
+    - python >=3.7
     - pip
     - hatchling >=1.5.0
   run:
@@ -33,6 +33,7 @@ requirements:
     - numpy
     - pandas
     - pyfaidx >=0.5.7
+    - python >=3.7
     - requests
     - tqdm >=4.51
     - tabix
@@ -46,6 +47,7 @@ test:
   imports:
     - genomepy
   commands:
+    - genomepy -v
     - genomepy -h
 
 extra:


### PR DESCRIPTION
Set the minimum python version to 3.7
Set the minimum filelock version to 3.5
