### PR TITLE
Add crispector2 2.0.0

### DIFF
--- a/recipes/crispector2/build.sh
+++ b/recipes/crispector2/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+$PYTHON setup.py install --single-version-externally-managed --record=rec.txt

--- a/recipes/crispector2/build.sh
+++ b/recipes/crispector2/build.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-$PYTHON setup.py install --single-version-externally-managed --record=rec.txt

--- a/recipes/crispector2/meta.yaml
+++ b/recipes/crispector2/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.0.2" %}
+{% set version = "2.0.3" %}
 
 package:
   name: crispector2
@@ -13,7 +13,7 @@ build:
 
 source:
   url: https://github.com/theAguy/crispector2/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: ccf31ab6d66ba6ff79f5d7bc70a871a6bb5bb89f7f05a4dc4520762e8f2ef53d
+  sha256: 16993214f5f037197fd16ac27b5da231016d741c749ab390c3a77683823abae9
 
 requirements:
   host:

--- a/recipes/crispector2/meta.yaml
+++ b/recipes/crispector2/meta.yaml
@@ -12,8 +12,8 @@ build:
   script: python -m pip install . --no-deps -vv
 
 source:
-  url: https://github.com/theAguy/crispector2/archive/v{{ version }}.tar.gz
-  sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+  url: https://github.com/theAguy/crispector2/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: f11022ffae33caa0774cd7b30a599d862ed0c66f433996f2ba2f8b4630032018
 
 requirements:
   host:

--- a/recipes/crispector2/meta.yaml
+++ b/recipes/crispector2/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.0.3" %}
+{% set version = "2.0.4" %}
 
 package:
   name: crispector2
@@ -13,7 +13,7 @@ build:
 
 source:
   url: https://github.com/theAguy/crispector2/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 16993214f5f037197fd16ac27b5da231016d741c749ab390c3a77683823abae9
+  sha256: 5d90bd9148931d6c905eee6e757b60d53fd7fb2da9ec3289d0ba9b57891c9308
 
 requirements:
   host:

--- a/recipes/crispector2/meta.yaml
+++ b/recipes/crispector2/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.0.1" %}
+{% set version = "2.0.2" %}
 
 package:
   name: crispector2
@@ -13,7 +13,7 @@ build:
 
 source:
   url: https://github.com/theAguy/crispector2/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: d2341d28f9f1aa244deb571d0aae6056c9d349db2f627fd74086f908a4b83919
+  sha256: ccf31ab6d66ba6ff79f5d7bc70a871a6bb5bb89f7f05a4dc4520762e8f2ef53d
 
 requirements:
   host:

--- a/recipes/crispector2/meta.yaml
+++ b/recipes/crispector2/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.0.0" %}
+{% set version = "2.0.1" %}
 
 package:
   name: crispector2
@@ -13,7 +13,7 @@ build:
 
 source:
   url: https://github.com/theAguy/crispector2/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: f11022ffae33caa0774cd7b30a599d862ed0c66f433996f2ba2f8b4630032018
+  sha256: d2341d28f9f1aa244deb571d0aae6056c9d349db2f627fd74086f908a4b83919
 
 requirements:
   host:

--- a/recipes/crispector2/meta.yaml
+++ b/recipes/crispector2/meta.yaml
@@ -7,7 +7,7 @@ package:
 build:
   number: 0
   entry_points:
-    - crispector = crispector.cli:main
+    - crispector = crispector2.cli:main
   noarch: python
   script: python -m pip install . --no-deps -vv
 

--- a/recipes/crispector2/meta.yaml
+++ b/recipes/crispector2/meta.yaml
@@ -16,6 +16,8 @@ source:
   sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 
 requirements:
+  build:
+    - {{ compiler('c') }}
   host:
     - python 3.7
     - pip

--- a/recipes/crispector2/meta.yaml
+++ b/recipes/crispector2/meta.yaml
@@ -16,8 +16,6 @@ source:
   sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 
 requirements:
-  build:
-    - {{ compiler('c') }}
   host:
     - python 3.7
     - pip

--- a/recipes/crispector2/meta.yaml
+++ b/recipes/crispector2/meta.yaml
@@ -35,7 +35,7 @@ requirements:
     - pandas >=0.24.2
     - statsmodels
     - jinja2
-    - tqdm >=4.66.1
+    - tqdm >=4.66.0
 
 test:
   commands:

--- a/recipes/crispector2/meta.yaml
+++ b/recipes/crispector2/meta.yaml
@@ -1,7 +1,7 @@
 {% set version = "2.0.0" %}
 
 package:
-  name: crispector
+  name: crispector2
   version: "{{ version }}"
 
 build:
@@ -12,7 +12,7 @@ build:
   script: python -m pip install . --no-deps -vv
 
 source:
-  url: https://github.com/theAguy/crispector2/v{{ version }}.tar.gz
+  url: https://github.com/theAguy/crispector2/archive/v{{ version }}.tar.gz
   sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 
 requirements:

--- a/recipes/crispector2/meta.yaml
+++ b/recipes/crispector2/meta.yaml
@@ -1,0 +1,54 @@
+{% set version = "2.0.0" %}
+
+package:
+  name: crispector
+  version: "{{ version }}"
+
+build:
+  number: 0
+  entry_points:
+    - crispector = crispector.cli:main
+  noarch: python
+  script: python -m pip install . --no-deps -vv
+
+source:
+  url: https://github.com/theAguy/crispector2/v{{ version }}.tar.gz
+  sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+
+requirements:
+  host:
+    - python 3.7
+    - pip
+    - setuptools
+  run:
+    - python 3.7
+    - biopython >=1.74
+    - fastp
+    - python-edlib
+    - click >=7.0
+    - pyyaml >=5.1.2
+    - matplotlib-base >=3.1.2
+    - scipy >=1.2.1
+    - numpy >=1.12.1
+    - seaborn >=0.9.0
+    - plotly >=4.3.0
+    - pandas >=0.24.2
+    - statsmodels
+    - jinja2
+    - tqdm >=4.66.1
+
+test:
+  commands:
+    - crispector -h
+
+about:
+  home: https://github.com/theAguy/crispector2
+  # The license forbids redistribution, but the author has granted an exception, see
+  # https://github.com/bioconda/bioconda-recipes/pull/21129#issuecomment-605051102
+  license: free to academic and non-for-profit research work, non-commercial use, see LICENSE file
+  license_file: LICENSE
+  summary: "Accurate estimation of off-target editing activity from comparative NGS data"
+
+extra:
+  recipe-maintainers:
+    - theAguy


### PR DESCRIPTION
This is an extension of the existence crispector tool that was published 2 years ago.
It has some added abilities and analyses that were lacking in the previous edition.
The additional code is significant, thus it is published as a new tool with the same name.
----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
