### PR TITLE
Don't run build-failures workflow on forked repositories

### DIFF
--- a/.github/workflows/build-failures.yml
+++ b/.github/workflows/build-failures.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   update-build-failure-page:
     name: Update build failure page
+    if: github.repository == 'bioconda/bioconda-recipes'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Pushing to a fork's **master** branch currently runs the _build-failures_ workflow, which (of course) fails due to forked repositories not having the credentials to upload to the bioconda organisation's wiki.

See e.g. https://github.com/jmarshall/bioconda-recipes/actions/runs/5502459010/jobs/10026724933.

Fix this as per 5297fed1e7a19ce6a8d76ed04fee9ed9d4ca1117 by running it only on bioconda's repository.
Attention @johanneskoester.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
