### PR TITLE
Update Bismark

### DIFF
--- a/recipes/bismark/meta.yaml
+++ b/recipes/bismark/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 build:
   noarch: generic
-  number: 0
+  number: 1
 
 source:
   url: https://github.com/FelixKrueger/Bismark/archive/{{ version }}.tar.gz
@@ -16,6 +16,7 @@ source:
 requirements:
   build:
   run:
+    - coreutils
     - perl
     - samtools
     - bowtie2


### PR DESCRIPTION
As discussed in #37865, the `coreutils` dependency misses for Bismark in bioconda. This pull request adds coreutils to dependency list of Bismark on behalf of @JudithR.

Tagging @FelixKrueger as he seems to be the maintainer for this bioconda recipe. This issue might also be related to https://github.com/FelixKrueger/Bismark/issues/358 on the Bismark GitHub page of which he is the owner.