### PR TITLE
Update TASSEL package to 5.2.89

### DIFF
--- a/recipes/tassel/meta.yaml
+++ b/recipes/tassel/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "TASSEL" %}
-{% set version = "5.2.40" %}
+{% set version = "5.2.89" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://bitbucket.org/tasseladmin/tassel-5-standalone/get/V{{ version }}.tar.gz
-  md5: 66c6ededa0a8e495ec7c86bc8aa441f8
+  md5: 71563a38cd7b512eeb0a38dcd7f3a13b
   patches:
     - patches/run_anything.patch
     - patches/run_pipeline.patch
@@ -15,7 +15,7 @@ source:
 
 build:
   noarch: generic
-  number: 3
+  number: 0
 
 requirements:
   run:
@@ -27,6 +27,6 @@ test:
     - run_pipeline.pl -ListPlugins
 
 about:
-  home: 'http://www.maizegenetics.net/tassel'
+  home: 'https://www.maizegenetics.net/tassel'
   license: LGPL V2.1
   summary: "TASSEL is a software package to evaluate traits associations, evolutionary patterns, and linkage disequilibrium."


### PR DESCRIPTION
This PR updates the TASSEL Bioconda package to the most recent public release, `5.2.89`.