### PR TITLE
Re-enable Spades OSX build

### DIFF
--- a/recipes/spades/0002-spades-compile-remove-expr.patch
+++ b/recipes/spades/0002-spades-compile-remove-expr.patch
@@ -1,0 +1,15 @@
+--- SPAdes-3.15.5.orig/spades_compile.sh	2022-07-11 15:49:32.000000000 -0600
++++ SPAdes-3.15.5/spades_compile.sh	2022-11-02 13:03:47.000000000 -0600
+@@ -36,10 +36,10 @@
+ }
+
+ # return the argument first character
+-str_head() { echo "$(expr substr "$1" 1 1)"; }
++str_head() { echo "${1::1}"; }
+
+ # return the argument without the first character
+-str_tail() { echo "$(expr substr "$1" 2 $((${#1}-1)))"; }
++str_tail() { echo "${1:1}"; }
+
+ print_help() {
+   echo

--- a/recipes/spades/meta.yaml
+++ b/recipes/spades/meta.yaml
@@ -12,29 +12,23 @@ source:
     - 0001-change-verbosity.patch
 
 build:
-  number: 1
-  skip: True  # [osx]
+  number: 2
 
 requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - clangdev  # [osx]
     - llvm-openmp  # [osx]
-    - openmp  # [linux]
+    - libgomp  # [linux]
     - cmake
     - make
     - pkg-config
     - sysroot_linux-64=2.17 # [linux]
   host:
-    - llvm-openmp  # [osx]
-    - openmp  # [linux]
     - zlib
     - bzip2
     - sysroot_linux-64=2.17 # [linux]
   run:
-    - llvm-openmp  # [osx]
-    - openmp  # [linux]
     - python
     - sysroot_linux-64=2.17 # [linux]
 
@@ -73,6 +67,7 @@ extra:
   recipe-maintainers:
     - druvus
     - notestaff
+    - epruesse
   identifiers:
     - biotools:spades
     - usegalaxy-eu:spades
@@ -81,4 +76,4 @@ extra:
     - doi:10.1093/gigascience/giz100
     - doi:10.1093/bioinformatics/btz349
   skip-lints:
-    - should_not_be_noarch_source
+    #- should_not_be_noarch_source

--- a/recipes/spades/meta.yaml
+++ b/recipes/spades/meta.yaml
@@ -10,6 +10,7 @@ source:
   sha256: {{ sha256 }}
   patches:
     - 0001-change-verbosity.patch
+    - 0002-spades-compile-remove-expr.patch
 
 build:
   number: 2

--- a/recipes/spades/meta.yaml
+++ b/recipes/spades/meta.yaml
@@ -23,14 +23,14 @@ requirements:
     - cmake
     - make
     - pkg-config
-    - sysroot_linux-64=2.17 # [linux]
+    - sysroot_linux-64 2.17  # [linux]
   host:
     - zlib
     - bzip2
-    - sysroot_linux-64=2.17 # [linux]
+    - sysroot_linux-64 2.17  # [linux]
   run:
     - python
-    - sysroot_linux-64=2.17 # [linux]
+    - sysroot_linux-64 2.17  # [linux]
 
 test:
   commands:


### PR DESCRIPTION
This got turned off in bulk update. Let's see if it's hard to turn back on...