### PR TITLE
Update IsoQuant to 3.2.0

### DIFF
--- a/recipes/isoquant/meta.yaml
+++ b/recipes/isoquant/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "IsoQuant" %}
-{% set version = "3.1.2" %}
-{% set sha256 = "91b3360474415b575bf9048eb3a64058cea67bf7b8384452b84bb64e18ca2fe2" %}
+{% set version = "3.2.0" %}
+{% set sha256 = "75d57d913a2cfa9281c698402e20a76586ceb83a0268cfcf23b3148b67fe13e3" %}
 
 package:
   name: {{ name | lower }}
@@ -11,19 +11,18 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 0
   noarch: generic
 
 requirements:
   run:
-    - python
+    - python >=3.7
     - argcomplete >=1.11.1
     - argh >=0.26.2
     - biopython >=1.76
     - gffutils >=0.10.1
     - minimap2 >=2.18
-    - numpy
-    - pandas
+    - pandas >=1.0
     - pybedtools >=0.8.1
     - pyfaidx >=0.5.8
     - pysam >=0.15


### PR DESCRIPTION
A major update for IsoQuant:
- significant performance improvements (10x lower RAM, 5x lower disk space)
- improved output formats
- intuitive option usage