### PR TITLE
Update pggb: copy python scripts instead of moving them

### DIFF
--- a/recipes/pggb/build.sh
+++ b/recipes/pggb/build.sh
@@ -9,5 +9,5 @@ mkdir -p $PREFIX/bin
 
 mv pggb $PREFIX/bin
 mv partition-before-pggb $PREFIX/bin
-mv scripts/*.py $PREFIX/bin
+cp scripts/*.py $PREFIX/bin
 mv scripts $PREFIX/bin

--- a/recipes/pggb/meta.yaml
+++ b/recipes/pggb/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: generic
-  number: 1
+  number: 2
 
 requirements:
   run:


### PR DESCRIPTION
This fixes https://github.com/pangenome/pggb/issues/276.
