### PR TITLE
Update callingcardstools

### DIFF
--- a/recipes/callingcardstools/meta.yaml
+++ b/recipes/callingcardstools/meta.yaml
@@ -19,7 +19,7 @@ build:
 requirements:
   host:
     - biopython
-    - edlib
+    - edlib >=1.3.9
     - numpy
     - pandas
     - pip
@@ -28,7 +28,7 @@ requirements:
     - python >=3.9
   run:
     - biopython
-    - edlib
+    - edlib >=1.3.9
     - numpy
     - pandas
     - pysam

--- a/recipes/callingcardstools/meta.yaml
+++ b/recipes/callingcardstools/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   entry_points:
     - callingcardstools = callingcardstools:__main__.main
   script: "{{ PYTHON }} -m pip install . -vv"

--- a/recipes/seqscreen/meta.yaml
+++ b/recipes/seqscreen/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.1" %}
+{% set version = "4.2" %}
 
 package:
   name: seqscreen
@@ -6,11 +6,11 @@ package:
 
 source:
   url: 'https://gitlab.com/treangenlab/seqscreen/-/archive/v{{version}}/seqscreen-v{{version}}.tar.gz'  
-  sha256: 310062b35e1ba16131d340988d926ea0cf1cf5cc7b9440ced8f1d42eb6f900f5                                 
+  sha256: 16bd9f647360449e1d50fad938a1958b4dae7429a373afca531a3b64178e2659                                 
 
 build:
   noarch: generic
-  number: 2
+  number: 0
 
 requirements:
   run:


### PR DESCRIPTION
Adding a version to the software dependency `edlib`. This should address an issue in which `callingcardstools` installs, but does not behave correctly, when an earlier version of `edlib` is used.
