### PR TITLE
deeptools np.float is not supported anymore

### DIFF
--- a/recipes/deeptools/meta.yaml
+++ b/recipes/deeptools/meta.yaml
@@ -7,7 +7,7 @@ source:
   sha256: 62eea132513afa5f6bb51387e5866a5c3a26613aeb7e8c9600c38becf2ecb716
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv"
 
@@ -18,7 +18,7 @@ requirements:
   run:
     - python >=3
     - pybigwig >=0.2.3
-    - numpy >=1.9.0
+    - numpy >=1.9.0,<1.24
     - scipy >=0.17.0
     - matplotlib-base >=3.1.0
     - pysam >=0.14.0


### PR DESCRIPTION
Deeptools makes use of np.float and np.int, but those are depcrecated since 1.20 and not supported since 1.24 anymore: https://numpy.org/doc/stable/release/1.24.0-notes.html#expired-deprecations