### PR TITLE
update ltr_retriever to v2.9.5

### DIFF
--- a/recipes/ltr_retriever/meta.yaml
+++ b/recipes/ltr_retriever/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "LTR_retriever" %}
-{% set version = "2.9.4" %}
-{% set sha256 = "a9f4668113d2d75ab97cd85b456f11b00afd4876848a8ef099622ec0d9e505e7" %}
+{% set version = "2.9.5" %}
+{% set sha256 = "f50812e6342a1d427a69e11e7ccbf21d7d72acf52c373fbd4ffdbe8a96dd62b7" %}
 
 package:
   name: "{{ name|lower }}"
@@ -15,15 +15,19 @@ build:
   noarch: generic
 
 channels:
-  - conda-forge
   - bioconda
+  - anaconda
+  - conda-forge
+  - defaults
   
 requirements:
   run:
-    - perl
     - perl-text-soundex
+    - perl
     - cd-hit
-    - repeatmasker
+    - repeatmasker <4.1.5
+    - rmblast <2.11
+    - libstdcxx-ng <13
     - tesorter
 
 test:


### PR DESCRIPTION
The auto-update of `ltr_retriever` v2.9.5 encounters dependency conflicts (#41933) which are resolved in this manual update. Setting version restrictions for `repeatmasker`, `rmblast`, and `libstdcxx-ng` solve this conflict.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
