### PR TITLE
Require usher >=0.6.2 for pangolin

### DIFF
--- a/recipes/pangolin/meta.yaml
+++ b/recipes/pangolin/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: dfe4ecc272482107f2a04b106ac7eacea61b78aa01f15c02293e7ca58948b679
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: python -m pip install --no-deps --ignore-installed .
 
@@ -28,7 +28,7 @@ requirements:
     - minimap2 >=2.16
     - snakemake-minimal >=5.13,<=6.8.0
     - gofasta
-    - usher >=0.6.1
+    - usher >=0.6.2
     - ucsc-fatovcf >=426
     - git
     - git-lfs

--- a/recipes/pangolin/run_test.py
+++ b/recipes/pangolin/run_test.py
@@ -6,13 +6,6 @@ from subprocess import run, PIPE, STDOUT
 import pangolin
 
 test_data = Path(pangolin.__file__).parent / 'data/reference.fasta'
-refseq = open(test_data).read()
-
-# usher 0.6.1 hangs on input with no mutations
-# see https://github.com/cov-lineages/pangolin/issues/500
-# so we need to engineer suitable test input.
-with open('tmp.fa', 'w') as o:
-    o.write(refseq.replace('ACATGGTTTAGTCAGCGTGG', 'ACATGGTTTAGCCAGCGTGG'))
-cmd = ['pangolin', 'tmp.fa']
+cmd = ['pangolin', str(test_data)]
 pangolin_proc = run(cmd, stdout=PIPE, stderr=STDOUT)
 assert b'Output file written to' in pangolin_proc.stdout, pangolin_proc.stdout


### PR DESCRIPTION
The new minimal version of usher fixes a bug with input sequences without mutations, which makes it possible to revert the previous patch of run_test.py.
