### PR TITLE
new recipe for qiskit-xyz2pdb

### DIFF
--- a/recipes/qiskit-xyz2pdb/meta.yaml
+++ b/recipes/qiskit-xyz2pdb/meta.yaml
@@ -1,0 +1,47 @@
+{% set name = "qiskit-xyz2pdb" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: aabd4c37258d9d45db8c0cf89b19368497de6d7c15a514bb9f616b3f5871eab9
+
+build:
+  number: 0
+  noarch: python
+  entry_points:
+    - qiskit-xyz2pdb=xyz2pdb.xyz2pdb:main
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - python >=3.6
+    - pip
+    - setuptools
+  run:
+    - python >=3.6
+
+test:
+  imports:
+    - qiskit-xyz2pdb
+  commands:
+    - pip check
+    - qiskit-xyz2pdb --version
+  requires:
+    - pip
+
+about:
+  home: https://github.com/thepineapplepirate/qiskit-xyz2pdb
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: qiskit-xyz2pdb
+  description: |
+    qiskit-xyz2pdb is a tool to convert XYZ files from the results of Qiskit's protein folding algorithm
+
+extra:
+  recipe-maintainers:
+    - thepineapplepirate

--- a/recipes/qiskit-xyz2pdb/meta.yaml
+++ b/recipes/qiskit-xyz2pdb/meta.yaml
@@ -26,7 +26,7 @@ requirements:
 
 test:
   imports:
-    - qiskit-xyz2pdb
+    - xyz2pdb
   commands:
     - pip check
     - qiskit-xyz2pdb --version


### PR DESCRIPTION
Added recipe for qiskit-xyz2pdb. This is a program used to convert XYZ files from Qiskit workflows, into proper PDB files.

