### PR TITLE
Update ninja-nj for OSX

### DIFF
--- a/recipes/ninja-nj/meta.yaml
+++ b/recipes/ninja-nj/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 3
   run_exports:
-    - {{ pin_subpackage(name, max_pin="x") }}
+    - {{ pin_subpackage("ninja-nj", max_pin="x") }}
 
 requirements:
   build:

--- a/recipes/ninja-nj/meta.yaml
+++ b/recipes/ninja-nj/meta.yaml
@@ -11,6 +11,8 @@ source:
 
 build:
   number: 3
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x") }}
 
 requirements:
   build:

--- a/recipes/ninja-nj/meta.yaml
+++ b/recipes/ninja-nj/meta.yaml
@@ -10,12 +10,12 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 2
-  skip: True  # [osx]
+  number: 3
 
 requirements:
   build:
     - {{ compiler('cxx') }}
+    - llvm-openmp  # [osx]
     - make
 
 test:


### PR DESCRIPTION
I was looking into the ninja-nj package on bioconda for macOS and I found out that it still is an issue for `mamba install repeatmodeler` on macOS. I noticed that it should be quite simple to fix this for macOS, so that's what this PR changes.

Related to this, #33626 seems to mention that there were problems to add this recipe in the past for macOS. @Juke34 since you originally looked into this issue, could you please confirm whether this PR fixes it for macOS?