### PR TITLE
update/fix SEPP recipe

### DIFF
--- a/recipes/sepp/meta.yaml
+++ b/recipes/sepp/meta.yaml
@@ -16,7 +16,6 @@ source:
 
 build:
   number: 2
-  skip: true  # [py != 37]
   run_exports:
     - {{ pin_subpackage('sepp', max_pin="x") }}
 

--- a/recipes/sepp/meta.yaml
+++ b/recipes/sepp/meta.yaml
@@ -16,6 +16,7 @@ source:
 
 build:
   number: 2
+  skip: true  # [py != 37]
   run_exports:
     - {{ pin_subpackage('sepp', max_pin="x") }}
 

--- a/recipes/sepp/meta.yaml
+++ b/recipes/sepp/meta.yaml
@@ -15,8 +15,10 @@ source:
       - nodeps.setup.py.patch
 
 build:
-  number: 1
+  number: 2
   skip: true  # [py != 37]
+  run_exports:
+    - {{ pin_subpackage('sepp', max_pin="x") }}
 
 requirements:
   host:

--- a/recipes/sepp/meta.yaml
+++ b/recipes/sepp/meta.yaml
@@ -31,7 +31,7 @@ requirements:
 
   run:
     - python
-    - dendropy ==4.5.1
+    - dendropy <=4.5.1
     - openjdk
     - hmmer ==3.1b2
     - pasta

--- a/recipes/sepp/meta.yaml
+++ b/recipes/sepp/meta.yaml
@@ -23,15 +23,16 @@ requirements:
     - python
     - setuptools
     - pip
-    - dendropy
+    - dendropy <=4.5.1
     - openjdk
     - hmmer ==3.1b2
 
   run:
     - python
-    - dendropy
+    - dendropy ==4.5.1
     - openjdk
     - hmmer ==3.1b2
+    - pasta
     # TODO: source bundled binaries as conda packages.
     # But pplacer / guppy are not available for OSX.
     # - pplacer

--- a/recipes/sepp/meta.yaml
+++ b/recipes/sepp/meta.yaml
@@ -16,13 +16,12 @@ source:
 
 build:
   number: 2
-  skip: true  # [py != 37]
   run_exports:
     - {{ pin_subpackage('sepp', max_pin="x") }}
 
 requirements:
   host:
-    - python
+    - python 3.7
     - setuptools
     - pip
     - dendropy <=4.5.1
@@ -30,7 +29,7 @@ requirements:
     - hmmer ==3.1b2
 
   run:
-    - python
+    - python 3.7
     - dendropy <=4.5.1
     - openjdk
     - hmmer ==3.1b2


### PR DESCRIPTION
Currently, SEPP breaks for dendropy version 4.6.0 and above (see smirarab/sepp#126).
This PR pins the dendropy version requirement to `<= 4.5.1`, the latest working version.
Also, it adds pasta to the requirements (it's required to run UPP).
When SEPP supports a current dendropy version, I will create another PR to update the version requirement.