### PR TITLE
Update scanpy-scripts: require anndata >=0.8.0 (previously unversioned)

### DIFF
--- a/recipes/scanpy-scripts/meta.yaml
+++ b/recipes/scanpy-scripts/meta.yaml
@@ -16,7 +16,7 @@ source:
       - scrublet.patch
 
 build:
-  number: 0
+  number: 1
   noarch: python
   entry_points:
     - scanpy-cli=scanpy_scripts.cli:cli

--- a/recipes/scanpy-scripts/meta.yaml
+++ b/recipes/scanpy-scripts/meta.yaml
@@ -48,7 +48,7 @@ requirements:
     - pytoml
     - packaging
   run:
-    - anndata
+    - anndata>=0.8.0
     - bbknn>=1.5.0
     - click<8
     - fa2

--- a/recipes/scanpy-scripts/meta.yaml
+++ b/recipes/scanpy-scripts/meta.yaml
@@ -18,6 +18,8 @@ source:
 build:
   number: 1
   noarch: python
+  run_exports:
+    - {{ pin_subpackage('scanpy-scripts', max_pin="x.x") }}
   entry_points:
     - scanpy-cli=scanpy_scripts.cli:cli
     - scanpy-read-10x=scanpy_scripts.cmds:READ_CMD

--- a/recipes/scanpy-scripts/meta.yaml
+++ b/recipes/scanpy-scripts/meta.yaml
@@ -48,21 +48,21 @@ requirements:
     - pytoml
     - packaging
   run:
-    - anndata>=0.8.0
-    - bbknn>=1.5.0
-    - click<8
+    - anndata >=0.8.0
+    - bbknn >=1.5.0
+    - click <8
     - fa2
-    - h5py<3.0.0
-    - harmonypy>=0.0.5
+    - h5py <3.0.0
+    - harmonypy >=0.0.5
     - leidenalg
     - loompy
     - louvain
     - matplotlib-base
-    - mnnpy>=0.1.9.5
+    - mnnpy >=0.1.9.5
     - packaging
     - pandas
-    - python>=3.6
-    - scanpy=1.8.1
+    - python >=3.6
+    - scanpy =1.8.1
     - scikit-misc
     - scipy 
     - scrublet


### PR DESCRIPTION
Added a requirement of AnnData >=0.8.0 (previously unversioned) for scanpy-scripts. I have incremented build version from 0=>1.

AnnData objects saved with > 0.8.0 (Mar 2022) are not backwards compatible with objects saved with current AnnData versions (e.g. current 0.10.5) https://anndata.readthedocs.io/en/latest/release-notes/index.html#version-0-8
Scanpy and scanpy-scripts will work in isolation with either version, but when data objects are shared between tools, issues arise. 

I expect for most users/builds this will not affect much about the build (since it should default to the latest anndata), but in the case where an old version of anndata is available in a higher priority channel, this will mean a current version is sought. This particuar edge case has been seen in galaxy tool builds via biocontainers; See https://github.com/bioconda/bioconda-recipes/issues/45164 and https://github.com/ebi-gene-expression-group/container-galaxy-sc-tertiary/issues/311 for details.

Its been a couple of years now, so I anticipate that there will not be many people wanting to stick with the old library.   Is it fair to assume they can seek the previous build version (0) of this recipe if required? This is my first recipie update, so if I should be seeking a different aproach to this pull request please advise and I'll check it out. Thanks.