### PR TITLE
pantools dependency change

### DIFF
--- a/recipes/pantools/conda_build_config.yaml
+++ b/recipes/pantools/conda_build_config.yaml
@@ -1,0 +1,3 @@
+busco_version:
+  - >=5 # [linux]
+  -  # [osx]

--- a/recipes/pantools/conda_build_config.yaml
+++ b/recipes/pantools/conda_build_config.yaml
@@ -1,3 +1,7 @@
+# Ideally, we would like to use BUSCO v5 as dependency of PanTools but since
+# this conflicts with the other dependencies on macOS we specify version 4 for
+# macOS specifically (even though this likely results in a non-functional BUSCO
+# version).
 busco_version:
-  - >=5 # [linux]
-  -  # [osx]
+  - 5 # [linux]
+  - 4 # [osx]

--- a/recipes/pantools/meta.yaml
+++ b/recipes/pantools/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   noarch: generic
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -66,9 +66,6 @@ extra:
     For example run it with "pantools -Xms512m -Xmx1g".
     NB: "pantools add_functions" currently doesn't work because of the expected
     directory structure by PanTools. We are looking into this.
-    NB: For MacOS, BUSCO is **not** included in the dependency list but it is
-    still required for one subcommand of pantools ("pantools busco_protein").
-    Please manually install BUSCO for running this command.
   identifiers:
     - doi:https://doi.org/10.1093/bioinformatics/btw455
     - doi:https://doi.org/10.1186/s12859-018-2362-4

--- a/recipes/pantools/meta.yaml
+++ b/recipes/pantools/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - blast
     - mash =2.3
     - fastani
-    - busco >=5 # [linux]
+    - busco {{ busco_version }}
     - r-base =3.4.3
     - r-ggplot2 =2.2.1
     - r-ape =5.0


### PR DESCRIPTION
The version of BUSCO as dependency of pantools went wrong in the previous pull request for macOS specifically (#38626 and related issue #38646). Hopefully this pull request solves this by specifying specific BUSCO versions in a separate `conda_build_config.yaml`.