### PR TITLE
Update meta.yaml

### DIFF
--- a/recipes/trycycler/meta.yaml
+++ b/recipes/trycycler/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install --no-deps --ignore-installed .
 
 source:
@@ -27,7 +27,7 @@ requirements:
     - miniasm
     - minimap2
     - mash
-    - muscle <4
+    - muscle
     - r-base
     - r-ape
     - r-phangorn


### PR DESCRIPTION
I believe @rrwick can confirm, my perusal of the source suggests that muscle 5 is supported and so the pin can be removed.


