### PR TITLE
Apply patches to GRIDSS 2.13.2

### DIFF
--- a/recipes/gridss/0001-fix-samtools-version-check.patch
+++ b/recipes/gridss/0001-fix-samtools-version-check.patch
@@ -1,0 +1,11 @@
+--- a/gridss_extract_overlapping_fragments
++++ b/gridss_extract_overlapping_fragments
+@@ -206,7 +206,7 @@ for tool in gridsstools samtools ; do
+ 	fi
+ 	write_status "Found $(which $tool)"
+ done
+-samtools_version=$(samtools --version | grep samtools | cut -b 10-)
++samtools_version=$(samtools --version | head -n1 | grep samtools | cut -b 10-)
+ write_status "samtools version: $samtools_version"
+ samtools_major_version=$(echo $samtools_version | cut -f 1 -d ".")
+ samtools_minor_version=$(echo $samtools_version | cut -f 2 -d ".")

--- a/recipes/gridss/0002-set-gridssargs-for-virusbreakend-annotation.patch
+++ b/recipes/gridss/0002-set-gridssargs-for-virusbreakend-annotation.patch
@@ -1,0 +1,10 @@
+--- a/virusbreakend
++++ b/virusbreakend
+@@ -777,6 +777,7 @@ if [[ ! -f $file_host_annotated_vcf ]] ; then
+ 		-t $threads \
+ 		-r $reference \
+ 		-j $gridss_jar \
++		$gridssargs \
+ 		-s setupreference \
+ 		1>&2 2>> $logfile
+ 	$timecmd java -Xmx4g $jvm_args \

--- a/recipes/gridss/meta.yaml
+++ b/recipes/gridss/meta.yaml
@@ -14,6 +14,8 @@ source:
 
 build:
   number: 3
+  run_exports:
+    - {{ pin_subpackage('gridss', max_pin="x.x.x") }}
   skip: True # [osx]
 
 requirements:

--- a/recipes/gridss/meta.yaml
+++ b/recipes/gridss/meta.yaml
@@ -13,7 +13,7 @@ source:
     - 0002-set-gridssargs-for-virusbreakend-annotation.patch
 
 build:
-  number: 2
+  number: 3
   skip: True # [osx]
 
 requirements:

--- a/recipes/gridss/meta.yaml
+++ b/recipes/gridss/meta.yaml
@@ -8,6 +8,9 @@ package:
 source:
   url: https://github.com/PapenfussLab/gridss/releases/download/v{{ version }}/gridss-{{ version }}.tar.gz
   sha256: '{{ sha256 }}'
+  patches:
+    - 0001-fix-samtools-version-check.patch
+    - 0002-set-gridssargs-for-virusbreakend-annotation.patch
 
 build:
   number: 2


### PR DESCRIPTION
Apply two patches to GRIDSS:

1. make SAMtools version retrieval more robust (rel: SAMtools from bioconda had an unhanded version string format)
1. pass `gridssargs` to VIRUSbreakend annotation to enable users to control default heap size

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
