### PR TITLE
fix Pyrodigal to 2.x

### DIFF
--- a/recipes/bakta/meta.yaml
+++ b/recipes/bakta/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: python -m pip install --no-deps --ignore-installed .
   entry_points:
     - bakta = bakta.main:main

--- a/recipes/bakta/meta.yaml
+++ b/recipes/bakta/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - requests >=2.25.1
     - alive-progress ==3.0.1
     - pyyaml >=6.0
-    - pyrodigal >=2.1.0
+    - pyrodigal >=2.1.0, <3.0
     - trnascan-se >=2.0.11
     - aragorn >=1.2.41
     - infernal >=1.1.4


### PR DESCRIPTION
Pin Pyrodigal to `2.x` forestalling installation of the not yet supported version `3.0`