### PR TITLE
Update haptools to 0.4.0

### DIFF
--- a/recipes/haptools/meta.yaml
+++ b/recipes/haptools/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "haptools" %}
-{% set version = "0.3.0" %}
+{% set version = "0.4.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/haptools-{{ version }}.tar.gz
-  sha256: 9ecb9891ce01bb91c460426e1f94d4e939a0465e13529f3ec3d122f9b2c3ee77
+  sha256: 85dba0bde58e33ac71c298eb37e1272ca83276d06714d6516f8bc722c3455fe0
 
 build:
   number: 0
@@ -22,21 +22,25 @@ requirements:
   host:
     - pip >=19.0.3
     - poetry-core >=1.0.0
-    - python >=3.7,<3.11
+    - python >=3.7,<4.0
   run:
     - click >=8.0.3
     - cyvcf2 >=0.30.14
     - matplotlib-base >=3.5.1
     - numpy >=1.20.0
+    - pgenlib >=0.90.1
     - pysam >=0.19.0
-    - python >=3.7,<3.11
+    - python >=3.7,<4.0
 
 test:
   imports:
     - haptools
     - haptools.data
   commands:
+    - pip check
     - haptools --help
+  requires:
+    - pip
 
 about:
   home: https://github.com/cast-genomics/haptools


### PR DESCRIPTION
Closes https://github.com/bioconda/bioconda-recipes/pull/45224

Update [`haptools`](https://bioconda.github.io/recipes/haptools/README.html): **0.3.0** → **0.4.0**

Please merge this PR instead of #45224. We added a new dependency and changed some of the version constraints for python to support 3.11+

----

`haptools` is a collection of tools for simulating and analyzing genotypes and phenotypes while taking into account haplotype and ancestry information

https://pypi.org/project/haptools/
https://github.com/CAST-genomics/haptools