### PR TITLE
3.1.6 mob-suite build #1 to remove sequenoscope entry point

### DIFF
--- a/recipes/mob_suite/meta.yaml
+++ b/recipes/mob_suite/meta.yaml
@@ -22,6 +22,7 @@ build:
 
 requirements:
   host:
+   run_exports:
     - python >=3.7
     - pip
     - pytest-runner

--- a/recipes/mob_suite/meta.yaml
+++ b/recipes/mob_suite/meta.yaml
@@ -10,7 +10,6 @@ source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/mob_suite-{{ version }}.tar.gz
   sha256: {{ sha256 }}
   
-
 build:
   number: 1
   noarch: python

--- a/recipes/mob_suite/meta.yaml
+++ b/recipes/mob_suite/meta.yaml
@@ -12,11 +12,10 @@ source:
   
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . --use-pep517 --no-deps -vvv
   entry_points:
-    - Sequenoscope=Sequenoscope:main
     - mob_init=mob_suite.mob_init:main
     - mob_recon=mob_suite.mob_recon:main
     - mob_cluster=mob_suite.mob_cluster:main


### PR DESCRIPTION
This build #1 is to address the `sequenoscope` entrypoint that was added by accident. This built just erases that entry point from the list of available ones to avoid propagation in future recipes