### PR TITLE
Bump graphtools requirement

### DIFF
--- a/recipes/phate/meta.yaml
+++ b/recipes/phate/meta.yaml
@@ -22,7 +22,7 @@ requirements:
   run:
     - deprecated
     - future
-    - graphtools >=1.3.1
+    - graphtools >=1.5.3
     - matplotlib-base >=3.0
     - numpy >=1.16.0
     - python >=3.5


### PR DESCRIPTION
PHATE requires graphtools 1.5.3