### PR TITLE
Pin tabulate dependency in pangolin

### DIFF
--- a/recipes/pangolin/meta.yaml
+++ b/recipes/pangolin/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: ecb5d69ccf2533e4f9da888068261e5639b65ee65755653254ba091a28fc286e
 
 build:
-  number: 1
+  number: 2
   noarch: python
   script: python -m pip install --no-deps --ignore-installed .
 
@@ -21,6 +21,7 @@ requirements:
     - python >=3.7
     - biopython ==1.74
     - pandas >=1.0.1
+    - tabulate ==0.8.10
     - joblib >=0.11
     - scikit-learn >=0.23.1
     - pulp >=2


### PR DESCRIPTION
Pangolin's packaged snakemake will break with the current tabulate 0.9.0.

See https://github.com/cov-lineages/pangolin/issues/489 and https://github.com/cov-lineages/pangolin/pull/491.