### PR TITLE
Update e-PCR source URL and correct license

### DIFF
--- a/recipes/e-pcr/meta.yaml
+++ b/recipes/e-pcr/meta.yaml
@@ -3,11 +3,12 @@ package:
   version: "2.3.12"
 
 build:
-  number: 1
+  number: 2
   skip: True # [osx]
 
 source:
-  url: ftp://ftp.ncbi.nlm.nih.gov/pub/schuler/e-PCR/e-PCR-2.3.12-1-src.tar.gz
+  # url: ftp://ftp.ncbi.nlm.nih.gov/pub/schuler/e-PCR/e-PCR-2.3.12-1-src.tar.gz
+  url: http://archive.ubuntu.com/ubuntu/pool/universe/e/epcr/epcr_2.3.12-1.orig.tar.gz
   md5: 516b111f78769af24393e61b0bf7fd80
 
 requirements:
@@ -21,6 +22,12 @@ test:
 
 about:
   home: http://www.ncbi.nlm.nih.gov/tools/epcr/
-  license: GPLv2
-  summary: e-PCR identifies sequence tagged sites(STSs)within DNA sequences..
-
+  license: Public Domain
+  summary: e-PCR identifies sequence tagged sites(STSs) within DNA sequences.
+  description: |
+    Electronic PCR (e-PCR) was developed by Gregory D. Schuler at the
+    NCBI, described in https://doi.org/10.1101/gr.7.5.541 Schuler (1997).
+    The NCBI retired and withdrew e-PCR on 2017-06-28, suggesting the
+    online-only tool Primer-BLAST instead. However, this is not suitable
+    for offline high throughput usage. See also Jim Kent's isPCR (also
+    available in BioConda).


### PR DESCRIPTION
The NCBI withdrew the downloads, see https://ftp.ncbi.nih.gov/pub/schuler/e-PCR/RETIRED_README.txt and https://ncbiinsights.ncbi.nlm.nih.gov/2017/06/28/e-pcr-is-retiring-use-primer-blast/ - so using the Ubuntu mirror instead.

Also correcting license, NCBI e-PCR is Public Domain (but the Ubuntu/Debian package definition is GPL-2+). See e.g. http://changelogs.ubuntu.com/changelogs/pool/universe/e/epcr/epcr_2.3.12-1-8build1/copyright

Cross reference #43751 for packaging me-PCR, a fork of e-PCR.