### PR TITLE
Relax Maplotlib version dependency for Integron Finder

### DIFF
--- a/recipes/integron_finder/meta.yaml
+++ b/recipes/integron_finder/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - python >=3.7,<=3.10
     - biopython ==1.78
     - numpy ==1.19.4
-    - matplotlib-base ==3.3.3
+    - matplotlib-base >=3.3.3
     - colorlog <=6.6.0
     - pandas ==1.1.5
     - hmmer >=3.1b2,<=3.3.2

--- a/recipes/integron_finder/meta.yaml
+++ b/recipes/integron_finder/meta.yaml
@@ -1,5 +1,5 @@
 {% set name="integron_finder" %}
-{% set version="2.0.2" %}
+{% set version="2.0.3" %}
 
 package:
   name: {{ name }}
@@ -9,6 +9,8 @@ build:
   noarch: python
   number: 0
   script: python -m pip install --no-deps --ignore-installed .
+  run_exports:
+    - {{ pin_subpackage(name, max_pin='x') }}
 
 source:
   url: https://files.pythonhosted.org/packages/4a/39/816165ed051a41560c9167590bf974a83de34e5a43509e9501f79cdf4ba4/integron_finder-2.0.2.tar.gz 


### PR DESCRIPTION
Integron Finder have pretty strict requirement of Matplotlib  (== 3.3.3). Relaxing the requirement (>= 3.3.3) so that conda can install upper version of Matplotlib during solving environment. 

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
