### PR TITLE
Update lisa2 to version 2.3.1

### DIFF
--- a/recipes/lisa2/meta.yaml
+++ b/recipes/lisa2/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "lisa2" %}
-{% set version = "2.3.0" %}
+{% set version = "2.3.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/lisa2-{{ version }}.tar.gz
-  sha256: 95cec0ea2faadf3df384097ee3478f00b1d3d6bbe8cfe53187eeddfe6a221a50
+  sha256: 26843ba6b29f3d5af94571ea0a99ac39e80f2fe4d13a04fb3481593ff0374cef
 
 build:
   number: 0
@@ -22,7 +22,7 @@ requirements:
     - h5py >=2
     - numpy <2,>=1.17
     - python >=3.5
-    - scikit-learn <1,>=0.22
+    - scikit-learn <2,>=0.22
     - scipy <2,>=1.4
 
 test:


### PR DESCRIPTION
Changed code which failed when using deprecated numpy idioms, changed sklearn dependency to use version 1
