### PR TITLE
Remove outdated dependency restrictions for pangolin

### DIFF
--- a/recipes/pangolin/meta.yaml
+++ b/recipes/pangolin/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: daf13c111799943b05bc2c8eee8deb2316e1347ca8f40f0b40d22cdbcc72e3c1
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: python -m pip install --no-deps --ignore-installed .
 
@@ -21,12 +21,12 @@ requirements:
     - python >=3.7
     - biopython ==1.74
     - pandas >=1.0.1
-    - tabulate ==0.8.10
+    - tabulate
     - joblib >=0.11
     - scikit-learn >=0.23.1
     - pulp >=2
     - minimap2 >=2.16
-    - snakemake-minimal >=5.13,<=6.8.0
+    - snakemake-minimal >=5.13
     - gofasta
     - usher >=0.6.2
     - ucsc-fatovcf >=426


### PR DESCRIPTION
Since v4.3 pangolin works again with the latest releases of all its dependencies.
