### PR TITLE
Update OSTIR to 1.1.0

### DIFF
--- a/recipes/ostir/meta.yaml
+++ b/recipes/ostir/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "OSTIR" %}
-{% set version = "1.0.6" %}
+{% set version = "1.1.0" %}
 
 package:
   name: "{{ name|lower }}"
@@ -7,7 +7,7 @@ package:
 
 source:
   url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
-  sha256: 629e8e4fe7b35cc880b8fa3512e846906ce80ec43050f2a28aa59b90b0e19963
+  sha256: 05df18370a371ea1fa5260d1eeeebf015368363b4174ee1005b3047c697489b4
 
 build:
   number: 0
@@ -23,6 +23,7 @@ requirements:
   run:
     - python >=3.7
     - viennarna >=2.4.18
+    - numpy >=1.20.1
 
 test:
   imports:


### PR DESCRIPTION
This PR manually updates the recipe for OSTIR to 1.1.0 after the the automated attempt at #37884 failed.