### PR TITLE
Update pantools to v4.1.1

### DIFF
--- a/recipes/pantools/meta.yaml
+++ b/recipes/pantools/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "PanTools" %}
-{% set version = "4.1.0" %}
-{% set sha256 = "329a934ab38cbd6b0066f4246566c80b6ac2813db45cb54bfc3f99c7c4760f74" %}
+{% set version = "4.1.1" %}
+{% set sha256 = "fa940b131c54942fdeb85c454f04381df95a05d7e07ba32d78d92e9ab6517e02" %}
 
 package:
   name: {{ name|lower }}
@@ -63,8 +63,6 @@ extra:
     If you want to overwrite it you can specify these values directly after your binaries.
     If you have _JAVA_OPTIONS set globally this will take precedence.
     For example run it with "pantools -Xms512m -Xmx1g".
-    NB: "pantools add_functions" currently doesn't work because of the expected
-    directory structure by PanTools. We are looking into this.
     NB: BUSCO is a dependency of PanTools but it is not included in this recipe due to conflicts on MacOS.
   identifiers:
     - doi:https://doi.org/10.1093/bioinformatics/btw455


### PR DESCRIPTION
This pull request updates the PanTools recipe to v4.1.1 (needed because v4.1.0 seemed disfunctional via bioconda and this updated version fixes that).