### PR TITLE
Update meta.yaml

### DIFF
--- a/recipes/rfplasmid/meta.yaml
+++ b/recipes/rfplasmid/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "rfplasmid" %}
-{% set version = "0.0.18" %}
-{% set blake2_sha256 = "94c0f87aa1a4be2bdd34846922c5a2e53241fd384868bfd8469d3f83a94bf8b1" %}
+{% set version = "1.0" %}
+{% set blake2_sha256 = "2b4e26a55d15aeadc206da4536411309451adb56fedb96428fbb9279b4e30874" %}
 
 package:
   name:  {{ name }}
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://files.pythonhosted.org/packages/{{ blake2_sha256[0:2] }}/{{ blake2_sha256[2:4] }}/{{ blake2_sha256[4:] }}/{{ name }}-{{ version }}-py3-none-any.whl
-  sha256: 45f2e380a82d75b1eb31ee27007197a55013b40d9b4cb6bd28457f9acce30b2e
+  sha256: d4659b6d0f1a322f65c0e31b6dc3e2729a0017cf73fd67acc6edcf1c12e438f9
 
 build:
   noarch: python


### PR DESCRIPTION
Syncing version numbers to version 1.0. 
Includes a bugfix for:
split() from python =3.10
citation for the paper

