### PR TITLE
Update diamond: build with zstd & blast support

### DIFF
--- a/recipes/diamond/build.sh
+++ b/recipes/diamond/build.sh
@@ -10,6 +10,8 @@ cmake .. \
       -DCMAKE_INSTALL_PREFIX=$PREFIX \
       -DCMAKE_PREFIX_PATH=$PREFIX \
       -DBOOST_NO_SYSTEM_PATHS=on \
+      -DWITH_ZSTD=on \
+      -DBLAST_LIB_DIR=$PREFIX/lib/ncbi-blast+ \
       -DCMAKE_OSX_DEPLOYMENT_TARGET=""
 
 cmake --build . --config Release --target install

--- a/recipes/diamond/build.sh
+++ b/recipes/diamond/build.sh
@@ -11,7 +11,7 @@ cmake .. \
       -DCMAKE_PREFIX_PATH=$PREFIX \
       -DBOOST_NO_SYSTEM_PATHS=on \
       -DWITH_ZSTD=on \
-      -DZSTD_LIBRARY=$PREFIX/lib/libzstd.so \
+      -DZSTD_LIBRARY=$PREFIX/lib/libzstd.a \
       -DZSTD_INCLUDE_DIR=$PREFIX/include/ \
       -DBLAST_LIB_DIR=$PREFIX/lib/ncbi-blast+ \
       -DCMAKE_OSX_DEPLOYMENT_TARGET=""

--- a/recipes/diamond/build.sh
+++ b/recipes/diamond/build.sh
@@ -11,6 +11,8 @@ cmake .. \
       -DCMAKE_PREFIX_PATH=$PREFIX \
       -DBOOST_NO_SYSTEM_PATHS=on \
       -DWITH_ZSTD=on \
+      -DZSTD_LIBRARY=$PREFIX/lib/libzstd.so \
+      -DZSTD_INCLUDE_DIR=$PREFIX/include/ \
       -DBLAST_LIB_DIR=$PREFIX/lib/ncbi-blast+ \
       -DCMAKE_OSX_DEPLOYMENT_TARGET=""
 

--- a/recipes/diamond/build.sh
+++ b/recipes/diamond/build.sh
@@ -9,12 +9,11 @@ cd build
 cmake .. \
       -DCMAKE_INSTALL_PREFIX=$PREFIX \
       -DCMAKE_PREFIX_PATH=$PREFIX \
-      -DCMAKE_LIBRARY_PATH="$CONDA_PREFIX;$PREFIX;" \
-      -DBOOST_NO_SYSTEM_PATHS=on \
+      -DCMAKE_LIBRARY_PATH="$PREFIX" \
       -DWITH_ZSTD=on \
-      -DZSTD_LIBRARY=$CONDA_PREFIX/lib/libzstd.a \
-      -DZSTD_INCLUDE_DIR=$CONDA_PREFIX/include/ \
-      -DBLAST_LIB_DIR=$CONDA_PREFIX/lib/ncbi-blast+ \
+      -DZSTD_LIBRARY=$PREFIX/lib/libzstd.a \
+      -DZSTD_INCLUDE_DIR=$PREFIX/include/ \
+      -DBLAST_LIBRARY_DIR=$PREFIX/lib/ncbi-blast+ \
       -DCMAKE_OSX_DEPLOYMENT_TARGET=""
 
 cmake --build . --config Release --target install

--- a/recipes/diamond/build.sh
+++ b/recipes/diamond/build.sh
@@ -9,11 +9,12 @@ cd build
 cmake .. \
       -DCMAKE_INSTALL_PREFIX=$PREFIX \
       -DCMAKE_PREFIX_PATH=$PREFIX \
+      -DCMAKE_LIBRARY_PATH="$CONDA_PREFIX;$PREFIX;" \
       -DBOOST_NO_SYSTEM_PATHS=on \
       -DWITH_ZSTD=on \
-      -DZSTD_LIBRARY=$PREFIX/lib/libzstd.a \
-      -DZSTD_INCLUDE_DIR=$PREFIX/include/ \
-      -DBLAST_LIB_DIR=$PREFIX/lib/ncbi-blast+ \
+      -DZSTD_LIBRARY=$CONDA_PREFIX/lib/libzstd.a \
+      -DZSTD_INCLUDE_DIR=$CONDA_PREFIX/include/ \
+      -DBLAST_LIB_DIR=$CONDA_PREFIX/lib/ncbi-blast+ \
       -DCMAKE_OSX_DEPLOYMENT_TARGET=""
 
 cmake --build . --config Release --target install

--- a/recipes/diamond/meta.yaml
+++ b/recipes/diamond/meta.yaml
@@ -20,8 +20,10 @@ requirements:
     - make
   host:
     - zlib
+    - blast
     - zstd
   run:
+    - blast
     - zlib
     - zstd
 

--- a/recipes/diamond/meta.yaml
+++ b/recipes/diamond/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -20,8 +20,10 @@ requirements:
     - make
   host:
     - zlib
+    - zstd
   run:
     - zlib
+    - zstd
 
 test:
   commands:

--- a/recipes/diamond/meta.yaml
+++ b/recipes/diamond/meta.yaml
@@ -21,11 +21,10 @@ requirements:
   host:
     - zlib
     - blast
-    - zstd
+    - zstd-static
   run:
     - blast
     - zlib
-    - zstd
 
 test:
   commands:


### PR DESCRIPTION
This PR pulls in libzstd for compression and the BLAST C++ libaries to be able to read NCBI blast formatted databases, two compile-time optional features DIAMOND has recently supported.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
