### PR TITLE
Update barriers recipe: add perl requirement

### DIFF
--- a/recipes/barriers/meta.yaml
+++ b/recipes/barriers/meta.yaml
@@ -12,7 +12,7 @@ source:
     - patch
 
 build:
-  number: 2
+  number: 3
 
 requirements:
   build:

--- a/recipes/barriers/meta.yaml
+++ b/recipes/barriers/meta.yaml
@@ -23,6 +23,7 @@ requirements:
     - autoconf
   host:
     - gengetopt
+    - perl
     - viennarna
   run:
     - viennarna


### PR DESCRIPTION
There is an issue concerning the Perl interface of the `barriers` package. It is caused by a missing `perl` host requirement in the recipe of barriers. This causes problems when the Perl version changes, as `barriers` installs a Perl module `RNA::barrier` in a version-dependent path (e.g. `$PREFIX/lib/site_perl/5.32.0/RNA/barrier.pm`). In such cases, the module cannot be loaded by Perl. Since the `perl` recipe defines a run export including a version pinning, adding it as a host requirement would prevent this issues and ensure that the Perl module can be found and loaded. This is what this PR does.