### PR TITLE
fix numpy dependency to 1.23

### DIFF
--- a/recipes/deepsig/meta.yaml
+++ b/recipes/deepsig/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   entry_points:
     - deepsig = deepsig.deepsig:main
 

--- a/recipes/deepsig/meta.yaml
+++ b/recipes/deepsig/meta.yaml
@@ -21,12 +21,14 @@ requirements:
   run:
     - python =3.8, <3.9
     - biopython >=1.78
+    - numpy =1.23
     - keras =2.4.3
     - tensorflow =2.2.0
 
 test:
   import:
     - Bio.SeqIO
+    - numpy
     - keras
     - tensorflow
   commands:


### PR DESCRIPTION
Numpy dependency of Deepsig was pinned to version 1.23 since Tensorflow 2.2.0 uses `numpy.object` which was deprecated in version `1.24`.

np.object attribute is deprecated since Numpy 1.24 resulting in the following error:
```
File ".../lib/python3.8/site-packages/tensorflow/python/framework/dtypes.py", line 513, in <module>
    np.object,
  File ".../lib/python3.8/site-packages/numpy/__init__.py", line 284, in __getattr__
    raise AttributeError("module {!r} has no attribute "
AttributeError: module 'numpy' has no attribute 'object'
```