### PR TITLE
Update linearpartition to 1.0.1.dev20240123

### DIFF
--- a/recipes/linearpartition/0001-FIX-command-broken-with-symbolic-link.patch
+++ b/recipes/linearpartition/0001-FIX-command-broken-with-symbolic-link.patch
@@ -1,25 +1,13 @@
-From 7413bfa18dddf47924be0839df0147045db0d045 Mon Sep 17 00:00:00 2001
-From: Fabien Pertuy <Fabien.Pertuy@Sanofi.com>
-Date: Fri, 21 May 2021 10:39:10 +0000
-Subject: [PATCH] FIX command broken with symbolic link
-
----
- linearpartition | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
-
 diff --git a/linearpartition b/linearpartition
-index 6c9d877..9d8a5b6 100755
+index f6c2a4e..7b0fe1d 100755
 --- a/linearpartition
 +++ b/linearpartition
-@@ -87,7 +87,7 @@ def main():
-     #     if os.path.exists(ThreshKnot_output): os.remove(ThreshKnot_output)
- 
+@@ -80,7 +80,7 @@ def main():
+             print("Exit!\n");
+             exit();
  
 -    path = os.path.dirname(os.path.abspath(__file__))
 +    path = os.path.dirname(os.path.realpath(__file__))
-     cmd = ["%s/%s" % (path, ('bin/linearpartition_v' if use_vienna else 'bin/linearpartition_c')), beamsize, is_sharpturn, is_verbose, bpp_file, bpp_prefix, pf_only, bpp_cutoff, forest_file, mea, gamma, TK, threshold, ThreshKnot_prefix, MEA_prefix, MEA_bpseq]
+     cmd = ["%s/%s" % (path, ('bin/linearpartition_v' if use_vienna else 'bin/linearpartition_c')), beamsize, is_sharpturn, is_verbose, bpp_file, bpp_prefix, pf_only, bpp_cutoff, forest_file, mea, gamma, TK, threshold, ThreshKnot_prefix, MEA_prefix, MEA_bpseq, shape_file_path, is_fasta, dangles]
      subprocess.call(cmd, stdin=sys.stdin)
      
--- 
-2.30.2
-

--- a/recipes/linearpartition/meta.yaml
+++ b/recipes/linearpartition/meta.yaml
@@ -1,17 +1,20 @@
 {% set name = "LinearPartition" %}
-{% set version = "1.0" %}
-{% set sha256 = "4fdea96f7ffbd4804d9308ddb46db5f96d1abc4b7bd737725f9bedcae3c88178" %}
+{% set version = "1.0.1.dev20240123" %}
+{% set git_sha1 = "fa953f6323274eeadd92cc1f4e5535417f3fb821" %}
+{% set sha256 = "e93c6a26c246c2e0927592052516d6fb15e7e1e8a378f74474136ba85746be58" %}
 
 package:
   name: {{ name | lower }}
   version: {{ version }}
 
 build:
-  number: 3
+  number: 0
   skip: True  # [osx]
+  run_exports:
+    - {{ pin_subpackage(name | lower, max_pin="x.x.x") }}
 
 source:
-  url: https://github.com/LinearFold/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  url: https://github.com/LinearFold/{{ name }}/archive/{{ git_sha1 }}.tar.gz
   sha256: {{ sha256 }}
   patches:
     - 0001-FIX-command-broken-with-symbolic-link.patch
@@ -25,7 +28,7 @@ requirements:
     - matplotlib-base
     - numpy
     - pandas
-    - python=2.7
+    - python >=3,<4
     - python-gflags
     - seaborn
 

--- a/recipes/linearpartition/meta.yaml
+++ b/recipes/linearpartition/meta.yaml
@@ -44,3 +44,4 @@ about:
   license: custom
   license_file: LICENSE
   summary: 'Linear-Time Approximation of RNA Folding Partition Function and Base Pairing Probabilities'
+


### PR DESCRIPTION
This updates linearpartition to git-sha1
fa953f6323274eeadd92cc1f4e5535417f3fb821 from 2024-01-23.

The main reason for the update to an unreleased version is that all releases by the upstream repo require python2.

Changes since 1.0 (my summary):

- driver script uses python3
- support for SHAPE chemical probing data
- FASTA file input
- dangles -d0 mode support

Describe your pull request here

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
