### PR TITLE
Update arriba to 2.4.0

### DIFF
--- a/recipes/arriba/meta.yaml
+++ b/recipes/arriba/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "2.3.0" %}
-{% set sha256 = "bf7156be297a34fae274b7d2383cd37b90013860c2bfc637ff1b9f3d1f8de666" %}
+{% set version = "2.4.0" %}
+{% set sha256 = "a5173f44195d7f864aab95972d0cc3da85671c4b7e602e5a4e1a4fc143810e4a" %}
 
 package:
   name: arriba
@@ -10,7 +10,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 0
 
 requirements:
   build:


### PR DESCRIPTION
Just a version bump. The Bioconda bot did not create a PR automatically.