### PR TITLE
Update Pantools v4.2.3 recipe

### DIFF
--- a/recipes/pantools/meta.yaml
+++ b/recipes/pantools/meta.yaml
@@ -17,7 +17,7 @@ build:
     - {{ pin_subpackage("pantools", max_pin="x") }}
 
 requirements:
-  build:
+  host:
     - openjdk =8
     - maven
     - jq

--- a/recipes/pantools/meta.yaml
+++ b/recipes/pantools/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   noarch: generic
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage("pantools", max_pin="x") }}
 
@@ -32,13 +32,13 @@ requirements:
     - blast
     - mash =2.3
     - fastani
-      #- busco =5  #causes conflicts on macOS
+    - busco =5  # [linux]
     - r-base >=3.5.0
     - r-ggplot2
     - r-ape
     - graphviz
     - aster =1.3
-      #- bcftools >=1.12  #causes conflicts on macOS
+    - bcftools >=1.12  # [linux]
     - tabix
 
 test:
@@ -68,7 +68,6 @@ extra:
     If you want to overwrite it you can specify these values directly after your binaries.
     If you have _JAVA_OPTIONS set globally this will take precedence.
     For example run it with "pantools -Xms512m -Xmx1g".
-    NB: Both `BUSCO` and `bcftools` are dependencies of PanTools but they are not included in this recipe due to conflicts on MacOS.
   identifiers:
     - doi:https://doi.org/10.1093/bioinformatics/btw455
     - doi:https://doi.org/10.1186/s12859-018-2362-4


### PR DESCRIPTION
Previously, I had assumed that dependencies in the `run` section have to be valid for both Linux and macOS. I have just found out that these can be platform specific too. Therefore, this PR makes two previously excluded dependencies Linux specific since they are not conflicting on Linux. They are still conflicting on macOS and therefore the `# [linux]` has been added for them. This will also make sure that these dependencies are included for the PanTools image on biocontainers.