### PR TITLE
use bioconda-common/master branch for script

### DIFF
--- a/azure-pipeline-master.yml
+++ b/azure-pipeline-master.yml
@@ -18,7 +18,7 @@ jobs:
     displayName: Add conda to PATH
 
   - bash: |
-      wget https://raw.githubusercontent.com/bioconda/bioconda-common/fix/install-and-set-up-conda.sh
+      wget https://raw.githubusercontent.com/bioconda/bioconda-common/master/install-and-set-up-conda.sh
     displayName: Fetch bioconda install script
 
   - task: Cache@2
@@ -72,7 +72,7 @@ jobs:
     displayName: Add conda to PATH
 
   - bash: |
-      wget https://raw.githubusercontent.com/bioconda/bioconda-common/fix/install-and-set-up-conda.sh
+      wget https://raw.githubusercontent.com/bioconda/bioconda-common/master/install-and-set-up-conda.sh
     displayName: Fetch bioconda install script
 
   - bash: |

--- a/azure-pipeline-nightly.yml
+++ b/azure-pipeline-nightly.yml
@@ -27,7 +27,7 @@ jobs:
     displayName: Add conda to PATH
 
   - bash: |
-      wget https://raw.githubusercontent.com/bioconda/bioconda-common/fix/install-and-set-up-conda.sh
+      wget https://raw.githubusercontent.com/bioconda/bioconda-common/master/install-and-set-up-conda.sh
     displayName: Fetch bioconda install script
 
   - bash: |
@@ -90,7 +90,7 @@ jobs:
     displayName: Add conda to PATH
 
   - bash: |
-      wget https://raw.githubusercontent.com/bioconda/bioconda-common/fix/install-and-set-up-conda.sh
+      wget https://raw.githubusercontent.com/bioconda/bioconda-common/master/install-and-set-up-conda.sh
     displayName: Fetch bioconda install script
 
   - bash: |

--- a/azure-pipeline.yml
+++ b/azure-pipeline.yml
@@ -20,7 +20,7 @@ stages:
       displayName: Add conda to PATH
 
     - bash: |
-        wget https://raw.githubusercontent.com/bioconda/bioconda-common/fix/install-and-set-up-conda.sh
+        wget https://raw.githubusercontent.com/bioconda/bioconda-common/master/install-and-set-up-conda.sh
       displayName: Fetch bioconda install script
 
     - bash: |
@@ -61,7 +61,7 @@ stages:
       displayName: Add conda to PATH
 
     - bash: |
-        wget https://raw.githubusercontent.com/bioconda/bioconda-common/fix/install-and-set-up-conda.sh
+        wget https://raw.githubusercontent.com/bioconda/bioconda-common/master/install-and-set-up-conda.sh
       displayName: Fetch bioconda install script
 
     - bash: |
@@ -133,7 +133,7 @@ stages:
       displayName: Add conda to PATH
 
     - bash: |
-        wget https://raw.githubusercontent.com/bioconda/bioconda-common/fix/install-and-set-up-conda.sh
+        wget https://raw.githubusercontent.com/bioconda/bioconda-common/master/install-and-set-up-conda.sh
       displayName: Fetch bioconda install script
 
     - bash: |


### PR DESCRIPTION
Now that https://github.com/bioconda/bioconda-common/pull/32 is merged, use the script on the master branch of bioconda-common.