### PR TITLE
update pantools to v4.0.0

### DIFF
--- a/recipes/pantools/meta.yaml
+++ b/recipes/pantools/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "PanTools" %}
-{% set version = "3.4.0" %}
-{% set sha256 = "8491362498b915fe6b920d85ddd79394e4fe21d947a317c1871eb3afaeb07110" %}
+{% set version = "4.0.0" %}
+{% set sha256 = "746e3e50f9341e5734e89ec63c4f2fd34058158ec0f5739a0d541664b15bc1c5" %}
 
 package:
   name: {{ name|lower }}
@@ -39,8 +39,8 @@ requirements:
 
 test:
   commands:
-    # pantools returns non-zero exit code for version and help; grep a known output string to work around this
-    - pantools version | grep -i "pantools version" >/dev/null
+    - pantools --version
+    - pantools --help
 
 about:
   home: https://git.wur.nl/bioinformatics/pantools
@@ -65,6 +65,8 @@ extra:
     NB: BUSCO is **not** included in the dependency list but is required for
     one subcommand of pantools ("pantools busco_protein"). Please manually
     install BUSCO for running this subcommand.
+    NB: "pantools add_functions" currently doesn't work because of the expected
+    directory structure by PanTools. We are looking into this.
   identifiers:
     - doi:https://doi.org/10.1093/bioinformatics/btw455
     - doi:https://doi.org/10.1186/s12859-018-2362-4

--- a/recipes/pantools/meta.yaml
+++ b/recipes/pantools/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - blast
     - mash =2.3
     - fastani
-    # - busco >=5 #this only works on linux unfortunately, gives a conflict with blast on macos
+    - busco >=5 # [linux]
     - r-base =3.4.3
     - r-ggplot2 =2.2.1
     - r-ape =5.0
@@ -62,11 +62,11 @@ extra:
     specify these values directly after your binaries. If you have _JAVA_OPTIONS
     set globally this will take precedence.
     For example run it with "pantools -Xms512m -Xmx1g".
-    NB: BUSCO is **not** included in the dependency list but is required for
-    one subcommand of pantools ("pantools busco_protein"). Please manually
-    install BUSCO for running this subcommand.
     NB: "pantools add_functions" currently doesn't work because of the expected
     directory structure by PanTools. We are looking into this.
+    NB: For MacOS, BUSCO is **not** included in the dependency list but it is
+    still required for one subcommand of pantools ("pantools busco_protein").
+    Please manually install BUSCO for running this command.
   identifiers:
     - doi:https://doi.org/10.1093/bioinformatics/btw455
     - doi:https://doi.org/10.1186/s12859-018-2362-4

--- a/recipes/pantools/meta.yaml
+++ b/recipes/pantools/meta.yaml
@@ -44,6 +44,8 @@ test:
 
 about:
   home: https://git.wur.nl/bioinformatics/pantools
+  dev_url: https://git.wur.nl/bioinformatics/pantools
+  doc_url: https://pantools.readthedocs.io/
   license: GPL-3.0-only
   license_family: GPL
   license_file: LICENSE


### PR DESCRIPTION
PanTools received a major API change and therefore we updated the major version of PanTools (to 4.0.0).