### PR TITLE
Update r-recetox-xmsannotator: change repo URL

### DIFF
--- a/recipes/r-recetox-xmsannotator/meta.yaml
+++ b/recipes/r-recetox-xmsannotator/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "recetox-xMSannotator" %}
 {% set version = "0.10.0" %}
-{% set github = "https://github.com/recetox/recetox-xMSannotator" %}
+{% set github = "https://github.com/RECETOX/recetox-xMSannotator" %}
 
 package:
   name: "r-{{ name|lower }}"

--- a/recipes/r-recetox-xmsannotator/meta.yaml
+++ b/recipes/r-recetox-xmsannotator/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 362abcd78bff8ca8149efa5e66d43611e5e8bb23443db84c33fa026af0aa6eaa
 
 build:
-  number: 0
+  number: 1
   noarch: generic
   rpaths:
     - lib/


### PR DESCRIPTION
The `r-recetox-xmsannotator` package does not create automatic PR on a new release.
This might be caused by minor issue with the URL (`recetox` was not uppercase).