### PR TITLE
Update hybran to 1.6

### DIFF
--- a/recipes/hybran/meta.yaml
+++ b/recipes/hybran/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.5.2" %}
+{% set version = "1.6" %}
 
 package:
   name: hybran
@@ -6,19 +6,19 @@ package:
 
 source:
   url: https://gitlab.com/LPCDRP/hybran/-/archive/{{ version }}/hybran-{{ version }}.tar.gz
-  sha256: 'fb062fa0561b068dc59a147a11bbff106079c58ac2de4332bd2774c33c040bc0'
+  sha256: '42f7096f21ae16ddc469391cb81a5d76b6302438be493db82f624be6af64d40a'
 
 build:
   noarch: python
-  number: 1
+  number: 0
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
   host:
-    - python >=3
+    - python >=3.9
     - pip
   run:
-    - biopython >=1.79
+    - biopython >=1.80
     - blast
     - cd-hit
     - diamond
@@ -28,10 +28,8 @@ requirements:
     - entrez-direct
     - mcl
     - multiprocess
-    - mummer
-    - prodigal
     - prokka >=1.14
-    - python >=3
+    - python >=3.9
     - ratt
     - tbl2asn-forever
 


### PR DESCRIPTION
- Version 1.6 requires biopython >=1.80
- Removed direct dependency on prodigal (no longer called directly in v1.6)
- Removed direct dependency on mummer (never used directly. (required by and depended on by ratt)
----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
