### PR TITLE
Update plannotate recipe: lint and dependencies

### DIFF
--- a/recipes/plannotate/meta.yaml
+++ b/recipes/plannotate/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 3
+  number: 4
   noarch: python
 
 source:
@@ -22,6 +22,7 @@ requirements:
     - python >=3.7
     - pip
   run:
+    - altair=4.2.2
     - biopython >1.77
     - bokeh=2.4.1
     - click

--- a/recipes/plannotate/meta.yaml
+++ b/recipes/plannotate/meta.yaml
@@ -22,20 +22,20 @@ requirements:
     - python >=3.7
     - pip
   run:
-    - altair=4.2.2
-    - biopython >1.77
-    - bokeh=2.4.1
-    - click
+    - altair =4.2.2
+    - biopython =1.78
+    - bokeh =2.4.1
+    - click =7.1.2
     - curl
-    - blast >=2.10.1
-    - diamond >=2.0.13
-    - numpy
-    - pandas
-    - python >=3.7
-    - ripgrep >=13.0.0
-    - streamlit=1.2.0
-    - tabulate >=0.8.9
-    - trnascan-se >=2.0.7
+    - blast =2.10.1
+    - diamond =2.0.13
+    - numpy 1.21.5
+    - pandas 1.3.5
+    - python =3.7
+    - ripgrep =13.0.0
+    - streamlit =1.8.1
+    - tabulate =0.8.9
+    - trnascan-se =2.0.7
 
 test:
   commands:


### PR DESCRIPTION
1. The following dependency is missing from the recipe: https://github.com/barricklab/pLannotate/blob/daabf1a63be79c43ff6166c76403d358b1d53da8/environment.yml#LL20C5-L20C18

2. Pinned to match versions from repo.  Higher versions of dependencies caused exceptions on my machine.

3. Fixed linting issues
