### PR TITLE
Mob_suite v3.1.8 build 1 due to restrict pandas to <=1.5.3

### DIFF
--- a/recipes/mob_suite/meta.yaml
+++ b/recipes/mob_suite/meta.yaml
@@ -12,7 +12,7 @@ source:
   
 
 build:
-  number: 0
+  number: 1
   noarch: python
   run_exports:
     - {{ pin_subpackage(name, max_pin="x") }}
@@ -31,12 +31,12 @@ requirements:
   run:
     - python >=3.7
     - {{ pin_compatible('numpy', max_pin="x") }}
+    - pandas >=0.22,<=1.5.3
     - pytables
-    - pandas >=0.22.0,<2
     - biopython >=1.8,<2
     - {{ pin_compatible('pycurl') }}
     - {{ pin_compatible('scipy') }}
-    - ete3 >=3.1.3
+    - ete3 ==3.1.3
     - six
     - blast >=2.9.0
     - mash >=2.0
@@ -44,10 +44,13 @@ requirements:
 test:
   imports:
     - mob_suite
+  requires:
+    - pytest 
   commands:
     - mob_recon --help
     - mob_cluster --help
     - mob_typer --help
+    - mob_init --help
 
 about:
   home: 'https://pypi.org/project/mob-suite/'

--- a/recipes/mob_suite/run_test.sh
+++ b/recipes/mob_suite/run_test.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+pytest --pyargs mob_suite.tests.test_mobrecon::test_mob_recon_typical_run


### PR DESCRIPTION
Since pandas v1.5.0 the `line_separator` parameter is deprecated  in `df.to_csv()` so we need to restrict pandas version to <2. Hence the new build for the same version 3.1.8. Addressing issue https://github.com/phac-nml/mob-suite/issues/155