### PR TITLE
Update abricate: add missing dep to fix database download issues

### DIFF
--- a/recipes/abricate/meta.yaml
+++ b/recipes/abricate/meta.yaml
@@ -10,6 +10,8 @@ package:
 build:
   number: 2
   noarch: generic
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x") }}
 
 source:
   url: https://github.com/{{ user }}/{{ name }}/archive/v{{ version }}.tar.gz

--- a/recipes/abricate/meta.yaml
+++ b/recipes/abricate/meta.yaml
@@ -8,7 +8,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 1
+  number: 2
   noarch: generic
 
 source:
@@ -32,6 +32,7 @@ requirements:
     - perl-path-tiny
     - perl-list-moreutils
     - perl-json
+    - perl-lwp-protocol-https
     - perl-lwp-simple
     - blast >=2.7
     - zlib


### PR DESCRIPTION
Some database downloads using `abricate-get_db` (those that fetch over HTTPS) fail in the latest version because of missing HTTPS support (see e.g. https://github.com/tseemann/abricate/issues/193). This PR adds the required library.