### PR TITLE
mob_suite version update to 3.1.2. Numpy version restriction 

### DIFF
--- a/recipes/mob_suite/meta.yaml
+++ b/recipes/mob_suite/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.1.0" %}
+{% set version = "3.1.2" %}
 
 package:
   name: mob_suite
@@ -11,7 +11,7 @@ build:
 
 source:
   url: https://github.com/phac-nml/mob-suite/archive/{{ version }}.tar.gz
-  sha256: 7d69abe3d106a7880c27a9a1160be3041ef4d2d3b0e6f341b0d2e143dbc5267b
+  sha256: 7f4690f1df5ebeaa2c8f256678334275991d44239c8d9c729745b34ce428018f
 
 requirements:
   host:
@@ -19,7 +19,7 @@ requirements:
     - pip
   run:
     - python >=3.7,<4
-    - numpy >=1.11.1,<2
+    - numpy >=1.11.1,<1.23.5
     - pytables >=3.3,<4
     - pandas >=0.22.0,<=1.0.5
     - biopython >=1.70,<2


### PR DESCRIPTION
Update the mob_suite tool to version 3.1.2. Restricted the upper bound for the numpy version <1.23.5 to avoid the 'bool' data type warning as a temporary fix
