### PR TITLE
Update ncbi-fcs-gx to use github and explicit requirements

### DIFF
--- a/recipes/ncbi-fcs-gx/build.sh
+++ b/recipes/ncbi-fcs-gx/build.sh
@@ -14,6 +14,5 @@ make VERBOSE=1
 cp $SRC_DIR/build/src/gx    ${PREFIX}/bin/
 cp $SRC_DIR/scripts/*      ${PREFIX}/bin/
 cp $SRC_DIR/make_gxdb/blast_names_mapping.tsv ${PREFIX}/bin/ 
-echo PREFIX: ${PREFIX}
 chmod ua+x ${PREFIX}/bin/gx
 

--- a/recipes/ncbi-fcs-gx/build.sh
+++ b/recipes/ncbi-fcs-gx/build.sh
@@ -3,22 +3,17 @@ set -uex
 
 mkdir -vp ${PREFIX}/bin
 
-# file is already present and unzipped
-# URL='https://ftp.ncbi.nlm.nih.gov/genomes/TOOLS/FCS/releases/0.4.0/gx_conda_0.4.0.zip'
-# curl -o gx_conda_0.4.0.zip ${URL}
-# unzip  -u  -o gx_conda_0.4.0.zip
-# rm gx_conda_0.4.0.zip
+ls -l .
 
-chmod ua+x ./gx
-mv ./gx ${PREFIX}/bin/
-mv ./blast_names_mapping.tsv ${PREFIX}/bin/
-mv ./db_exclude.locs.tsv  ${PREFIX}/bin/
-mv ./classify_taxonomy.py ${PREFIX}/bin/
-mv ./action_report.py     ${PREFIX}/bin/
-mv ./run_gx.py            ${PREFIX}/bin/
-mv ./sync_files.py        ${PREFIX}/bin/
+$GCC --version
+$GCC -print-search-dirs 
 
-# not installing the docker runners
-# chmod ua+x ${PREFIX}/bin/run_fcsgx.py
-# chmod ua+x ${PREFIX}/bin/run_fcsadaptor.sh
+#cd fcs-gx-0.4.0
+make VERBOSE=1 
+
+cp $SRC_DIR/build/src/gx    ${PREFIX}/bin/
+cp $SRC_DIR/scripts/*      ${PREFIX}/bin/
+cp $SRC_DIR/make_gxdb/blast_names_mapping.tsv ${PREFIX}/bin/ 
+echo PREFIX: ${PREFIX}
+chmod ua+x ${PREFIX}/bin/gx
 

--- a/recipes/ncbi-fcs-gx/meta.yaml
+++ b/recipes/ncbi-fcs-gx/meta.yaml
@@ -26,13 +26,11 @@ build:
   number: 0
   skip: True  # [not linux or not x86_64]
   run_exports:
-    - {{ pin_compatible('nxbi-fcs-gx', max_pin="0.4") }}
+    - {{ pin_compatible('nxbi-fcs-gx', max_pin="x.x") }}
 
 test:
   commands:
     - gx --help 
-    - ls -l ${PREFIX}/bin/
-    - ${PREFIX}/bin/gx --help 
 
 about:
   home: https://github.com/ncbi/fcs

--- a/recipes/ncbi-fcs-gx/meta.yaml
+++ b/recipes/ncbi-fcs-gx/meta.yaml
@@ -1,24 +1,38 @@
 package:
   name: ncbi-fcs-gx
-  version: 0.4.0
+  version: 0.4.1
 
 source:
-  url: https://ftp.ncbi.nlm.nih.gov/genomes/TOOLS/FCS/releases/0.4.0/gx_conda_0.4.0.zip
-  sha256: 35a93f3d86b82a1657cf926e36dc0821d8048b6a83542b72eacd60bfc363f278
+  url: https://github.com/ncbi/fcs-gx/archive/refs/tags/v0.4.1.zip
+  sha256: 7bedb6a43945df4821d3e23fd1c5c4bf117cd70001cb96b310d177f0fd049a6b
+
 
 requirements:
   build:
     - {{ compiler('cxx') }}
+    - make
+    - cmake
+    - libstdcxx-ng
+    - libgcc-ng
   run:
     - python >=3.9
+    - aria2 =1.36.0
+    - gzip >=1.5
+    - pv >=1.4.6
+    - rclone =1.61.1
+    - grep >=3.4
 
 build:
-  number: 2
+  number: 0
   skip: True  # [not linux or not x86_64]
+  run_exports:
+    - {{ pin_compatible('nxbi-fcs-gx', max_pin="0.4") }}
 
 test:
   commands:
     - gx --help 
+    - ls -l ${PREFIX}/bin/
+    - ${PREFIX}/bin/gx --help 
 
 about:
   home: https://github.com/ncbi/fcs


### PR DESCRIPTION
This PR replaced a pre-compiled binary with bioconda normal cxx compilation from github. It also makes certain called external programs explicit dependencies at the request of galaxy.  
