### PR TITLE
add m6anet recipe

### DIFF
--- a/recipes/m6anet/meta.yaml
+++ b/recipes/m6anet/meta.yaml
@@ -1,0 +1,65 @@
+{% set name = "m6anet" %}
+{% set version = "2.0.2" %}
+
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/m6anet-{{ version }}.tar.gz
+  sha256: 4e49bbc118a0cd15b3fc9a21601d304684552cff0158449fd943a830cafdcf20
+
+build:
+  number: 0
+  noarch: python
+  entry_points:
+    - m6anet = m6anet:main
+    - m6anet-dataprep=m6anet.deprecated.dataprep:main
+    - m6anet-run_inference=m6anet.deprecated.inference:main
+    - m6anet-compute_norm_factors=m6anet.deprecated.compute_norm_factors:main
+    - m6anet-train=m6anet.deprecated.train:main
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - pip
+    - python >=3.7, <3.9
+  run:
+    - python >=3.7, <3.9
+    - numpy >=1.18.0
+    - pandas >=0.25.3
+    - scikit-learn >=0.24.0  # [py>=38]
+    - scikit-learn >=0.24.0, <1.1.0  # [py<38]
+    - scipy >=1.10  # [py>=38]
+    - scipy >=1.4.1, <1.8.0  # [py<38]
+    - toml >=0.10.2
+    - pytorch ==1.6.0
+    - tqdm
+    - typing-extensions
+    - ujson
+    - joblib
+
+test:
+  imports:
+    - m6anet
+    - m6anet.deprecated
+  commands:
+    - pip check
+    - m6anet --help
+    - m6anet dataprep --help
+    - m6anet inference --help
+    - m6anet compute_norm_factors --help
+    - m6anet train --help
+  requires:
+    - pip
+
+about:
+  home: https://github.com/GoekeLab/m6anet
+  summary: m6anet is a python package for detection of m6a modifications from Nanopore direct RNA sequencing data.
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - chrishendra93


### PR DESCRIPTION
Add conda recipe to build m6anet package. m6anet is a Python tool that leverages Multiple Instance Learning framework to detect m6a modifications from Nanopore Direct RNA Sequencing data
----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
