### PR TITLE
Update PanTools to v4.2.0

### DIFF
--- a/recipes/pantools/meta.yaml
+++ b/recipes/pantools/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - maven
     - jq
   run:
+    - python >=3.7
     - openjdk =8
     - mcl
     - kmc =3.0.1
@@ -50,9 +51,9 @@ about:
   license: GPL-3.0-only
   license_family: GPL
   license_file: LICENSE
-  summary: "PanTools is a pangenomic toolkit for comparative analysis of large number of genomes."
+  summary: "PanTools is a pangenomic toolkit for comparative analysis of large numbers of genomes."
   description: |
-    PanTools is a pangenomic toolkit for comparative analysis of large number
+    PanTools is a pangenomic toolkit for comparative analysis of large numbers
     of genomes. It is developed in the Bioinformatics Group of Wageningen
     University, the Netherlands. Please cite the relevant publication(s) from
     the list of publications if you use PanTools in your research.

--- a/recipes/pantools/meta.yaml
+++ b/recipes/pantools/meta.yaml
@@ -32,8 +32,8 @@ requirements:
     - fastani
       #- busco =5  #causes conflicts on macOS
     - r-base =3.4.3
-    - r-ggplot2
-    - r-ape
+    - r-ggplot2 =2.2.1
+    - r-ape =5.0
     - graphviz
     - aster =1.3
       #- bcftools >=1.12  #causes conflicts on macOS

--- a/recipes/pantools/meta.yaml
+++ b/recipes/pantools/meta.yaml
@@ -31,9 +31,9 @@ requirements:
     - mash =2.3
     - fastani
       #- busco =5  #causes conflicts on macOS
-    - r-base =3.4.3
-    - r-ggplot2 =2.2.1
-    - r-ape =5.0
+    - r-base >=3.5.0
+    - r-ggplot2
+    - r-ape
     - graphviz
     - aster =1.3
       #- bcftools >=1.12  #causes conflicts on macOS

--- a/recipes/pantools/meta.yaml
+++ b/recipes/pantools/meta.yaml
@@ -20,7 +20,6 @@ requirements:
     - maven
     - jq
   run:
-    - python =3.7
     - openjdk =8
     - mcl
     - kmc =3.0.1

--- a/recipes/pantools/meta.yaml
+++ b/recipes/pantools/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "PanTools" %}
-{% set version = "4.1.1" %}
-{% set sha256 = "fa940b131c54942fdeb85c454f04381df95a05d7e07ba32d78d92e9ab6517e02" %}
+{% set version = "4.2.0" %}
+{% set sha256 = "a0a85708b5cbc61c01d169d8a3a287c18a3cfd25f0257ee07f20a1850cce39aa" %}
 
 package:
   name: {{ name|lower }}
@@ -30,11 +30,14 @@ requirements:
     - blast
     - mash =2.3
     - fastani
+      #- busco =5  #causes conflicts on macOS
     - r-base =3.4.3
-    - r-ggplot2 =2.2.1
-    - r-ape =5.0
+    - r-ggplot2
+    - r-ape
     - graphviz
     - aster =1.3
+      #- bcftools >=1.12  #causes conflicts on macOS
+    - tabix
 
 test:
   commands:
@@ -63,7 +66,7 @@ extra:
     If you want to overwrite it you can specify these values directly after your binaries.
     If you have _JAVA_OPTIONS set globally this will take precedence.
     For example run it with "pantools -Xms512m -Xmx1g".
-    NB: BUSCO is a dependency of PanTools but it is not included in this recipe due to conflicts on MacOS.
+    NB: Both `BUSCO` and `bcftools` are dependencies of PanTools but they are not included in this recipe due to conflicts on MacOS.
   identifiers:
     - doi:https://doi.org/10.1093/bioinformatics/btw455
     - doi:https://doi.org/10.1186/s12859-018-2362-4


### PR DESCRIPTION
Update PanTools recipe from 4.1.1 to 4.2.0 (manual bump since PanTools source code is hosted on git.wur.nl instead of github.com).