### PR TITLE
Update trtools to 6.0.0

### DIFF
--- a/recipes/trtools/meta.yaml
+++ b/recipes/trtools/meta.yaml
@@ -28,6 +28,7 @@ build:
 requirements:
   host:
     - python >=3.7.1
+    - poetry-core >=1.0.0
     - pip >=20.3
   run:
     - python >=3.7.1,<4.0

--- a/recipes/trtools/meta.yaml
+++ b/recipes/trtools/meta.yaml
@@ -27,20 +27,19 @@ build:
 
 requirements:
   host:
-    - python >=3.5
-    - pip >=20.1.1
+    - python >=3.7.1
+    - pip >=20.3
   run:
-    - cyvcf2 >=0.30.1
-    - matplotlib-base >=3.2.2
-    - numpy >=1.18.5
-    - pandas >=1.0.5
-    - pybedtools >=0.8.1
-    - pysam >=0.16.0.1
-    - python >=3.5
+    - python >=3.7.1,<4.0
+    - cyvcf2 >=0.30.4
+    - matplotlib-base >=3.1.2
+    - numpy >=1.17.3,<2.0
+    - pandas >=1.2.0
+    - pysam >=0.15.4
     - scikit-learn >=0.23.1
-    - scipy >=1.4.1
-    - statsmodels >=0.13.5
-    - pyfaidx >=0.5.3
+    - scipy >=1.3.3
+    - statsmodels >=0.10.2
+    - pyfaidx >=0.5.6
     - ART >=2016.06.05
 
 test:

--- a/recipes/trtools/meta.yaml
+++ b/recipes/trtools/meta.yaml
@@ -14,8 +14,6 @@ source:
 build:
   noarch: python
   entry_points:
-    - "test_trtools.sh = {'reference': 'trtools/testsupport/test_trtools.sh', 'type': 'file'}"
-    - "trtools_prep_beagle_vcf.sh = {'reference': 'scripts/trtools_prep_beagle_vcf.sh', 'type': 'file'}"
     - dumpSTR=trtools.dumpSTR:run
     - mergeSTR=trtools.mergeSTR:run
     - statSTR=trtools.statSTR:run

--- a/recipes/trtools/meta.yaml
+++ b/recipes/trtools/meta.yaml
@@ -8,10 +8,14 @@ package:
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: afb0337a27aab41a9974ce3390e5d3d0932f5740631db8a91f7cb3c3c10ad148
+  patches:
+    - test_trtools.sh.patch
 
 build:
   noarch: python
   entry_points:
+    - "test_trtools.sh = {'reference': 'trtools/testsupport/test_trtools.sh', 'type': 'file'}"
+    - "trtools_prep_beagle_vcf.sh = {'reference': 'scripts/trtools_prep_beagle_vcf.sh', 'type': 'file'}"
     - dumpSTR=trtools.dumpSTR:run
     - mergeSTR=trtools.mergeSTR:run
     - statSTR=trtools.statSTR:run
@@ -71,7 +75,7 @@ test:
     - simTR --help
 
 about:
-  home: http://github.com/gymreklab/TRTools
+  home: https://github.com/gymreklab/TRTools
   license: MIT
   license_family: MIT
   license_file: LICENSE.txt
@@ -83,3 +87,6 @@ extra:
   recipe-maintainers:
     - LiterallyUniqueLogin
     - aryarm
+  identifiers:
+    - biotools:trtools
+    - doi:10.1093/bioinformatics/btaa736

--- a/recipes/trtools/test_trtools.sh.patch
+++ b/recipes/trtools/test_trtools.sh.patch
@@ -1,0 +1,13 @@
+diff --git a/trtools/testsupport/test_trtools.sh b/trtools/testsupport/test_trtools.sh
+index 67eb46d5..09e1bf3b 100755
+--- a/trtools/testsupport/test_trtools.sh
++++ b/trtools/testsupport/test_trtools.sh
+@@ -15,7 +15,7 @@ if [ ! -d "$TMP" ] ; then
+ 	echo "Downloading test data ..."
+ 	mkdir $TMP
+ 	pushd $TMP
+-	git clone -b v$(dumpSTR --version) https://github.com/gymrek-lab/TRTools.git
++	git clone -b v$(dumpSTR --version) https://github.com/gymrek-lab/TRTools.git .
+ 	popd
+ 	echo "Download done"
+ else


### PR DESCRIPTION
Closes https://github.com/bioconda/bioconda-recipes/pull/45892

Update [trtools](https://bioconda.github.io/recipes/trtools/README.html): 5.1.1 → 6.0.0

Please merge this PR instead of https://github.com/bioconda/bioconda-recipes/pull/45892. We've removed a dependency, added a build dependency, and changed nearly all of our version constraints (via extensive testing in https://github.com/gymrek-lab/TRTools/pull/203)