### PR TITLE
Add recipes for `bigtools` and `pybigtools`

### DIFF
--- a/recipes/bigtools/build.sh
+++ b/recipes/bigtools/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -ex
+
+# Add workaround for SSH-based Git connections from Rust/cargo.  See https://github.com/rust-lang/cargo/issues/2078 for details.
+# We set CARGO_HOME because we don't pass on HOME to conda-build, thus rendering the default "${HOME}/.cargo" defunct.
+export CARGO_NET_GIT_FETCH_WITH_CLI=true CARGO_HOME="${BUILD_PREFIX}/.cargo"
+export RUST_BACKTRACE=full
+
+cargo install --verbose --path ./bigtools --root $PREFIX --locked
+

--- a/recipes/bigtools/meta.yaml
+++ b/recipes/bigtools/meta.yaml
@@ -1,0 +1,35 @@
+{% set version = "0.4.1" %}
+
+package:
+  name: bigtools
+  version: {{ version }}
+
+build:
+  number: 0
+  run_exports:
+    - {{ pin_subpackage('bigtools', max_pin="x.x") }}
+
+source:
+  url: https://github.com/jackh726/bigtools/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: "92b9ea165adb1f9b13222d6c78e12148d9ba04a0d6ae96001820d43d9af7b39e"
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - rust >=1.70
+
+test:
+  commands:
+    - bigtools --help | grep Usage
+
+about:
+  home: https://github.com/jackh726/bigtools/
+  license: MIT
+  doc_url: https://docs.rs/bigtools/latest/bigtools/
+  summary: 'Bigtools provides a high-level, performant API for reading and writing bigWig and bigBed files.'
+  license_family: MIT
+  license_file: LICENSE
+
+extra:
+  identifiers:
+    - doi:10.5281/zenodo.10606493

--- a/recipes/pybigtools/build.sh
+++ b/recipes/pybigtools/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# -e = exit on first error
+# -x = print every executed command
+set -ex
+
+# Use a custom temporary directory as home on macOS.
+# (not sure why this is useful, but people use it in bioconda recipes)
+if [ `uname` == Darwin ]; then
+  export HOME=`mktemp -d`
+fi
+
+# Build the package using maturin - should produce *.whl files.
+maturin build -m pybigtools/Cargo.toml --interpreter $PYTHON --release
+
+# Install *.whl files using pip
+$PYTHON -m pip install target/wheels/*.whl --no-deps --ignore-installed -vv

--- a/recipes/pybigtools/meta.yaml
+++ b/recipes/pybigtools/meta.yaml
@@ -29,7 +29,7 @@ test:
 
 about:
   home: https://github.com/jackh726/bigtools/
-  license: MIT License
+  license: MIT
   summary: 'pybigtools: Python bindings to the Bigtools Rust library for high-performance BigWig and BigBed I/O'
   license_family: MIT
   license_file: LICENSE

--- a/recipes/pybigtools/meta.yaml
+++ b/recipes/pybigtools/meta.yaml
@@ -1,0 +1,40 @@
+{% set version = "0.1.0" %}
+
+package:
+  name: pybigtools
+  version: {{ version }}
+
+source:
+  url: https://github.com/jackh726/bigtools/archive/refs/tags/pybigtools@v{{ version }}.tar.gz
+  sha256: "bb1a1f1d1f39ce0b73eafb40e291b1ded26fbb283898371ade3414c008b80cdf"
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('rust') }}
+    - maturin
+  host:
+    - pip
+    - python
+  run:
+    - python
+    - numpy
+
+test:
+  imports:
+    - pybigtools
+
+about:
+  home: https://github.com/jackh726/bigtools/
+  license: MIT License
+  summary: 'pybigtools: Python bindings to the Bigtools Rust library for high-performance BigWig and BigBed I/O'
+  license_family: MIT
+  license_file: LICENSE
+  doc_url: https://bigtools.readthedocs.io
+
+extra:
+  identifiers:
+    - doi:10.5281/zenodo.10606493


### PR DESCRIPTION
This adds two recipes: one for the `bigtools` Rust crate binaries; and the second for `pybigtools`, a Python wrapper for Bigtools (also available on PyPI).

Bigtools is a library and associated tools for reading and writing bigwig and bigbed files, common files for storing processed NGS data.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
