### PR TITLE
Update PanTools to v4.1.0

### DIFF
--- a/recipes/pantools/conda_build_config.yaml
+++ b/recipes/pantools/conda_build_config.yaml
@@ -1,7 +1,0 @@
-# Ideally, we would like to use BUSCO v5 as dependency of PanTools but since
-# this conflicts with the other dependencies on macOS we specify version 4 for
-# macOS specifically (even though this likely results in a non-functional BUSCO
-# version).
-busco_version:
-  - 5 # [linux]
-  - 4 # [osx]

--- a/recipes/pantools/meta.yaml
+++ b/recipes/pantools/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "PanTools" %}
-{% set version = "4.0.0" %}
-{% set sha256 = "746e3e50f9341e5734e89ec63c4f2fd34058158ec0f5739a0d541664b15bc1c5" %}
+{% set version = "4.1.0" %}
+{% set sha256 = "329a934ab38cbd6b0066f4246566c80b6ac2813db45cb54bfc3f99c7c4760f74" %}
 
 package:
   name: {{ name|lower }}
@@ -12,7 +12,7 @@ source:
 
 build:
   noarch: generic
-  number: 1
+  number: 0
 
 requirements:
   build:
@@ -30,7 +30,6 @@ requirements:
     - blast
     - mash =2.3
     - fastani
-    - busco {{ busco_version }}
     - r-base =3.4.3
     - r-ggplot2 =2.2.1
     - r-ape =5.0
@@ -59,13 +58,14 @@ about:
 extra:
   notes: |
     PanTools is Java program that comes with a custom wrapper Python script.
-    This wrapper is called "pantools" and is on $PATH by default. By default
-    "-Xms512m -Xmx1g" is set in the wrapper. If you want to overwrite it you can
-    specify these values directly after your binaries. If you have _JAVA_OPTIONS
-    set globally this will take precedence.
+    This wrapper is called "pantools" and is on $PATH by default.
+    By default "-Xms512m -Xmx1g" is set in the wrapper.
+    If you want to overwrite it you can specify these values directly after your binaries.
+    If you have _JAVA_OPTIONS set globally this will take precedence.
     For example run it with "pantools -Xms512m -Xmx1g".
     NB: "pantools add_functions" currently doesn't work because of the expected
     directory structure by PanTools. We are looking into this.
+    NB: BUSCO is a dependency of PanTools but it is not included in this recipe due to conflicts on MacOS.
   identifiers:
     - doi:https://doi.org/10.1093/bioinformatics/btw455
     - doi:https://doi.org/10.1186/s12859-018-2362-4


### PR DESCRIPTION
Update PanTools to v4.1.0 (newest release).

One important change in this recipe is the removal of BUSCO as dependency even though it is still used by PanTools (related  to #38646). We decided to remove this because we find it more important that this recipe works on both Linux and macOS than that one of the more obscure subcommands of PanTools which relies on BUSCO is functional. For Linux users reading this, please manually install BUSCO >=5 next to PanTools in your conda environment for PanTools.