### PR TITLE
Add Mindagap recipe

### DIFF
--- a/recipes/mindagap/meta.yaml
+++ b/recipes/mindagap/meta.yaml
@@ -11,18 +11,20 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 2003
 
+  noarch: generic
 requirements:
   host:
     - python
   run:
   - scipy
   - numpy
-  - matplotlib
+  - matplotlib-base
   - tifffile
   - cv2 
   - rich
+  - procps-ng
 
 test:
   commands:

--- a/recipes/mindagap/meta.yaml
+++ b/recipes/mindagap/meta.yaml
@@ -1,0 +1,40 @@
+{% set version = "0.0.2" %}
+{% set sha256 = "7b8f74ae8424edcb7b6b78c9b12a354ca5276cf22f4e3d4ad8343671f301d8e6" %}
+{% set user = "FloWuenne" %}
+
+package:
+  name: {{ mindagap }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/FloWuenne/MindaGap/archive/refs/tags/0.0.2.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+
+requirements:
+  host:
+    - python
+  run:
+  - scipy
+  - numpy
+  - matplotlib
+  - tifffile
+  - cv2 
+  - rich
+
+test:
+  commands:
+    - python /mindagap/mindagap.py -v test
+
+about:
+  home: "https://github.com/ViriatoII/MindaGap"
+  license: BSD 3-Clause License
+  license_file: LICENSE
+  summary: "Takes a single panorama image and fills the empty grid lines with neighbour-weighted values."
+  doc_url: https://github.com/ViriatoII/MindaGap/blob/main/README.md
+
+extra:
+  recipe-maintainers:
+    - FloWuenne

--- a/recipes/mindagap/meta.yaml
+++ b/recipes/mindagap/meta.yaml
@@ -1,19 +1,18 @@
 {% set version = "0.0.2" %}
 {% set sha256 = "7b8f74ae8424edcb7b6b78c9b12a354ca5276cf22f4e3d4ad8343671f301d8e6" %}
-{% set user = "FloWuenne" %}
 
 package:
   name: {{ mindagap }}
   version: {{ version }}
 
 source:
-  url: https://github.com/FloWuenne/MindaGap/archive/refs/tags/0.0.2.tar.gz
+  url: https://github.com/ViriatoII/MindaGap/archive/refs/tags/0.0.2.tar.gz
   sha256: {{ sha256 }}
 
 build:
-  number: 2003
+  number: 0
 
-  noarch: generic
+noarch: generic
 requirements:
   host:
     - python


### PR DESCRIPTION
This is a new recipe.

This PR adds the recipe for [Mindagap](https://github.com/ViriatoII/MindaGap) a suite of python scripts to pre-process imaging data such as Molecular Cartography data by Resolve Biosciences.


----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
