### PR TITLE
bedtools: adjusted checksum to what is downloaded from GitHub

### DIFF
--- a/recipes/bedtools/meta.yaml
+++ b/recipes/bedtools/meta.yaml
@@ -7,10 +7,13 @@ package:
 
 source:
   url: https://github.com/arq5x/bedtools2/releases/download/v{{ version }}/bedtools-{{ version }}.tar.gz
-  sha256: 183cf9a96aabc50ef4bd557a53fd01557a123c05a0dc87651371878f357439ec
+  sha256: a93e6b6bfdd8d33db1e6decbefdd2b03771e0ac63ac69a4059b7b3464efe281d
 
 build:
-  number: 2
+  number: 3
+  run_exports:
+    - {{ pin_subpackage('bedtools', max_pin="x") }}
+
 
 requirements:
   build:

--- a/recipes/bedtools/meta.yaml
+++ b/recipes/bedtools/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/arq5x/bedtools2/releases/download/v{{ version }}/bedtools-{{ version }}.tar.gz
-  sha256: 8462980301da669b2976ef821a5cfd902c6653a5f7ed348a243a978ecf4593e1
+  sha256: 183cf9a96aabc50ef4bd557a53fd01557a123c05a0dc87651371878f357439ec
 
 build:
   number: 2
@@ -35,3 +35,4 @@ extra:
   identifiers:
     - biotools:bedtools
     - usegalaxy-eu:bedtools_intersectbed
+    - debian:bedtools


### PR DESCRIPTION
`$ /Users/u005069/miniconda3/bin/conda build .`
brings
```
...
        raise RuntimeError(
    RuntimeError: SHA256 mismatch: 'a93e6b6bfdd8d33db1e6decbefdd2b03771e0ac63ac69a4059b7b3464efe281d' != '183cf9a96aabc50ef4bd557a53fd01557a123c05a0dc87651371878f357439ec'
...
```
I do not really understand why this happens, since the bioconda package was indeed released later than the code on GitHub - but I executed `shasum -a 256 ` directly on the tarball and the runtime error is correct - the SHA256 mismaches.