### PR TITLE
Fix shinyngs recipe hackery for packrat

### DIFF
--- a/recipes/r-shinyngs/build.sh
+++ b/recipes/r-shinyngs/build.sh
@@ -16,16 +16,16 @@ ammend_description_for_packrat(){
     remotesha=$(git ls-remote https://github.com/$remoteusername/$remoterepo tags/$remoteref | cut -f1) 
 
     echo -e """RemoteType: github
-    RemoteHost: api.github.com
-    RemoteRepo: $remoterepo
-    RemoteUsername: $remoteusername
-    RemoteRef: $remoteref
-    RemoteSha: $remotesha
-    GithubRepo: $remoterepo
-    GithubUsername: $remoteusername
-    GithubRef: $remoteref
-    GithubSHA1: $remotesha
-    NeedsCompilation: no""" >> $description
+RemoteHost: api.github.com
+RemoteRepo: $remoterepo
+RemoteUsername: $remoteusername
+RemoteRef: $remoteref
+RemoteSha: $remotesha
+GithubRepo: $remoterepo
+GithubUsername: $remoteusername
+GithubRef: $remoteref
+GithubSHA1: $remotesha
+NeedsCompilation: no""" >> $description
 }
 
 ammend_description_for_packrat "shinyngs/DESCRIPTION" "shinyngs" "pinin4fjords" "v$PKG_VERSION"

--- a/recipes/r-shinyngs/meta.yaml
+++ b/recipes/r-shinyngs/meta.yaml
@@ -14,7 +14,7 @@ source:
     folder: d3heatmap
 
 build:
-  number: 0
+  number: 1
   noarch: generic
 
   # This is required to make R link correctly on Linux.


### PR DESCRIPTION
The shinyapps.io deployment as started failing again with shinyngs, due to packrat issues. For some reason the hack here to edit DESCRIPTION was not working, so I'm attempting a fix.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
