### PR TITLE
Add drtransformer recipe

### DIFF
--- a/recipes/drtransformer/meta.yaml
+++ b/recipes/drtransformer/meta.yaml
@@ -19,10 +19,12 @@ build:
 requirements:
   host:
     - pip
+    - flit
     - viennarna >={{ vrnaversion }}
     - python >=3.8 
   run:
     - viennarna >={{ vrnaversion }}
+    - flit
     - matplotlib-base
     - numpy
     - packaging

--- a/recipes/drtransformer/meta.yaml
+++ b/recipes/drtransformer/meta.yaml
@@ -1,0 +1,50 @@
+{% set name = "drtransformer" %}
+{% set version = "1.0" %}
+{% set vrnaversion = "2.4.13" %}
+
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/drtransformer-{{ version }}.tar.gz
+  sha256: 75b0363255866ece1aa80577d8c086ee94d85ee2bbec29c3ef53cc332d7a4878
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - pip
+    - python >=3.8
+    - viennarna >={{ vrnaversion }}
+  run:
+    - viennarna >={{ vrnaversion }}
+    - matplotlib-base
+    - numpy
+    - packaging
+    - python >=3.8
+    - scipy
+
+test:
+  imports:
+    - drtransformer
+  commands:
+    - pip check
+    - DrTransformer --version
+    - DrPlotter --version
+  requires:
+    - pip
+
+about:
+  home: https://pypi.org/project/drtransformer/
+  summary: Heuristic cotranscriptional folding using the nearest neighbor energy model.
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - bad-ants-fleet

--- a/recipes/drtransformer/meta.yaml
+++ b/recipes/drtransformer/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "drtransformer" %}
 {% set version = "1.0" %}
-{% set vrnaversion = "2.4.13" %}
+{% set vrnaversion = "2.5.1" %}
 
 
 package:
@@ -19,8 +19,8 @@ build:
 requirements:
   host:
     - pip
-    - python >=3.8
     - viennarna >={{ vrnaversion }}
+    - python >=3.8 
   run:
     - viennarna >={{ vrnaversion }}
     - matplotlib-base
@@ -31,8 +31,8 @@ requirements:
 
 test:
   imports:
-    - RNA
     - drtransformer
+    - RNA
   commands:
     - DrTransformer --version
     - DrPlotter --version

--- a/recipes/drtransformer/meta.yaml
+++ b/recipes/drtransformer/meta.yaml
@@ -31,9 +31,9 @@ requirements:
 
 test:
   imports:
+    - RNA
     - drtransformer
   commands:
-    - pip check
     - DrTransformer --version
     - DrPlotter --version
   requires:
@@ -46,5 +46,5 @@ about:
   license_file: LICENSE
 
 extra:
-  recipe-maintainers:
-    - bad-ants-fleet
+  identifiers:
+    -  doi:10.1093/bioinformatics/btad034


### PR DESCRIPTION
Describe your pull request here

This pull request adds the Python package / program: DrTransformer for cotranscriptional RNA folding.

See:
https://doi.org/10.1093/bioinformatics/btad034

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
