### PR TITLE
fix: freebayes

### DIFF
--- a/recipes/freebayes/meta.yaml
+++ b/recipes/freebayes/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 6016c1e58fdf34a1f6f77b720dd8e12e13a127f7cbac9c747e47954561b437f5
 
 build:
-  number: 6
+  number: 7
   skip: true  # [osx]
 
 requirements:

--- a/recipes/freebayes/meta.yaml
+++ b/recipes/freebayes/meta.yaml
@@ -32,7 +32,8 @@ requirements:
     - parallel
     - samtools
     - tabixpp
-    - vcflib
+    - vcflib=1.0.3  # vcflib=1.0.9 does not work with freebayes-parallel, see https://github.com/vcflib/vcflib/issues/389
+    - htslib =1.16  # htslib=1.17 does not work with freebayes-parallel
     
 test:
   commands:

--- a/recipes/freebayes/meta.yaml
+++ b/recipes/freebayes/meta.yaml
@@ -25,13 +25,11 @@ requirements:
   host:
     - bzip2
     - htslib
-    - tabixpp =1.1.0 # tabixpp =1.1.2 no working with freebayes-parallel
-    - vcflib =1.0.3  # vcflib=1.0.9 not working with freebayes-parallel, see https://github.com/vcflib/vcflib/issues/389
+    - vcflib
   run:
     - parallel
     - samtools
-    - tabixpp =1.1.0 # tabixpp =1.1.2 no working with freebayes-parallel
-    - vcflib =1.0.3  # vcflib=1.0.9 does not work with freebayes-parallel, see https://github.com/vcflib/vcflib/issues/389
+    - vcflib
     
 test:
   commands:

--- a/recipes/freebayes/meta.yaml
+++ b/recipes/freebayes/meta.yaml
@@ -11,6 +11,8 @@ source:
 build:
   number: 7
   skip: true  # [osx]
+  run_exports:
+    - {{ pin_subpackage("freebayes", max_pin="x") }}
 
 requirements:
   build:
@@ -24,7 +26,7 @@ requirements:
     - bzip2
     - htslib
     - tabixpp
-    - vcflib=1.0.3  # vcflib=1.0.9 not working with freebayes-parallel
+    - vcflib=1.0.3  # vcflib=1.0.9 not working with freebayes-parallel, see https://github.com/vcflib/vcflib/issues/389
     - htslib=1.16   # htslib=1.17 not working with freebayes-parallel
   run:
     - parallel

--- a/recipes/freebayes/meta.yaml
+++ b/recipes/freebayes/meta.yaml
@@ -24,7 +24,8 @@ requirements:
     - bzip2
     - htslib
     - tabixpp
-    - vcflib
+    - vcflib=1.0.3  # vcflib=1.0.9 not working with freebayes-parallel
+    - htslib=1.16   # htslib=1.17 not working with freebayes-parallel
   run:
     - parallel
     - samtools

--- a/recipes/freebayes/meta.yaml
+++ b/recipes/freebayes/meta.yaml
@@ -25,10 +25,12 @@ requirements:
   host:
     - bzip2
     - htslib
+    - tabixpp
     - vcflib
   run:
     - parallel
     - samtools
+    - tabixpp
     - vcflib
     
 test:

--- a/recipes/freebayes/meta.yaml
+++ b/recipes/freebayes/meta.yaml
@@ -26,8 +26,8 @@ requirements:
     - bzip2
     - htslib
     - tabixpp
-    - vcflib=1.0.3  # vcflib=1.0.9 not working with freebayes-parallel, see https://github.com/vcflib/vcflib/issues/389
-    - htslib=1.16   # htslib=1.17 not working with freebayes-parallel
+    - vcflib =1.0.3  # vcflib=1.0.9 not working with freebayes-parallel, see https://github.com/vcflib/vcflib/issues/389
+    - htslib =1.16   # htslib=1.17 not working with freebayes-parallel
   run:
     - parallel
     - samtools

--- a/recipes/freebayes/meta.yaml
+++ b/recipes/freebayes/meta.yaml
@@ -25,15 +25,13 @@ requirements:
   host:
     - bzip2
     - htslib
-    - tabixpp
+    - tabixpp =1.1.0 # tabixpp =1.1.2 no working with freebayes-parallel
     - vcflib =1.0.3  # vcflib=1.0.9 not working with freebayes-parallel, see https://github.com/vcflib/vcflib/issues/389
-    - htslib =1.16   # htslib=1.17 not working with freebayes-parallel
   run:
     - parallel
     - samtools
-    - tabixpp
+    - tabixpp =1.1.0 # tabixpp =1.1.2 no working with freebayes-parallel
     - vcflib=1.0.3  # vcflib=1.0.9 does not work with freebayes-parallel, see https://github.com/vcflib/vcflib/issues/389
-    - htslib =1.16  # htslib=1.17 does not work with freebayes-parallel
     
 test:
   commands:

--- a/recipes/freebayes/meta.yaml
+++ b/recipes/freebayes/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - parallel
     - samtools
     - tabixpp =1.1.0 # tabixpp =1.1.2 no working with freebayes-parallel
-    - vcflib=1.0.3  # vcflib=1.0.9 does not work with freebayes-parallel, see https://github.com/vcflib/vcflib/issues/389
+    - vcflib =1.0.3  # vcflib=1.0.9 does not work with freebayes-parallel, see https://github.com/vcflib/vcflib/issues/389
     
 test:
   commands:


### PR DESCRIPTION
Fix freebayes-prarallel because of bug in vcflib=1.0.9 (https://github.com/vcflib/vcflib/issues/389).
Also, htslib=1.17 does not work with freebayes-parallel.
