### PR TITLE
Update: Bump build number of agat and perl-lwp-simple

### DIFF
--- a/recipes/agat/meta.yaml
+++ b/recipes/agat/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   noarch: generic
-  number: 0
+  number: 1
 
 requirements:
   host:

--- a/recipes/perl-lwp-simple/meta.yaml
+++ b/recipes/perl-lwp-simple/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: '6.39'
 
 build:
-  number: 5
+  number: 6
 
 requirements:
   host:


### PR DESCRIPTION
Agat is currently uninstallable due to a dependency version issue with lwp-simple. This bumps the build of both to hopefully make it installable with current perl versions

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
