### PR TITLE
Update: Rebuild samtools

### DIFF
--- a/recipes/samtools/meta.yaml
+++ b/recipes/samtools/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 1
+  number: 2
 
 source:
   url: https://github.com/samtools/samtools/releases/download/{{ version }}/samtools-{{ version }}.tar.bz2

--- a/recipes/samtools/meta.yaml
+++ b/recipes/samtools/meta.yaml
@@ -6,6 +6,8 @@ package:
 
 build:
   number: 2
+  run_exports:
+    - {{ pin_subpackage('samtools', max_pin="x.x") }}
 
 source:
   url: https://github.com/samtools/samtools/releases/download/{{ version }}/samtools-{{ version }}.tar.bz2


### PR DESCRIPTION
I'm having the same issue with samtools 1.17 as described in this old issue from 2018: https://github.com/samtools/samtools/issues/790

Last time a build bump fixed it, so probably there's been an update to ncurses that broke the linkage