### PR TITLE
Update cogent3 recipe to version 2023 12 15a1

### DIFF
--- a/recipes/cogent3/meta.yaml
+++ b/recipes/cogent3/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "cogent3" %}
-{% set version = "2023.9.22a1" %}
+{% set version = "2023.12.15a1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: b842df9ca55f9bb8bcc4d66787ddf25afd796f88d22663c3d14c0954c115ffcb
+  sha256: 8cccfdb39aff746c9225b1e063a6506502c840276c843bcb93fea10bb2f31bfb
 
 build:
   noarch: python

--- a/recipes/cogent3/meta.yaml
+++ b/recipes/cogent3/meta.yaml
@@ -18,15 +18,15 @@ build:
 
 requirements:
   host:
-    - python >=3.8, <3.12
+    - python >=3.9, <3.12
     - pip
     - flit-core >=3.2, <4
   run:
-    - python >=3.8, <3.12
+    - python >=3.9, <3.12
     - scipy
     - chardet
     - numpy
-    - numba >0.48.0
+    - numba >0.53.0
     - scitrack
     - tqdm
     - tinydb


### PR DESCRIPTION
Updating bioconda autobump to include changes to minimum supported python release, and numba

NB: Max python support is constrained by most recent numba release
----

