### PR TITLE
Exclude hesslab-gambit from future builds

### DIFF
--- a/build-fail-blacklist
+++ b/build-fail-blacklist
@@ -1037,6 +1037,7 @@ recipes/tqdist/1.0.0
 
 # tool renamed
 recipes/titan-gc
+recipes/hesslab-gambit
 
 # failing in bulk for now
 recipes/cmip


### PR DESCRIPTION
This tool/recipe was renamed to `gambit`, the last version was supposed to be `0.5.1`. I think this is the correct change to achieve that outcome (was made in #36569 but closed for some reason).