### PR TITLE
Arm builds circleci fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,21 +104,12 @@ jobs: # a basic unit of work in a run
           name: Fetch bioconda install script
           command: wget https://raw.githubusercontent.com/bioconda/bioconda-common/master/{common,install-and-set-up-conda,configure-conda}.sh
 
-      - restore_cache:
-          keys:
-            - bioconda-utils-{{ arch }}-{{ checksum "install-and-set-up-conda.sh" }}-{{ checksum "configure-conda.sh" }}-{{ checksum "common.sh" }}
-
       - run:
           name: Install bioconda-utils
           command: |
             sudo mkdir -p /opt
             sudo chmod o+rwx /opt
             bash install-and-set-up-conda.sh
-
-      - save_cache:
-          key: bioconda-utils-{{ arch }}-{{ checksum "install-and-set-up-conda.sh" }}-{{ checksum "configure-conda.sh" }}-{{ checksum "common.sh" }}
-          paths:
-            - /opt/mambaforge
 
       - run:
           name: Setup PATH
@@ -182,10 +173,6 @@ jobs: # a basic unit of work in a run
           name: Fetch bioconda install script
           command: wget https://raw.githubusercontent.com/bioconda/bioconda-common/bulk/{common,install-and-set-up-conda,configure-conda}.sh
 
-      - restore_cache:
-          keys:
-            - bioconda-utils-{{ arch }}-bulk--{{ checksum "install-and-set-up-conda.sh" }}-{{ checksum "configure-conda.sh" }}-{{ checksum "common.sh" }}
-
       - run:
           name: Install bioconda-utils
           command: |
@@ -193,11 +180,6 @@ jobs: # a basic unit of work in a run
             sudo chmod o+rwx /opt
             bash install-and-set-up-conda.sh
 
-      - save_cache:
-          key: bioconda-utils-{{ arch }}--bulk--{{ checksum "install-and-set-up-conda.sh" }}-{{ checksum "configure-conda.sh" }}-{{ checksum "common.sh" }}
-          paths:
-            - /opt/mambaforge/
-    
       - run:
           name: Setup PATH
           command:
@@ -218,8 +200,9 @@ jobs: # a basic unit of work in a run
           name: Build and upload
           command: |
             set -e
-            eval "$(conda shell.bash hook)"
-            conda activate bioconda
+            source /opt/mambaforge/etc/profile.d/conda.sh
+            source /opt/mambaforge/etc/profile.d/mamba.sh
+            mamba activate bioconda
             echo '============'
             conda info --all
             conda config --show-sources
@@ -228,7 +211,10 @@ jobs: # a basic unit of work in a run
             bioconda-utils build recipes config.yml \
               --worker-offset << parameters.runner >> --n-workers 6 \
               --docker --mulled-test --docker-base-image quay.io/bioconda/bioconda-utils-build-env-cos7-$(arch) \
-              --anaconda-upload --record-build-failures  --skiplist-leafs
+              --anaconda-upload \
+              --mulled-upload-target biocontainers \
+              --record-build-failures \
+              --skiplist-leafs
             conda clean -y --all
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs: # a basic unit of work in a run
             source /opt/mambaforge/etc/profile.d/mamba.sh
             mamba activate bioconda
             bioconda-utils build recipes config.yml \
-                --docker --mulled-test \
+                --lint --docker --mulled-test \
                 --docker-base-image quay.io/bioconda/bioconda-utils-build-env-cos7-$(arch) \
                 --git-range origin/master HEAD
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,10 +28,6 @@ jobs: # a basic unit of work in a run
           name: Fetch bioconda install script
           command: wget https://raw.githubusercontent.com/bioconda/bioconda-common/master/{common,install-and-set-up-conda,configure-conda}.sh
 
-      - restore_cache:
-          keys:
-            - bioconda-utils-{{ arch }}-{{ checksum "install-and-set-up-conda.sh" }}-{{ checksum "configure-conda.sh" }}-{{ checksum "common.sh" }}
-
       - run:
           name: Install bioconda-utils
           command: |
@@ -39,11 +35,6 @@ jobs: # a basic unit of work in a run
             sudo chmod o+rwx /opt
             bash install-and-set-up-conda.sh
 
-      - save_cache:
-          key: bioconda-utils-{{ arch }}-{{ checksum "install-and-set-up-conda.sh" }}-{{ checksum "configure-conda.sh" }}-{{ checksum "common.sh" }}
-          paths:
-            - /opt/mambaforge/
-    
       - run:
           name: Setup PATH
           command:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -238,7 +238,9 @@ workflows:
       - build_and_test:
           filters:
             branches:
-              ignore: master
+              ignore:
+                - master
+                - bulk
           matrix:
             parameters:
               os:


### PR DESCRIPTION
This targets the `arm-builds` branch. It incorporates some fixes identified from testing over on https://github.com/bioconda/bioconda-recipes/pull/43995.

Specifically:

1. **Disable caching.** Turns out the cache restore was not working, apparently because the CircleCI restore process doesn't make a directory if it doesn't exist. So the cache restore was taking 7+ minutes....just to report 130k+ times that the directory didn't exist! Making the directory ahead of time fixed that, allowing the cache to be restored in 21s. But then the bioconda-common install script failed, because the directory `/opt/mambaforge` already existed (from aforementioned cache restore...). It appears that CircleCI does not have a mechanism for detecting a cache hit, which would otherwise allow us to conditionally run the install script. However, when looking at the timings, I noticed it was only taking 50s to install bioconda-utils from scratch. We originally added caching because building the env could take many minutes; the build speed now is quite fast, only 30s longer than the restore process. So I figured the easiest solution was to remove caching altogether for CircleCI in this PR.

2. **Add linting.** The Azure DevOps pipelines fail early on linting issues (where the linting runs on `x86_64` linux), preventing subsequent resources from being used. I couldn't come up with straightforward way of triggering CircleCI jobs conditionally from within Azure DevOps such that CircleCI would only run on a successful lint. But after measuring it, linting only takes a a second or two once everything else is set up. So this PR adds `--lint` to the bioconda-utils argument.

3. **Branch control.** When bulk is running, we shouldn't have the regular tests also running which will waste resources. So this only runs the regular tests if the branch != (master | bulk).

4. **Upload ARM containers.** Adds `--mulled-upload-target biocontainers` to upload containers to quay.io. ***NOTE:*** This still needs https://github.com/bioconda/bioconda-utils/pull/941 to be merged in to bioconda-utils, which makes mulled-build use the right involucro and base image for `mulled-build push`.