### PR TITLE
Update MEDICC2: bugfix in openfst dependency

### DIFF
--- a/build-fail-blacklist
+++ b/build-fail-blacklist
@@ -68,9 +68,6 @@ recipes/perl-xml-dom-xpath
 recipes/perl-xml-dom
 recipes/perl-util-properties
 
-# cython errors in the vendored fstlib. Authors contacted
-recipes/medicc2
-
 # perl package with no proper installation method
 recipes/feelnc
 

--- a/recipes/medicc2/meta.yaml
+++ b/recipes/medicc2/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - pip
     # The following are needed for building the Cython extension
     - numpy >=1.20.1
-    - openfst >=1.8.1
+    - openfst ==1.8.1
     - setuptools
     - cython >=0.29.21
   run:


### PR DESCRIPTION
Updated openfst dependency to specific version which is required for correct build.
Removed MEDICC2 from blacklist.

----

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
