### PR TITLE
Add Phylogenize

### DIFF
--- a/recipes/phylogenize/build.sh
+++ b/recipes/phylogenize/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+R -e "devtools::install_bitbucket('pbradz/phylogenize/package/phylogenize')"

--- a/recipes/phylogenize/meta.yaml
+++ b/recipes/phylogenize/meta.yaml
@@ -1,0 +1,47 @@
+{% set version = "0.91" %}
+{% set name = "phylogenize" %}
+
+package:
+  name: phylogenize
+  version: "{{ version }}"
+
+source: 
+  url: https://github.com/pbradleylab/phylogenize/archive/refs/tags/v{{ version }}.tar.gz
+  build:
+    name: 0
+    rpaths:
+      - lib/R/lib/
+      - lib/
+    noarch: generic
+
+requirements:
+  build:
+    - vsearch
+    - bioconductor-ggtree
+    - bioconductor-biomformat
+    - r-devtools
+    - r-ragg
+    - r-phylolm
+    - r-phangorn
+  run:
+    - vsearch
+    - bioconductor-ggtree
+    - bioconductor-biomformat
+    - r-devtools
+    - r-ragg
+    - r-phylolm
+    - r-phangorn
+  test:
+    commands:
+      - '$R -c "library(''{{ name }}'')"'
+
+about:
+  home: https://github.com/bitbucket/phylogenize
+  license: MIT
+  summary: "An R package that allows users to link microbial genes to environments, accounting for phylogeny"
+  summary: "Phylogenize is a tool that allows users to link microbial genes to environments, accounting for phylogeny. More specifically, given community composition data, Phylogenize links genes in microbial genomes to either microbial prevalence in, or specificity for, a given environment, while also taking into account an important potential confounder: the phylogenetic relationships between microbes."
+  extra:
+    recipe-maintainers:
+      - kathrynkananen
+    indentifiers:
+      - doi: https://doi.org/10.1093/bioinformatics/btz722

--- a/recipes/phylogenize/meta.yaml
+++ b/recipes/phylogenize/meta.yaml
@@ -21,25 +21,25 @@ build:
 
 requirements:
   host:
-    - perl 5.32.1
-    - r-base 4.3.1
-    - r-devtools 2.4.5 
-    - vsearch 2.24.0
-    - r-ragg 1.2.5
-    - r-phylolm 2.6.2
-    - r-phangorn 2.11.1
-    - 'bioconductor-ggtree 3.8.0'
-    - 'bioconductor-biomformat 1.28.0'
+    - perl =5.32.1
+    - r-base =4.3.1
+    - r-devtools <=2.4.5 
+    - vsearch =2.24.0
+    - r-ragg <=1.2.6
+    - r-phylolm =2.6.2
+    - r-phangorn =2.11.1
+    - 'bioconductor-ggtree <=3.8.0,>1.16.0'
+    - 'bioconductor-biomformat =1.28.0'
   run:
-    - perl 5.32.1
-    - vsearch 2.24.0
-    - r-base 4.3.1
-    - 'bioconductor-ggtree 3.8.0'
-    - 'bioconductor-biomformat 1.28.0'
-    - r-devtools 2.4.5
-    - r-ragg 1.2.5
-    - r-phylolm 2.6.2
-    - r-phangorn 2.11.1
+    - perl =5.32.1
+    - r-base =4.3.1
+    - r-devtools <=2.4.5
+    - vsearch =2.24.0
+    - r-ragg <=1.2.6
+    - r-phylolm =2.6.2
+    - r-phangorn =2.11.1
+    - 'bioconductor-ggtree <=3.8.0,>1.16.0'
+    - 'bioconductor-biomformat =1.28.0'
 
 test:
   commands:

--- a/recipes/phylogenize/meta.yaml
+++ b/recipes/phylogenize/meta.yaml
@@ -21,25 +21,25 @@ build:
 
 requirements:
   host:
-    - perl
-    - r-base
-    - r-devtools
-    - vsearch
-    - r-ragg
-    - r-phylom
-    - r-phangorn
-    - 'bioconductor-ggtree'
-    - 'bioconductor-biomformat'
+    - perl 5.32.1
+    - r-base 4.3.1
+    - r-devtools 2.4.5 
+    - vsearch 2.24.0
+    - r-ragg 1.2.5
+    - r-phylolm 2.6.2
+    - r-phangorn 2.11.1
+    - 'bioconductor-ggtree 3.8.0'
+    - 'bioconductor-biomformat 1.28.0'
   run:
-    - perl
-    - vsearch
-    - r-base
-    - 'bioconductor-ggtree'
-    - 'bioconductor-biomformat'
-    - r-devtools
-    - r-ragg
-    - r-phylolm
-    - r-phangorn
+    - perl 5.32.1
+    - vsearch 2.24.0
+    - r-base 4.3.1
+    - 'bioconductor-ggtree 3.8.0'
+    - 'bioconductor-biomformat 1.28.0'
+    - r-devtools 2.4.5
+    - r-ragg 1.2.5
+    - r-phylolm 2.6.2
+    - r-phangorn 2.11.1
 
 test:
   commands:
@@ -53,6 +53,6 @@ about:
   summary: "Phylogenize is a tool that allows users to link microbial genes to environments, accounting for phylogeny."
 extra:
   recipe-maintainers:
-    - kathryn kananen
+    - kekananen
   indentifiers:
     - doi: "https://doi.org/10.1093/bioinformatics/btz722"

--- a/recipes/phylogenize/meta.yaml
+++ b/recipes/phylogenize/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "0.91" %}
-{% set name = "phylogenize" %}
 {% set sha256 = "3d428440f7a8aed3be18bbe094d3afe94f2d5357daa715d13e963c665384f2ab" %}
+{% set name = "phylogenize" %}
 
 package:
   name: phylogenize
@@ -8,42 +8,43 @@ package:
 
 source: 
   url: https://github.com/pbradleylab/phylogenize/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: {{ sha256 }} 
-  build:
-    name: 0
-    rpaths:
-      - lib/R/lib/
-      - lib/
-    noarch: generic
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  rpaths:
+    - lib/R/lib/
+    - lib/
+  noarch: generic
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x.x") }}
 
 requirements:
-  build:
-    - vsearch
-    - bioconductor-ggtree
-    - bioconductor-biomformat
-    - r-devtools
-    - r-ragg
-    - r-phylolm
-    - r-phangorn
+  host:
+    - perl
+    - r-base
   run:
+    - perl
     - vsearch
-    - bioconductor-ggtree
-    - bioconductor-biomformat
+    - 'bioconductor-ggtree'
+    - 'bioconductor-biomformat'
     - r-devtools
     - r-ragg
     - r-phylolm
     - r-phangorn
-  test:
-    commands:
-      - '$R -c "library(''{{ name }}'')"'
+
+test:
+  commands:
+    - '$R -e "library(devtools)"'
+    - $R -e "devtools::install_github('pbradleylab/phylogenize/package/phylogenize')"
+    - '$R -e "?phylogenize"'
 
 about:
-  home: https://github.com/bitbucket/phylogenize
+  home: https://github.com/pbradleylab/phylogenize
   license: MIT
-  summary: "An R package that allows users to link microbial genes to environments, accounting for phylogeny"
-  summary: "Phylogenize is a tool that allows users to link microbial genes to environments, accounting for phylogeny. More specifically, given community composition data, Phylogenize links genes in microbial genomes to either microbial prevalence in, or specificity for, a given environment, while also taking into account an important potential confounder: the phylogenetic relationships between microbes."
-  extra:
-    recipe-maintainers:
-      - kathrynkananen
-    indentifiers:
-      - doi: https://doi.org/10.1093/bioinformatics/btz722
+  summary: "Phylogenize is a tool that allows users to link microbial genes to environments, accounting for phylogeny."
+extra:
+  recipe-maintainers:
+    - kathryn kananen
+  indentifiers:
+    - doi: "https://doi.org/10.1093/bioinformatics/btz722"

--- a/recipes/phylogenize/meta.yaml
+++ b/recipes/phylogenize/meta.yaml
@@ -1,5 +1,6 @@
 {% set version = "0.91" %}
 {% set name = "phylogenize" %}
+{% set sha256 = "3d428440f7a8aed3be18bbe094d3afe94f2d5357daa715d13e963c665384f2ab" %}
 
 package:
   name: phylogenize
@@ -7,6 +8,7 @@ package:
 
 source: 
   url: https://github.com/pbradleylab/phylogenize/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: {{ sha256 }} 
   build:
     name: 0
     rpaths:

--- a/recipes/phylogenize/meta.yaml
+++ b/recipes/phylogenize/meta.yaml
@@ -23,9 +23,17 @@ requirements:
   host:
     - perl
     - r-base
+    - r-devtools
+    - vsearch
+    - r-ragg
+    - r-phylom
+    - r-phangorn
+    - 'bioconductor-ggtree'
+    - 'bioconductor-biomformat'
   run:
     - perl
     - vsearch
+    - r-base
     - 'bioconductor-ggtree'
     - 'bioconductor-biomformat'
     - r-devtools


### PR DESCRIPTION
Adds [Phylogenize](https://github.com/pbradleylab/phylogenize) to conda. Allows for users to link microbial genes to environments, accounting for phylogeny. More specifically, given community composition data, phylogenize links genes in microbial genomes to either microbial prevalence in, or specificity for, a given environment, while also taking into account an important potential confounder: the phylogenetic relationships between microbes.

Paper: [(Bradley and Pollard, 2020)](https://pubmed.ncbi.nlm.nih.gov/31588499/)