### PR TITLE
Update trtools to 5.1.1

### DIFF
--- a/recipes/trtools/meta.yaml
+++ b/recipes/trtools/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "trtools" %}
-{% set version = "5.1.0" %}
+{% set version = "5.1.1" %}
 
 package:
   name: "{{ name|lower }}"
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 22472f1983614c15780d7ec6de845095a2a7f6cb4be049942f38f6f9b1a7e359
+  sha256: e3b107d3d4a2ba2f0df49c382df911ab79bfbdf04aa15c84d3093bed67e4220d
 
 build:
   noarch: python
@@ -40,7 +40,8 @@ requirements:
     - scikit-learn >=0.23.1
     - scipy >=1.4.1
     - statsmodels >=0.13.5
-    - pyfaidx
+    - pyfaidx >=0.5.3
+    - ART >=2016.06.05
 
 test:
   imports:
@@ -51,6 +52,8 @@ test:
     - trtools.mergeSTR
     - trtools.qcSTR
     - trtools.statSTR
+    - trtools.prancSTR
+    - trtools.simTR
     - trtools.utils
   requires:
     - bcftools
@@ -64,6 +67,8 @@ test:
     - statSTR --help
     - compareSTR --help
     - qcSTR --help
+    - prancSTR --help
+    - simTR --help
 
 about:
   home: http://github.com/gymreklab/TRTools
@@ -77,3 +82,4 @@ about:
 extra:
   recipe-maintainers:
     - LiterallyUniqueLogin
+    - aryarm


### PR DESCRIPTION
Closes #44482

Update [`trtools`](https://bioconda.github.io/recipes/trtools/README.html): **5.1.0** → **5.1.1**

Please merge this PR instead of #44482. We've added a new dependency and some additional tests.