### PR TITLE
Add DIA-NN 1.8.1

### DIFF
--- a/recipes/diann/build.sh
+++ b/recipes/diann/build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+mkdir -p $PREFIX/bin
+
+tar xvf data.tar.gz
+
+DIANN_PATH=$(find . -type f -executable -print | grep diann)
+DIANN_DIR=$(dirname $DIANN_PATH)
+
+cp -r $DIANN_DIR/* $PREFIX/bin/
+
+chmod +x $PREFIX/bin/*

--- a/recipes/diann/meta.yaml
+++ b/recipes/diann/meta.yaml
@@ -1,0 +1,37 @@
+{% set version = "1.8.1" %}
+{% set sha256 = "2c38201b5e04e9e0df621ba053bbad93d70dc9b23bd6e0b78a1f6b22315cc1c0" %}
+
+package:
+  name: diann
+  version: {{ version }}
+
+source:
+  - url: https://github.com/vdemichev/DiaNN/releases/download/{{ version }}/diann_{{ version }}.deb
+    sha256: {{ sha256 }}
+    fn: diann_{{ version }}.deb
+
+build:
+  number: 0
+  binary_relocation: False
+
+requirements:
+  build:
+    - python
+  host:
+    - python
+    - pip
+  run:
+    - python
+
+test:
+  commands:
+    - diann-{{ version }}
+
+about:
+  home: https://github.com/vdemichev/DiaNN
+  license: https://github.com/vdemichev/DiaNN/blob/master/LICENSE.txt
+  summary: 'DIA-NN - a universal automated software suite for DIA proteomics data analysis.'
+
+extra:
+  recipe-maintainers:
+    - npinter


### PR DESCRIPTION
This PR adds DIA-NN,  a universal software for data-independent acquisition (DIA) proteomics data processing. 

https://github.com/vdemichev/DiaNN