### PR TITLE
Update FitHiC recipe

### DIFF
--- a/recipes/fithic/meta.yaml
+++ b/recipes/fithic/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - scipy
     - scikit-learn
     - sortedcontainers
-    - argparse
+    - argparse  # [py < 32]
 
 test:
   commands:

--- a/recipes/fithic/meta.yaml
+++ b/recipes/fithic/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   entry_points:
     - fithic = fithic.fithic:main
 

--- a/recipes/fithic/meta.yaml
+++ b/recipes/fithic/meta.yaml
@@ -17,15 +17,14 @@ source:
 
 requirements:
   build:
-    - python >=3
+    - python >=3.2
   run:
-    - python >=3
+    - python >=3.2
     - numpy
     - matplotlib-base
     - scipy
     - scikit-learn
     - sortedcontainers
-    - argparse  # [py < 32]
 
 test:
   commands:


### PR DESCRIPTION
Update FitHiC recipe to:
- Require Python 3.2 or newer
- Remove [argparse](https://anaconda.org/conda-forge/argparse) dependency

This should make it easier to install FitHiC on environments using a recent version of Python (e.g. >=3.7), where the argparse module is already part of the stdlib, and the [argparse](https://anaconda.org/conda-forge/argparse) package is not available.

----

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
