### PR TITLE
Update gum to 2.0.1

### DIFF
--- a/recipes/gum/meta.yaml
+++ b/recipes/gum/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "gum" %}
-{% set version = "1.1.1" %}
+{% set version = "2.0.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,27 +7,29 @@ package:
 
 source:
   - url: https://github.com/cartoonist/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-    sha256: c60e7c1cc323ceb965222488b22875305daa5bdd3fe9d5f0cb3aa7ccb4520215
+    sha256: 70f314ec89d8dc767eaf7184c43fdb793948dbdf6bec63a88ba3e8a539e465aa
     patches:
       - 00-fix-ext-cmake.patch
-  - url: https://github.com/cartoonist/sdsl-lite/archive/d3562fdd873e3dd3a8b92d9a914ff5f723b30794.tar.gz
-    sha256: 6e2f9fe832faff39c8bd78edd3ee44f2c2b6b31ead385602b4a6c6aa0f82c9db
+  - url: https://github.com/cartoonist/sdsl-lite/archive/af1820fa3c25d2eb64bbab37a1a94938af862ec8.tar.gz
+    sha256: bac8afcf2f2fa2e25115b1dbdd1269c2ae114572dbd2b8bcff0efeb0f5859aa1
     folder: ext/sdsl-lite
-  - url: https://github.com/greg7mdp/parallel-hashmap/archive/25293cefd8b85491b45600c03fe8edf07647553f.tar.gz
-    sha256: 1162723b13814e4e4538b95af37f56f3c1b49fb03c6a5888127716f7bae33a42
+  - url: https://github.com/greg7mdp/parallel-hashmap/archive/d2bed96d2947c13b8fc90337198c315b2200e058.tar.gz
+    sha256: 387ce116c8568f2d2be43658024a233ed807f420cc9152b4723a780472b97c04
     folder: ext/parallel-hashmap
-  - url: https://github.com/cartoonist/gfakluge/archive/3389908112faa128c19b13208fb31969c3ff89a6.tar.gz
-    sha256: 66b1041a7f9dea6a4d8707a65c4aa63e7f1c717214e585b4770b2f14b28cc53b
+  - url: https://github.com/cartoonist/gfakluge/archive/e4cd7b02317d65b321385cac5415a3cab0a1d0cc.tar.gz
+    sha256: 1303152ea59cade4f21528c414da6fba073b86299c11f259ad8a3d50a450b5ab
     folder: ext/gfakluge
-  - url: https://github.com/cartoonist/tinyFA/archive/819e2eef58a7ca70646e7d59b619d96fe5d3d252.tar.gz
-    sha256: 3918a0c502088c7b4b118fdfef5c8a410a4fd74e38a38793983d03526ad07328
+  - url: https://github.com/cartoonist/tinyFA/archive/bfe1eea6bc5dbd2c87b7b3d48d99e05dafce7073.tar.gz
+    sha256: 92d00462cd770c421a2d30f99aef0de997c732714defead8e05da390e3528755
     folder: ext/gfakluge/src/tinyFA
   - url: https://github.com/cartoonist/pliib/archive/26d27f87fa6781a2aeed2c7a99e41fcad5bd7c4c.tar.gz
     sha256: 6996ce5167345238c6a2929651531f5340f1275f95622a8bf7b2be1cb97a8125
     folder: ext/gfakluge/src/tinyFA/pliib
 
 build:
-  number: 2
+  number: 0
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x") }}
 
 requirements:
   host:


### PR DESCRIPTION
Update [gum](https://bioconda.github.io/recipes/gum/README.html) from 1.1.1 to 2.0.1.
