### PR TITLE
Move zlib to host requirements

### DIFF
--- a/recipes/kseqpp/meta.yaml
+++ b/recipes/kseqpp/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 6f0c4ad6aaa6f2364363801801ef3d25e62bece88587b946b5646f37d01e211c
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   host:

--- a/recipes/kseqpp/meta.yaml
+++ b/recipes/kseqpp/meta.yaml
@@ -13,11 +13,12 @@ build:
   number: 0
 
 requirements:
+  host:
+    - zlib
   build:
     - cmake
     - make  # [unix]
     - {{ compiler('cxx') }}
-    - zlib
 
 test:
   commands:


### PR DESCRIPTION
This PR fixes an issues in `kseqpp` recipe: 'zlib' should be in the 'host' section of requirements.