### PR TITLE
Update hostile to 1.0.0, add new dep, update DOI

### DIFF
--- a/recipes/hostile/meta.yaml
+++ b/recipes/hostile/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.4.0" %}
+{% set version = "1.0.0" %}
 
 package:
   name: hostile
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/h/hostile/hostile-{{ version }}.tar.gz
-  sha256: dd003b09a7f17a8fc126bc81c2b402d1ab5946916f1f55dbcffa4c9c3014a56a
+  sha256: abe985acf384703ff482d5712cc4b3367e7f777818a66cbd389e7bfc6c6ac76a
 
 build:
   noarch: python
@@ -25,6 +25,7 @@ requirements:
   run:
     - bowtie2 ==2.4.5
     - defopt >=6.4.0
+    - dnaio >=1.2.0
     - gawk >=5.1.0
     - httpx >=0.24.1
     - minimap2 >=2.26
@@ -50,4 +51,4 @@ about:
 
 extra:
   identifiers:
-    - doi:10.1101/2023.07.04.547735
+    - doi:10.1093/bioinformatics/btad728


### PR DESCRIPTION
This replaces the autobump PR for version `1.0.0` which is missing a new dependency (https://github.com/bioconda/bioconda-recipes/pull/45351)