### PR TITLE
Update Hapog to 1.3.4

### DIFF
--- a/recipes/hapog/meta.yaml
+++ b/recipes/hapog/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.3.3" %}
+{% set version = "1.3.4" %}
 
 package:
   name: hapog
@@ -9,7 +9,7 @@ build:
 
 source:
   url: https://github.com/institut-de-genomique/HAPO-G/archive/refs/tags/{{ version }}.tar.gz
-  sha256: "cc70b0b2948180cb898d488be077df1f2210d078a7e1f443b1429f6cd5694fcd"
+  sha256: "51acbd27ec6db328404256b9a0166a7f3911c572a3a53a818a83945a9c85623f"
 
 requirements:
   build:

--- a/recipes/hapog/meta.yaml
+++ b/recipes/hapog/meta.yaml
@@ -17,12 +17,12 @@ requirements:
     - cmake
     - make
   host:
-    - python>=3.7
+    - python >= 3.7
     - htslib
     - setuptools
   run:
     - htslib
-    - python>=3.7
+    - python >= 3.7
     - setuptools
     - biopython
     - bwa

--- a/recipes/hapog/meta.yaml
+++ b/recipes/hapog/meta.yaml
@@ -5,6 +5,7 @@ package:
   version: {{ version }}
 
 build:
+  skip: True  # [py < 37]
   number: 0
 
 source:
@@ -17,12 +18,12 @@ requirements:
     - cmake
     - make
   host:
-    - python >=3.7
+    - python
     - htslib
     - setuptools
   run:
     - htslib
-    - python >=3.7
+    - python
     - setuptools
     - biopython
     - bwa

--- a/recipes/hapog/meta.yaml
+++ b/recipes/hapog/meta.yaml
@@ -17,12 +17,12 @@ requirements:
     - cmake
     - make
   host:
-    - python >= 3.7
+    - python >=3.7
     - htslib
     - setuptools
   run:
     - htslib
-    - python >= 3.7
+    - python >=3.7
     - setuptools
     - biopython
     - bwa


### PR DESCRIPTION
Hello,

this PR updates the Hapog package already included in Bioconda to the 1.3.4 version to fix a critical bug.