### PR TITLE
Update rnaQUAST to 2.2.3

### DIFF
--- a/recipes/rnaquast/meta.yaml
+++ b/recipes/rnaquast/meta.yaml
@@ -7,7 +7,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/ablab/rnaquast/releases/download/v{{ version}}/{{ name }}-{{ version }}.tar.gz
+  url: https://github.com/ablab/rnaquast/releases/download/v.{{ version}}/{{ name }}-{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:

--- a/recipes/rnaquast/meta.yaml
+++ b/recipes/rnaquast/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - blat
     - busco >=5
     - emboss
-    - gmap <2021.02.22
+    - gmap <2021.02.22, >=2020.03.12
     - gffutils
     - joblib
     - matplotlib-base

--- a/recipes/rnaquast/meta.yaml
+++ b/recipes/rnaquast/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "rnaQUAST" %}
-{% set version = "2.2.1" %}
-{% set sha256 = "352cc27ea08d296ee28f44d4734cec48e4a43b31f5d923b840650a34205f2e01" %}
+{% set version = "2.2.3" %}
+{% set sha256 = "581f2632e76d61c168a0b60aac14fd5ce9b26518ec410e17ff876d9c85c42066" %}
 
 package:
   name: {{ name | lower }}
@@ -19,7 +19,7 @@ requirements:
     - python
     - blast
     - blat
-    - busco >=4
+    - busco >=5
     - emboss
     - gmap <2021.02.22
     - gffutils


### PR DESCRIPTION
Update rnaQUAST to 2.2.3
- Fixes BUSCO offline usage
