### PR TITLE
MultiQC: add missing dependencies, pin to Python >=3.8

### DIFF
--- a/recipes/multiqc/meta.yaml
+++ b/recipes/multiqc/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - python >=3.8
     - pip
   run:
-    - python >=3.8,<3.12
+    - python >=3.8
     - setuptools
     - click
     - coloredlogs

--- a/recipes/multiqc/meta.yaml
+++ b/recipes/multiqc/meta.yaml
@@ -19,10 +19,10 @@ build:
 
 requirements:
   host:
-    - python >=3.8
+    - python >=3.8,<3.12
     - pip
   run:
-    - python >=3.8
+    - python >=3.8,<3.12
     - setuptools
     - click
     - coloredlogs
@@ -40,6 +40,7 @@ requirements:
     - rich >=10
     - rich-click
     - simplejson
+    - importlib-metadata
     - spectra >=0.0.10
 
 test:

--- a/recipes/multiqc/meta.yaml
+++ b/recipes/multiqc/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: f28268e50ef57dbc330ba40eb8dcbb2b86029bc4542dd420fe180c914c284d34
 
 build:
-  number: 0
+  number: 1
   entry_points:
     - multiqc=multiqc.__main__:run_multiqc
   noarch: python

--- a/recipes/multiqc/meta.yaml
+++ b/recipes/multiqc/meta.yaml
@@ -19,7 +19,7 @@ build:
 
 requirements:
   host:
-    - python >=3.8,<3.12
+    - python >=3.8
     - pip
   run:
     - python >=3.8,<3.12

--- a/recipes/multiqc/meta.yaml
+++ b/recipes/multiqc/meta.yaml
@@ -42,7 +42,6 @@ requirements:
     - simplejson
     - spectra >=0.0.10
 
-
 test:
   # Python imports
   imports:

--- a/recipes/multiqc/meta.yaml
+++ b/recipes/multiqc/meta.yaml
@@ -41,7 +41,6 @@ requirements:
     - rich >=10
     - rich-click
     - simplejson
-    - importlib-metadata
     - spectra >=0.0.10
 
 test:

--- a/recipes/multiqc/meta.yaml
+++ b/recipes/multiqc/meta.yaml
@@ -29,6 +29,7 @@ requirements:
     - future >0.14.0
     - humanize
     - jinja2 >=3.0.0
+    - importlib-metadata
     - lzstring
     - markdown
     - matplotlib-base >=2.1.1

--- a/recipes/multiqc/meta.yaml
+++ b/recipes/multiqc/meta.yaml
@@ -19,26 +19,29 @@ build:
 
 requirements:
   host:
-    - python >=3.6
+    - python >=3.8
     - pip
   run:
-    - python >=3.6
+    - python >=3.8
     - setuptools
     - click
     - coloredlogs
     - future >0.14.0
+    - humanize
     - jinja2 >=3.0.0
     - lzstring
     - markdown
     - matplotlib-base >=2.1.1
     - networkx >=2.5.1
     - numpy
+    - packaging
     - pyyaml >=4
     - requests
     - rich >=10
     - rich-click
     - simplejson
     - spectra >=0.0.10
+
 
 test:
   # Python imports


### PR DESCRIPTION
After version 1.17, MultiQC stopped supporting Python 3.6 and 3.7, and added the `packaging` dependency to handle the calls of the deprecated `distutils` that was removed in 3.12: https://github.com/ewels/MultiQC/pull/2113

However, we forgot to updated the bioconda recipe accordingly. Thos PR:
- Pins Python to >=3.8
- Adds the missing `packaging` dependency
- Additionally, adds the `humanize` dependency that is added in the dev version and will be used in the future MultiQC 1.18 version.

Addresses https://github.com/nextflow-io/rnaseq-nf/issues/22