### PR TITLE
Upgrade dbCAN to dbCAN4

### DIFF
--- a/recipes/dbcan/meta.yaml
+++ b/recipes/dbcan/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "dbcan" %}
-{% set version = "3.0.7" %}
+{% set version = "4.0.0" %}
 
 package:
   name: "{{ name|lower }}"
@@ -7,8 +7,7 @@ package:
 
 source:
   url: https://github.com/linnabrown/run_dbcan/releases/download/{{ version }}/dbcan-{{ version }}.tar.gz
-  sha256: b32246a5874aac99ca956a51c42d8203e33566469934fdad8f280db4e6e7999c
-
+  sha256: c90e99168fa3414696575b8f5a6c2862173151d1f0d7246ebd5713704b597435
 build:
   number: 0
   script: "{{ PYTHON }} -m pip install . -vv"
@@ -31,6 +30,8 @@ requirements:
     - scipy
     - psutil
     - numpy>1.19
+    - biopython
+    - pandas
 
 test:
   imports:
@@ -46,3 +47,4 @@ about:
 extra:
   recipe-maintainers:
     - Le Huang
+

--- a/recipes/dbcan/meta.yaml
+++ b/recipes/dbcan/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - prodigal
     - scipy
     - psutil
-    - numpy>1.19
+    - numpy >1.19
     - biopython
     - pandas
 
@@ -47,4 +47,3 @@ about:
 extra:
   recipe-maintainers:
     - Le Huang
-


### PR DESCRIPTION
Describe your pull request here

----

Upgrade dbCAN to dbCAN4. 
1. CAZyme substrate prediction based on [dbCAN-sub ](https://bcb.unl.edu/dbCAN_sub/); 
2. CGC substrate prediction based on dbCAN-PUL searching and dbCAN-sub majority voting. For CGC substrate prediction, please see our [dbCAN-seq update paper ](https://academic.oup.com/nar/article/51/D1/D557/6833251)for details. With these new functions (esp. the dbCAN-sub search), dbCAN3 is now slower to get the result back to you. Please be patience