### PR TITLE
Update ucsc-fatotwobit from 447 to 455

### DIFF
--- a/recipes/ucsc-fatotwobit/meta.yaml
+++ b/recipes/ucsc-fatotwobit/meta.yaml
@@ -1,7 +1,7 @@
 {% set package = "ucsc-fatotwobit" %}
 {% set program = "faToTwoBit" %}
-{% set version = "447" %}
-{% set sha256 = "747a48486f7481d891e297baf63623b15d699265ede7339f654bcbc42481ac81" %}
+{% set version = "455" %}
+{% set sha256 = "e458cadad7c4a5c1b8385edafffa1b29380ac725a0c20535bf5a3bab99fe80db" %}
 
 package:
   name: "{{ package }}"
@@ -15,7 +15,7 @@ source:
 
 build:
   skip: True # [osx]
-  number: 0
+  number: 1
   ignore_run_exports:
     - libpng
     - libuuid

--- a/recipes/ucsc-fatotwobit/meta.yaml
+++ b/recipes/ucsc-fatotwobit/meta.yaml
@@ -15,7 +15,7 @@ source:
 
 build:
   skip: True # [osx]
-  number: 1
+  number: 0
   ignore_run_exports:
     - libpng
     - libuuid

--- a/recipes/ucsc-fatotwobit/meta.yaml
+++ b/recipes/ucsc-fatotwobit/meta.yaml
@@ -19,6 +19,8 @@ build:
   ignore_run_exports:
     - libpng
     - libuuid
+  run_exports:
+    - {{ pin_subpackage("ucsc-fatotwobit", max_pin=None) }}
 
 requirements:
   build:


### PR DESCRIPTION
Updates ucsc-fatotwobit of the UCSC kent utils from version 447 to 455. This also triggers a rebuild, to update the openssl version, because it is otherwise incompatible with more recently built kent utils.

There are two other PRs that I opened in parallel to this one, which have very similar changes: https://github.com/bioconda/bioconda-recipes/pull/44039 and https://github.com/bioconda/bioconda-recipes/pull/44041.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
