### PR TITLE
Patch ivar version reporting

### DIFF
--- a/recipes/ivar/meta.yaml
+++ b/recipes/ivar/meta.yaml
@@ -8,9 +8,11 @@ package:
 source:
   url: "https://github.com/andersen-lab/ivar/archive/v{{ version }}.tar.gz"
   sha256: "{{ sha256 }}"
+  patches:
+    - patches/ivar_version.patch
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipes/ivar/patches/ivar_version.patch
+++ b/recipes/ivar/patches/ivar_version.patch
@@ -1,0 +1,13 @@
+diff --git a/src/ivar.cpp b/src/ivar.cpp
+index 5fd0027..88dc801 100755
+--- a/src/ivar.cpp
++++ b/src/ivar.cpp
+@@ -17,7 +17,7 @@
+ #include "suffix_tree.h"
+ #include "trim_primer_quality.h"
+ 
+-const std::string VERSION = "1.3.1";
++const std::string VERSION = "1.3.2";
+ 
+ struct args_t {
+   std::string bam;               // -i


### PR DESCRIPTION
ivar 1.3.2 got released without bumping its version string.

see upstream issue at: https://github.com/andersen-lab/ivar/issues/148
