### PR TITLE
Add rsrq v1.0.0

### DIFF
--- a/recipes/rsrq/build.sh
+++ b/recipes/rsrq/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -e
+
+cargo install --no-track --verbose --root "${PREFIX}" --path .

--- a/recipes/rsrq/build.sh
+++ b/recipes/rsrq/build.sh
@@ -1,3 +1,10 @@
-#!/bin/bash -e
+#!/bin/bash -euo
+export CFLAGS="${CFLAGS} -fcommon"
+export CXXFLAGS="${CFLAGS} -fcommon"
 
-cargo install --no-track --verbose --root "${PREFIX}" --path .
+# Add workaround for SSH-based Git connections from Rust/cargo.  See https://github.com/rust-lang/cargo/issues/2078 for details.
+# We set CARGO_HOME because we don't pass on HOME to conda-build, thus rendering the default "${HOME}/.cargo" defunct.
+export CARGO_NET_GIT_FETCH_WITH_CLI=true CARGO_HOME="$(pwd)/.cargo"
+
+# build statically linked binary with Rust
+RUST_BACKTRACE=1 cargo install --verbose --root $PREFIX --path .

--- a/recipes/rsrq/meta.yaml
+++ b/recipes/rsrq/meta.yaml
@@ -16,7 +16,7 @@ build:
 
 requirements:
   build:
-    - rust >=1.70.0
+    - {{ compiler('rust') }}
 
 test:
   commands:

--- a/recipes/rsrq/meta.yaml
+++ b/recipes/rsrq/meta.yaml
@@ -11,6 +11,9 @@ source:
 
 build:
   number: 0
+  noarch: generic
+  run_exports:
+    - {{ pin_subpackage('rsrq', max_pin="x") }}
 
 requirements:
   build:

--- a/recipes/rsrq/meta.yaml
+++ b/recipes/rsrq/meta.yaml
@@ -1,0 +1,32 @@
+{% set name = "rsrq" %}
+{% set version = "1.0.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/aaronmussig/rsrq/archive/v{{version}}.tar.gz
+  sha256: 3c758e11f8552296220bd880d21094b2809038440f2a08d198ad86441fea2761
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - rust >=1.70.0
+
+test:
+  commands:
+    - {{ name }} --version | grep '{{ version }}'
+
+about:
+  home: https://github.com/aaronmussig/rsrq
+  license: GNU General Public v3 (GPLv3)
+  license_family: GPL3
+  license_file: LICENSE
+  summary: A minimal Redis-backed queue system.
+
+extra:
+  recipe-maintainers:
+    - aaronmussig

--- a/recipes/rsrq/meta.yaml
+++ b/recipes/rsrq/meta.yaml
@@ -11,7 +11,6 @@ source:
 
 build:
   number: 0
-  noarch: generic
   run_exports:
     - {{ pin_subpackage('rsrq', max_pin="x") }}
 


### PR DESCRIPTION
Adds a new package rsrq to Bioconda. This program is a minimal Redis-backed queueing system that integrates with Snakemake.

https://github.com/aaronmussig/rsrq