### PR TITLE
Update SPAdes 3.12.0

### DIFF
--- a/recipes/spades/3.12.0/meta.yaml
+++ b/recipes/spades/3.12.0/meta.yaml
@@ -11,11 +11,11 @@ source:
     sha256: 5e8988b0cfd8b5a84b718e1e5af21524c7b1369bcba337dfebeed9c22a4f7141  # [linux]
 
 build:
-  number: 2
+  number: 3
 
 requirements:
   run:
-    - python
+    - python <3.10
 
 test:
   commands:


### PR DESCRIPTION
Using SPAdes 3.12.0 with a Python version >3.9 leads to the error described in [this issue](https://github.com/ablab/spades/issues/873). Python versions 3.10 and above don't have the alias to the old collections class anymore (see [this issue](https://github.com/python/cpython/issues/81505)).

Setting the python version to below 3.10 fixes the problem for SPAdes 3.12.0 (it is anyways fixed in SPAdes >=3.15.4).