### PR TITLE
Update dropest to fix libbamtools shared library version mismatch

### DIFF
--- a/recipes/dropest/meta.yaml
+++ b/recipes/dropest/meta.yaml
@@ -12,7 +12,7 @@ source:
     - patch
 
 build:
-  number: 5
+  number: 7
   skip: True  # [osx]
   rpaths:
     - lib/R/lib/
@@ -23,8 +23,8 @@ requirements:
     - make
     - {{ compiler('cxx') }}
     - cmake
-    - bamtools
   host:
+    - bamtools
     - r-base
     - boost
     - boost-cpp
@@ -41,6 +41,7 @@ requirements:
     - r-pcapp
     - r-rcppprogress
   run:
+    - bamtools
     - r-base
     - boost
     - zlib
@@ -58,6 +59,7 @@ requirements:
 
 test:
   commands:
+    - dropest --help
     - droptag --help
     - R -e "library('dropestr')"
 


### PR DESCRIPTION
The `dropest` executable from dropest-0.8.6-r42he6cf555_5 is impacted by the following link error:

```
(dropest) $ dropest
dropest: error while loading shared libraries: libbamtools.so.2.5.1: cannot open shared object file: No such file or directory
```

When `bamtools` is specified in the meta.yml as "build" and "run" dependencies, bamtools=2.5.1 is installed at build time, and 2.5.2 in the run environment; moving bamtools (which is a link dependency) from "build" to "host" appears to resolve this inconsistency (bamtools=2.5.1 is used at build time and installed as a run requirement). 

That said, I'm not certain if this is a guarantee from my (incomplete) reading (and even more incomplete understanding) of the conda-build documentation. Any advice on a more-robust approach would be appreciated!

On a more minor note, it appears that ownership of hms-dbmi/dropEst was apparently transferred to kharchenkolab (as https://github.com/hms-dbmi/dropEst redirects to https://github.com/kharchenkolab/dropEst).