### PR TITLE
Add unifrac-binaries-cpu recipe for unifrac-bionaries package

### DIFF
--- a/recipes/unifrac-binaries-cpu/build.sh
+++ b/recipes/unifrac-binaries-cpu/build.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -e
+set -x
+export PERFORMING_CONDA_BUILD=True
+export LIBRARY_PATH="${CONDA_PREFIX}/lib"
+export LD_LIBRARY_PATH=${LIBRARY_PATH}:${LD_LIBRARY_PATH}
+export CPLUS_INCLUDE_PATH="${CONDA_PREFIX}/include"
+
+echo "=== PREIX ==="
+env |grep PREFIX
+
+echo "Arch: $(uname -s)"
+pwd
+
+if [[ "$(uname -s)" == "Linux" ]];
+then
+          which x86_64-conda-linux-gnu-gcc
+          x86_64-conda-linux-gnu-gcc -v
+          x86_64-conda-linux-gnu-g++ -v
+else
+          which clang
+          clang -v
+fi
+which h5c++
+# use default compiler on Linux, too (no NVIDIA compiler)
+
+make api && \
+make main && \
+make install
+
+make test
+

--- a/recipes/unifrac-binaries-cpu/meta.yaml
+++ b/recipes/unifrac-binaries-cpu/meta.yaml
@@ -47,6 +47,11 @@ outputs:
         - ssu --help
         - faithpd --help
 
+test:
+  commands:
+    - ssu --help
+    - faithpd --help
+
 about:
   home: https://github.com/biocore/unifrac-binaries
   license: BSD-3-Clause

--- a/recipes/unifrac-binaries-cpu/meta.yaml
+++ b/recipes/unifrac-binaries-cpu/meta.yaml
@@ -1,7 +1,7 @@
 {% set version = "1.3" %}
 
 package:
-  name: unifrac-binaries-cpu
+  name: unifrac-binaries
   version: {{ version }}
 
 source:
@@ -10,42 +10,36 @@ source:
 
 build:
   number: 0
+  string: cpu_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}
+  # MacOS default package is already CPU-only, no need to duplicate
+  skip: True [macos]
+  # weight down cpu implementation and give default build preference
+  track_features:
+    - unifrac-binaries-cpu
 
-outputs:
-  - name: unifrac-binaries
-    script: build.sh
-    build:
-      string: cpu_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}
-      # weight down cpu implementation and give default build preference
-      track_features:
-        - unifrac-binaries-cpu
-    requirements:
-      build:
-        - {{ compiler('c') }}
-        - {{ compiler('cxx') }}
-        - hdf5
-        - mkl-include
-        - hdf5-static
-        - lz4
-        - zlib
-        - libcblas
-        - liblapacke
-        - make
-        - curl
-      host:
-        - lz4
-        - zlib
-        - libcblas
-        - liblapacke
-      run:
-        - lz4
-        - zlib
-        - libcblas
-        - liblapacke
-    test:
-      commands:
-        - ssu --help
-        - faithpd --help
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - hdf5
+    - mkl-include
+    - hdf5-static
+    - lz4
+    - zlib
+    - libcblas
+    - liblapacke
+    - make
+    - curl
+  host:
+    - lz4
+    - zlib
+    - libcblas
+    - liblapacke
+  run:
+    - lz4
+    - zlib
+    - libcblas
+    - liblapacke
 
 test:
   commands:

--- a/recipes/unifrac-binaries-cpu/meta.yaml
+++ b/recipes/unifrac-binaries-cpu/meta.yaml
@@ -1,0 +1,71 @@
+{% set version = "1.3" %}
+
+package:
+  name: unifrac-binaries-cpu
+  version: {{ version }}
+
+source:
+  url: https://github.com/biocore/unifrac-binaries/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: c8d5542357096262b8c9a5ee7cb4b460390591ded0138d94ae352e792b15839e
+
+build:
+  number: 0
+
+outputs:
+  - name: unifrac-binaries
+    script: build.sh
+    build:
+      string: cpu_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}
+      # weight down cpu implementation and give default build preference
+      track_features:
+        - unifrac-binaries-cpu
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+        - hdf5
+        - mkl-include
+        - hdf5-static
+        - lz4
+        - zlib
+        - libcblas
+        - liblapacke
+        - make
+        - curl
+      host:
+        - lz4
+        - zlib
+        - libcblas
+        - liblapacke
+      run:
+        - lz4
+        - zlib
+        - libcblas
+        - liblapacke
+    test:
+      commands:
+        - ssu --help
+        - faithpd --help
+
+about:
+  home: https://github.com/biocore/unifrac-binaries
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE
+  summary: 'Fast phylogenetic diversity calculations'
+  description: |
+    UniFrac is a commonly phylogenetic diversity distance metric used in
+    microbiome research. The metric relates two microbiome samples together
+    within the context of an evolutionary history, and produces a distance
+    that corresponds to how similar two samples by the amount of overlapping
+    branch length. This package contains command line utilities and
+    a shared library.
+    This recipe provides a CPU-only version
+
+  doc_url: https://github.com/biocore/unifrac-binaries
+  dev_url: https://github.com/biocore/unifrac-binaries
+
+extra:
+  recipe-maintainers:
+    - sfiligoi
+    - wasade


### PR DESCRIPTION
Create a CPU-only package based on default compiler on Linux.
Has lower priority than the default package in the unifrac-binaries recipe directory.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
