### PR TITLE
Update lima: set binary_relocation: False to fix EL8 segfault

### DIFF
--- a/recipes/lima/meta.yaml
+++ b/recipes/lima/meta.yaml
@@ -10,8 +10,9 @@ source:
   sha256: a13437bc7a90ab5df3c19eac44384de2a14370d0391586b5aa63a6478f9c2c53
 
 build:
-  number: 0
+  number: 1
   skip: True  # [osx]
+  binary_relocation: False
   run_exports:
     - {{ pin_subpackage('lima', max_pin='x.x') }}
 


### PR DESCRIPTION
lima consistently segfaults on EL8 (RHEL 8, Rocky Linux 8, etc.) due to an interaction with `patchelf --set-rpath` (possibly for certain versions of patchelf?) and the kernel version used by EL8. This PR disables such binary relocation ordinarily performed by `conda-build`, resulting in the packaging of unmodified PacBio-built lima executables.

Tested locally (`bioconda-utils build --packages lima`) on Rocky 8.

Reference: https://github.com/PacificBiosciences/pbbioconda/issues/557#issuecomment-1819767535
