### PR TITLE
Update deepvariant dependency versions

### DIFF
--- a/recipes/deepvariant/meta.yaml
+++ b/recipes/deepvariant/meta.yaml
@@ -19,7 +19,7 @@ source:
   sha256: '{{ sha256 }}'
 
 build:
-  number: 0
+  number: 1
   skip: true  # [osx or not py36]
 
 requirements:
@@ -33,8 +33,9 @@ requirements:
     # - google-cloud-sdk
     # - bazel
   run:
+    # NB: maintainers, check versions with upstream's settings.sh
     - openjdk >=8,<9
-    - python 3.6.*
+    - python 3.8.*
     # TF slim is difficult because there is an existing tf-slim package in conda-forge
     # https://github.com/conda-forge/tf-slim-feedstock
     # which is different than the google one: https://github.com/google-research/tf-slim
@@ -48,14 +49,14 @@ requirements:
     - htslib
     - numpy
     - curl
-    - tensorflow-gpu 2.0.*
-    - tensorflow-estimator 2.0.*
+    - tensorflow-gpu 2.11.*
+    - tensorflow-estimator 2.11.*
     - protobuf
     - contextlib2
     - enum34
     - intervaltree
     - mock
-    - numpy 1.16.*
+    - numpy 1.19.*
     - psutil
     - requests
     - scipy

--- a/recipes/deepvariant/meta.yaml
+++ b/recipes/deepvariant/meta.yaml
@@ -21,6 +21,8 @@ source:
 build:
   number: 1
   skip: true  # [osx or not py36]
+  run_exports:
+    - {{ pin_subpackage("deepvariant", max_pin="x") }}
 
 requirements:
   host:


### PR DESCRIPTION
The deepvariant package pins out-of-date tensorflow versions. The upstream built against 2.11, and we pin 2.0.XXX which is no longer available, making the package uninstallable.

Also added a run-exports section