### PR TITLE
Update igblast to 1.22.0

### DIFF
--- a/recipes/igblast/build.sh
+++ b/recipes/igblast/build.sh
@@ -13,37 +13,17 @@ mkdir -p $PREFIX/bin
 mkdir -p $SHARE_DIR/bin
 
 if [[ $(uname) == Linux ]]; then
-    export CPPFLAGS="$CPPFLAGS -I$PREFIX/include/ncbi-vdb"
-    export CC_FOR_BUILD=$CC
     export AR="$AR rcs"
 
     cd c++
 
-    # IgBLAST is based on the BLAST source code and building it produces
-    # a similar set of shared libraries if --with-dll is used. To avoid
-    # conflicts when installing IgBLAST and BLAST simultaneously,
-    # we link IgBLAST statically.
-    ./configure.orig \
-        --with-static-exe \
-        --with-mt \
-        --with-openmp \
-        --without-autodep \
-        --without-makefile-auto-update \
-        --with-flat-makefile \
-        --with-caution \
-        --without-lzo \
-        --without-debug \
-        --with-strip \
-        --with-z=$PREFIX \
-        --with-bz2=$PREFIX \
-        --with-vdb=$PREFIX \
-        --without-krb5 \
-        --without-openssl \
-        --without-gnutls \
-        --without-gcrypt \
-        --with-build-root=ReleaseMT \
-        --prefix=$PREFIX
+    ./configure \
+         --with-z=$PREFIX \
+         --with-bz2=$PREFIX \
+         --with-vdb=$PREFIX
+
     make -j2
+
     # Move one up so it looks like the binary release
     mv ReleaseMT/bin .
     mv src/app/igblast/{internal_data,optional_file} $SHARE_DIR

--- a/recipes/igblast/meta.yaml
+++ b/recipes/igblast/meta.yaml
@@ -43,6 +43,7 @@ requirements:
     - gnutls  # [osx]
     - libidn11
     - lzo # [osx]
+    - libsqlite >=3
     - ncbi-vdb >=2.9.6
   run:
     - ncbi-vdb >=2.9.6

--- a/recipes/igblast/meta.yaml
+++ b/recipes/igblast/meta.yaml
@@ -28,6 +28,8 @@ source:
 
 build:
   number: 0
+  run_exports:
+  - {{ pin_subpackage('igblast', max_pin="x") }}
 
 requirements:
   build:

--- a/recipes/igblast/meta.yaml
+++ b/recipes/igblast/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.21.0" %}
+{% set version = "1.22.0" %}
 
 package:
   name: igblast
@@ -20,14 +20,14 @@ about:
 
 source:
   url: ftp://ftp.ncbi.nih.gov/blast/executables/igblast/release/{{ version }}/ncbi-igblast-{{ version }}-src.tar.gz  # [linux]
-  sha256: f679a417b170e96103c088a9d1e82bfd40571526080da00fdf62de74aee82d16 # [linux]
+  sha256: a04eb195087447cf42e673401ae2d9f6ef8414b34f1534724a6953f41224df68 # [linux]
   url: ftp://ftp.ncbi.nih.gov/blast/executables/igblast/release/{{ version }}/ncbi-igblast-{{ version }}-x64-macosx.tar.gz  # [osx]
-  sha256: 9d8f13a7ab3b2ab42df3565cdf3b480bd9c04fb0ffb1d54834e67fa37d4fc09b # [osx]
+  sha256: b8a0034642b5dbef7f41c7fcfbb4bc035d2c5877d3e987af43605ea8e3d55c40 # [osx]
   patches:
     - shared_vdb.patch  # [linux]
 
 build:
-  number: 1
+  number: 0
 
 requirements:
   build:

--- a/recipes/igblast/shared_vdb.patch
+++ b/recipes/igblast/shared_vdb.patch
@@ -1,12 +1,11 @@
-diff -u -ru ncbi-igblast-1.15.0-src/c++/src/app/igblast/Makefile.igblastn.app ncbi-igblast-1.15.0-src-patched/c++/src/app/igblast/Makefile.igblastn.app
---- ncbi-igblast-1.15.0-src/c++/src/app/igblast/Makefile.igblastn.app	2019-08-04 23:12:21.000000000 +0200
-+++ ncbi-igblast-1.15.0-src-patched/c++/src/app/igblast/Makefile.igblastn.app	2020-02-19 14:30:43.571473876 +0100
-@@ -11,7 +11,7 @@
- CXXFLAGS = $(FAST_CXXFLAGS:ppc=i386)
+--- ncbi-igblast-1.22.0-src/c++/src/app/igblast/Makefile.igblastn.app	2023-10-06 15:33:05.000000000 -0400
++++ ncbi-igblast-1.22.0-src-patched/c++/src/app/igblast/Makefile.igblastn.app	2024-01-10 11:35:41.231820985 -0500
+@@ -12,7 +12,7 @@
  LDFLAGS  = $(FAST_LDFLAGS:ppc=i386)
  
--LIBS = $(GENBANK_THIRD_PARTY_LIBS) $(VDB_STATIC_LIBS) $(CMPRS_LIBS) $(DL_LIBS) $(NETWORK_LIBS) $(BLAST_THIRD_PARTY_LIBS) $(ORIG_LIBS)
-+LIBS = $(GENBANK_THIRD_PARTY_LIBS) $(VDB_LIBS) $(CMPRS_LIBS) $(DL_LIBS) $(NETWORK_LIBS) $(BLAST_THIRD_PARTY_LIBS) $(ORIG_LIBS)
+ LIBS = $(BLAST_THIRD_PARTY_LIBS) $(GENBANK_THIRD_PARTY_LIBS) \
+-       $(VDB_STATIC_LIBS) $(CMPRS_LIBS) $(DL_LIBS) $(NETWORK_LIBS) $(ORIG_LIBS)
++       $(VDB_LIBS) $(CMPRS_LIBS) $(DL_LIBS) $(NETWORK_LIBS) $(ORIG_LIBS)
  
  REQUIRES = VDB objects -Cygwin
  


### PR DESCRIPTION
Updates igblast from 1.21.0 to 1.22.0.

I updated the `shared_vdb.patch` file to account for a now-wrapped line in the original source, but other than confirming that it should patch correctly I don't know any details about that patch.  I also defined `run_exports` in the `meta.yaml` to use `max_pin="x"` following the [linter's advice](https://bioconda.github.io/contributor/linting.html#missing-run-exports) (as far as I can tell igblast seems to follow semantic versioning).