### PR TITLE
Add gtfsort recipe

### DIFF
--- a/recipes/gtfsort/build.sh
+++ b/recipes/gtfsort/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Add workaround for SSH-based Git connections from Rust/cargo.  See https://github.com/rust-lang/cargo/issues/2078 for details.
+# We set CARGO_HOME because we don't pass on HOME to conda-build, thus rendering the default "${HOME}/.cargo" defunct.
+export CARGO_NET_GIT_FETCH_WITH_CLI=true CARGO_HOME="${BUILD_PREFIX}/.cargo"
+
+# build statically linked binary with Rust
+RUST_BACKTRACE=1
+cargo install --verbose --path . --root ${PREFIX}

--- a/recipes/gtfsort/meta.yaml
+++ b/recipes/gtfsort/meta.yaml
@@ -1,24 +1,24 @@
+{% set name = "gtfsort" %}
 {% set version = "0.2.1" %}
 
 package:
- name: gtfsort
+ name: {{ name }}
  version: {{ version }}
 
 source:
- url: https://github.com/alejandrogzi/gtfsort/archive/refs/tags/v.{{ version }}.tar.gz
- sha256: 0fdaa15e22bd34193e2b16b53697b413af0fcf485401f45d48ac48054f1d70f4 
+ url: https://github.com/alejandrogzi/{{ name }}/archive/refs/tags/v.{{ version }}.tar.gz
+ sha256: 0fdaa15e22bd34193e2b16b53697b413af0fcf485401f45d48ac48054f1d70f4
 
 build:
  number: 0
- script: cargo install --path . --root $PREFIX
+ run_exports:
+    - {{ pin_subpackage('gtfsort', max_pin="x.x") }}
 
 requirements:
   build:
     - {{ compiler("cxx") }}
-    - rust>=1.39
+    - rust >=1.39
     - pkg-config
-  host:
-  run:
 
 test:
  commands:
@@ -28,8 +28,12 @@ test:
 about:
  home: https://github.com/alejandrogzi/gtfsort
  license: MIT
+ license_family: MIT
+ license_file: LICENSE
  summary: "A chr/pos/feature GTF sorter that uses a lexicographically-based index ordering algorithm."
 
 extra:
   recipe-maintainers:
     - alejandrogzi
+  identifiers:
+    - doi:10.1101/2023.10.21.563454

--- a/recipes/gtfsort/meta.yaml
+++ b/recipes/gtfsort/meta.yaml
@@ -1,0 +1,35 @@
+{% set version = "0.2.1" %}
+
+package:
+ name: gtfsort
+ version: {{ version }}
+
+source:
+ url: https://github.com/alejandrogzi/gtfsort/archive/refs/tags/v.{{ version }}.tar.gz
+ sha256: 0fdaa15e22bd34193e2b16b53697b413af0fcf485401f45d48ac48054f1d70f4 
+
+build:
+ number: 0
+ script: cargo install --path . --root $PREFIX
+
+requirements:
+  build:
+    - {{ compiler("cxx") }}
+    - rust>=1.39
+    - pkg-config
+  host:
+  run:
+
+test:
+ commands:
+   - gtfsort --help
+   - gtfsort --version
+
+about:
+ home: https://github.com/alejandrogzi/gtfsort
+ license: MIT
+ summary: "A chr/pos/feature GTF sorter that uses a lexicographically-based index ordering algorithm."
+
+extra:
+  recipe-maintainers:
+    - alejandrogzi


### PR DESCRIPTION
Added recipe for gtfsort, a tool for sorting GTF files efficiently.
----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
