### PR TITLE
fix: [t-coffee] unpin viennarna to avoid pulling in old python

### DIFF
--- a/recipes/t-coffee/meta.yaml
+++ b/recipes/t-coffee/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 6
+  number: 7
 
 source:
   # The latest stable release is at http://www.tcoffee.org/Packages/Stable/Latest/ ,

--- a/recipes/t-coffee/meta.yaml
+++ b/recipes/t-coffee/meta.yaml
@@ -10,7 +10,7 @@ build:
 source:
   # The latest stable release is at http://www.tcoffee.org/Packages/Stable/Latest/ ,
   # but is then archived at http://www.tcoffee.org/Packages/Archives/
-  url: https://s3.eu-central-1.amazonaws.com/tcoffee-packages/Stable/Latest/T-COFFEE_distribution_Version_{{ version }}.tar.gz
+  url: http://tcoffee-packages.s3-website.eu-central-1.amazonaws.com/#Archives/T-COFFEE_distribution_Version_{{ version }}.tar.gz
   sha256: c8e5ba17de11ddf07cf2ed37f077d81c1432d55b77761f115f9374de6f8d0d03
   patches:
     - expose-os-detection.patch

--- a/recipes/t-coffee/meta.yaml
+++ b/recipes/t-coffee/meta.yaml
@@ -10,7 +10,7 @@ build:
 source:
   # The latest stable release is at http://www.tcoffee.org/Packages/Stable/Latest/ ,
   # but is then archived at http://www.tcoffee.org/Packages/Archives/
-  url: http://tcoffee-packages.s3-website.eu-central-1.amazonaws.com/#Archives/T-COFFEE_distribution_Version_{{ version }}.tar.gz
+  url: https://s3.eu-central-1.amazonaws.com/tcoffee-packages/Archives/T-COFFEE_distribution_Version_{{ version }}.tar.gz
   sha256: c8e5ba17de11ddf07cf2ed37f077d81c1432d55b77761f115f9374de6f8d0d03
   patches:
     - expose-os-detection.patch

--- a/recipes/t-coffee/meta.yaml
+++ b/recipes/t-coffee/meta.yaml
@@ -42,7 +42,7 @@ requirements:
     - ruby
     - sap
     - tmalign
-    - viennarna 2.1.9
+    - viennarna
   run:
     - blast
     - clustalo
@@ -65,7 +65,7 @@ requirements:
     - ruby
     - sap
     - tmalign
-    - viennarna 2.1.9
+    - viennarna
     
 test:
   commands:


### PR DESCRIPTION
TL;DR: `viennarna = 2.1.9` pulls in the very old python `3.7` and this can easily clash with other dependencies nowadays. And I don't see any reason for the pinning to be necessary, here's where I checked:

* [The original commit that introduced the pinning gives no reason](https://github.com/bioconda/bioconda-recipes/commit/90fad72c3dbe47ff0a1284a659afaa3dd7573062), so I am assuming this was introduced as a side-effect while trying to get the recipe to work.
* [t-coffee README.md mentions the `vienna` package for using `RNAplfold`, but gives no specific version requirements.](https://github.com/cbcrg/tcoffee/blob/master/docs/tcoffee_installation.rst#r-coffee-associated-packages)
* [The `viennarna` package Changelog only mentions fixes for the `RNAplfold` functionality, but no breaking changes in the general usage (only improved results, from what I can see).](https://www.tbi.univie.ac.at/RNA/changelog.html)

So simply unpinning this should be fine. If we want to be extra careful, we could go for `viennarna =2` to avoid major version jumps.

A concrete example where the unwanted pulling in of ptyhon `3.7` happens is when using the [`ensembl-vep =109.3` snakemake wrapper]() with `snakemake` version `7.31.0`. This gives:
```
ValueError: Snakemake requires at least Python 3.9.
```

It seems a bit obscure that `ensembl-vep` that seems to be a plain perl tool requires python and pulls in python `3.7`. From what I can see, this happens via the route of:
- [`ensembl-vep =109.3`](https://bioconda.github.io/recipes/ensembl-vep/README.html) requires:
- [`perl-bioperl  >=1.7.2`](https://bioconda.github.io/recipes/perl-bioperl/README.html#package-perl-bioperl) requires:
- [`perl-bio-tools-run-alignment-tcoffee`](https://bioconda.github.io/recipes/perl-bio-tools-run-alignment-tcoffee/README.html#package-perl-bio-tools-run-alignment-tcoffee) requires:
- [`t-coffee`](https://bioconda.github.io/recipes/t-coffee/README.html#package-t-coffee) requires:
- [`viennarna =2.1.9.*`](https://bioconda.github.io/recipes/viennarna/README.html#package-viennarna) requires:
- `python`

And I guess that really old version of `viennarna` only exists as a package built with `python 3.7`, so I think the root cause of pulling in this old python version is really the pinning of `viennarna` in this recipe. And from what I can see, this is not necessary.

I'm pinging in the people on the original commit that introduced the pinning for review:
@pditommaso @apeltzer 

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
