### PR TITLE
Add get_fasta_info

### DIFF
--- a/recipes/get_fasta_info/build.sh
+++ b/recipes/get_fasta_info/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+export CFLAGS="-I$PREFIX/include"
+export LDFLAGS="-L$PREFIX/lib"
+export CPATH=${PREFIX}/include
+autoreconf -i --verbose
+./configure --prefix=$PREFIX
+make install

--- a/recipes/get_fasta_info/meta.yaml
+++ b/recipes/get_fasta_info/meta.yaml
@@ -1,0 +1,35 @@
+{% set version = "2.4" %}
+{% set sha256 = "ebe27e3481597cac86468fdf0917a605c4672183ab65a9dc7a34d309b33d0457" %}
+
+package:
+  name: get_fasta_info
+  version: '{{ version }}'
+
+source:
+  url: https://github.com/nylander/get_fasta_info/archive/refs/tags/v.{{ version }}.tar.gz
+  sha256: '{{ sha256 }}'
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - make
+    - {{ compiler('c') }}
+    - autoconf
+    - automake
+  host:
+    - zlib
+  run:
+    - zlib
+
+test:
+  commands:
+    - get_fasta_info -h 2>/dev/null
+    - get_fastq_info -h 2>/dev/null
+
+about:
+  home: https://github.com/nylander/get_fasta_info
+  license: MIT
+  license_file: LICENSE
+  summary: "get_FAST{A,Q}_info - Get fast info on fasta and fastq files"


### PR DESCRIPTION
Add get_fasta_info (<https://github.com/nylander/get_fasta_info>) - a tool for fast info on fasta- or fastq-formatted files
