### PR TITLE
fix: snakemake dependencies

### DIFF
--- a/recipes/snakemake/meta.yaml
+++ b/recipes/snakemake/meta.yaml
@@ -1,3 +1,5 @@
+# Attention: when upgrading the version, please compare below dependencies with
+# https://github.com/snakemake/snakemake/blob/{version}/setup.cfg
 {% set version = "8.4.11" %}
 
 package:
@@ -9,7 +11,7 @@ source:
   sha256: 6c176d2f3e9cb163a81d1b0e9876b2178c6d8187971d95c9ac2be3470d94d246
 
 build:
-  number: 0
+  number: 1
   noarch: generic
   run_exports:
     - {{ pin_subpackage("snakemake", max_pin="x") }}
@@ -81,16 +83,14 @@ outputs:
       run:
         # Keep in sync with snakemake/setup.cfg
         - python >=3.11,<3.13
-        - immutables
         - appdirs
-        - conda-inject >=1.3.1,<2.0
+        - immutables
         - configargparse
         - connection_pool >=0.0.3
         - datrie
         - docutils
         - gitpython
         - humanfriendly
-        - immutables
         - jinja2 >=3.0,<4.0
         - jsonschema
         - nbformat
@@ -100,17 +100,18 @@ outputs:
         - pyyaml
         - requests >=2.8.1
         - reretry
-        - smart_open >=3.0
+        - smart_open >=3.0,<4.0
         - snakemake-interface-executor-plugins >=8.1.3,<9.0
-        - snakemake-interface-common >=1.15.0,<2.0
-        - snakemake-interface-storage-plugins >=3.0.0,<4.0
+        - snakemake-interface-common >=1.17.0,<2.0
+        - snakemake-interface-storage-plugins >=3.1.0,<4.0
         - stopit
         - tabulate
         - throttler
-        - toposort >=1.10
-        - yte  >=1.5.1,<2.0
+        - toposort >=1.10,<2.0
         - wrapt
+        - yte  >=1.5.1,<2.0
         - dpath >=2.1.6,<3.0.0
+        - conda-inject >=1.3.1,<2.0
 
     test:
       imports:


### PR DESCRIPTION
Fix wrong Snakemake dependencies in last version bump

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
