### PR TITLE
hybran: improve dependency constraints

### DIFF
--- a/recipes/hybran/meta.yaml
+++ b/recipes/hybran/meta.yaml
@@ -15,10 +15,10 @@ build:
 
 requirements:
   host:
-    - python <=3.7
+    - python >=3
     - pip
   run:
-    - biopython
+    - biopython >=1.79
     - blast
     - cd-hit
     - diamond
@@ -30,8 +30,8 @@ requirements:
     - multiprocess
     - mummer
     - prodigal
-    - prokka
-    - python <=3.7
+    - prokka >=1.14
+    - python >=3
     - ratt
     - tbl2asn-forever
 

--- a/recipes/hybran/meta.yaml
+++ b/recipes/hybran/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
@@ -41,6 +41,7 @@ test:
 
 about:
   home: https://lpcdrp.gitlab.io/hybran
+  dev_url: https://gitlab.com/LPCDRP/hybran
   license: GPLv3
   license_file: LICENSE
   summary: Hybrid reference transfer and ab initio prokaryotic genome annotation


### PR DESCRIPTION
conda and mamba sometimes tried to use python 2.7, which is not compatible. See https://gitlab.com/LPCDRP/hybran/-/issues/54

Also, the existing python<=3.7 constraint was not due to anything on the part of hybran, but rather as a workaround for https://github.com/bioconda/bioconda-recipes/issues/32576 which was recently fixed.