### PR TITLE
Create new recipe for rebar

### DIFF
--- a/recipes/rebar/LICENSE
+++ b/recipes/rebar/LICENSE
@@ -1,0 +1,201 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2023 Public Health Agency of Canada
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/recipes/rebar/build.sh
+++ b/recipes/rebar/build.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+ls "${SRC_DIR}"
+chmod +x "${SRC_DIR}"/rebar*
+mkdir -p "${PREFIX}/bin"
+mv "${SRC_DIR}"/rebar* "${PREFIX}"/bin/rebar

--- a/recipes/rebar/meta.yaml
+++ b/recipes/rebar/meta.yaml
@@ -12,7 +12,6 @@ source:
     sha256: b3577c5ea7965133fc5b934a9c4f9b5e1ba41603d5f9ce47fff79d6ee11adaa7                                      # [osx-64]
 
 build:
-  binary_relocation: false
   number: 0
   # If the software version starts with a 0 (e.g. 0.3.2) semantic versioning allows breaking changes in minor releases.
   # https://bioconda.github.io/contributor/linting.html#missing-run-exports
@@ -25,8 +24,9 @@ test:
 
 about:
   home: https://github.com/phac-nml/rebar
-  license: Apache
-  license_family: Apache
+  license: Apache-2.0
+  license_family: APACHE
+  license_file: LICENSE
   summary: "Genomic recombination detection using mutational barcodes."
   doc_url: https://github.com/phac-nml/rebar
   dev_url: https://github.com/phac-nml/rebar

--- a/recipes/rebar/meta.yaml
+++ b/recipes/rebar/meta.yaml
@@ -37,3 +37,4 @@ extra:
     - ktmeaton
   skip-lints:
     - should_be_noarch_generic
+

--- a/recipes/rebar/meta.yaml
+++ b/recipes/rebar/meta.yaml
@@ -12,11 +12,12 @@ source:
     sha256: b3577c5ea7965133fc5b934a9c4f9b5e1ba41603d5f9ce47fff79d6ee11adaa7                                      # [osx-64]
 
 build:
+  binary_relocation: False
   number: 0
   # If the software version starts with a 0 (e.g. 0.3.2) semantic versioning allows breaking changes in minor releases.
   # https://bioconda.github.io/contributor/linting.html#missing-run-exports
   run_exports:
-      - {{ pin_subpackage("rebar", max_pin="x.x") }}
+      - {{ pin_compatible(name, max_pin="x.x") }}      
 
 test:
   commands:

--- a/recipes/rebar/meta.yaml
+++ b/recipes/rebar/meta.yaml
@@ -16,7 +16,7 @@ build:
   # If the software version starts with a 0 (e.g. 0.3.2) semantic versioning allows breaking changes in minor releases.
   # https://bioconda.github.io/contributor/linting.html#missing-run-exports
   run_exports:
-      - {{ pin_subpackage(name, max_pin="x.x") }}
+      - {{ pin_subpackage("rebar", max_pin="x.x") }}
 
 test:
   commands:
@@ -28,8 +28,6 @@ about:
   license_family: APACHE
   license_file: LICENSE
   summary: "Genomic recombination detection using mutational barcodes."
-  doc_url: https://github.com/phac-nml/rebar
-  dev_url: https://github.com/phac-nml/rebar
 
 extra:
   maintainers:

--- a/recipes/rebar/meta.yaml
+++ b/recipes/rebar/meta.yaml
@@ -6,12 +6,10 @@ package:
   version: "{{ version }}"
 
 source:
-  - url: https://github.com/phac-nml/rebar/releases/download/{{ version }}/{{ name }}-x86_64-unknown-linux-musl       # [linux-64]
-    sha256: 7b5648b353552662c66aab8347657dfebe92ee2d83e4a4f0b7a9526c58502b28                                          # [linux-64]
-  - url: https://github.com/phac-nml/rebar/releases/download/{{ version }}/{{ name }}-x86_64-apple-darwin             # [osx-64]
-    sha256: b3577c5ea7965133fc5b934a9c4f9b5e1ba41603d5f9ce47fff79d6ee11adaa7                                          # [osx-64]
-  - url: https://github.com/phac-nml/rebar/releases/download/{{ version }}/{{ name }}-rebar-x86_64-pc-windows-gnu.exe # [win-64]
-    sha256: 2a6047a9a31e3f509878231462cdd48658f08546495e0c50b51e03d594503b66                                          # [win-64]
+  - url: https://github.com/phac-nml/rebar/releases/download/v{{ version }}/{{ name }}-x86_64-unknown-linux-musl  # [linux-64]
+    sha256: 7b5648b353552662c66aab8347657dfebe92ee2d83e4a4f0b7a9526c58502b28                                      # [linux-64]
+  - url: https://github.com/phac-nml/rebar/releases/download/v{{ version }}/{{ name }}-x86_64-apple-darwin        # [osx-64]
+    sha256: b3577c5ea7965133fc5b934a9c4f9b5e1ba41603d5f9ce47fff79d6ee11adaa7                                      # [osx-64]
 
 build:
   binary_relocation: false

--- a/recipes/rebar/meta.yaml
+++ b/recipes/rebar/meta.yaml
@@ -1,0 +1,42 @@
+{% set name = "rebar" %}
+{% set version = "0.2.0" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  - url: https://github.com/phac-nml/rebar/releases/download/{{ version }}/{{ name }}-x86_64-unknown-linux-musl       # [linux-64]
+    sha256: 7b5648b353552662c66aab8347657dfebe92ee2d83e4a4f0b7a9526c58502b28                                          # [linux-64]
+  - url: https://github.com/phac-nml/rebar/releases/download/{{ version }}/{{ name }}-x86_64-apple-darwin             # [osx-64]
+    sha256: b3577c5ea7965133fc5b934a9c4f9b5e1ba41603d5f9ce47fff79d6ee11adaa7                                          # [osx-64]
+  - url: https://github.com/phac-nml/rebar/releases/download/{{ version }}/{{ name }}-rebar-x86_64-pc-windows-gnu.exe # [win-64]
+    sha256: 2a6047a9a31e3f509878231462cdd48658f08546495e0c50b51e03d594503b66                                          # [win-64]
+
+build:
+  binary_relocation: false
+  number: 0
+  # If the software version starts with a 0 (e.g. 0.3.2) semantic versioning allows breaking changes in minor releases.
+  # https://bioconda.github.io/contributor/linting.html#missing-run-exports
+  run_exports:
+      - {{ pin_subpackage(name, max_pin="x.x") }}
+
+test:
+  commands:
+    - rebar --help
+
+about:
+  home: https://github.com/phac-nml/rebar
+  license: Apache
+  license_family: Apache
+  summary: "Genomic recombination detection using mutational barcodes."
+  doc_url: https://github.com/phac-nml/rebar
+  dev_url: https://github.com/phac-nml/rebar
+
+extra:
+  maintainers:
+    - ktmeaton
+  recipe-maintainers:
+    - ktmeaton
+  skip-lints:
+    - should_be_noarch_generic

--- a/recipes/rebar/meta.yaml
+++ b/recipes/rebar/meta.yaml
@@ -6,10 +6,10 @@ package:
   version: "{{ version }}"
 
 source:
-  - url: https://github.com/phac-nml/rebar/releases/download/v{{ version }}/{{ name }}-x86_64-unknown-linux-musl  # [linux-64]
-    sha256: 7b5648b353552662c66aab8347657dfebe92ee2d83e4a4f0b7a9526c58502b28                                      # [linux-64]
-  - url: https://github.com/phac-nml/rebar/releases/download/v{{ version }}/{{ name }}-x86_64-apple-darwin        # [osx-64]
-    sha256: b3577c5ea7965133fc5b934a9c4f9b5e1ba41603d5f9ce47fff79d6ee11adaa7                                      # [osx-64]
+  - url: https://github.com/phac-nml/rebar/releases/download/v{{ version }}/{{ name }}-x86_64-unknown-linux-musl  # [linux64]
+    sha256: 7b5648b353552662c66aab8347657dfebe92ee2d83e4a4f0b7a9526c58502b28                                      # [linux64]
+  - url: https://github.com/phac-nml/rebar/releases/download/v{{ version }}/{{ name }}-x86_64-apple-darwin        # [osx and x86_64]
+    sha256: b3577c5ea7965133fc5b934a9c4f9b5e1ba41603d5f9ce47fff79d6ee11adaa7                                      # [osx and x86_64]
 
 build:
   binary_relocation: False

--- a/recipes/rebar/run_test.sh
+++ b/recipes/rebar/run_test.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -x
+set -e
+
+rebar --version
+
+# Dataset: Toy1
+rebar dataset download --name toy1 --tag custom --output-dir dataset/toy1
+rebar run --dataset-dir dataset/toy1 --populations "*" --mask 0,0 --min-length 3 --output-dir output/toy1
+rebar plot  --run-dir output/toy1 --annotations dataset/toy1/annotations.tsv
+
+# Dataset: SARS-CoV-2
+rebar dataset download --name sars-cov-2 --tag 2023-11-30 --output-dir dataset/sars-cov-2/2023-11-30
+rebar run --dataset-dir dataset/sars-cov-2/2023-11-30  --populations "AY.4.2*,BA.5.2,XBC.1.6*,XBB.1.5.1,XBL" --output-dir output/sars-cov-2
+rebar plot --run-dir output/sars-cov-2 --annotations dataset/sars-cov-2/2023-11-30/annotations.tsv


### PR DESCRIPTION
This pull request creates a new recipe for the program [`rebar`](https://github.com/phac-nml/rebar). `rebar` is a **RE**combination **BAR**code detector, that _detects_ and _visualizes_ recombination between genomic sequences. It was designed primarily with SARS-CoV-2 in mind but has been generalized for other organisms.

`rebar` is written in Rust and I've used the [`nextclade`](https://github.com/nextstrain/bioconda-recipes/blob/f7b372627ae2f65862c03e555fd593f641633889/recipes/nextclade/meta.yaml) recipe as a template. The binaries are pre-compiled for `linux-64`, `osx-64`, and `win-64`. This is my first bioconda PR for a Rust program, so please bear with me as I update the recipe according to the CI results.