### PR TITLE
Update mnnpy: Pin scipy to <1.9.0 as mmnpy uses n_jobs

### DIFF
--- a/recipes/mnnpy/meta.yaml
+++ b/recipes/mnnpy/meta.yaml
@@ -11,7 +11,7 @@ source:
     - 0001-Fix-missing-forceobj-for-numba.jit.patch
 
 build:
-  number: 4
+  number: 5
   # uses __futures__, which didn't exist until 3.7
   skip: True  # [py<37]
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv
@@ -31,7 +31,7 @@ requirements:
     - numpy
     - pandas
     - python
-    - scipy
+    - scipy <1.9.0
 
 test:
   imports:


### PR DESCRIPTION
n_jobs was deprecated from cKDTree in scipy 1.6.0 on and removed on 1.9.0, which mnnpy uses and fails due to it in current installations that get a newer scipy.

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
