### PR TITLE
update bioconductor-rhdf5: rebuild after including libcurl dependency downstream in bioconductor-rhdf5lib, include pin_subpackage syntax

### DIFF
--- a/recipes/bioconductor-rhdf5/meta.yaml
+++ b/recipes/bioconductor-rhdf5/meta.yaml
@@ -13,7 +13,7 @@ source:
     - 'https://depot.galaxyproject.org/software/bioconductor-{{ name }}/bioconductor-{{ name }}_{{ version }}_src_all.tar.gz'
   md5: 19c8340a70f1ce28043ba56bb9da1238
 build:
-  number: 0
+  number: 1
   rpaths:
     - lib/R/lib/
     - lib/

--- a/recipes/bioconductor-rhdf5/meta.yaml
+++ b/recipes/bioconductor-rhdf5/meta.yaml
@@ -57,6 +57,6 @@ extra:
     - biotools:rhdf5
   parent_recipe:
     name: '{{ full_name }}'
-    path: `recipes/{{ full_name }}'
+    path: 'recipes/{{ full_name }}'
     version: 2.24.0
 

--- a/recipes/bioconductor-rhdf5/meta.yaml
+++ b/recipes/bioconductor-rhdf5/meta.yaml
@@ -26,6 +26,7 @@ requirements:
     - r-base
     - libblas
     - liblapack
+    - libcurl
   run:
     - 'bioconductor-rhdf5filters >=1.12.0,<1.13.0'
     - 'bioconductor-rhdf5lib >=1.22.0,<1.23.0'

--- a/recipes/bioconductor-rhdf5/meta.yaml
+++ b/recipes/bioconductor-rhdf5/meta.yaml
@@ -29,6 +29,11 @@ build:
 # Suggests: bit64, BiocStyle, knitr, rmarkdown, testthat, bench, dplyr, ggplot2, mockery, BiocParallel
 # SystemRequirements: GNU make
 requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - automake
+    - make
   host:
     - 'bioconductor-rhdf5filters >=1.12.0,<1.13.0'
     - 'bioconductor-rhdf5lib >=1.22.0,<1.23.0'
@@ -39,11 +44,6 @@ requirements:
     - 'bioconductor-rhdf5filters >=1.12.0,<1.13.0'
     - 'bioconductor-rhdf5lib >=1.22.0,<1.23.0'
     - r-base
-  build:
-    - {{ compiler('c') }}
-    - {{ compiler('cxx') }}
-    - automake
-    - make
 test:
   commands:
     - '$R -e "library(''{{ name }}'')"'

--- a/recipes/bioconductor-rhdf5/meta.yaml
+++ b/recipes/bioconductor-rhdf5/meta.yaml
@@ -1,16 +1,17 @@
 {% set version = "2.44.0" %}
 {% set name = "rhdf5" %}
+{% set full_name = "bioconductor-" ~ name %}
 {% set bioc = "3.17" %}
 
 package:
-  name: 'bioconductor-{{ name|lower }}'
+  name: '{{ full_name|lower }}'
   version: '{{ version }}'
 source:
   url:
     - 'https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/{{ name }}_{{ version }}.tar.gz'
     - 'https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/Archive/{{ name }}/{{ name }}_{{ version }}.tar.gz'
     - 'https://bioarchive.galaxyproject.org/{{ name }}_{{ version }}.tar.gz'
-    - 'https://depot.galaxyproject.org/software/bioconductor-{{ name }}/bioconductor-{{ name }}_{{ version }}_src_all.tar.gz'
+    - 'https://depot.galaxyproject.org/software/{{ full_name }}/{{ full_name }}_{{ version }}_src_all.tar.gz'
   md5: 19c8340a70f1ce28043ba56bb9da1238
 build:
   number: 1
@@ -18,7 +19,7 @@ build:
     - lib/R/lib/
     - lib/
   run_exports:
-    - {{ pin_subpackage(name, max_pin="x.x") }}
+    - {{ pin_subpackage(full_name, max_pin="x.x") }}
 # Suggests: bit64, BiocStyle, knitr, rmarkdown, testthat, bench, dplyr, ggplot2, mockery, BiocParallel
 # SystemRequirements: GNU make
 requirements:
@@ -50,7 +51,7 @@ extra:
   identifiers:
     - biotools:rhdf5
   parent_recipe:
-    name: bioconductor-rhdf5
+    name: '{{ full_name|lower }}'
     path: recipes/bioconductor-rhdf5
     version: 2.24.0
 

--- a/recipes/bioconductor-rhdf5/meta.yaml
+++ b/recipes/bioconductor-rhdf5/meta.yaml
@@ -1,10 +1,10 @@
 {% set version = "2.44.0" %}
 {% set name = "rhdf5" %}
-{% set full_name = "bioconductor-" ~ name %}
+{% set full_name = "bioconductor-" ~ name|lower %}
 {% set bioc = "3.17" %}
 
 package:
-  name: '{{ full_name|lower }}'
+  name: '{{ full_name }}'
   version: '{{ version }}'
 source:
   url:
@@ -50,7 +50,7 @@ extra:
   identifiers:
     - biotools:rhdf5
   parent_recipe:
-    name: '{{ full_name|lower }}'
-    path: recipes/bioconductor-rhdf5
+    name: '{{ full_name }}'
+    path: `recipes/{{ full_name }}'
     version: 2.24.0
 

--- a/recipes/bioconductor-rhdf5/meta.yaml
+++ b/recipes/bioconductor-rhdf5/meta.yaml
@@ -19,6 +19,12 @@ build:
     - lib/R/lib/
     - lib/
   run_exports:
+    # This pinning is preliminary. It should be changed if either:
+    # * a general policy for pinning bioconductor packages is decided and differs:
+    #   https://github.com/bioconda/bioconda-recipes/issues/43905
+    # * the author of this package assures us that he adheres to semantic
+    #   versioning, in which case we can unpin the minor version, see:
+    #   https://github.com/grimbough/rhdf5/issues/131#issuecomment-1782567153
     - {{ pin_subpackage(full_name, max_pin="x.x") }}
 # Suggests: bit64, BiocStyle, knitr, rmarkdown, testthat, bench, dplyr, ggplot2, mockery, BiocParallel
 # SystemRequirements: GNU make

--- a/recipes/bioconductor-rhdf5/meta.yaml
+++ b/recipes/bioconductor-rhdf5/meta.yaml
@@ -17,6 +17,8 @@ build:
   rpaths:
     - lib/R/lib/
     - lib/
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x.x") }}
 # Suggests: bit64, BiocStyle, knitr, rmarkdown, testthat, bench, dplyr, ggplot2, mockery, BiocParallel
 # SystemRequirements: GNU make
 requirements:

--- a/recipes/bioconductor-rhdf5/meta.yaml
+++ b/recipes/bioconductor-rhdf5/meta.yaml
@@ -29,7 +29,6 @@ requirements:
     - r-base
     - libblas
     - liblapack
-    - libcurl
   run:
     - 'bioconductor-rhdf5filters >=1.12.0,<1.13.0'
     - 'bioconductor-rhdf5lib >=1.22.0,<1.23.0'


### PR DESCRIPTION
I think that this will fix an issue with `libcrypto.so` not being found that I reported over at `rhdf5`: https://github.com/grimbough/rhdf5/issues/131

Describe your pull request here

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
