### PR TITLE
Remove mamba from Snakemake deps

### DIFF
--- a/recipes/snakemake/meta.yaml
+++ b/recipes/snakemake/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 0cb86cf9b43b9f2f45d5685cd932595131031c7087690f64c5bc7eaec88df029
 
 build:
-  number: 0
+  number: 1
   noarch: generic
 
 requirements:
@@ -24,8 +24,6 @@ requirements:
     - pysftp >=0.2.8
     - psutil
     - aioeasywebdav
-    # mamba is optional, but is the default/recommended replacement for conda package manager
-    - mamba
     # pandas is optional, but required for many workflows
     - pandas
     - python-irodsclient


### PR DESCRIPTION
Mamba is only meant to be installed in the base environment. Furthermore, the recommendation is to install no packages other than conda and mamba deps in the base environment. See the [mamba docs](https://mamba.readthedocs.io/en/latest/installation.html#installation).

See #41477

Closes snakemake/snakemake#2288, closes snakemake/snakemake#2343