### PR TITLE
Add modkit (Oxford Nanopore)

### DIFF
--- a/recipes/ont-modkit/build.sh
+++ b/recipes/ont-modkit/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -euo
+export CFLAGS="${CFLAGS} -fcommon"
+export CXXFLAGS="${CFLAGS} -fcommon"
+
+# Add workaround for SSH-based Git connections from Rust/cargo.  See https://github.com/rust-lang/cargo/issues/2078 for details.
+# We set CARGO_HOME because we don't pass on HOME to conda-build, thus rendering the default "${HOME}/.cargo" defunct.
+export CARGO_NET_GIT_FETCH_WITH_CLI=true CARGO_HOME="$(pwd)/.cargo"
+
+# build statically linked binary with Rust
+RUST_BACKTRACE=1 cargo install --verbose --root $PREFIX --path .

--- a/recipes/ont-modkit/meta.yaml
+++ b/recipes/ont-modkit/meta.yaml
@@ -11,6 +11,8 @@ source:
   
 build:
   number: 0
+  run_exports:
+    - {{ pin_subpackage("ont-modkit", max_pin="x") }}
 
 requirements:
   build:

--- a/recipes/ont-modkit/meta.yaml
+++ b/recipes/ont-modkit/meta.yaml
@@ -1,0 +1,38 @@
+{% set version = "0.2.0" %}
+{% set sha256 = "bb9970c5fb9ef2387d01c92078df0b6723c331d600567a6b6b9e011bdfbbdd97" %}
+
+package:
+  name: ont-modkit
+  version: {{ version }}
+
+source:
+  url: https://github.com/nanoporetech/modkit/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+  
+build:
+  number: 0
+
+requirements:
+  build:
+    - rust >=1.40
+    - cmake
+    - make
+    - autoconf
+    - {{ compiler('cxx') }}
+    - pkg-config
+    - zlib
+  host:
+    - zlib
+  run:
+
+
+test:
+  commands:
+    - modkit --version
+
+about:
+  home: https://github.com/nanoporetech/modkit
+  license: Oxford Nanopore Technologies PLC. Public License Version 1.0
+  license_family: PROPRIETARY
+  license_file: LICENCE.txt
+  summary: A bioinformatics tool for working with modified bases in Oxford Nanopore sequencing data.


### PR DESCRIPTION
This PR adds a recipe for Oxford Nanopore Technologies' [modkit](https://github.com/nanoporetech/modkit). The tool is e.g. used to convert basecalls for methylated bases to other formats like CSV/TSV and published under _Oxford Nanopore Technologies PLC. Public License Version 1.0_. 

----

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
