### PR TITLE
mob_suite v3.1.8 manual recipe submit

### DIFF
--- a/recipes/mob_suite/meta.yaml
+++ b/recipes/mob_suite/meta.yaml
@@ -32,7 +32,7 @@ requirements:
     - python >=3.7
     - {{ pin_compatible('numpy', max_pin="x") }}
     - pytables
-    - pandas >=0.22.0,<=1.0.5
+    - pandas >=0.22.0,<2
     - biopython >=1.8,<2
     - {{ pin_compatible('pycurl') }}
     - {{ pin_compatible('scipy') }}


### PR DESCRIPTION
Release for mob_suite v.3.1.8 as automatic version bump failed by the bot. Please close [PR#44753](https://github.com/bioconda/bioconda-recipes/pull/44753). 