### PR TITLE
Update agfusion to 1.4.1

### DIFF
--- a/recipes/agfusion/meta.yaml
+++ b/recipes/agfusion/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 1
+  number: 0
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
@@ -21,7 +21,7 @@ requirements:
     - setuptools
   run:
     - python
-    - matplotlib >=3.6.1
+    - matplotlib-base >=3.6.1
     - pandas >=1.5.1
     - biopython >=1.79
     - future >=0.16.0

--- a/recipes/agfusion/meta.yaml
+++ b/recipes/agfusion/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "1.252" %}
-{% set sha256 = "5ac8d27b1e8ece014b8b8138615712ffd3c2f6602dc854d199335986559b7946" %}
+{% set version = "1.4.1" %}
+{% set sha256 = "fd04591d764deeff69978f9d495c3baf854ccfba27366aa0ae4859ad85ca2c60" %}
 
 package:
   name: agfusion
@@ -21,9 +21,9 @@ requirements:
     - setuptools
   run:
     - python
-    - matplotlib >=1.5.0
-    - pandas >=0.18.1
-    - biopython >=1.67
+    - matplotlib >=3.6.1
+    - pandas >=1.5.1
+    - biopython >=1.79
     - future >=0.16.0
     - pyensembl >=1.1.0
     - nose2 >=0.6.5

--- a/recipes/agfusion/meta.yaml
+++ b/recipes/agfusion/meta.yaml
@@ -13,6 +13,8 @@ build:
   noarch: python
   number: 0
   script: python -m pip install --no-deps --ignore-installed .
+  run_exports:
+    - {{ pin_subpackage("agfusion", max_pin="x.x") }}
 
 requirements:
   host:


### PR DESCRIPTION
update agfusion 1.252->1.4.1

home: [AGFusion](https://github.com/murphycj/AGFusion)
reason: An [error](https://github.com/murphycj/AGFusion/issues/40) is repirted when the agfusion of the 1.252 version is used.
```
>>> import agfusion
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/app/software/Python/Python-3.8.6/lib/python3.8/site-packages/agfusion/__init__.py", line 2, in <module>
    from .model import *
  File "/app/software/Python/Python-3.8.6/lib/python3.8/site-packages/agfusion/model.py", line 9, in <module>
    from Bio.Alphabet import generic_dna, generic_protein
  File "/app/software/Biopython/1.78/Python-3.8.6/lib/python3.8/site-packages/Bio/Alphabet/__init__.py", line 20, in <module>
    raise ImportError(
ImportError: Bio.Alphabet has been removed from Biopython. In many cases, the alphabet can simply be ignored and removed from scripts. In a few cases, you may need to specify the ``molecule_type`` as an annotation on a SeqRecord for your script to work correctly. Please see https://biopython.org/wiki/Alphabet for more information.
```
However, this problen has been fixed in version 1.3.1, and the latest version is 1.4.1.
