### PR TITLE
Update pixelator to 0.15.0

### DIFF
--- a/recipes/pixelator/meta.yaml
+++ b/recipes/pixelator/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pixelator" %}
-{% set version = "0.14.0" %}
+{% set version = "0.15.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
  url: https://github.com/pixelgentechnologies/{{ name }}/archive/v{{ version }}.tar.gz
- sha256: f8c251f3b50a0cd8609d1360f6caee183abf6e2c10436e4021f4a91dd918e2d3
+ sha256: 78ffabc98868679773b3a17f4dee7da9413f76353c253973108dbc72dafb4203
 
 build:
   noarch: python
@@ -25,7 +25,7 @@ requirements:
     - poetry-dynamic-versioning >=1.1.0
     - pip
   run:
-    - python >=3.8,<3.11
+    - python >=3.8,<3.12
     - igraph >=0.10.2,<=0.11.0
     - louvain >=0.8.0,<=0.9.0
     - click


### PR DESCRIPTION
Update pixelator to 0.15.0. 

- Add python 3.11 as supported python version