### PR TITLE
Update transposonpsi to pass any arguments to tools properly

### DIFF
--- a/recipes/transposonpsi/build.sh
+++ b/recipes/transposonpsi/build.sh
@@ -10,8 +10,8 @@ cp -r *  ${TPSI_DIR}
 cat <<END >>${PREFIX}/bin/transposonPSI.pl
 #!/bin/bash
 
-NAME=\$(basename \$0)
-${TPSI_DIR}/\${NAME}
+NAME=\$(basename "\$0")
+${TPSI_DIR}/"\${NAME}" "\$@"
 END
 
 # copy tools in the bin

--- a/recipes/transposonpsi/meta.yaml
+++ b/recipes/transposonpsi/meta.yaml
@@ -18,7 +18,7 @@ requirements:
   run:
     - perl >=5.8
     - perl-bioperl >=1.7.2
-    - blast-legacy=2.2.26
+    - blast-legacy =2.2.26
 
 test:
   commands:

--- a/recipes/transposonpsi/meta.yaml
+++ b/recipes/transposonpsi/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 build:
   noarch: generic
-  number: 2
+  number: 3
 
 source:
   url: https://github.com/NBISweden/TransposonPSI/archive/v{{ version }}.tar.gz


### PR DESCRIPTION
TransposonPSI uses a wrapper in the enviornments bin, this PR makes sure we pass any arguments onwards.