### PR TITLE
pbhoover: add missing runtime dependency on htslib

### DIFF
--- a/recipes/pbhoover/meta.yaml
+++ b/recipes/pbhoover/meta.yaml
@@ -13,7 +13,7 @@ source:
 build:
   noarch: python
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv"
-  number: 0
+  number: 1
 
 requirements:
   host:
@@ -23,6 +23,7 @@ requirements:
     - python <3
     - pbh5tools <=0.8.0
     - bcftools <=1.3.1
+    - htslib <=1.3.2 # for bgzip and tabix
     - pyvcf <=0.6.7
     - pbcore <=1.2.7
 


### PR DESCRIPTION
Missing `bgzip` resulted in errors like
```
No such file or directory
```
at the normalization step following variant calling