### PR TITLE
Update IsoQuant to 3.1.2

### DIFF
--- a/recipes/isoquant/meta.yaml
+++ b/recipes/isoquant/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "IsoQuant" %}
-{% set version = "3.1.1" %}
-{% set sha256 = "5642176a7f9bdaaf0c38beede3e7f142724037fa6a9ef9414f22f5c30ac84ffb" %}
+{% set version = "3.1.2" %}
+{% set sha256 = "08246d20f47769be2c71a22ffa23033a41359e04555b67869394d9280c935546" %}
 
 package:
   name: {{ name | lower }}


### PR DESCRIPTION
Updates IsoQuant to 3.1.2, an important bug-fix release