### PR TITLE
Fix dependency issue between perl and bioperl

### DIFF
--- a/recipes/iphop/meta.yaml
+++ b/recipes/iphop/meta.yaml
@@ -10,31 +10,31 @@ source:
   sha256: d61ef488175f1a99784d48a9a8d98c40959a3f49d6129ad11e5ace81b08be4f5
 
 build:
-  number: 1
+  number: 2
   noarch: python
 
 requirements:
   build:
-    - python=3.8
+    - python 3.8
     - pip
   run:
-    - python=3.8
-    - perl=5.26
-    - perl-bioperl=1.6.924
-    - blast=2.12.0
-    - biopython=1.79
-    - scikit-learn=0.22
-    - click=8.0.1
-    - pandas=1.3.2
-    - joblib=1.0.1
-    - tensorflow=2.7.0
-    - libstdcxx-ng=11.2.0
-    - diamond=2.0.11
-    - prodigal=2.6.3
-    - hmmer=3.3.2
-    - r-ranger=0.13.1
-    - piler-cr=1.06
-    - crisper_recognition_tool=1.2
+    - python 3.8
+    - perl <6
+    - perl-bioperl <=1.7
+    - blast 2.12.0
+    - biopython 1.79
+    - scikit-learn 0.22
+    - click 8.0.1
+    - pandas 1.3.2
+    - joblib 1.0.1
+    - tensorflow 2.7.0
+    - libstdcxx-ng 11.2.0
+    - diamond 2.0.11
+    - prodigal 2.6.3
+    - hmmer 3.3.2
+    - r-ranger 0.13.1
+    - piler-cr 1.06
+    - crisper_recognition_tool 1.2
 
 test:
   commands:


### PR DESCRIPTION
Fixing dependency issue between perl and bioperl that prevented the recipe to be installed as of Nov 18 2022. See issue https://bitbucket.org/srouxjgi/iphop/issues/17/unsatisfiableerror-the-following

