### PR TITLE
Update: snakemake, BugFix dependencies

### DIFF
--- a/recipes/snakemake/meta.yaml
+++ b/recipes/snakemake/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: ee7b413559935d00326c78ead1004781cbb262eae1eab02fc4939e8f502cc3b4
 
 build:
-  number: 0
+  number: 1
   noarch: generic
 
 requirements:
@@ -87,6 +87,7 @@ outputs:
         - pip
         - setuptools
       run:
+        # Keep in sync with snakemake/setup.cfg
         - python >=3.9
         - setuptools
         - wrapt
@@ -104,9 +105,9 @@ outputs:
         - toposort >=1.10
         - nbformat
         - connection_pool >=0.0.3
+        - packaging
         - pulp >=2.0
         - smart_open >=3.0
-        - filelock
         - stopit
         - tabulate
         - jinja2 >=3.0,<4.0


### PR DESCRIPTION
BugFix: dependencies for snakemake-minimal
- since snakemake 7.2.0, filelock isn't used anymore
- since snakemake 7.29.0, packaging is used instead of distutils

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

For members of the Bioconda project, the following command is also available:

<table>
  <tr>
    <td><code>@BiocondaBot please merge</code></td>
    <td>Upload built packages/containers and merge a PR. <br />Someone must approve a PR first! <br />This reduces CI build time by reusing built artifacts.</td>
  </tr>
</table>

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
