### PR TITLE
Update metabuli1.0.2

### DIFF
--- a/recipes/metabuli/meta.yaml
+++ b/recipes/metabuli/meta.yaml
@@ -7,6 +7,8 @@ package:
 
 build:
   number: 0
+  run_exports:
+    - {{ pin_subpackage('metabuli', max_pin="x") }}
 
 source:
   url: https://github.com/steineggerlab/metabuli/archive/{{ version }}.tar.gz

--- a/recipes/metabuli/meta.yaml
+++ b/recipes/metabuli/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "1.0.1" %}
-{% set sha256 = "544926b73e7e0ed7c34d5f4f76e78e483261e5b13db6a6bb45217551bce1fae0" %}
+{% set version = "1.0.2" %}
+{% set sha256 = "cf5c74a7aa585457c0014614e59cf850aaacfab03f326e6113466fa2b436d2c2" %}
 
 package:
   name: metabuli
@@ -45,3 +45,4 @@ about:
 extra:
   recipe-maintainers:
     - milot-mirdita
+    - jaebeom-kim


### PR DESCRIPTION
### v1.0.2
- `--accession-level` option for `build` and `classify` workflow: It reports not only the taxon but also the accession of the best match.
- Fix minor bugs in `build` workflow.
- Generate `taxonomyDB` during `build` and load it during `classify` workflow for faster loading of taxonomy information.
- Support gzipped FASTA/FASTQ files in `add-to-library` and `classify` workflows.
- low-complexity filtering in `build` workflow as default with `--mask-prob 0.9`.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
