### PR TITLE
Update mapad to 0.42.1

### DIFF
--- a/recipes/mapad/meta.yaml
+++ b/recipes/mapad/meta.yaml
@@ -33,5 +33,5 @@ about:
   summary: An aDNA aware short-read mapper
 
 extra:
-  recipe.maintainers:
+  recipe-maintainers:
     - jch-13

--- a/recipes/mapad/meta.yaml
+++ b/recipes/mapad/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.41.0" %}
+{% set version = "0.42.1" %}
 
 package:
   name: mapad
@@ -9,7 +9,7 @@ build:
 
 source:
   url: https://github.com/mpieva/mapAD/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 7ad56a19b070a29db7e2c401f6a2524849fae4c7e0ef6998a492bc248198a1e5
+  sha256: fe7bb18cc81f53b9f1a6f896aeffa60042b15de46214b7eb60b9e6d9d3d5f0fd
 
 requirements:
   build:


### PR DESCRIPTION
Update [mapad](https://bioconda.github.io/recipes/mapad/README.html): 0.41.0 → 0.42.1

This PR includes a fix of a typo (`recipe.maintainers` instead of `recipe-maintainers`) preventing me ( @jch-13 ) from being listed as a maintainer. 