### PR TITLE
Update FastANI

### DIFF
--- a/recipes/fastani/meta.yaml
+++ b/recipes/fastani/meta.yaml
@@ -8,6 +8,8 @@ package:
 
 build:
   number: 1
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x") }}
 
 source:
   url: https://github.com/ParBLiSS/{{ name }}/archive/v{{ version }}.tar.gz

--- a/recipes/fastani/meta.yaml
+++ b/recipes/fastani/meta.yaml
@@ -9,7 +9,7 @@ package:
 build:
   number: 1
   run_exports:
-    - {{ pin_subpackage(name, max_pin="x") }}
+    - {{ pin_subpackage(fastani, max_pin="x") }}
 
 source:
   url: https://github.com/ParBLiSS/{{ name }}/archive/v{{ version }}.tar.gz

--- a/recipes/fastani/meta.yaml
+++ b/recipes/fastani/meta.yaml
@@ -9,7 +9,7 @@ package:
 build:
   number: 1
   run_exports:
-    - {{ pin_subpackage(fastani, max_pin="x") }}
+    - {{ pin_subpackage('fastani', max_pin="x") }}
 
 source:
   url: https://github.com/ParBLiSS/{{ name }}/archive/v{{ version }}.tar.gz

--- a/recipes/fastani/meta.yaml
+++ b/recipes/fastani/meta.yaml
@@ -7,7 +7,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 0
+  number: 1
 
 source:
   url: https://github.com/ParBLiSS/{{ name }}/archive/v{{ version }}.tar.gz
@@ -22,14 +22,15 @@ requirements:
   host:
     - zlib
     - gsl >=2.6, <2.7.1
-    - openmp
+    - openmp  # [linux]
+    - llvm-openmp  # [osx]
     - clangdev  # [osx]
     - libcxx >=4.0  # [osx]
   run:
     - zlib
     - gsl
     - libcxx >=4.0  # [osx]
-    - openmp >=4.0  # [osx]
+    - llvm-openmp >=4.0  # [osx]
 
 test:
   commands:


### PR DESCRIPTION
This PR fixes the openmp version for FastANI by using llvm-openmp instead on OSX.