### PR TITLE
Add vcfbub

### DIFF
--- a/recipes/vcfbub/build.sh
+++ b/recipes/vcfbub/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -euo
+
+RUST_BACKTRACE=1 CARGO_HOME="${BUILD_PREFIX}/.cargo" cargo build --release
+
+mkdir -p $PREFIX/bin
+cp target/release/vcfbub $PREFIX/bin 

--- a/recipes/vcfbub/meta.yaml
+++ b/recipes/vcfbub/meta.yaml
@@ -1,0 +1,32 @@
+{% set name = "vcfbub" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/pangenome/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
+  sha256: bd8af0ed38ea11ee073bef1d611c78844341ff1c60961fc0d12eb26b5da27e09 
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - rust >=1.51
+
+test:
+  commands:
+    - vcfbub --help
+
+about:
+  home: https://github.com/pangenome/{{ name }}
+  license: MIT
+  license_file: LICENSE
+  summary: popping bubbles in vg deconstruct VCFs
+
+extra:
+  recipe-maintainers:
+    - AndreaGuarracino

--- a/recipes/vcfbub/meta.yaml
+++ b/recipes/vcfbub/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/pangenome/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
+  url: https://github.com/pangenome/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
   sha256: bd8af0ed38ea11ee073bef1d611c78844341ff1c60961fc0d12eb26b5da27e09 
 
 build:


### PR DESCRIPTION
**Overview**
The VCF output produced by a command like `vg deconstruct -e -a -H '#' ...` includes information about the nesting of variants. With `-a, --all-snarls`, we obtain not just the top-level bubbles, but all nested ones. This exposed snarl tree information can be used to filter the VCF to obtain a set of non-overlapping sites (n.b. "snarl" is a generic model of graph bubbles including tips and loops).

`vcfbub` accomplishes a simple task: we keep sites that are the children of those which we "pop" due to their size. These occur around complex large SVs, such as multi-Mbp inversions and segmental duplications. We often need to remove these, as they provide little information for many downstream applications, such as haplotype panels or other imputation references.