### PR TITLE
Add peer

### DIFF
--- a/recipes/peer/build.sh
+++ b/recipes/peer/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -eux
+
+mkdir build
+cd build
+cmake ../ -DBUILD_PYTHON_PACKAGE=OFF -DBUILD_PEERTOOL=ON
+make -j $CPU_COUNT
+mkdir -p "${PREFIX}/bin"
+install src/peertool "${PREFIX}/bin"

--- a/recipes/peer/meta.yaml
+++ b/recipes/peer/meta.yaml
@@ -23,6 +23,7 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - cmake
+    - make
 
 test:
   commands:

--- a/recipes/peer/meta.yaml
+++ b/recipes/peer/meta.yaml
@@ -1,0 +1,36 @@
+{% set name = "peer" %}
+{% set version = "1.3" %}
+# no tags in upstream repository yet
+{% set commit = "40bc4b2cd92459ce42f44dfe279717436395f3f6" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/PMBio/peer/archive/{{ commit }}.tar.gz
+  sha256: 80a549354569ae5ec7d4d92c78e7f8fa72da08fcd11322611f737044c34861ed
+  patches:
+    - patches/0001-Comment-out-SWIG-package-search.patch
+
+build:
+  number: 0
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x") }}
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - cmake
+
+test:
+  commands:
+    - peertool --help | grep -q USAGE
+
+about:
+  home: https://github.com/PMBio/peer
+  license_file:
+    - LICENSE
+    - External/yaml-cpp/license.txt
+  summary: 'A collection of Bayesian approaches to infer hidden determinants and their effects from gene expression profiles using factor analysis methods'

--- a/recipes/peer/meta.yaml
+++ b/recipes/peer/meta.yaml
@@ -30,6 +30,7 @@ test:
 
 about:
   home: https://github.com/PMBio/peer
+  license: GPL-2.0-or-later
   license_file:
     - LICENSE
     - External/yaml-cpp/license.txt

--- a/recipes/peer/patches/0001-Comment-out-SWIG-package-search.patch
+++ b/recipes/peer/patches/0001-Comment-out-SWIG-package-search.patch
@@ -1,0 +1,31 @@
+From a66ffa0d4b5e0aca5a1de1ffad387eadef49447f Mon Sep 17 00:00:00 2001
+From: Travis Wrightsman <tw493@cornell.edu>
+Date: Mon, 5 Feb 2024 12:21:17 -0500
+Subject: [PATCH] Comment out SWIG package search
+
+---
+ CMakeLists.txt | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 80455af..0e0c66c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -71,11 +71,11 @@ endif (BUILD_UNIVERSAL)
+ #for finding external libraries. 
+ #see /usr/local/share/cmake-2.6/Modules/Find*.cmake for more examples
+ 
+-find_package(SWIG REQUIRED)
+-include(${SWIG_USE_FILE})
++#find_package(SWIG REQUIRED)
++#include(${SWIG_USE_FILE})
+ 
+ include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+-set(CMAKE_SWIG_FLAGS "")
++#set(CMAKE_SWIG_FLAGS "")
+ 
+ set(CMAKE_MODULE_PATH "${PEER_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
+ include_directories(./include)
+-- 
+2.39.2
+


### PR DESCRIPTION
This adds `peertool` for PEER factor correction of gene expression. It has optional R and Python bindings but given that it hasn't had an update in over a decade, it is probably going to take a lot to get working with modern Python and R, so I've skipped building the bindings.

@dpryan79, you removed the recipe for the R bindings in https://github.com/bioconda/bioconda-recipes/commit/123a056fd083a2bf3a8a9de60149d9fc4efc4d54, but perhaps the CLI `peertool` is fine to keep in Bioconda?

---

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
