### PR TITLE
Update angsd recipe enable osx build

### DIFF
--- a/recipes/angsd/meta.yaml
+++ b/recipes/angsd/meta.yaml
@@ -12,8 +12,8 @@ source:
 
 
 build:
-  number: 1
-  skip: True  # [osx]
+  number: 2
+  skip: False
 
 requirements:
   build:
@@ -21,10 +21,10 @@ requirements:
     - {{ compiler('cxx') }}
     - {{ compiler('c') }}
   host:
+    - htslib
     - zlib
     - bzip2
     - xz
-    - htslib
   run:
     - htslib
     - zlib


### PR DESCRIPTION
Remove osx build skip statement.
Increase build number since it is a new build of the same version.