### PR TITLE
Update HiTaC to v2.1.0

### DIFF
--- a/recipes/hitac/meta.yaml
+++ b/recipes/hitac/meta.yaml
@@ -13,6 +13,8 @@ build:
   noarch: python
   number: 0
   script: {{ PYTHON }} -m pip install . --ignore-installed --no-deps -vv
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x") }}
 
 requirements:
   host:

--- a/recipes/hitac/meta.yaml
+++ b/recipes/hitac/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "hitac" %}
-{% set version = "2.0.30" %}
+{% set version = "2.1.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 1697dfc588bc433a361dda376dc3f6beb8d1f842bc545be5003ea02829ea67c9
+  sha256: 0c21354bc940260fe18d053b9bfa8186465fff725922721fde448e59586080b7
 
 build:
   noarch: python
@@ -31,7 +31,7 @@ test:
     - hitac
 
 about:
-  home: https://github.com/mirand863/hitac
+  home: https://gitlab.com/dacs-hpi/hitac
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE

--- a/recipes/hitac/meta.yaml
+++ b/recipes/hitac/meta.yaml
@@ -29,6 +29,11 @@ requirements:
     - scikit-learn >=0.24
 
 test:
+  commands:
+    - hitac-fit --help
+    - hitac-classify --help
+    - hitac-fit-filter --help
+    - hitac-filter --help
   imports:
     - hitac
 


### PR DESCRIPTION
This PR updates HiTaC to v 2.1.0. It fixes a lint error with `run_export` and adds the command line tests for the new version.