### PR TITLE
bump magus to 0.1.3

### DIFF
--- a/recipes/magus-msa/meta.yaml
+++ b/recipes/magus-msa/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "magus-msa" %}
-{% set version = "0.1.2" %}
-{% set sha256 = "9ee1156921dba68b55d6d737aab75e68f6f3b29d76ce31a9a30cb3dcb69b2eb8" %}
+{% set version = "0.1.3" %}
+{% set sha256 = "de96170bd768a15d07e03724fc4f32b6c7cb8992e2cd259a45f1371363b6a7c1" %}
 
 package:
   name: {{ name }}


### PR DESCRIPTION
Bumps MAGUS (magus-msa) to version 0.1.3, which brings some minor changes to output file handling.