### PR TITLE
Update RiboDetector meta.yaml

### DIFF
--- a/recipes/ribodetector/meta.yaml
+++ b/recipes/ribodetector/meta.yaml
@@ -21,9 +21,9 @@ build:
 requirements:
   host:
     - pip
-    - python >=3.8,<=3.10
+    - python ==3.8
   run:
-    - python >=3.8,<=3.10
+    - python ==3.8
     - pandas
     - numpy
     - tqdm


### PR DESCRIPTION
Hi, 
I fixed the required version of python since 3.9 and 3.10 seems to have a problem with multi-threadings:

See:


https://github.com/hzi-bifo/RiboDetector/issues/46

Luca 