### PR TITLE
Update MEDICC2 to version 1.0.2

### DIFF
--- a/recipes/medicc2/meta.yaml
+++ b/recipes/medicc2/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ hash }}
 
 build:
-  number: 1
+  number: 0
   skip: true  # [py < 37]
   script: {{ PYTHON }} -m pip install . -vv
 
@@ -27,7 +27,7 @@ requirements:
     - numpy >=1.20.1
     - openfst ==1.8.2
     - setuptools
-    - cython ~=0.29
+    - cython ==0.29.*
   run:
     - python
     - numpy >=1.20.1

--- a/recipes/medicc2/meta.yaml
+++ b/recipes/medicc2/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "medicc2" %}
-{% set version = "1.0.0" %}
+{% set version = "1.0.2" %}
+{% set hash = "0acfcea5646706ce4ceb787a36eef2e9d7272928442b147e23813c56ecde5987" %}
 
 
 package:
@@ -8,7 +9,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 79386ba51a183183dc14798b5c0b6b492902f8de115ee3504ebd7b22d6dc42f1
+  sha256: {{ hash }}
 
 build:
   number: 1
@@ -26,7 +27,7 @@ requirements:
     - numpy >=1.20.1
     - openfst ==1.8.2
     - setuptools
-    - cython >=0.29.21
+    - cython ~=0.29
   run:
     - python
     - numpy >=1.20.1


### PR DESCRIPTION
Manual update to MEDICC2 version 1.0.2 due to some dependency changes with Cython.

Cython was recently updated to version 3.0, however, MEDICC2 does not compile with the new version which is why the old version 0.29 was pinned.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).


<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
