### PR TITLE
Update gdc-client by removing incompatible pyyaml pin

### DIFF
--- a/recipes/gdc-client/meta.yaml
+++ b/recipes/gdc-client/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - ndg-httpsclient >=0.5.0,<1
     - pyasn1 >=0.4.3,<1
     - pyopenssl >=18,<19
-    - pyyaml >=3.13,<4
+    - pyyaml >=3.13
     - progressbar2 >=3.43.1
     - intervaltree >=3.0.2
     - termcolor >=1.1.0


### PR DESCRIPTION
Remove incompatible pin from gdc-client. 

Previous error was:
```
Could not solve for environment specs
The following packages are incompatible
└─ gdc-client   is uninstallable because there are no viable options
   ├─ gdc-client 1.3.0 would require
   │  └─ python [2.7* |>=2.7,<2.8.0a0 ], which conflicts with any installable versions previously reported;
   ├─ gdc-client 1.4.0 would require
   │  └─ python <3 , which conflicts with any installable versions previously reported;
   └─ gdc-client [1.5.0|1.6.0|1.6.1] would require
      └─ pyyaml >=3.13,<4  but there are no viable options
         ├─ pyyaml 3.13 would require
         │  └─ python >=2.7,<2.8.0a0 , which conflicts with any installable versions previously reported;
         ├─ pyyaml 3.13 would require
         │  └─ python >=3.5,<3.6.0a0 , which conflicts with any installable versions previously reported;
         ├─ pyyaml 3.13 would require
         │  └─ python >=3.6,<3.7.0a0 , which conflicts with any installable versions previously reported;
         ├─ pyyaml 3.13 would require
         │  └─ python >=3.7,<3.8.0a0 , which conflicts with any installable versions previously reported;
         └─ pyyaml 3.13 would require
            └─ python >=3.8,<3.9.0a0 , which conflicts with any installable versions previously reported.
```
