### PR TITLE
Update to ThermoRawFileParser v 1.4.2

### DIFF
--- a/recipes/thermorawfileparser/meta.yaml
+++ b/recipes/thermorawfileparser/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "ThermoRawFileParser" %}
-{% set version = "1.4.1" %}
+{% set version = "1.4.2" %}
 
 package:
   name: {{ name|lower }}
@@ -19,14 +19,13 @@ build:
 source:
   # downloading pre-compiled packages, msbuild is a hell to compile unter Linux
   url: https://github.com/compomics/ThermoRawFileParser/releases/download/v{{ version }}/ThermoRawFileParser{{ version }}.zip
-  sha256: 1bd656327ccba9213bfcf56ec2d19643a34021ff91451cc67a539c9cf182b681
+  sha256: 2a8ef05a954f6dd2ffb6181a9bdb0b9fb0e05a949822c3f8b780b9425fcd5d49
 
 requirements:
   build:
     - zlib
   run:
-    # mono <6 due to https://github.com/compomics/ThermoRawFileParser/issues/108
-    - mono >=5, <6
+    - mono >=5
     - zlib
 
 test:

--- a/recipes/thermorawfileparser/meta.yaml
+++ b/recipes/thermorawfileparser/meta.yaml
@@ -10,7 +10,7 @@ build:
   noarch: generic
   script:
     - mkdir $PREFIX/bin
-    - cp * $PREFIX/bin
+    - cp -r * $PREFIX/bin
     - cp $RECIPE_DIR/ThermoRawFileParser.sh $PREFIX/bin
     - chmod +x $PREFIX/bin/ThermoRawFileParser.sh
     - ln -s $PREFIX/bin/ThermoRawFileParser.sh $PREFIX/bin/ThermoRawFileParser


### PR DESCRIPTION
Update the recipe to the latest version of ThermoRawFileParser
Mono <6 requirement is removed
