### PR TITLE
Update president recipe for migration to GitHub

### DIFF
--- a/recipes/president/meta.yaml
+++ b/recipes/president/meta.yaml
@@ -2,17 +2,17 @@
 {% set name = "president" %}
 
 package:
-  name: {{ name }}
+  name: {{ name|lower }}
   version: {{ version }}
 
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/py{{ name }}/py{{ name }}-{{ version }}.tar.gz
+  sha256: d7151afb3e3c09cebf46656fb97eea1915c4db3528095c338737771fe2aa5cba
+
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . --ignore-installed --no-deps -vv
-
-source:
-  url: https://gitlab.com/RKIBioinformaticsPipelines/{{ name }}/-/archive/v{{ version }}/{{ name }}-v{{ version }}.tar.gz
-  sha256: c4ed62d7e969cccbc981edb6a8133241039011f72fed16e0f193e08e7f8d2c35
 
 requirements:
   host:
@@ -33,11 +33,11 @@ test:
     - president -v | grep {{ version }}
 
 about:
-  home: https://gitlab.com/RKIBioinformaticsPipelines/president
+  home: https://github.com/rki-mf1/president
   license: MIT
   license_file: LICENSE
   summary: 'Calculate pairwise nucleotide identity with respect to a reference sequence.'
 
 extra:
-  identifiers:
-    - biotools:president
+  recipe-maintainers:
+    - mirand863


### PR DESCRIPTION
This recipe is being updated to support a migration from GitLab to GitHub. I decided to update the source to pypi instead, since it makes things easier.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
