### PR TITLE
update to new release tarball url

### DIFF
--- a/recipes/harpy/meta.yaml
+++ b/recipes/harpy/meta.yaml
@@ -6,7 +6,8 @@ package:
   version: '{{ version }}'
 
 source:
-  url: https://github.com/pdimens/harpy/archive/{{ version }}.tar.gz
+  url: https://github.com/pdimens/harpy/releases/download/{{ version }}/harpy.{{ version }}.tar.gz
+  #url: https://github.com/pdimens/harpy/archive/{{ version }}.tar.gz
   sha256: '{{ sha256 }}'
 
 build:


### PR DESCRIPTION
This is to change the URL to match the new release tarball that's automatically generated