### PR TITLE
complete build for t-coffee

### DIFF
--- a/recipes/t-coffee/build.sh
+++ b/recipes/t-coffee/build.sh
@@ -11,4 +11,7 @@ set -eu -o pipefail
 
 SHARE_DIR="${PREFIX}/libexec/${PKG_NAME}-${PKG_VERSION}-${PKG_BUILDNUM}"
 
-./install all -exec="${PREFIX}/bin" -tcdir="${SHARE_DIR}" CC="$CXX" CFLAGS="$CFLAGS"
+mkdir -p "${PREFIX}/bin"
+sed -e "s|CHANGEME|${SHARE_DIR}|" "$RECIPE_DIR/t_coffee.sh" > "${PREFIX}/bin/t_coffee"
+
+./install all -tcdir="${SHARE_DIR}" CC="$CXX" CFLAGS="$CFLAGS"

--- a/recipes/t-coffee/build.sh
+++ b/recipes/t-coffee/build.sh
@@ -10,8 +10,9 @@
 set -eu -o pipefail
 
 SHARE_DIR="${PREFIX}/libexec/${PKG_NAME}-${PKG_VERSION}-${PKG_BUILDNUM}"
+OS=$(./install get_os)
 
 mkdir -p "${PREFIX}/bin"
-sed -e "s|CHANGEME|${SHARE_DIR}|" "$RECIPE_DIR/t_coffee.sh" > "${PREFIX}/bin/t_coffee"
+sed -e "s|CHANGEME|${SHARE_DIR}|" -e "s|__OS__|${OS}|" "$RECIPE_DIR/t_coffee.sh" > "${PREFIX}/bin/t_coffee"
 
 ./install all -tcdir="${SHARE_DIR}" CC="$CXX" CFLAGS="$CFLAGS"

--- a/recipes/t-coffee/build.sh
+++ b/recipes/t-coffee/build.sh
@@ -7,7 +7,7 @@
 # $PKG_VERSION The version of the package
 # $PKG_BUILDNUM The build number of the package
 #
-set -eu -o pipefail
+set -eux -o pipefail
 
 SHARE_DIR="${PREFIX}/libexec/${PKG_NAME}-${PKG_VERSION}-${PKG_BUILDNUM}"
 OS=$(./install get_os)
@@ -15,6 +15,15 @@ OS=$(./install get_os)
 mkdir -p "${PREFIX}/bin"
 
 ./install all -tcdir="${SHARE_DIR}" CC="$CXX" CFLAGS="$CFLAGS"
+
+# llvm-otool -l fails for these plugins on macosx
+if [ "$OS" = macosx ]
+then
+    for bad_plug in probconsRNA prank
+    do
+	rm -fv "${SHARE_DIR}/plugins/macosx/${bad_plug}"
+    done
+fi
 
 # The installer may try to update dependencies and install them to bin/,
 # which will cause conflicts with the dependencies as separately packaged.

--- a/recipes/t-coffee/build.sh
+++ b/recipes/t-coffee/build.sh
@@ -9,16 +9,6 @@
 #
 set -eu -o pipefail
 
-cd t_coffee_source
-make CC="$CXX" CFLAGS="$CFLAGS"
+SHARE_DIR="${PREFIX}/libexec/${PKG_NAME}-${PKG_VERSION}-${PKG_BUILDNUM}"
 
-SHARE_DIR="${PREFIX}/share/${PKG_NAME}-${PKG_VERSION}-${PKG_BUILDNUM}"
-# install t_coffee binary in SHARE_DIR
-mkdir -p "${SHARE_DIR}/bin"
-cp t_coffee "${SHARE_DIR}/bin/"
-# install mcoffee data files
-cd ..
-mv mcoffee/ "$SHARE_DIR/"
-# install t_coffer wrapper
-mkdir -p "${PREFIX}/bin"
-sed -e "s|CHANGEME|${SHARE_DIR}|" "$RECIPE_DIR/t_coffee.sh" > "${PREFIX}/bin/t_coffee"
+./install all -exec="${PREFIX}/bin" -tcdir="${SHARE_DIR}" CC="$CXX" CFLAGS="$CFLAGS"

--- a/recipes/t-coffee/build.sh
+++ b/recipes/t-coffee/build.sh
@@ -13,6 +13,12 @@ SHARE_DIR="${PREFIX}/libexec/${PKG_NAME}-${PKG_VERSION}-${PKG_BUILDNUM}"
 OS=$(./install get_os)
 
 mkdir -p "${PREFIX}/bin"
-sed -e "s|CHANGEME|${SHARE_DIR}|" -e "s|__OS__|${OS}|" "$RECIPE_DIR/t_coffee.sh" > "${PREFIX}/bin/t_coffee"
 
 ./install all -tcdir="${SHARE_DIR}" CC="$CXX" CFLAGS="$CFLAGS"
+
+# The installer may try to update dependencies and install them to bin/,
+# which will cause conflicts with the dependencies as separately packaged.
+# t_coffee itself is not installed here
+rm -fv ${PREFIX}/bin/*
+
+sed -e "s|CHANGEME|${SHARE_DIR}|" -e "s|__OS__|${OS}|" "$RECIPE_DIR/t_coffee.sh" > "${PREFIX}/bin/t_coffee"

--- a/recipes/t-coffee/expose-os-detection.patch
+++ b/recipes/t-coffee/expose-os-detection.patch
@@ -1,0 +1,13 @@
+--- a/install	2020-10-15 10:52:29.000000000 -0700
++++ b/install	2022-12-09 23:49:53.287199754 -0800
+@@ -77,6 +77,10 @@
+      print "\n!!!!!!! ./install  -h                   --> print usage\n\n";
+      if ( $#ARGV==-1){exit ($EXIT_FAILURE);}
+    }
++if ($cl=~/get_os/) {
++    print "$OS\n";
++    exit ($EXIT_SUCCESS);
++}
+      
+ if (($cl=~/-h/) ||($cl=~/-H/) )
+   {

--- a/recipes/t-coffee/meta.yaml
+++ b/recipes/t-coffee/meta.yaml
@@ -12,6 +12,8 @@ source:
   # but is then archived at http://www.tcoffee.org/Packages/Archives/
   url: https://s3.eu-central-1.amazonaws.com/tcoffee-packages/Stable/Latest/T-COFFEE_distribution_Version_{{ version }}.tar.gz
   sha256: c8e5ba17de11ddf07cf2ed37f077d81c1432d55b77761f115f9374de6f8d0d03
+  patches:
+    - expose-os-detection.patch
 
 requirements:
   build:

--- a/recipes/t-coffee/meta.yaml
+++ b/recipes/t-coffee/meta.yaml
@@ -25,6 +25,7 @@ requirements:
     - consan # [not osx]
     - dca
     - dialign-tx 1.0.2
+    - famsa
     - kalign2
     - mafft 7.310
     - muscle
@@ -47,6 +48,7 @@ requirements:
     - consan # [not osx]
     - dca
     - dialign-tx 1.0.2
+    - famsa
     - kalign2
     - mafft 7.310
     - muscle

--- a/recipes/t-coffee/meta.yaml
+++ b/recipes/t-coffee/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 4
+  number: 5
 
 source:
   # The latest stable release is at http://www.tcoffee.org/Packages/Stable/Latest/ ,
@@ -18,6 +18,28 @@ requirements:
     - make
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - perl-xml-simple
+    - blast
+    - clustalo
+    - clustalw
+    - consan # [not osx]
+    - dca
+    - dialign-tx 1.0.2
+    - kalign2
+    - mafft 7.310
+    - muscle
+    - mustang 3.2.3
+    - pasta
+    - perl
+    - phylip
+    - poa 2.0 # [not osx]
+    - prank
+    - probcons
+    - probconsrna
+    - ruby
+    - sap
+    - tmalign
+    - viennarna 2.1.9
   run:
     - blast
     - clustalo

--- a/recipes/t-coffee/post-link.sh
+++ b/recipes/t-coffee/post-link.sh
@@ -1,6 +1,0 @@
-echo "** WARNING: This T-Coffee recipe is still under development **"
-echo ""
-echo "It does not contain all required packages to use all T-Coffee modes."
-echo "We suggest to use the Bioconda 't_coffee' recipe instead or download it"
-echo "from the web site http://www.tcoffee.org"
-echo ""

--- a/recipes/t-coffee/t_coffee.sh
+++ b/recipes/t-coffee/t_coffee.sh
@@ -8,5 +8,7 @@ else
 fi
 export MAX_N_PID_4_TCOFFEE
 export MCOFFEE_4_TCOFFEE=CHANGEME/mcoffee
+# last part of the directory is "linux" on linux and something else otherwise
+export PLUGINS_4_TCOFFEE=CHANGEME/plugins/*
 
-"CHANGEME/bin/t_coffee" "$@"
+exec "CHANGEME/bin/t_coffee" "$@"

--- a/recipes/t-coffee/t_coffee.sh
+++ b/recipes/t-coffee/t_coffee.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 if [[ -f /proc/sys/kernel/pid_max ]] ; then

--- a/recipes/t-coffee/t_coffee.sh
+++ b/recipes/t-coffee/t_coffee.sh
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 
-if [[ -f /proc/sys/kernel/pid_max ]] ; then
+if [ -f /proc/sys/kernel/pid_max ] ; then
     MAX_N_PID_4_TCOFFEE=$(cat /proc/sys/kernel/pid_max)
 else
     MAX_N_PID_4_TCOFFEE=99998

--- a/recipes/t-coffee/t_coffee.sh
+++ b/recipes/t-coffee/t_coffee.sh
@@ -7,8 +7,6 @@ else
     MAX_N_PID_4_TCOFFEE=99998
 fi
 export MAX_N_PID_4_TCOFFEE
-export MCOFFEE_4_TCOFFEE=CHANGEME/mcoffee
-# last part of the directory is "linux" on linux and something else otherwise
-export PLUGINS_4_TCOFFEE=CHANGEME/plugins/*
+export PLUGINS_4_TCOFFEE=CHANGEME/plugins/__OS__
 
-exec "CHANGEME/bin/t_coffee" "$@"
+exec "CHANGEME/bin/__OS__/t_coffee" "$@"


### PR DESCRIPTION
This build uses the developer-provided installer script to handle the complete build and installation.

closes #38346, which is a blocker for #38199, in turn needed to take care of #32576
