### PR TITLE
Rebuild unitig caller for new bifrost version

### DIFF
--- a/recipes/unitig-caller/meta.yaml
+++ b/recipes/unitig-caller/meta.yaml
@@ -16,6 +16,8 @@ build:
   skip: True  # [py27]
   entry_points:
     - unitig-caller = unitig_caller.__main__:main
+  run_exports:
+    - {{ pin_subpackage({{ name|lower }}, max_pin="x.x") }}
 
 requirements:
   build:

--- a/recipes/unitig-caller/meta.yaml
+++ b/recipes/unitig-caller/meta.yaml
@@ -17,7 +17,7 @@ build:
   entry_points:
     - unitig-caller = unitig_caller.__main__:main
   run_exports:
-    - {{ pin_subpackage({{ name|lower }}, max_pin="x.x") }}
+    - {{ pin_subpackage(name, max_pin="x.x") }}
 
 requirements:
   build:

--- a/recipes/unitig-caller/meta.yaml
+++ b/recipes/unitig-caller/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 0001-No-experimental.patch
 
 build:
-  number: 2
+  number: 3
   skip: True  # [py27]
   entry_points:
     - unitig-caller = unitig_caller.__main__:main
@@ -29,12 +29,12 @@ requirements:
     - pybind11
     - zlib
     - bzip2
-    - bifrost >=1.2.0
+    - bifrost >=1.3.0
     - libgomp      # [linux64]
     - llvm-openmp  # [osx]
   run:
     - python
-    - bifrost >=1.2.0
+    - bifrost >=1.3.0
 
 test:
   imports:


### PR DESCRIPTION
New bifrost versions 1.3.0 have breaking changes, rebuilding library to use correct functions

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
