### PR TITLE
add r-misha 3.7.0 (history version)

### DIFF
--- a/recipes/r-misha/3.7.0/build.sh
+++ b/recipes/r-misha/3.7.0/build.sh
@@ -1,0 +1,1 @@
+$R CMD INSTALL --build .

--- a/recipes/r-misha/3.7.0/build.sh
+++ b/recipes/r-misha/3.7.0/build.sh
@@ -1,1 +1,2 @@
+sed -i 's/CC=g++/CC=\$(CXX)/' src/Makefile
 $R CMD INSTALL --build .

--- a/recipes/r-misha/3.7.0/meta.yaml
+++ b/recipes/r-misha/3.7.0/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: 'https://github.com/tanaylab/misha/archive/{{ commit }}.zip'
-  sha256: 304d33bb514e3532cedbf451e189d5367cc80bdce86462b4426f8f3cc4809391
+  sha256: a27885729422368972734cf7a657a0a4f8abada8aa5728cb9a4ac745f3184d5a
 
 build:
   # https://github.com/tanaylab/misha/issues/9

--- a/recipes/r-misha/3.7.0/meta.yaml
+++ b/recipes/r-misha/3.7.0/meta.yaml
@@ -21,6 +21,7 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - sed
   host:
     - r-base
     - r-devtools

--- a/recipes/r-misha/3.7.0/meta.yaml
+++ b/recipes/r-misha/3.7.0/meta.yaml
@@ -1,0 +1,41 @@
+{% set version = "3.7.0" %}
+{% set commit = "fb45473ac27833154724bac04136c601e7b2a6f0" %}
+
+package:
+  name: 'r-misha'
+  version: '{{ version }}'
+
+source:
+  url: 'https://github.com/tanaylab/misha/archive/{{ commit }}.zip'
+  sha256: 304d33bb514e3532cedbf451e189d5367cc80bdce86462b4426f8f3cc4809391
+
+build:
+  # https://github.com/tanaylab/misha/issues/9
+  skip: True  # [osx]
+  number: 0
+  rpaths:
+    - lib/R/lib
+    - lib/
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+  host:
+    - r-base
+    - r-devtools
+  run:
+    - r-base
+
+test:
+  commands:
+    - '$R -e "library(misha)"'
+
+about:
+  home: 'https://tanaylab.github.io/misha/index.html'
+  license: GPL-2
+  summary: 'Toolkit for analysis of genomic data'
+
+extra:
+  maintainers:
+    - Misha Hoichman <misha@hoichman.com>

--- a/recipes/r-misha/3.7.0/meta.yaml
+++ b/recipes/r-misha/3.7.0/meta.yaml
@@ -1,8 +1,9 @@
 {% set version = "3.7.0" %}
+{% set name = "r-misha" %}
 {% set commit = "fb45473ac27833154724bac04136c601e7b2a6f0" %}
 
 package:
-  name: 'r-misha'
+  name: "{{ name|lower }}"
   version: '{{ version }}'
 
 source:

--- a/recipes/r-misha/3.7.0/meta.yaml
+++ b/recipes/r-misha/3.7.0/meta.yaml
@@ -17,6 +17,8 @@ build:
   rpaths:
     - lib/R/lib
     - lib/
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x") }}
 
 requirements:
   build:


### PR DESCRIPTION
The package `r-misha` has only versions 4.x available in bioconda, but in our case seems some package like `umi4cpackage` depends on misha 3.x. so I found misha history version (not tagged) in github repo and created this pr.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
