### PR TITLE
Update bbknn to 1.6.0

### DIFF
--- a/build-fail-blacklist
+++ b/build-fail-blacklist
@@ -1061,10 +1061,6 @@ recipes/d4binding
 # maturin build fails
 recipes/taxonomy
 
-# from numba.np.ufunc import _internal
-# SystemError: initialization of _internal failed without raising an exception
-recipes/bbknn
-
 # no matching package named `quickersort` found
 recipes/mudskipper
 

--- a/recipes/bbknn/meta.yaml
+++ b/recipes/bbknn/meta.yaml
@@ -26,6 +26,7 @@ requirements:
     - numpy >=1.13
     - pip
     - python
+    - flit-core >=3.2,<4
     - scipy >=1.6.0
     - scikit-learn >=1.0.2
     - umap-learn

--- a/recipes/bbknn/meta.yaml
+++ b/recipes/bbknn/meta.yaml
@@ -10,9 +10,11 @@ source:
   sha256: 1c01a9d6df2fc52a527de8a403617897a4b672724863299a7026f2132f1b041b 
 
 build:
-  number: 3
-  skip: true  # [py2k or py == 310]
+  number: 0
+  skip: true  # [py2k]
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv "
+  run_exports:
+    - {{ pin_subpackage('bbknn', max_pin="x") }}
 
 requirements:
   build:

--- a/recipes/bbknn/meta.yaml
+++ b/recipes/bbknn/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "bbknn" %} 
-{% set version = "1.5.1" %}
+{% set version = "1.6.0" %}
 
 package:
   name: "{{ name|lower }}"
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 16da9c778ddfe363f8a3fa0d72707694d2217f94d3a87482336e8a2c6beb2160 
+  sha256: 1c01a9d6df2fc52a527de8a403617897a4b672724863299a7026f2132f1b041b 
 
 build:
   number: 3
@@ -24,19 +24,18 @@ requirements:
     - numpy >=1.13
     - pip
     - python
-    - scipy
-    - scikit-learn
+    - scipy >=1.6.0
+    - scikit-learn >=1.0.2
     - umap-learn
-    - packaging
+    - pandas
   run:
     - python
     - python-annoy
     - pynndescent
     - numpy >=1.13
-    - scipy
-    - scikit-learn
+    - scipy >=1.6.0
+    - scikit-learn >=1.0.2
     - umap-learn
-    - packaging
     - pandas
 
 test:


### PR DESCRIPTION
Someone else contributed a package I wrote to conda (many thanks for that!). I've since released a new version, and have taken a stab at updating the recipe to match current dependencies, versions, and the hash.