### PR TITLE
Update linearfold to 1.0.1.dev20220829

### DIFF
--- a/recipes/linearfold/0001-FIX-command-broken-with-symbolic-link.patch
+++ b/recipes/linearfold/0001-FIX-command-broken-with-symbolic-link.patch
@@ -1,25 +1,13 @@
-From bb95a8f98b874fb9061c5ee1b3178f4d40f96416 Mon Sep 17 00:00:00 2001
-From: Fabien Pertuy <Fabien.Pertuy@Sanofi.com>
-Date: Fri, 21 May 2021 09:23:34 +0000
-Subject: [PATCH] FIX command broken with symbolic link
-
----
- linearfold | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
-
 diff --git a/linearfold b/linearfold
-index f5541d2..2c86b63 100755
+index fca4a30..7e68544 100755
 --- a/linearfold
 +++ b/linearfold
-@@ -28,7 +28,7 @@ def main():
-     zuker_subopt = '1' if FLAGS.zuker else '0'
-     delta = str(FLAGS.delta)
+@@ -38,7 +38,7 @@ def main():
+         
+     dangles = str(FLAGS.dangles)    
  
 -    path = os.path.dirname(os.path.abspath(__file__))
 +    path = os.path.dirname(os.path.realpath(__file__))
-     cmd = ["%s/%s" % (path, ('bin/linearfold_v' if use_vienna else 'bin/linearfold_c')), beamsize, is_sharpturn, is_verbose, is_eval, is_constraints, zuker_subopt, delta]
+     cmd = ["%s/%s" % (path, ('bin/linearfold_v' if use_vienna else 'bin/linearfold_c')), beamsize, is_sharpturn, is_verbose, is_eval, is_constraints, zuker_subopt, delta, shape_file_path, is_fasta, dangles]
      subprocess.call(cmd, stdin=sys.stdin)
      
--- 
-2.30.2
-

--- a/recipes/linearfold/meta.yaml
+++ b/recipes/linearfold/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "LinearFold" %}
 {% set git_sha1 = "c3ee9bd80c06c2fc39a7bb7ae5e77b9566227cac" %}
-{% set version = "1.0.1.dev20220829+git." + git_sha1 %}
+{% set version = "1.0.1.dev20220829" %}
 {% set sha256 = "cad8b93ba961820ca3701a1d931944bd307b1d1f92d74e1b02d5bd34d4ffe998" %}
 
 package:

--- a/recipes/linearfold/meta.yaml
+++ b/recipes/linearfold/meta.yaml
@@ -1,18 +1,18 @@
 {% set name = "LinearFold" %}
-{% set version = "1.0" %}
-{% set sha256 = "2ae56b5f183472c2de96782e770a91e57f82e0ab511dfc0d9d612aa4e6155f60" %}
+{% set git_sha1 = "c3ee9bd80c06c2fc39a7bb7ae5e77b9566227cac" %}
+{% set version = "1.0.1.dev20220829+git." + git_sha1 %}
 
 package:
   name: {{ name | lower }}
   version: {{ version }}
 
 build:
-  number: 3
+  number: 0
   skip: True  # [osx]
 
 source:
-  url: https://github.com/{{ name }}/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  git_url: https://github.com/{{ name }}/{{ name }}.git
+  git_rev: {{ git_sha1 }}
   patches:
     - 0001-FIX-command-broken-with-symbolic-link.patch
 
@@ -23,7 +23,7 @@ requirements:
 
   run:
     - python-gflags
-    - python=2.7
+    - python >=3,<4
 
 test:
   source_files:

--- a/recipes/linearfold/meta.yaml
+++ b/recipes/linearfold/meta.yaml
@@ -9,6 +9,8 @@ package:
 build:
   number: 0
   skip: True  # [osx]
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x.x.x") }}
 
 source:
   git_url: https://github.com/{{ name }}/{{ name }}.git

--- a/recipes/linearfold/meta.yaml
+++ b/recipes/linearfold/meta.yaml
@@ -1,6 +1,7 @@
 {% set name = "LinearFold" %}
 {% set git_sha1 = "c3ee9bd80c06c2fc39a7bb7ae5e77b9566227cac" %}
 {% set version = "1.0.1.dev20220829+git." + git_sha1 %}
+{% set sha256 = "cad8b93ba961820ca3701a1d931944bd307b1d1f92d74e1b02d5bd34d4ffe998" %}
 
 package:
   name: {{ name | lower }}
@@ -10,11 +11,11 @@ build:
   number: 0
   skip: True  # [osx]
   run_exports:
-    - {{ pin_subpackage(name, max_pin="x.x.x") }}
+    - {{ pin_subpackage(name | lower, max_pin="x.x.x") }}
 
 source:
-  git_url: https://github.com/{{ name }}/{{ name }}.git
-  git_rev: {{ git_sha1 }}
+  url: https://github.com/{{ name }}/{{ name }}/archive/{{ git_sha1 }}.tar.gz
+  sha256: {{ sha256 }}
   patches:
     - 0001-FIX-command-broken-with-symbolic-link.patch
 


### PR DESCRIPTION
This is a release from the last commit on github from 2022-08-29, git-sha1 c3ee9bd80c06c2fc39a7bb7ae5e77b9566227cac to fix issues with the currently released version.

Changes since the last release 1.0 (my summary):
- driver script works with python3
- fixes for dangles
- SHAPE support
- other bugfixes

All upstream releases require python2 for the driver script, making it difficult to use the package with other packages depending on python3.

Upstream issue:

https://github.com/LinearFold/LinearFold/issues/14
