### PR TITLE
Add MapThin

### DIFF
--- a/recipes/hapnest/meta.yaml
+++ b/recipes/hapnest/meta.yaml
@@ -1,0 +1,22 @@
+package:
+  name: hapnest
+  version: "1"
+build:
+  noarch: generic
+  number: 1
+requirements:
+  run:
+    - plink
+    - plink2
+    - king
+    - vcftools
+    - bcftools
+about:
+  summary: "Meta-package for hapnest including plink"
+  license: "The license for this meta-package is GNU General Public License v3.0; individual tools vary"
+
+extra:
+  skip-lints:
+    - missing_home
+    - missing_tests
+

--- a/recipes/mapthin/build.sh
+++ b/recipes/mapthin/build.sh
@@ -1,0 +1,3 @@
+#g++ -O3 *.cpp -o mapthin 
+mkdir -p $PREFIX/bin
+cp mapthin $PREFIX/bin/mapthin

--- a/recipes/mapthin/build.sh
+++ b/recipes/mapthin/build.sh
@@ -1,3 +1,3 @@
 #g++ -O3 *.cpp -o mapthin 
 mkdir -p $PREFIX/bin
-cp mapthin $PREFIX/bin/mapthin
+cp mapthin-v1.11-linux-x86_64 $PREFIX/bin/mapthin

--- a/recipes/mapthin/meta.yaml
+++ b/recipes/mapthin/meta.yaml
@@ -7,7 +7,7 @@ source:
   sha256: aa998e4e7a20246e112b041ab7feba021d4123e3e46cf292803a99cbf1ad91ae # [linux]
 
 build:
-  number: 1
+  number: 0
 
 requirements:
   build:

--- a/recipes/mapthin/meta.yaml
+++ b/recipes/mapthin/meta.yaml
@@ -1,0 +1,24 @@
+package:
+  name: mapthin
+  version: 1.11
+
+source:
+  url: https://www.staff.ncl.ac.uk/richard.howey/mapthin/mapthin-v1.11-linux-x86_64.zip # [linux] 
+  sha256: aa998e4e7a20246e112b041ab7feba021d4123e3e46cf292803a99cbf1ad91ae # [linux]
+
+build:
+  number: 1
+
+requirements:
+  build:
+    -  {{ compiler('c') }}
+
+test:
+ commands:
+    - ./mapthin
+    ### | grep  "MapThin (v1.11)"
+
+about:
+  home: https://www.staff.ncl.ac.uk/richard.howey/mapthin/index.html
+  summary: The program MapThin takes a PLINK map file as input (either .map or .bim) and produces another map file with less SNPs than the original.
+


### PR DESCRIPTION
This PR add a recipe for [MapThin](https://www.staff.ncl.ac.uk/richard.howey/mapthin/index.html) tool which produces a map file with less SNPs than the original plink map file.



