### PR TITLE
Bot consolidation

### DIFF
--- a/.github/workflows/Bulk.yml
+++ b/.github/workflows/Bulk.yml
@@ -15,14 +15,11 @@ jobs:
         runner: [0, 1, 2, 3, 4, 5]
     steps:
       - uses: actions/checkout@v3
-        with:
-          # checkout as bioconda-bot in order to have the permission to push fail logs
-          token: ${{secrets.BIOCONDA_BOT_REPO_TOKEN}}
       
       - name: set git user
         run: |
-          git config user.name bioconda-bot
-          git config user.email bioconda-bot@users.noreply.github.com
+          git config user.name BiocondaBot
+          git config user.email BiocondaBot@users.noreply.github.com
 
       - name: set path
         run: echo "/opt/mambaforge/bin" >> $GITHUB_PATH
@@ -85,9 +82,11 @@ jobs:
         runner: [0, 1, 2, 3]
     steps:
       - uses: actions/checkout@v3
-        with:
-          # checkout as bioconda-bot in order to have the permission to push fail logs
-          token: ${{secrets.BIOCONDA_BOT_REPO_TOKEN}}
+      
+      - name: set git user
+        run: |
+          git config user.name BiocondaBot
+          git config user.email BiocondaBot@users.noreply.github.com
 
       - name: set path
         run: echo "/opt/mambaforge/bin" >> $GITHUB_PATH

--- a/.github/workflows/build-failures.yml
+++ b/.github/workflows/build-failures.yml
@@ -59,8 +59,8 @@ jobs:
         uses: docker://decathlon/wiki-page-creator-action:latest
         env:
           GH_PAT: ${{secrets.BIOCONDA_BOT_REPO_TOKEN}}
-          ACTION_MAIL: bioconda-bot@users.noreply.github.com
-          ACTION_NAME: bioconda-bot
+          ACTION_MAIL: BiocondaBot@users.noreply.github.com
+          ACTION_NAME: BiocondaBot
           OWNER: bioconda
           REPO_NAME: bioconda-recipes
           MD_FOLDER: build-failures

--- a/.github/workflows/build-failures.yml
+++ b/.github/workflows/build-failures.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Upload build failure to wiki
         uses: docker://decathlon/wiki-page-creator-action:latest
         env:
-          GH_PAT: ${{secrets.BIOCONDA_BOT_REPO_TOKEN}}
+          GH_PAT: ${{secrets.GITHUB_TOKEN}}
           ACTION_MAIL: BiocondaBot@users.noreply.github.com
           ACTION_NAME: BiocondaBot
           OWNER: bioconda

--- a/.github/workflows/build-failures.yml
+++ b/.github/workflows/build-failures.yml
@@ -6,7 +6,7 @@ on:
   push:
     branches:
       - master
-      - bot-consolidation # FIXME: remove after testing
+      - bot-consolidation # FIXME: remove after testing TEST
     paths:
       - "**build_failure.*.yaml"
 

--- a/.github/workflows/build-failures.yml
+++ b/.github/workflows/build-failures.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - master
-      - bot-consolidation # FIXME: remove after testing TEST
     paths:
       - "**build_failure.*.yaml"
 
@@ -59,6 +58,7 @@ jobs:
       - name: Upload build failure to wiki
         uses: docker://decathlon/wiki-page-creator-action:latest
         env:
+          GH_PAT: ${{secrets.BIOCONDA_BOT_REPO_TOKEN}}
           ACTION_MAIL: BiocondaBot@users.noreply.github.com
           ACTION_NAME: BiocondaBot
           OWNER: bioconda

--- a/.github/workflows/build-failures.yml
+++ b/.github/workflows/build-failures.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - master
+      - bot-consolidation # FIXME: remove after testing
     paths:
       - "**build_failure.*.yaml"
 

--- a/.github/workflows/build-failures.yml
+++ b/.github/workflows/build-failures.yml
@@ -59,7 +59,6 @@ jobs:
       - name: Upload build failure to wiki
         uses: docker://decathlon/wiki-page-creator-action:latest
         env:
-          GH_PAT: ${{secrets.GITHUB_TOKEN}}
           ACTION_MAIL: BiocondaBot@users.noreply.github.com
           ACTION_NAME: BiocondaBot
           OWNER: bioconda

--- a/recipes/art/build_failure.osx-64.yaml
+++ b/recipes/art/build_failure.osx-64.yaml
@@ -101,4 +101,4 @@ log: |2-
   conda.exceptions.CondaSSLError: Encountered an SSL error. Most likely a certificate verification issue.
 
   Exception: HTTPSConnectionPool(host='www.niehs.nih.gov', port=443): Max retries exceeded with url: /research/resources/assets/docs/artsrcmountrainier2016.06.05linux.tgz (Caused by SSLError(SSLError(1, '[SSL: UNSAFE_LEGACY_RENEGOTIATION_DISABLED] unsafe legacy renegotiation disabled (_ssl.c:1131)')))
-# Last 100 lines of the build log.
+# Last 100 lines of the build log. 

--- a/recipes/art/build_failure.osx-64.yaml
+++ b/recipes/art/build_failure.osx-64.yaml
@@ -101,4 +101,4 @@ log: |2-
   conda.exceptions.CondaSSLError: Encountered an SSL error. Most likely a certificate verification issue.
 
   Exception: HTTPSConnectionPool(host='www.niehs.nih.gov', port=443): Max retries exceeded with url: /research/resources/assets/docs/artsrcmountrainier2016.06.05linux.tgz (Caused by SSLError(SSLError(1, '[SSL: UNSAFE_LEGACY_RENEGOTIATION_DISABLED] unsafe legacy renegotiation disabled (_ssl.c:1131)')))
-# Last 100 lines of the build log.  
+# Last 100 lines of the build log.

--- a/recipes/art/build_failure.osx-64.yaml
+++ b/recipes/art/build_failure.osx-64.yaml
@@ -101,4 +101,4 @@ log: |2-
   conda.exceptions.CondaSSLError: Encountered an SSL error. Most likely a certificate verification issue.
 
   Exception: HTTPSConnectionPool(host='www.niehs.nih.gov', port=443): Max retries exceeded with url: /research/resources/assets/docs/artsrcmountrainier2016.06.05linux.tgz (Caused by SSLError(SSLError(1, '[SSL: UNSAFE_LEGACY_RENEGOTIATION_DISABLED] unsafe legacy renegotiation disabled (_ssl.c:1131)')))
-# Last 100 lines of the build log.
+# Last 100 lines of the build log.  

--- a/recipes/art/build_failure.osx-64.yaml
+++ b/recipes/art/build_failure.osx-64.yaml
@@ -101,4 +101,4 @@ log: |2-
   conda.exceptions.CondaSSLError: Encountered an SSL error. Most likely a certificate verification issue.
 
   Exception: HTTPSConnectionPool(host='www.niehs.nih.gov', port=443): Max retries exceeded with url: /research/resources/assets/docs/artsrcmountrainier2016.06.05linux.tgz (Caused by SSLError(SSLError(1, '[SSL: UNSAFE_LEGACY_RENEGOTIATION_DISABLED] unsafe legacy renegotiation disabled (_ssl.c:1131)')))
-# Last 100 lines of the build log. 
+# Last 100 lines of the build log.


### PR DESCRIPTION
Use BiocondaBot instead of bioconda-bot in GitHub actions for consistency.

Removed the token from Bulk.yml which should now be using the built in credentials from GitHub Actions. (tested on bulk arm builds test branch: https://github.com/bioconda/bioconda-recipes/pull/43995)

The build-failures.yml uses an action to update the wiki and still requires the token from what I can tell. This PR will not fix the action directly. However, since bioconda-bot has been giving errors, that action doesn't work anyway. So, I am making the change now to BiocondaBot.