### PR TITLE
Add gff2bed recipe

### DIFF
--- a/recipes/gff2bed/build.sh
+++ b/recipes/gff2bed/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+$PYTHON setup.py install

--- a/recipes/gff2bed/build.sh
+++ b/recipes/gff2bed/build.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-$PYTHON setup.py install
+$PYTHON setup.py install --single-version-externally-managed --record=record.txt

--- a/recipes/gff2bed/meta.yaml
+++ b/recipes/gff2bed/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.6.0" %}
+{% set version = "1.0.1" %}
 {% set sha256 = "f35ab762d7ff547d04c0fe9a060a27ad9fb00b5caf6fb167571053c34b0ccbf8" %}
 
 package:

--- a/recipes/gff2bed/meta.yaml
+++ b/recipes/gff2bed/meta.yaml
@@ -3,7 +3,6 @@ package:
   version: 1.0.1
 
 source:
-  fn: gff2bed-1.0.1.tar.gz
   url: https://files.pythonhosted.org/packages/31/2c/d56c1592a485e22955a4123b6f04bbe93a21d236a7bf1d039bf5506e6e7a/gff2bed-1.0.1.tar.gz
   sha256: f35ab762d7ff547d04c0fe9a060a27ad9fb00b5caf6fb167571053c34b0ccbf8
   md5: 22109e34dad019c4dd15ca96c16f45d2
@@ -26,5 +25,5 @@ test:
 
 about:
   home: https://gitlab.com/salk-tm/gff2bed
-  license: MIT License
+  license: MIT
   summary: 'Convert GFF3-formatted data to BED format'

--- a/recipes/gff2bed/meta.yaml
+++ b/recipes/gff2bed/meta.yaml
@@ -1,0 +1,30 @@
+package:
+  name: gff2bed
+  version: 1.0.1
+
+source:
+  fn: gff2bed-1.0.1.tar.gz
+  url: https://files.pythonhosted.org/packages/31/2c/d56c1592a485e22955a4123b6f04bbe93a21d236a7bf1d039bf5506e6e7a/gff2bed-1.0.1.tar.gz
+  sha256: f35ab762d7ff547d04c0fe9a060a27ad9fb00b5caf6fb167571053c34b0ccbf8
+  md5: 22109e34dad019c4dd15ca96c16f45d2
+
+build:
+  number: 0
+  noarch: python
+
+requirements:
+  build:
+    - python
+    - setuptools
+  
+  run:
+    - python
+
+test:
+  imports:
+    - gff2bed
+
+about:
+  home: https://gitlab.com/salk-tm/gff2bed
+  license: MIT License
+  summary: 'Convert GFF3-formatted data to BED format'

--- a/recipes/gff2bed/meta.yaml
+++ b/recipes/gff2bed/meta.yaml
@@ -1,11 +1,13 @@
+{% set version = "0.6.0" %}
+{% set sha256 = "f35ab762d7ff547d04c0fe9a060a27ad9fb00b5caf6fb167571053c34b0ccbf8" %}
+
 package:
   name: gff2bed
-  version: 1.0.1
+  version: '{{ version }}'
 
 source:
-  url: https://files.pythonhosted.org/packages/31/2c/d56c1592a485e22955a4123b6f04bbe93a21d236a7bf1d039bf5506e6e7a/gff2bed-1.0.1.tar.gz
-  sha256: f35ab762d7ff547d04c0fe9a060a27ad9fb00b5caf6fb167571053c34b0ccbf8
-  md5: 22109e34dad019c4dd15ca96c16f45d2
+  url: https://pypi.io/packages/source/g/gff2bed/gff2bed-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
 
 build:
   number: 0
@@ -13,11 +15,13 @@ build:
 
 requirements:
   build:
-    - python
+    - python >=3.7
     - setuptools
-  
+  host:
+    - python >=3.7
+    - pip
   run:
-    - python
+    - python >=3.7
 
 test:
   imports:
@@ -26,4 +30,5 @@ test:
 about:
   home: https://gitlab.com/salk-tm/gff2bed
   license: MIT
-  summary: 'Convert GFF3-formatted data to BED format'
+  license_familly: MIT
+  summary: Convert GFF3-formatted data to BED format


### PR DESCRIPTION
Add a `gff2bed` recipe to `bioconda-recipes`.

`gff2bed` is a python-only package containing two helper functions for converting GFF3-formated data to BED format.

It is found on PyPI here: https://pypi.org/project/gff2bed/

Source code is on GitLab here: https://gitlab.com/salk-tm/gff2bed/

Overview text from the readme:

# gff2bed

## Overview

[GFF3](https://github.com/The-Sequence-Ontology/Specifications/blob/master/gff3.md) and [BED](https://bedtools.readthedocs.io/en/latest/content/general-usage.html) are common formats for storing the coordinates of genomic features such as genes. GFF3 format is more versatile, but BED format is simpler and enjoys a rich ecosystem of utilities such as [bedtools](https://bedtools.readthedocs.io/en/latest/index.html). For this reason, it is often convenient to store genomic features in GFF3 format and convert them to BED format for genome arithmetic.

This module provides two convenience functions to streamline converting data from GFF3 to BED format for bioinformatics analysis: `parse()`, which reads data from a GFF3 file, and `convert()`, which converts GFF3-formatted data to BED-formatted data that can be passed on e.g. to [pybedtools](https://daler.github.io/pybedtools/).

## Documentation

See full online documentation at [http://salk-tm.gitlab.io/gff2bed](http://salk-tm.gitlab.io/gff2bed)