### PR TITLE
fix bioconductor-lpsymphony

### DIFF
--- a/recipes/bioconductor-lpsymphony/meta.yaml
+++ b/recipes/bioconductor-lpsymphony/meta.yaml
@@ -30,6 +30,7 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - {{ compiler('fortran') }}
     - automake
     - make
 test:


### PR DESCRIPTION
Adds fortran to build bioconductor-lpsymphony, addressing https://github.com/bioconda/bioconda-recipes/wiki/build-failures-bulk