### PR TITLE
ensure docker container is pulled first

### DIFF
--- a/azure-pipeline-master.yml
+++ b/azure-pipeline-master.yml
@@ -40,6 +40,8 @@ jobs:
       export OSTYPE="linux-gnu"
       export CI="true"
 
+      docker pull quay.io/dpryan79/mulled_container:latest
+
       bioconda-utils handle-merged-pr recipes config.yml \
         --repo bioconda/bioconda-recipes \
         --git-range ${BUILD_SOURCEVERSION}~1 ${BUILD_SOURCEVERSION} \


### PR DESCRIPTION
Recent builds when running the "Handle merged PR" are failing when trying to upload the container, this is due to the container not being pulled first (introduced in #40071).