### PR TITLE
Update PAML to 4.10.7

### DIFF
--- a/recipes/paml/meta.yaml
+++ b/recipes/paml/meta.yaml
@@ -1,17 +1,17 @@
 {% set name = "PAML" %}
-{% set version = "4.10.6" %}
-{% set sha256 = "d6437f04ee233209e1ded83addbfe65d1363185877a03ba7924ce81f9ebc7777" %}
+{% set version = "4.10.7" %}
+{% set sha256 = "0f29e768b3797b69eadc6332c3d046d8727702052d56c3b729883626c0a5a4e3" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://github.com/abacus-gene/paml/archive/v{{ version }}.tar.gz
+  url: https://github.com/abacus-gene/paml/archive/{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:
-  number: 2
+  number: 0
 
 requirements:
   build:

--- a/recipes/paml/meta.yaml
+++ b/recipes/paml/meta.yaml
@@ -12,6 +12,8 @@ source:
 
 build:
   number: 0
+  run_exports:
+    - {{ pin_subpackage('paml', max_pin="x.x") }}
 
 requirements:
   build:


### PR DESCRIPTION
Update PAML to [latest GitHub release 4.10.7](https://github.com/abacus-gene/paml/releases/tag/4.10.7)