### PR TITLE
Update picard and picard-slim to 3.1.0

### DIFF
--- a/recipes/picard-slim/build.sh
+++ b/recipes/picard-slim/build.sh
@@ -4,12 +4,7 @@ TGT="$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM"
 [ -d "$TGT" ] || mkdir -p "$TGT"
 [ -d "${PREFIX}/bin" ] || mkdir -p "${PREFIX}/bin"
 
-cd "${SRC_DIR}"
-# Do not install Linux specific x86-acceleration libraries
-if [ "$(uname)" == "Darwin" ]; then
-    rm -f libIntel*.so
-fi
-cp -rvp . "${TGT}"
+cp -p "$SRC_DIR"/*.jar "$TGT"
 
 cp $RECIPE_DIR/picard.sh $TGT/picard
 ln -s $TGT/picard $PREFIX/bin

--- a/recipes/picard-slim/meta.yaml
+++ b/recipes/picard-slim/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "3.0.0" %}
-{% set sha256 = "0d5e28ab301fad3b02030d01923888129ba82c5f722ac5ccb2d418ab76ac5499" %}
+{% set version = "3.1.0" %}
+{% set sha256 = "ea79ca6279a5e818cb6fa68a3476dde799c7ea03ffe52a26a3ca68c71ef28559" %}
 
 package:
   name: picard-slim

--- a/recipes/picard-slim/meta.yaml
+++ b/recipes/picard-slim/meta.yaml
@@ -12,6 +12,8 @@ source:
 build:
   noarch: generic
   number: 0
+  run_exports:
+    - {{ pin_subpackage('picard-slim', max_pin='x') }}
 
 requirements:
   run:

--- a/recipes/picard/build.sh
+++ b/recipes/picard/build.sh
@@ -4,12 +4,7 @@ TGT="$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM"
 [ -d "$TGT" ] || mkdir -p "$TGT"
 [ -d "${PREFIX}/bin" ] || mkdir -p "${PREFIX}/bin"
 
-cd "${SRC_DIR}"
-# Do not install Linux specific x86-acceleration libraries
-if [ "$(uname)" == "Darwin" ]; then
-    rm -f libIntel*.so
-fi
-cp -rvp . "${TGT}"
+cp -p "$SRC_DIR"/*.jar "$TGT"
 
 cp $RECIPE_DIR/picard.sh $TGT/picard
 ln -s $TGT/picard $PREFIX/bin

--- a/recipes/picard/meta.yaml
+++ b/recipes/picard/meta.yaml
@@ -12,6 +12,8 @@ source:
 build:
   noarch: generic
   number: 0
+  run_exports:
+    - {{ pin_subpackage('picard', max_pin='x') }}
 
 requirements:
   run:

--- a/recipes/picard/meta.yaml
+++ b/recipes/picard/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "3.0.0" %}
-{% set sha256 = "0d5e28ab301fad3b02030d01923888129ba82c5f722ac5ccb2d418ab76ac5499" %}
+{% set version = "3.1.0" %}
+{% set sha256 = "ea79ca6279a5e818cb6fa68a3476dde799c7ea03ffe52a26a3ca68c71ef28559" %}
 
 package:
   name: picard
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: generic
-  number: 1
+  number: 0
 
 requirements:
   run:


### PR DESCRIPTION
Autobump branches `bump/picard{,_slim}` exist for these, but appear never to have been turned into PRs — presumably due to autobump bot disruption at the time.

There has been a nontrivial organisational change upstream in v3.1.0: _picardcloud.jar_ is no more, and _picard.jar_ is now much larger and includes cloudy functionality and dependencies. However it appears that bioconda's recipes will not need any changes to deal with this.

~~I have not attempted to add `run_exports` because~~ I have seen no adequate explanation of the rationale for this.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
