### PR TITLE
Add ProteomIQon.QuantBasedAlignment

### DIFF
--- a/recipes/proteomiqon-quantbasedalignment/build.sh
+++ b/recipes/proteomiqon-quantbasedalignment/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+unzip $SRC_DIR/$PKG_VERSION
+PREFIX=$(echo "${PREFIX}" | tr '\\' '/')
+DOTNET_ROOT="${PREFIX}/lib/dotnet"
+TOOL_ROOT=$DOTNET_ROOT/tools/QuantBasedAlignment
+
+mkdir -p $PREFIX/bin $TOOL_ROOT
+cp -r $SRC_DIR/tools/net5.0/any/* $TOOL_ROOT
+cp "$RECIPE_DIR/proteomiqon-quantbasedalignment.sh" "$PREFIX/bin/proteomiqon-quantbasedalignment"
+chmod +x "$PREFIX/bin/proteomiqon-quantbasedalignment"

--- a/recipes/proteomiqon-quantbasedalignment/meta.yaml
+++ b/recipes/proteomiqon-quantbasedalignment/meta.yaml
@@ -1,0 +1,41 @@
+{% set version = "0.0.2" %}
+{% set sha256 = "db451c624f420cd1bfa1af47c27b8c42e45458b9f697ddf50a692fb39689de69" %}
+
+package:
+  name: proteomiqon-quantbasedalignment
+  version: '{{ version }}'
+
+source:
+  url: https://www.nuget.org/api/v2/package/ProteomIQon.QuantBasedAlignment_linux_x64/{{ version }}
+  sha256: '{{ sha256 }}'
+
+build:
+  noarch: generic
+  number: 0
+
+requirements:
+  host:
+    - unzip
+  run:
+    - dotnet-runtime =5.0
+    - openssl =1.1
+
+test:
+  commands:
+    - proteomiqon-quantbasedalignment --help
+
+about:
+  home: https://csbiology.github.io/ProteomIQon/
+  license: MIT
+  summary: The tool ProteomIQon.QuantBasedAlignment aligns quantifications from different runs.
+  description: | 
+    One of the drawbacks of data-dependent acquisition is the stochastic nature of peptide ion selection for MSMS fragmentation as a 
+    prerequisite for peptide identification and quantification. A way to overcome this drawback is the transfer of identified ions from 
+    one run to another using the assumption that the run is merely lacking a successful MSMS scan, but still containing the peptide itself. 
+    While this ion transfer is commonly referred to as 'run alignment', strictly speaking, the alignment itself is only the process of 
+    finding a function f that can map from one point of the rt/mz/intensity plane of a source run (parameter -ii) to a target run (parameter -i). 
+    In this tool, we use smoothing splines as a nonparametric regression technique to estimate the function f for all given source 
+    runs (parameter -ii). With this estimators at hand, we are able to predict the scan time of individual ions in the target runs. 
+    This calculation can then be used as a starting point for further refinements (e.g. local alignments) or quantification procedures.
+  dev_url: https://github.com/CSBiology/ProteomIQon
+  doc_url: https://csbiology.github.io/ProteomIQon/tools/QuantBasedAlignment.html

--- a/recipes/proteomiqon-quantbasedalignment/proteomiqon-quantbasedalignment.sh
+++ b/recipes/proteomiqon-quantbasedalignment/proteomiqon-quantbasedalignment.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+dotnet $CONDA_PREFIX/lib/dotnet/tools/QuantBasedAlignment/ProteomIQon.QuantBasedAlignment.dll "$@"


### PR DESCRIPTION
This PR adds the tool "ProteomIQon.QuantBasedAlignment"

Description:
One of the drawbacks of data-dependent acquisition is the stochastic nature of peptide ion selection for MSMS fragmentation as a prerequisite for peptide identification and quantification. A way to overcome this drawback is the transfer of identified ions from one run to another using the assumption that the run is merely lacking a successful MSMS scan, but still containing the peptide itself. While this ion transfer is commonly referred to as 'run alignment', strictly speaking, the alignment itself is only the process of finding a function f that can map from one point of the rt/mz/intensity plane of a source run (parameter -ii) to a target run (parameter -i). In this tool, we use smoothing splines as a nonparametric regression technique to estimate the function f for all given source runs (parameter -ii). With this estimators at hand, we are able to predict the scan time of individual ions in the target runs. This calculation can then be used as a starting point for further refinements (e.g. local alignments) or quantification procedures.
