### PR TITLE
Update tRNAscan-SE to 2.0.11

### DIFF
--- a/recipes/trnascan-se/meta.yaml
+++ b/recipes/trnascan-se/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "tRNAscan-SE" %}
-{% set version = "2.0.9" %}
+{% set version = "2.0.11" %}
 
 package:
   name: {{ name|lower }}
@@ -10,7 +10,7 @@ build:
 
 source:
   url: http://lowelab.ucsc.edu/software/trnascan-se-{{ version }}.tar.gz
-  sha256: 566b5c8221bf90c55eb3733e1dbe67ba6b722e70e8eae3065959c0633c02002a
+  sha256: 29b74edd0f84ad88139035e119b66397c54a37428e0b61c66a1b3d4733adcd1e
   patches:
     - patches/libdir.patch
 

--- a/recipes/trnascan-se/meta.yaml
+++ b/recipes/trnascan-se/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 3
+  number: 0
 
 source:
   url: http://lowelab.ucsc.edu/software/trnascan-se-{{ version }}.tar.gz

--- a/recipes/trnascan-se/meta.yaml
+++ b/recipes/trnascan-se/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - perl
   run:
     - perl
-    - infernal >=1.1.2
+    - infernal >=1.1.4
 
 test:
   commands:


### PR DESCRIPTION
Update tRNAscan-SE to 2.0.11 and bump Infernal dependency to 1.1.4 (~2 years old)