### PR TITLE
pinned tensorflow to 2.11.0

### DIFF
--- a/recipes/deepmicro/meta.yaml
+++ b/recipes/deepmicro/meta.yaml
@@ -9,7 +9,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 0
+  number: 1
   noarch: python
 
 source:
@@ -29,7 +29,7 @@ requirements:
     - matplotlib-base
     - psutil
     - keras >=2.3.0
-    - tensorflow
+    - tensorflow >=2.11.0
     - h5py
 
 test:


### PR DESCRIPTION
Update DeepMicro

Pinnned tensorflow to 2.11.0, in the hopes to avoid this error: 

```
Traceback (most recent call last):
  File "/usr/local/tools/_conda/envs/__deepmicro@1.4/bin/DM.py", line 16, in <module>
    import keras
  File "/usr/local/tools/_conda/envs/__deepmicro@1.4/lib/python3.10/site-packages/keras/__init__.py", line 21, in <module>
    from keras import models
  File "/usr/local/tools/_conda/envs/__deepmicro@1.4/lib/python3.10/site-packages/keras/models/__init__.py", line 18, in <module>
    from keras.engine.functional import Functional
  File "/usr/local/tools/_conda/envs/__deepmicro@1.4/lib/python3.10/site-packages/keras/engine/functional.py", line 24, in <module>
    import tensorflow.compat.v2 as tf
  File "/usr/local/tools/_conda/envs/__deepmicro@1.4/lib/python3.10/site-packages/tensorflow/__init__.py", line 37, in <module>
    from tensorflow.python.tools import module_util as _module_util
  File "/usr/local/tools/_conda/envs/__deepmicro@1.4/lib/python3.10/site-packages/tensorflow/python/__init__.py", line 36, in <module>
    from tensorflow.python import pywrap_tensorflow as _pywrap_tensorflow
  File "/usr/local/tools/_conda/envs/__deepmicro@1.4/lib/python3.10/site-packages/tensorflow/python/pywrap_tensorflow.py", line 77, in <module>
    raise ImportError(
ImportError: Traceback (most recent call last):
  File "/usr/local/tools/_conda/envs/__deepmicro@1.4/lib/python3.10/site-packages/tensorflow/python/pywrap_tensorflow.py", line 62, in <module>
    from tensorflow.python._pywrap_tensorflow_internal import *
ImportError: libflatbuffers.so.23.3.3: cannot open shared object file: No such file or directory

```
