### PR TITLE
Add ProteomIQon.AlignmentBasedQuantstatistics

### DIFF
--- a/recipes/proteomiqon-alignmentbasedquantstatistics/build.sh
+++ b/recipes/proteomiqon-alignmentbasedquantstatistics/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+unzip $SRC_DIR/$PKG_VERSION
+PREFIX=$(echo "${PREFIX}" | tr '\\' '/')
+DOTNET_ROOT="${PREFIX}/lib/dotnet"
+TOOL_ROOT=$DOTNET_ROOT/tools/AlignmentBasedQuantStatistics
+
+mkdir -p $PREFIX/bin $TOOL_ROOT
+cp -r $SRC_DIR/tools/net5.0/any/* $TOOL_ROOT
+cp "$RECIPE_DIR/proteomiqon-alignmentbasedquantstatistics.sh" "$PREFIX/bin/proteomiqon-alignmentbasedquantstatistics"
+chmod +x "$PREFIX/bin/proteomiqon-alignmentbasedquantstatistics"

--- a/recipes/proteomiqon-alignmentbasedquantstatistics/meta.yaml
+++ b/recipes/proteomiqon-alignmentbasedquantstatistics/meta.yaml
@@ -22,7 +22,7 @@ requirements:
 
 test:
   commands:
-    - proteomiqon-peptidedb --help
+    - proteomiqon-alignmentbasedquantstatistics --help
 
 about:
   home: https://csbiology.github.io/ProteomIQon/

--- a/recipes/proteomiqon-alignmentbasedquantstatistics/meta.yaml
+++ b/recipes/proteomiqon-alignmentbasedquantstatistics/meta.yaml
@@ -1,0 +1,37 @@
+{% set version = "0.0.1" %}
+{% set sha256 = "2818687e03d80eec5cdc6c48141455788c3cf451f92c658a89131216c5159a37" %}
+
+package:
+  name: proteomiqon-alignmentbasedquantstatistics
+  version: '{{ version }}'
+
+source:
+  url: https://www.nuget.org/api/v2/package/ProteomIQon.AlignmentBasedQuantStatistics/{{ version }}
+  sha256: '{{ sha256 }}'
+
+build:
+  noarch: generic
+  number: 0
+
+requirements:
+  host:
+    - unzip
+  run:
+    - dotnet-runtime =5.0
+    - openssl =1.1
+
+test:
+  commands:
+    - proteomiqon-peptidedb --help
+
+about:
+  home: https://csbiology.github.io/ProteomIQon/
+  license: MIT
+  summary: The tool ProteomIQon.AlignmentBasedQuantStatistics scores peptide ion quantifications obtained through alignment between runs.
+  description: | 
+    MS-based shotgun proteomics estimates protein abundances using a proxy: peptides. 
+    Due to the acquisition method for MS2, not every peptide ion present can be identified in every run. One approach to mitigate this problem is to 
+    align information obtained from similar runs to the current run, therefore getting more quantifications. This tool scores the quantifications 
+    obtained through alignment based on peak and run properties to obtain a measurement of reliability for the alignments.
+  dev_url: https://github.com/CSBiology/ProteomIQon
+  doc_url: https://csbiology.github.io/ProteomIQon/tools/AlignmentBasedQuantStatistics.html

--- a/recipes/proteomiqon-alignmentbasedquantstatistics/proteomiqon-alignmentbasedquantstatistics.sh
+++ b/recipes/proteomiqon-alignmentbasedquantstatistics/proteomiqon-alignmentbasedquantstatistics.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+dotnet $CONDA_PREFIX/lib/dotnet/tools/AlignmentBasedQuantStatistics/ProteomIQon.AlignmentBasedQuantStatistics.dll "$@"


### PR DESCRIPTION
This PR adds the tool "ProteomIQon.AlignmentBasedQuantStatistics"

Description:
MS-based shotgun proteomics estimates protein abundances using a proxy: peptides. 
Due to the acquisition method for MS2, not every peptide ion present can be identified in every run. One approach to mitigate this problem is to align information obtained from similar runs to the current run, therefore getting more quantifications. This tool scores the quantifications obtained through alignment based on peak and run properties to obtain a measurement of reliability for the alignments.