### PR TITLE
Update infernal 1.1.5

### DIFF
--- a/recipes/infernal/build.sh
+++ b/recipes/infernal/build.sh
@@ -2,9 +2,16 @@
 
 set -ex
 
+NAME=infernal
+VERSION=1.1.5
+TAG="${NAME}-${VERSION}"
+
 grep -l -r "/usr/bin/perl" . | xargs sed -i.bak -e 's/usr\/bin\/perl/usr\/bin\/env perl/g'
 
+git clone --depth 1 -b $TAG https://github.com/EddyRivasLab/hmmer
+git clone --depth 1 -b $TAG https://github.com/EddyRivasLab/easel
 
+autoreconf
 ./configure --prefix=$PREFIX
 make -j 2
 make check

--- a/recipes/infernal/build.sh
+++ b/recipes/infernal/build.sh
@@ -11,7 +11,7 @@ grep -l -r "/usr/bin/perl" . | xargs sed -i.bak -e 's/usr\/bin\/perl/usr\/bin\/e
 git clone --depth 1 -b $TAG https://github.com/EddyRivasLab/hmmer
 git clone --depth 1 -b $TAG https://github.com/EddyRivasLab/easel
 
-autoreconf
+autoreconf -i
 ./configure --prefix=$PREFIX
 make -j 2
 make check

--- a/recipes/infernal/meta.yaml
+++ b/recipes/infernal/meta.yaml
@@ -19,6 +19,7 @@ requirements:
     - {{ compiler('c') }}
     - make
     - autoconf
+    - automake
   host:
     - perl
   run:

--- a/recipes/infernal/meta.yaml
+++ b/recipes/infernal/meta.yaml
@@ -16,8 +16,9 @@ build:
 
 requirements:
   build:
-    - make
     - {{ compiler('c') }}
+    - make
+    - autoconf
   host:
     - perl
   run:

--- a/recipes/infernal/meta.yaml
+++ b/recipes/infernal/meta.yaml
@@ -1,15 +1,16 @@
-{% set version = "1.1.4" %}
+{% set name = "vadr" %}
+{% set version = "1.1.5" %}
 
 package:
-  name: infernal
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: http://eddylab.org/infernal/infernal-{{ version }}.tar.gz
-  sha256: f9493c7dee9fbf25f6405706818883d24b9f5e455121a0662c96c8f0307f95fc
+  url: https://github.com/EddyRivasLab/{{ name }}/archive/refs/tags/{{ name }}-{{ version }}.tar.gz
+  sha256: 24932a7a690a7ba391f4fec202550ee03d7e973cc94e423082121cfa0e483cb4
 
 build:
-  number: 4
+  number: 0
 
 requirements:
   build:

--- a/recipes/infernal/meta.yaml
+++ b/recipes/infernal/meta.yaml
@@ -1,4 +1,4 @@
-{% set name = "vadr" %}
+{% set name = "infernal" %}
 {% set version = "1.1.5" %}
 
 package:

--- a/recipes/infernal/meta.yaml
+++ b/recipes/infernal/meta.yaml
@@ -11,6 +11,8 @@ source:
 
 build:
   number: 0
+  run_exports:
+    - {{ pin_subpackage('infernal', max_pin="x") }}
 
 requirements:
   build:


### PR DESCRIPTION
This PR updates Infernal to 1.1.5 and changes the source URL from http://eddylab.org/infernal/ to the GitHub repo at https://github.com/EddyRivasLab/infernal so that new versions can be handled by the BiocondaBot autobump functionality.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
