### PR TITLE
chore: use mergify to automatically merge autobump PRs from BiocondaBot after waiting 3 days

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -5,6 +5,7 @@ pull_request_rules:
       - "label=autobump"
       - "created-at>=3 days ago"
       - "check-success=bioconda.bioconda-recipes"
+      - "#commits=1"
     actions:
       review:
         type: APPROVE

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -5,7 +5,7 @@ pull_request_rules:
       - "label=autobump"
       - "created-at>=3 days ago"
       - "check-success=bioconda.bioconda-recipes"
-      - "#commits=1"
+      - "#commits=1" # by enforcing only a single commit, we ensure that the PR is not hijacked by others to introduce additional changes
     actions:
       review:
         type: APPROVE

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,13 @@
+pull_request_rules:
+  - name: Approve and merge autobump PRs if tests are successful
+    conditions:
+      - "author=BiocondaBot"
+      - "label=autobump"
+      - "created-at>=3 days ago"
+      - "check-success=bioconda.bioconda-recipes"
+    actions:
+      review:
+        type: APPROVE
+        message: Automatically approving successfull autobump
+      merge:
+        method: squash


### PR DESCRIPTION
Still to solve: we need to ensure that the autobump PR does not contain additional commits from others than the BiocondaBot.