### PR TITLE
update iphop to 1.3.3, and addition of run_exports

### DIFF
--- a/recipes/iphop/meta.yaml
+++ b/recipes/iphop/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "iphop" %}
-  {% set version = "1.3.2" %}
+  {% set version = "1.3.3" %}
 
 package:
   name: "{{ name|lower }}"
@@ -7,11 +7,13 @@ package:
 
 source:
   url: https://bitbucket.org/srouxjgi/iphop/downloads/{{ name }}-{{ version }}.tar.gz
-  sha256: 1d4678c4ee8d47b798c0b105e156c382585f07aeac528ba9b7f3a2dc5d1d3ed3
+  sha256: dfa42bcd31a076b213a97e105a5ddc8725531f7a5e069ba2645789f6adcfb85e
 
 build:
   number: 0
   noarch: python
+  run_exports:
+    - {{ pin_subpackage('iphop', max_pin="x") }}
 
 requirements:
   build:


### PR DESCRIPTION
Updating iphop to 1.3.3, had to modify the meta.yaml to now include a run_exports clause. Using the standard one as the versioning follows standard numbering.
