### PR TITLE
MultiQC: pin Plotly version

### DIFF
--- a/recipes/multiqc/meta.yaml
+++ b/recipes/multiqc/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 46e01394ee4c213eee3c14fde01afcb0da3e87a29b09a119e5aaeabf2817313d
 
 build:
-  number: 0
+  number: 1
   entry_points:
     - multiqc=multiqc.__main__:run_multiqc
   noarch: python
@@ -33,7 +33,7 @@ requirements:
     - lzstring
     - markdown
     - matplotlib-base >=2.1.1
-    - plotly
+    - plotly >=5.18
     - python-kaleido
     - pillow >=10.2.0
     - networkx >=2.5.1


### PR DESCRIPTION
Pin Plotly version tag (to address issues like https://github.com/MultiQC/MultiQC/issues/2323) and bump build number.