### PR TITLE
Add el_gato package to Bioconda

### DIFF
--- a/recipes/el_gato/build.sh
+++ b/recipes/el_gato/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+$PYTHON -m pip install . -vv
+
+mkdir -p $PREFIX/bin/db
+cp el_gato/db/* $PREFIX/bin/db/

--- a/recipes/el_gato/meta.yaml
+++ b/recipes/el_gato/meta.yaml
@@ -11,6 +11,11 @@ source:
   url: https://github.com/{{ user }}/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
   sha256: {{ hash }}
 
+build:
+  number: 0
+  noarch: generic
+  run_exports:
+    - {{ pin_subpackage(name, max_pin='x.x') }}
 
 requirements:
   host:

--- a/recipes/el_gato/meta.yaml
+++ b/recipes/el_gato/meta.yaml
@@ -1,0 +1,37 @@
+{% set name = "el_gato" %}
+{% set version = "1.14.4" %}
+{% set hash = "120b294baa58d833d9973da2d203eb88090a4ecc9538a34b0c5d6c8382cac1a4" %}
+{% set user = "appliedbinf" %}
+
+package:
+  name: el_gato
+  version: {{ version }}
+
+source:
+  url: https://github.com/{{ user }}/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
+  sha256: {{ hash }}
+
+
+requirements:
+  host:
+    - python >=3.8,<3.12
+    - pip
+    - setuptools
+  run:
+    - python >=3.8,<3.12
+    - minimap2 >=2.24
+    - samtools >=1.15.1
+    - blast >=2.13
+    - ispcr >=33.0
+    - nextflow
+    - fpdf2
+
+test:
+  commands:
+    - el_gato.py --version
+
+about:
+  home: https://github.com/{{ user }}/{{ name }}
+  license: MIT
+  license_file: LICENSE
+  summary: Perform Legionella pneumophila Sequence Based Typing (SBT) from short reads or assemblies


### PR DESCRIPTION
Add el_gato recipe to Bioconda.

el_gato is a command line application for performing sequence typing of _Legionella pneuomphila_ samples from short reads or assemblies.

https://github.com/appliedbinf/el_gato/