### PR TITLE
Update thapbi-pict 1.0.6

### DIFF
--- a/recipes/thapbi-pict/meta.yaml
+++ b/recipes/thapbi-pict/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "thapbi-pict" %}
-{% set version = "1.0.5" %}
+{% set version = "1.0.6" %}
 
 package:
   name: "{{ name|lower }}"
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name | replace("-", "_") }}/{{ name | replace("-", "_") }}-{{ version }}.tar.gz
-  sha256: c7e42668397ac37b869b2c5774e721635e892ebb99eefc014d634b090d9f7c08
+  sha256: a80cc24cce224195e5f613353cfe63020daca949defea4511cef392b7a6f30ed
 
 build:
   noarch: python
@@ -21,18 +21,18 @@ build:
 requirements:
   host:
     - pip
-    - python >=3.7
+    - python >=3.8
   run:
     # Python
     - biom-format >=2.1.14
-    - biopython >=1.73
+    - biopython >=1.82
     - cutadapt >=4.0
     - matplotlib-base >=3.7
     - networkx >=2.4,!=2.8.3,!=2.8.4
     - pydot
-    - python >=3.7
+    - python >=3.8
     - rapidfuzz >=2.4.0
-    - sqlalchemy
+    - sqlalchemy >=2.0
     - xlsxwriter
     # Command line
     - blast


### PR DESCRIPTION
Assorted dependency updates as has some basic type annotations - indirectly now needs at least Python 3.8

----

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
