### PR TITLE
Update requirements for kitsune

### DIFF
--- a/recipes/kitsune/meta.yaml
+++ b/recipes/kitsune/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 8acdfd3aa73e2e993f0ccd444b4a9f83dc5f1c91a46180391bbd91abd0875eb2
 
 build:
-  number: 0
+  number: 1
   noarch: python
   entry_points:
     - kitsune=kitsune.kitsune:main
@@ -23,9 +23,9 @@ requirements:
     - setuptools
   run:
     - kmer-jellyfish >=2.2
-    - numpy >=1.22.3
+    - numpy >=1.19.2
     - python >=3.5
-    - scipy >=1.7.3
+    - scipy >=1.6.0
     - tqdm >=4.38.0
 
 test:


### PR DESCRIPTION
There is no reason this package should require v1.22.3 and v1.7.3 of numpy and scipy.

Downgrading to versions 1.19.2 and 1.6.0 respectively would ensure it works with other packages that require older numpy/scipy versions.