### PR TITLE
update pharokka v1.1.0

### DIFF
--- a/recipes/pharokka/meta.yaml
+++ b/recipes/pharokka/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "1.1.0" %}
 {% set name = "pharokka" %}
-{% set sha256 = "4f4248ef712d7a3a7fa118a1ed3363dc08afee3c5734b98f94ca328c7ddc1041" %}
+{% set sha256 = "57d546f501f201117f5d8037ac47c0d83ccd1ec518080145e8f28d3e9843fba6" %}
 {% set user = "gbouras13" %}
 
 package:

--- a/recipes/pharokka/meta.yaml
+++ b/recipes/pharokka/meta.yaml
@@ -1,6 +1,6 @@
-{% set version = "1.0.1" %}
+{% set version = "1.1.0" %}
 {% set name = "pharokka" %}
-{% set sha256 = "eb61d73b90763785613519d42f05103a31785ec7ce1d918a153f338a4f9a6ce9" %}
+{% set sha256 = "4f4248ef712d7a3a7fa118a1ed3363dc08afee3c5734b98f94ca328c7ddc1041" %}
 {% set user = "gbouras13" %}
 
 package:
@@ -20,7 +20,7 @@ requirements:
   - bcbio-gff
   - biopython >=1.78
   - phanotate >=1.5.0
-  - mmseqs2 >=13.45111
+  - mmseqs2 ==13.45111
   - trnascan-se >=2.0.9
   - prodigal >=2.6.3
   - minced >=0.4.2


### PR DESCRIPTION
Describe your pull request here

Replacing #37547. Dependencies required to lock mmseqs2 version 13.4511 as pharokka databases are not optimised for the new version of mmseqs2.


----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
