### PR TITLE
Add nextclade2 to allow nextclade 3 and nextclade 2 to exist in same environment

### DIFF
--- a/recipes/nextclade2/build.sh
+++ b/recipes/nextclade2/build.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+ls "${SRC_DIR}"
+chmod +x "${SRC_DIR}"/nextclade*
+mkdir -p "${PREFIX}/bin"
+mv "${SRC_DIR}"/nextclade* "${PREFIX}"/bin/nextclade2

--- a/recipes/nextclade2/meta.yaml
+++ b/recipes/nextclade2/meta.yaml
@@ -6,11 +6,11 @@ package:
   version: "{{ version }}"
 
 source:
-  - url: https://github.com/nextstrain/nextclade/releases/download/{{ version }}/{{ name }}-x86_64-unknown-linux-gnu   # [linux64]
+  - url: https://github.com/nextstrain/nextclade/releases/download/{{ version }}/nextclade-x86_64-unknown-linux-gnu   # [linux64]
     sha256: 1a9a82655830243ffd01937ebb895744ff46ec49f725ef6feff9a3f0e37d90d1                                           # [linux64]
-  - url: https://github.com/nextstrain/nextclade/releases/download/{{ version }}/{{ name }}-x86_64-apple-darwin        # [osx and x86_64]
+  - url: https://github.com/nextstrain/nextclade/releases/download/{{ version }}/nextclade-x86_64-apple-darwin        # [osx and x86_64]
     sha256: 432f56d2152edda49b8c4a2c3f81d9a5da7419a6cc7c4a3d5205d17d5f834cf6                                           # [osx and x86_64]
-  - url: https://github.com/nextstrain/nextclade/releases/download/{{ version }}/{{ name }}-aarch64-apple-darwin       # [arm64]
+  - url: https://github.com/nextstrain/nextclade/releases/download/{{ version }}/nextclade-aarch64-apple-darwin       # [arm64]
     sha256: aaac669618d953381428eac3674fe6cb22bef66e7c1ae55552f6a1567f3d3030                                           # [arm64]
 
 build:

--- a/recipes/nextclade2/meta.yaml
+++ b/recipes/nextclade2/meta.yaml
@@ -1,0 +1,41 @@
+{% set name = "nextclade2" %}
+{% set version = "2.14.0" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  - url: https://github.com/nextstrain/nextclade/releases/download/{{ version }}/{{ name }}-x86_64-unknown-linux-gnu   # [linux64]
+    sha256: 1a9a82655830243ffd01937ebb895744ff46ec49f725ef6feff9a3f0e37d90d1                                           # [linux64]
+  - url: https://github.com/nextstrain/nextclade/releases/download/{{ version }}/{{ name }}-x86_64-apple-darwin        # [osx and x86_64]
+    sha256: 432f56d2152edda49b8c4a2c3f81d9a5da7419a6cc7c4a3d5205d17d5f834cf6                                           # [osx and x86_64]
+  - url: https://github.com/nextstrain/nextclade/releases/download/{{ version }}/{{ name }}-aarch64-apple-darwin       # [arm64]
+    sha256: aaac669618d953381428eac3674fe6cb22bef66e7c1ae55552f6a1567f3d3030                                           # [arm64]
+
+build:
+  number: 0
+  binary_relocation: False
+  run_exports:
+  - {{ pin_compatible(name, max_pin='x') }}
+
+requirements:
+
+test:
+  commands:
+    - nextclade2 --help
+
+about:
+  home: https://github.com/nextstrain/nextclade
+  license: MIT
+  license_family: MIT
+  summary: "Viral genome alignment, mutation calling, clade assignment, quality checks and phylogenetic placement"
+  doc_url: https://docs.nextstrain.org/projects/nextclade/en/stable/
+  dev_url: https://github.com/nextstrain/nextclade
+
+extra:
+  recipe-maintainers:
+    - corneliusroemer
+  skip-lints:
+    # repackaged binary
+    - should_be_noarch_generic

--- a/recipes/nextclade2/run_test.sh
+++ b/recipes/nextclade2/run_test.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -x
+set -e
+
+nextclade2 --version
+
+nextclade2 dataset get --name 'sars-cov-2' --output-dir 'data/sars-cov-2'
+
+nextclade2 run \
+--input-dataset 'data/sars-cov-2' \
+'data/sars-cov-2/sequences.fasta' \
+--output-tsv 'output/nextclade.tsv' \
+--output-tree 'output/tree.json' \
+--output-all 'output/'
+
+rm -rf data output


### PR DESCRIPTION
The nextstrain conda runtime should be able to contain both nextclade2 and nextclade3 binaries.

The addition of this package means that workflows requiring nextclade2 once nextclade has moved to major version 3 can still use nextclade2 alongside nextclade(3).
----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
