### PR TITLE
Patch repodata to relax HTSlib dependency upper bounds

### DIFF
--- a/recipes/bioconda-repodata-patches/gen_patch_json.py
+++ b/recipes/bioconda-repodata-patches/gen_patch_json.py
@@ -165,6 +165,12 @@ def _gen_new_index(repodata, subdir):
         if record_name.startswith('samtools') and record['subdir']=='linux-64' and not has_dep(record, "openssl") and not has_dep(record, "htslib"):
             deps.append('openssl >=1.1.0,<=1.1.1')
 
+        # future HTSlib versions are binary compatible until they bump their soversion
+        if has_dep(record, 'htslib'):
+            # skip deps prior to 1.10, which was the first with soversion 3
+            # TODO adjust replacement (exclusive) upper bound with each new compatible HTSlib
+            _pin_looser(fn, record, 'htslib', min_lower_bound='1.10', upper_bound='1.19')
+
         # future libdeflate versions are compatible until they bump their soversion; relax dependencies accordingly
         if record_name in ['htslib', 'staden_io_lib', 'fastp'] and has_dep(record, 'libdeflate'):
             # skip deps that allow anything <1.3, which contained an incompatible library filename

--- a/recipes/bioconda-repodata-patches/meta.yaml
+++ b/recipes/bioconda-repodata-patches/meta.yaml
@@ -1,13 +1,13 @@
 package:
   name: bioconda-repodata-patches
-  version: 20230506  # ensure that this is the "current" date, and always higher than the latest version in master
+  version: 20230907  # ensure that this is the "current" date, and always higher than the latest version in master
 
 source:
   path: .
 
 build:
   noarch: generic
-  number: 1
+  number: 0
 
 requirements:
   build:

--- a/recipes/bioconda-repodata-patches/meta.yaml
+++ b/recipes/bioconda-repodata-patches/meta.yaml
@@ -8,6 +8,8 @@ source:
 build:
   noarch: generic
   number: 0
+  run_exports:
+    - {{ pin_subpackage("bioconda-repodata-patches", max_pin=None) }}
 
 requirements:
   build:


### PR DESCRIPTION
Somewhat similarly to PR #40675 for libdeflate, this PR recommends patching htslib dependencies to extend version ranges instead of pinning htslib in bioconda. Pinning htslib causes deployment difficulties each time there is an upstream htslib/samtools/bcftools joint release; e.g. #42167 and #42168 have still not been merged six weeks after bcftools and samtools 1.18 were released, because the htslib pinning still has not been updated (cf bioconda/bioconda-utils#915).

The reason for pinning htslib is that it is a common dependency and if several tools using it are all going to be installed in the same environment they all need to be using (and hence built against) the same htslib version.

If we patch repodata to loosen these htslib dependencies, this need will go away. Then we can simplify updates by removing the pinning of htslib (which is now bioconda/bioconda-utils#917).

Upstream HTSlib is careful to maintain binary compatibility between soversion bumps. Note though that those bumps are not correlated with e.g. major version number bumps, as the HTSlib maintainers would use that to reflect a break in source compatibility not binary compatibility.

Hence building other bioconda packages that use htslib produces a tight bound on a single `x.x` htslib version, but we can use repodata patching to widen the bounds on previously build packages, due to this forward compatibility. Doing so will mean bioconda no longer needs to pin HTSlib, as it will be less vital to ensure all dependent packages are built against the exact same version of htslib. In turn, this will simplify packaging htslib/samtools/bcftools updates.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
