### PR TITLE
Test ARM artifact merging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,7 +225,7 @@ workflows:
           filters:
             branches:
               ignore:
-                - master
+                - test-arm-artifact-merging
                 - bulk
           matrix:
             parameters:
@@ -238,7 +238,7 @@ workflows:
       - build_and_upload:
           filters:
             branches:
-              only: master
+              only: test-arm-artifact-merging
           matrix:
             parameters:
               os:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,7 +225,7 @@ workflows:
           filters:
             branches:
               ignore:
-                - test-arm-artifact-merging
+                - target-for-arm
                 - bulk
           matrix:
             parameters:
@@ -238,7 +238,7 @@ workflows:
       - build_and_upload:
           filters:
             branches:
-              only: test-arm-artifact-merging
+              only: target-for-arm
           matrix:
             parameters:
               os:

--- a/recipes/test/meta.yaml
+++ b/recipes/test/meta.yaml
@@ -5,7 +5,7 @@
 package:
 
   name: test
-  version: 0.1
+  version: 0.2
 
 source:
   url: https://github.com/lh3/seqtk/archive/v1.4.tar.gz


### PR DESCRIPTION
This adds a test package (likely to be deleted later from channel and biocontainers) to test that, once this PR is merged into master, `bioconda-utils handle-merged-pr` correctly picks up the package & container artifacts built on circleci and uploads them appropriately.

Edit: don't want to actually merge this into master, instead, this modifies the branches used by circleci to simulate the master branch.