### PR TITLE
Fix ASTER v1.13 compilation

### DIFF
--- a/recipes/aster/build.sh
+++ b/recipes/aster/build.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 
+sed -i.bak1 's/-march=native/-march=x86-64 -mtune=generic/g' makefile
 if [ "$(uname)" == "Darwin" ];
 then
-    sed -i.bak 's/g++/${CXX}/g' makefile
+    sed -i.bak2 's/g++/${CXX}/g' makefile
     make mac
 else
-    sed -i.bak 's/g++/${GXX}/g' makefile
+    sed -i.bak2 's/g++/${GXX}/g' makefile
     make
 fi
 

--- a/recipes/aster/meta.yaml
+++ b/recipes/aster/meta.yaml
@@ -7,7 +7,7 @@ package:
   version: "{{ version }}"
 
 build:
-  number: 0
+  number: 1
 
 source:
   url: "https://github.com/chaoszhang/ASTER/archive/refs/tags/v{{ version }}.tar.gz"


### PR DESCRIPTION
I noticed that the binaries created by bioconda resulted in an "Illegal instruction" error when running on my own (probably older) linux infrastructure; therefore, I am making the compilation a bit more general with `-march=x86-64` instead of `-march=native`.