### PR TITLE
Update python version for hicstuff bioconda recipe.

### DIFF
--- a/recipes/hicstuff/meta.yaml
+++ b/recipes/hicstuff/meta.yaml
@@ -17,10 +17,10 @@ build:
 
 requirements:
   host:
-    - python >=3.6,<3.8
+    - python >=3.7
     - pip
   run:
-    - python >=3.6,<3.8
+    - python >=3.7
     - biopython
     - docopt
     - matplotlib-base


### PR DESCRIPTION
Hi,
I am one of the hicstuff developper. I saw that the version of python used in the bioconda-recipe are not the same as the ones hicstuff is able to use. Is it possible to update them in the recipe ?
Thanks,
Amaury 

@bioconda/core
@BiocondaBot please add label
