### PR TITLE
Add HapLink recipe

### DIFF
--- a/recipes/haplink/build.sh
+++ b/recipes/haplink/build.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+# Avoid libgit2 issues as much as humanly possible
+export JULIA_PKG_USE_CLI_GIT=true
+
+# Start a fake Julia depot
+FAKEDEPOT="${PREFIX}/share/haplink/fake_depot"
+export JULIA_DEPOT_PATH="${FAKEDEPOT}"
+
+# Turn off automatic precompilation
+export JULIA_PKG_PRECOMPILE_AUTO=0
+
+# Copy the required files to a shared directory
+HAPLINK_SRC_DIR=${PREFIX}/share/haplink/src
+mkdir -p "${HAPLINK_SRC_DIR}"
+cp -r {src,deps,example,Project.toml,Comonicon.toml} "${HAPLINK_SRC_DIR}"
+
+# Work from the shared source directory
+cd "${HAPLINK_SRC_DIR}" || exit 1
+
+# Run the Comonicon install method
+julia \
+    --startup-file=no \
+    --history-file=no \
+    -e 'using Pkg; Pkg.develop(;path=pwd())'
+julia \
+    --startup-file=no \
+    --history-file=no \
+    "deps/build.jl"
+
+# Create a permanent depot
+HAPLINK_DEPOT="${PREFIX}/share/haplink/depot"
+mkdir -p "${HAPLINK_DEPOT}"
+
+# Copy the useful directories over to the permanent depot
+for SUBDIR in "packages" "artifacts" "environments" "scratchspaces"; do
+    mv "${FAKEDEPOT}/${SUBDIR}" "${HAPLINK_DEPOT}/${SUBDIR}"
+done
+
+# Copy the script to someplace more permanent
+mkdir -p "${PREFIX}/bin"
+mv "${JULIA_DEPOT_PATH}/bin/haplink" "${PREFIX}/bin"
+sed -i -E 's%JULIA_PROJECT=.+%JULIA_PROJECT=\${CONDA_PREFIX}/share/haplink/depot/scratchspaces/8ca39d33-de0d-4205-9b21-13a80f2b7eed/env%' "${PREFIX}/bin/haplink"
+sed -i -E 's%exec .+%exec ${CONDA_PREFIX}/bin/julia \\%' "${PREFIX}/bin/haplink"
+
+# Destroy the fake depot
+rm -rf "${FAKEDEPOT}"
+
+# Add activation scripts
+for CHANGE in "activate" "deactivate"; do
+    mkdir -p "${PREFIX}/etc/conda/${CHANGE}.d"
+    cp "${RECIPE_DIR}/scripts/${CHANGE}.sh" "${PREFIX}/etc/conda/${CHANGE}.d/${PKG_NAME}_${CHANGE}.sh"
+done

--- a/recipes/haplink/meta.yaml
+++ b/recipes/haplink/meta.yaml
@@ -1,0 +1,45 @@
+{% set name = "haplink" %}
+{% set version = "1.0.0" %}
+{% set sha256 = "2e9459d8b84c01b4503b1b6a68c664f6ba062d1a3123516a9e46a6d4f354374a" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+build:
+  number: 0
+  run_exports:
+    - {{ pin_subpackage('haplink', max_pin='x') }}
+  binary_relocation: false
+  skip: True # [osx]
+
+source:
+  url: https://github.com/ksumngs/HapLink.jl/archive/v{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+# HapLink only requires Julia v1.6 to run natively, but the changes made to how
+# conda changes JULIA_DEPOT_PATH makes the conda version require Julia v1.8 or
+# greater
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - git
+    - julia >=1.8
+  host:
+    - julia >=1.8
+  run:
+    - julia >=1.8
+
+test:
+  commands:
+    - haplink --help
+
+about:
+  home: https://ksumngs.github.io/HapLink.jl
+  license: MIT
+  license_file: LICENSE
+  summary: Viral haplotype calling via linkage disequilibrium
+
+extra:
+  container:
+    extended-base: True

--- a/recipes/haplink/scripts/activate.sh
+++ b/recipes/haplink/scripts/activate.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+export HAPLINK_JULIA_DEPOT_PATH_BACKUP="${JULIA_DEPOT_PATH:-}"
+export JULIA_DEPOT_PATH="${CONDA_PREFIX}/share/haplink/depot:${JULIA_DEPOT_PATH}"

--- a/recipes/haplink/scripts/deactivate.sh
+++ b/recipes/haplink/scripts/deactivate.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+export JULIA_DEPOT_PATH="${JULIA_DEPOT_PATH_BACKUP}"
+unset HAPLINK_JULIA_DEPOT_PATH_BACKUP
+if [ -z "${JULIA_DEPOT_PATH}" ]; then
+  unset JULIA_DEPOT_PATH
+fi


### PR DESCRIPTION
Adds a package for [HapLink](https://github.com/ksumngs/HapLink.jl). HapLink is a software tool for identifying viral haplotypes.

----

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
