### PR TITLE
Revert "don't download dfam database when in docker"

### DIFF
--- a/recipes/repeatmasker/post-link.sh
+++ b/recipes/repeatmasker/post-link.sh
@@ -1,17 +1,7 @@
 #!/bin/bash
 
-if [ -f /.dockerenv ]; then
-    cat >> "$PREFIX/.messages.txt" <<EOF
-To install the databases needed by RepeatMasker, execute:
-
+echo "Downloading Dfam_curatedonly.h5.gz from www.dfam.org"
 wget -O Dfam_curatedonly.h5.gz https://www.dfam.org/releases/Dfam_3.7/families/Dfam_curatedonly.h5.gz
+
 gunzip -c Dfam_curatedonly.h5.gz > ${PREFIX}/share/RepeatMasker/Libraries/Dfam.h5
 rm Dfam_curatedonly.h5.gz
-
-EOF
-else
-    echo "Downloading Dfam_curatedonly.h5.gz from www.dfam.org"
-    wget -O Dfam_curatedonly.h5.gz https://www.dfam.org/releases/Dfam_3.7/families/Dfam_curatedonly.h5.gz
-    gunzip -c Dfam_curatedonly.h5.gz > ${PREFIX}/share/RepeatMasker/Libraries/Dfam.h5
-    rm Dfam_curatedonly.h5.gz
-fi


### PR DESCRIPTION
This reverts commit 013fa23b460a66b98f257061462c96eb4f4f52ca. This broke execution in docker and singularity ... I think we could consider providing these through another mechanism when a new version is getting released, but this silently broke existing installations.