### PR TITLE
Fix Python version to macrel execution

### DIFF
--- a/recipes/macrel/meta.yaml
+++ b/recipes/macrel/meta.yaml
@@ -19,10 +19,10 @@ build:
 
 requirements:
   host:
-    - python < 3.11
+    - python <3.11
     - pip
   run:
-    - python < 3.11
+    - python <3.11
     - atomicwrites
     - ngless
     - megahit

--- a/recipes/macrel/meta.yaml
+++ b/recipes/macrel/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   entry_points:
     - macrel= macrel.main:main
   script: python -m pip install --disable-pip-version-check --no-cache-dir --ignore-installed --no-deps -vv .
@@ -31,6 +31,8 @@ requirements:
     - scikit-learn
     - tzlocal
     - pyrodigal
+  run_exports:
+    - {{ pin_subpackage('macrel', max_pin='1.2.0') }}
 
 test:
   imports:

--- a/recipes/macrel/meta.yaml
+++ b/recipes/macrel/meta.yaml
@@ -19,7 +19,7 @@ build:
 
 requirements:
   run_exports:
-    - {{ pin_subpackage( {{ name }} , max_pin= {{ version }} ) }}
+    - {{ pin_subpackage(name, max_pin=version) }}
   host:
     - python=3.10
     - pip

--- a/recipes/macrel/meta.yaml
+++ b/recipes/macrel/meta.yaml
@@ -18,6 +18,8 @@ build:
   script: python -m pip install --disable-pip-version-check --no-cache-dir --ignore-installed --no-deps -vv .
 
 requirements:
+  run_exports:
+    - {{ pin_subpackage( {{ name }} , max_pin= {{ version }} ) }}
   host:
     - python=3.10
     - pip
@@ -32,8 +34,6 @@ requirements:
     - joblib<1.3.0
     - tzlocal
     - pyrodigal>=0.7.3
-  run_exports:
-    - {{ pin_subpackage('macrel', max_pin='1.2.0') }}
   
 test:
   imports:

--- a/recipes/macrel/meta.yaml
+++ b/recipes/macrel/meta.yaml
@@ -12,17 +12,17 @@ source:
 
 build:
   noarch: python
-  number: 1
+  number: 0
   entry_points:
     - macrel= macrel.main:main
   script: python -m pip install --disable-pip-version-check --no-cache-dir --ignore-installed --no-deps -vv .
 
 requirements:
   host:
-    - python <3.11
+    - python=3.10
     - pip
   run:
-    - python <3.11
+    - python=3.10
     - atomicwrites
     - ngless
     - megahit
@@ -31,9 +31,7 @@ requirements:
     - scikit-learn
     - tzlocal
     - pyrodigal
-  run_exports:
-    - {{ pin_subpackage('macrel', max_pin='1.2.0') }}
-
+  
 test:
   imports:
     - macrel

--- a/recipes/macrel/meta.yaml
+++ b/recipes/macrel/meta.yaml
@@ -19,21 +19,21 @@ build:
 
 requirements:
   run_exports:
-    - {{ pin_subpackage(name, max_pin=version) }}
+    - {{ pin_subpackage("macrel", max_pin="1.2.0") }}
   host:
-    - python=3.10
+    - python <3.11
     - pip
   run:
-    - python=3.10
+    - python <3.11
     - atomicwrites
     - ngless
     - megahit
     - paladin
     - pandas
-    - scikit-learn<1.3.0
-    - joblib<1.3.0
+    - scikit-learn <1.3.0
+    - joblib <1.3.0
     - tzlocal
-    - pyrodigal>=0.7.3
+    - pyrodigal >=0.7.3,<3.0.0
   
 test:
   imports:

--- a/recipes/macrel/meta.yaml
+++ b/recipes/macrel/meta.yaml
@@ -11,6 +11,8 @@ source:
  sha256: {{ sha256 }}
 
 build:
+  run_exports:
+    - {{ pin_subpackage("macrel", max_pin="1.2.0") }}
   noarch: python
   number: 1
   entry_points:
@@ -18,8 +20,6 @@ build:
   script: python -m pip install --disable-pip-version-check --no-cache-dir --ignore-installed --no-deps -vv .
 
 requirements:
-  run_exports:
-    - {{ pin_subpackage("macrel", max_pin="1.2.0") }}
   host:
     - python <3.11
     - pip

--- a/recipes/macrel/meta.yaml
+++ b/recipes/macrel/meta.yaml
@@ -12,17 +12,17 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   entry_points:
     - macrel= macrel.main:main
   script: python -m pip install --disable-pip-version-check --no-cache-dir --ignore-installed --no-deps -vv .
 
 requirements:
   host:
-    - python=3.10
+    - python = 3.10
     - pip
   run:
-    - python=3.10
+    - python = 3.10
     - atomicwrites
     - ngless
     - megahit
@@ -31,6 +31,8 @@ requirements:
     - scikit-learn
     - tzlocal
     - pyrodigal
+  run_exports:
+    - {{ pin_subpackage('macrel', max_pin='1.2.0') }}
   
 test:
   imports:

--- a/recipes/macrel/meta.yaml
+++ b/recipes/macrel/meta.yaml
@@ -11,13 +11,13 @@ source:
  sha256: {{ sha256 }}
 
 build:
-  run_exports:
-    - {{ pin_subpackage("macrel", max_pin="1.2.0") }}
   noarch: python
   number: 1
   entry_points:
     - macrel= macrel.main:main
   script: python -m pip install --disable-pip-version-check --no-cache-dir --ignore-installed --no-deps -vv .
+  run_exports:
+    - {{ pin_subpackage("macrel", max_pin="x.x") }}
 
 requirements:
   host:

--- a/recipes/macrel/meta.yaml
+++ b/recipes/macrel/meta.yaml
@@ -19,18 +19,19 @@ build:
 
 requirements:
   host:
-    - python = 3.10
+    - python=3.10
     - pip
   run:
-    - python = 3.10
+    - python=3.10
     - atomicwrites
     - ngless
     - megahit
     - paladin
     - pandas
-    - scikit-learn
+    - scikit-learn<1.3.0
+    - joblib<1.3.0
     - tzlocal
-    - pyrodigal
+    - pyrodigal>=0.7.3
   run_exports:
     - {{ pin_subpackage('macrel', max_pin='1.2.0') }}
   

--- a/recipes/macrel/meta.yaml
+++ b/recipes/macrel/meta.yaml
@@ -19,10 +19,10 @@ build:
 
 requirements:
   host:
-    - python
+    - python < 3.11
     - pip
   run:
-    - python
+    - python < 3.11
     - atomicwrites
     - ngless
     - megahit


### PR DESCRIPTION
Python after 3.11 only accepts newer version of sklearn that does not unpickle the tree estimator properly inducing a error.

Describe your pull request here

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
