### PR TITLE
Update pear to v0.9.11

### DIFF
--- a/recipes/pear/build.sh
+++ b/recipes/pear/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -xeuo pipefail
-./configure --prefix=$PREFIX LDFLAGS="$(pkg-config --libs zlib)" CFLAGS="$(pkg-config --cflags zlib)"
+./configure --prefix=$PREFIX
 make
 make install
 ln -s $PREFIX/bin/pear $PREFIX/bin/pearRM

--- a/recipes/pear/meta.yaml
+++ b/recipes/pear/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: pear
-  version: '0.9.6'
+  version: '0.9.11'
 
 about:
   home: http://sco.h-its.org/exelixis/web/software/pear/
@@ -8,11 +8,11 @@ about:
   summary: 'paired-end read merger'
 
 source:
-  md5: 5ed68d50c1620cd55c58681e38771799
-  url: https://depot.galaxyproject.org/software/pear/pear_0.9.6_src_all.tar.gz
+  sha256: 311c5c34ab27ae2301b8135182ee95b5c92010dcc903d01d658c9870e3ae4728
+  url: https://github.com/ressy/pear/archive/refs/tags/v0.9.11.tar.gz
 
 build:
-  number: 10
+  number: 11
   skip: True  # [osx]
 
 requirements:
@@ -29,8 +29,8 @@ requirements:
 
 test:
   commands:
-    - pear 2>&1 | grep "PEAR v0.9.6"
-    - pearRM 2>&1 | grep "PEAR v0.9.6"
+    - pear 2>&1 | grep "PEAR v0.9.11"
+    - pearRM 2>&1 | grep "PEAR v0.9.11"
 
 extra:
   identifiers:

--- a/recipes/pear/meta.yaml
+++ b/recipes/pear/meta.yaml
@@ -12,14 +12,15 @@ source:
   url: https://github.com/ressy/pear/archive/refs/tags/v0.9.11.tar.gz
 
 build:
-  number: 11
+  number: 0
   skip: True  # [osx]
 
 requirements:
   build:
     - make
-    - {{ compiler('c') }}
+    - {{ compiler('gcc') }}
     - pkgconfig
+    - zlib
   host:
     - zlib
     - bzip2


### PR DESCRIPTION
Update Paired End Read Merging from 0.9.6 to 0.9.11 
I was unable to find the source for 0.9.11 from official sources, but someone had uploaded a copy of 0.9.11 on GitHub. If a different stable reference is preferred, assistance to identify it would be appreciated. Local build (non-docker) is working.

@BiocondaBot please add label