### PR TITLE
Update eigensoft: fix build for osx-arm64

### DIFF
--- a/recipes/eigensoft/0002-replace-finite.patch
+++ b/recipes/eigensoft/0002-replace-finite.patch
@@ -1,0 +1,13 @@
+diff --git a/src/admutils.c b/src/admutils.c
+index dae3657..35a4427 100644
+--- a/src/admutils.c
++++ b/src/admutils.c
+@@ -537,7 +537,7 @@ testnan (double *a, int n)
+   int i;
+ 
+   for (i = 0; i < n; i++) {
+-    if (!finite (a[i]))
++    if (!isfinite (a[i]))
+       fatalx ("(testnan) fails:  index %d\n", i);
+   }
+ }

--- a/recipes/eigensoft/0003-remove-wrong-cflag.patch
+++ b/recipes/eigensoft/0003-remove-wrong-cflag.patch
@@ -1,0 +1,10 @@
+diff --git a/src/nicksrc/Makefile b/src/nicksrc/Makefile
+index 55d7733..2d1742d 100644
+--- a/src/nicksrc/Makefile
++++ b/src/nicksrc/Makefile
+@@ -1,4 +1,4 @@
+-override CFLAGS += -c -O3   -g -p -Wimplicit -I../../include
++override CFLAGS += -c -O3  -g -Wimplicit -I../../include
+ 
+ all: libnick.a
+ 

--- a/recipes/eigensoft/build.sh
+++ b/recipes/eigensoft/build.sh
@@ -1,6 +1,5 @@
+set -xeuo pipefail
 cd src
-make clobber
-
 make all
 
 # Install (makefile install has hard-coded destination, so have to do this manually)

--- a/recipes/eigensoft/meta.yaml
+++ b/recipes/eigensoft/meta.yaml
@@ -1,15 +1,20 @@
-package:
-  name: eigensoft
-  version: "8.0.0"
+{% set name = "eigensoft" %}
+{% set version = "8.0.0" %}
 
-build:
-  number: 3
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
 
 source:
-  url: https://github.com/DReichLab/EIG/archive/refs/tags/v8.0.0.tar.gz
+  url: https://github.com/DReichLab/EIG/archive/v{{ version }}.tar.gz
   sha256: e3459e8ac0134da369910454854eae5c7b261e8816318ccbd2d371b4c6c35741
   patches:
     - 0001-Add-gfortran-to-LDLIBS.patch
+    - 0002-replace-finite.patch
+    - 0003-remove-wrong-cflag.patch  # [osx]
+
+build:
+  number: 4
 
 requirements:
   build:
@@ -25,12 +30,20 @@ requirements:
 
 test:
   commands:
-    - smartpca > /dev/null 2>&1
+    - smartpca
+    # both tools crash without input, there is other way to check whether installation worked...
+    - which convertf
+    - which mergeit
 
 about:
   home: https://github.com/DReichLab/EIG
   license: Custom OSS
+  license_file: LICENSE.txt
   summary: The EIGENSOFT package implements methods for analzing population structure and performing stratification correction
+
+extra:
+  recipe-maintainers:
+    - tschuelia
 
 extra:
   identifiers:

--- a/recipes/eigensoft/meta.yaml
+++ b/recipes/eigensoft/meta.yaml
@@ -15,6 +15,8 @@ source:
 
 build:
   number: 4
+  run_exports:
+    - {{ pin_subpackage('eigensoft', max_pin='x.x') }}
 
 requirements:
   build:

--- a/recipes/eigensoft/meta.yaml
+++ b/recipes/eigensoft/meta.yaml
@@ -42,10 +42,6 @@ about:
   summary: The EIGENSOFT package implements methods for analzing population structure and performing stratification correction
 
 extra:
-  recipe-maintainers:
-    - tschuelia
-
-extra:
   identifiers:
     - biotools:Eigensoft
     - doi:10.1371/journal.pgen.0020190


### PR DESCRIPTION
With these fixes eigensoft can also bei installed on OSX-arm64.
Two issues prevented this so far:
1.  The `finite` function is obsolete and should be replaced with `isfinite` (see https://linux.die.net/man/3/finite). Since this should be done not only for osx, I did not specify the `#  [osx]`  selector.
2. The compiler option `-p` seems to be invalid for the apple clang compiler. I never had this issue on a linux machine, so I added the `#  [osx]`  selector.

I further adjusted the name and version specifiers to match the recipe standard. 

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
