### PR TITLE
Update snakemake Python dependency

### DIFF
--- a/recipes/snakemake/meta.yaml
+++ b/recipes/snakemake/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 0cb86cf9b43b9f2f45d5685cd932595131031c7087690f64c5bc7eaec88df029
 
 build:
-  number: 0
+  number: 1
   noarch: generic
 
 requirements:
@@ -85,11 +85,11 @@ outputs:
 
     requirements:
       host:
-        - python >=3.7
+        - python >=3.9
         - pip
         - setuptools
       run:
-        - python >=3.7
+        - python >=3.9
         - setuptools
         - wrapt
         - requests


### PR DESCRIPTION
7.30.2 requires at least Python 3.9

I hope that's correct @johanneskoester?