### PR TITLE
bump hifiasm

### DIFF
--- a/recipes/hifiasm/meta.yaml
+++ b/recipes/hifiasm/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.17.3" %}
+{% set version = "0.18.2" %}
 
 package:
   name: hifiasm
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/chhylp123/hifiasm/archive/{{ version }}.tar.gz
-  sha256: 3d0ebc57d25b1fd3ecf84d7b5b80af755d996bb06207aa3c4c47abdf0a3acc40
+  sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 
 build:
   number: 0

--- a/recipes/hifiasm/meta.yaml
+++ b/recipes/hifiasm/meta.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/chhylp123/hifiasm/archive/{{ version }}.tar.gz
-  sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+  sha256: 480a51566efabf49174fce6158fcafed09d806a3f3b883c7830b22841b4f98e9
 
 build:
   number: 0


### PR DESCRIPTION
The autobumper seems to choke given hifiasm's mixed tag schemes (see https://github.com/bioconda/bioconda-utils/issues/834), so this manually bumps it to the latest version.


