### PR TITLE
Update Hostile, pinning older bowtie2==2.4.5

### DIFF
--- a/recipes/hostile/meta.yaml
+++ b/recipes/hostile/meta.yaml
@@ -10,7 +10,9 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
+  run_exports:
+    - {{ pin_subpackage('hostile', max_pin="1.0") }}
   entry_points:
     - hostile = hostile.cli:main
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
@@ -21,7 +23,7 @@ requirements:
     - python >=3.10
     - flit-core >=3.9.0
   run:
-    - bowtie2 >=2.5.1
+    - bowtie2 ==2.4.5
     - defopt >=6.4.0
     - gawk >=5.1.0
     - httpx >=0.24.1

--- a/recipes/hostile/meta.yaml
+++ b/recipes/hostile/meta.yaml
@@ -12,7 +12,7 @@ build:
   noarch: python
   number: 1
   run_exports:
-    - {{ pin_subpackage('hostile', max_pin="1.0") }}
+    - {{ pin_subpackage('hostile', max_pin="x.x") }}
   entry_points:
     - hostile = hostile.cli:main
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"


### PR DESCRIPTION
Workaround for performance issue associated with `bowtie2` >= `2.5.x`