### PR TITLE
Update fsnviz dependency crimson: add support for latest version of star-fusion output

### DIFF
--- a/recipes/fsnviz/meta.yaml
+++ b/recipes/fsnviz/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   noarch: python
-  number: 5
+  number: 6
   script: {{ PYTHON }} -m pip install . --ignore-installed --no-deps -vv
   entry_points:
     - fsnviz=fsnviz.cli:main
@@ -22,7 +22,7 @@ requirements:
   run:
     - python >=3
     - click >=6.6
-    - crimson >=0.3.0
+    - crimson >=1.1.0
     - jinja2 ==2.9.5
     - circos >=0.69.2
 


### PR DESCRIPTION
Update the requirement on crimson to version 1.1.0, to add support for the latest version of STAR-fusion to fsnviz.

Describe your pull request here

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.