### PR TITLE
update IsoQuant to 3.1.1

### DIFF
--- a/recipes/isoquant/meta.yaml
+++ b/recipes/isoquant/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "IsoQuant" %}
-{% set version = "3.1.0" %}
-{% set sha256 = "950dc709f261ccf4893e4fd001016467e1ecc7bffc5afdf89211355c327e40bf" %}
+{% set version = "3.1.1" %}
+{% set sha256 = "5642176a7f9bdaaf0c38beede3e7f142724037fa6a9ef9414f22f5c30ac84ffb" %}
 
 package:
   name: {{ name | lower }}


### PR DESCRIPTION
Updates IsoQuant to the latest 3.1.1, several bug-fixes made compared to 3.1.0