### PR TITLE
dnmtools rebuild

### DIFF
--- a/recipes/dnmtools/meta.yaml
+++ b/recipes/dnmtools/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 0
+  number: 1
 
 source:
   url: https://github.com/smithlabcode/dnmtools/releases/download/v{{ version }}/dnmtools-{{ version }}.tar.gz

--- a/recipes/dnmtools/meta.yaml
+++ b/recipes/dnmtools/meta.yaml
@@ -6,6 +6,8 @@ package:
 
 build:
   number: 1
+  run_exports:
+    - {{ pin_subpackage('dnmtools', max_pin="x.x") }}
 
 source:
   url: https://github.com/smithlabcode/dnmtools/releases/download/v{{ version }}/dnmtools-{{ version }}.tar.gz

--- a/recipes/dnmtools/meta.yaml
+++ b/recipes/dnmtools/meta.yaml
@@ -7,7 +7,7 @@ package:
 build:
   number: 1
   run_exports:
-    - {{ pin_subpackage('dnmtools', max_pin="x.x") }}
+    - {{ pin_subpackage('dnmtools', max_pin="x") }}
 
 source:
   url: https://github.com/smithlabcode/dnmtools/releases/download/v{{ version }}/dnmtools-{{ version }}.tar.gz


### PR DESCRIPTION
The previous build of dnmtools linked against GSL version 2.5 (as indicated within the binary) but the json file in "conda-meta" indicated version 2.7, which means it simply won't run. I'm rebuilding because I think this might be just a random problem, as it seems not to make any sense.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
