### PR TITLE
Update tiny-count 1.4.0

### DIFF
--- a/recipes/tiny-count/meta.yaml
+++ b/recipes/tiny-count/meta.yaml
@@ -23,6 +23,7 @@ requirements:
     - python 3.9.*
     - setuptools 63.1.*
     - cython 0.29.*
+    - pysam 0.19.*
     - pip 22.1.*
   run:
     - python 3.9.*

--- a/recipes/tiny-count/meta.yaml
+++ b/recipes/tiny-count/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "1.3.0" %}
-{% set sha256 = "a9b2e3c2cb324b3fda824ec0cb39f83ec26efe1b51cdc9e9f98f86b77334291b" %}
+{% set version = "1.4.0" %}
+{% set sha256 = "a4e6041c0e946dffe6dfdc4ca3c9e9e4c36a7ec29a148ebe198b3de8d3f6ccef" %}
 
 package:
   name: tiny-count


### PR DESCRIPTION
An autobump PR is already open under #40761 but this should supersede it and the other should be closed.

**Edit 5/5/23:** This PR should still supersede #40761. The v1.4.0 update required changes to the recipe.

Closes #40761