### PR TITLE
update snakemake-wrapper-utils to 0.5.2

### DIFF
--- a/recipes/snakemake-wrapper-utils/meta.yaml
+++ b/recipes/snakemake-wrapper-utils/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "snakemake-wrapper-utils" %}
-{% set version = "0.5.0" %}
+{% set version = "0.5.2" %}
 
 package:
   name: "{{ name|lower }}"
@@ -7,7 +7,7 @@ package:
 
 source:
   url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
-  sha256: f6533334a0ff53133727cf2a95eff915d101b773e53866ecad4d4b94009bf5f5
+  sha256: 9de956c8c191e382772be24cccd15be1e72d2a81048aaf5778ae662ce06552d3
 
 build:
   number: 0

--- a/recipes/snakemake-wrapper-utils/meta.yaml
+++ b/recipes/snakemake-wrapper-utils/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name|replace("-", "_") }}-{{ version }}.tar.gz"
-  sha256: 9de956c8c191e382772be24cccd15be1e72d2a81048aaf5778ae662ce06552d3
+  sha256: e23057a16b1acd2534b50e41583124a3155792f9c42e94c5bd40bc009c0a481a
 
 build:
   number: 0

--- a/recipes/snakemake-wrapper-utils/meta.yaml
+++ b/recipes/snakemake-wrapper-utils/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: "{{ version }}"
 
 source:
-  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace("-", "_" }}-{{ version }}.tar.gz"
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name|replace("-", "_") }}-{{ version }}.tar.gz"
   sha256: 9de956c8c191e382772be24cccd15be1e72d2a81048aaf5778ae662ce06552d3
 
 build:

--- a/recipes/snakemake-wrapper-utils/meta.yaml
+++ b/recipes/snakemake-wrapper-utils/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: "{{ version }}"
 
 source:
-  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace("-", "_" }}-{{ version }}.tar.gz"
   sha256: 9de956c8c191e382772be24cccd15be1e72d2a81048aaf5778ae662ce06552d3
 
 build:


### PR DESCRIPTION
Mainly, this is an update to `snakemake-wrapper-utils` version `0.5.2`. But `poetry` changed the file naming of the sdist files (`.tar.gz`) in its `build` command, and that is what is uploaded to `pypi` for `snakemake-wrapper-utils`. The long story is in one of the commit messages, that I reproduce here for better findability and cross-references on GitHub:

**Make package name in sdist .tar.gz filename conform to specs (using underscores)**

The official specs for sdist file names require that the package name is in snake case, see these places:
* https://peps.python.org/pep-0625/#specification
* https://packaging.python.org/en/latest/specifications/binary-distribution-format/#escaping-and-unicode
* https://peps.python.org/pep-0491/#escaping-and-unicode

[`poetry` switched to conforming to these specs with version `1.2.2`](https://github.com/python-poetry/poetry/releases/tag/1.2.2), see:
* poetry-core pull request with the actual code changes: https://github.com/python-poetry/poetry-core/pull/484
* poetry pull request pulling them in: https://github.com/python-poetry/poetry/pull/6621

Thus, all (bio-)conda recipes whose sources are built with `poetry` and uploaded to pypi are likely to face the same issue.

As `snakemake-wrapper-utils` only contains hyphens (`-`) as non-word characters, the suggested `replace("-","_")` should be safe and enough.

But a thorough solution should be implemented in `grayskull` (that does conda recipe templating for pypi packages), and in the tooling of `conda-forge` and `bioconda`. One solution to make such recipes more future-proof would be to make tooling respect the [official guidance to query the pypi JSON API to get download urls](https://warehouse.pypa.io/api-reference/integration-guide.html#official-guidance). Examples of how to do this are here:
* [stackoverflow answer with example code of querying the pypi JSON API for a download URL](https://stackoverflow.com/a/48327216)
* [link to the pypi code for generating the currently used standardized redirect links at `pypi.io`, that also uses the JSON API](https://github.com/pypi/warehouse/issues/13240#issuecomment-1475983414)

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
