### PR TITLE
snakemake: Pin pulp to <2.8, bump build number

### DIFF
--- a/recipes/snakemake/meta.yaml
+++ b/recipes/snakemake/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 767e165b9803a3eb91d50e5f7d4410f537f3f1db102c99fcc97a9b40371cd46a
 
 build:
-  number: 0
+  number: 1
   noarch: generic
   run_exports:
     - {{ pin_subpackage("snakemake", max_pin="x") }}
@@ -96,7 +96,7 @@ outputs:
         - nbformat
         - packaging
         - psutil
-        - pulp >=2.0
+        - pulp >=2.0,pulp<2.8 # https://github.com/snakemake/snakemake/issues/2607
         - pyyaml
         - requests >=2.8.1
         - reretry

--- a/recipes/snakemake/meta.yaml
+++ b/recipes/snakemake/meta.yaml
@@ -96,7 +96,7 @@ outputs:
         - nbformat
         - packaging
         - psutil
-        - pulp >=2.0,pulp<2.8 # https://github.com/snakemake/snakemake/issues/2607
+        - pulp >=2.0,<2.8 # https://github.com/snakemake/snakemake/issues/2607
         - pyyaml
         - requests >=2.8.1
         - reretry


### PR DESCRIPTION
See https://github.com/snakemake/snakemake/issues/2607

