### PR TITLE
Update pybigtools to v0.1.2

### DIFF
--- a/recipes/pybigtools/build.sh
+++ b/recipes/pybigtools/build.sh
@@ -14,4 +14,4 @@ fi
 maturin build -m pybigtools/Cargo.toml --interpreter $PYTHON --release
 
 # Install *.whl files using pip
-$PYTHON -m pip install target/wheels/*.whl --no-deps --ignore-installed -vv
+$PYTHON -m pip install pybigtools/target/wheels/*.whl --no-deps --ignore-installed -vv

--- a/recipes/pybigtools/build.sh
+++ b/recipes/pybigtools/build.sh
@@ -4,14 +4,20 @@
 # -x = print every executed command
 set -ex
 
+# Add workaround for SSH-based Git connections from Rust/cargo.  See https://github.com/rust-lang/cargo/issues/2078 for details.
+# We set CARGO_HOME because we don't pass on HOME to conda-build, thus rendering the default "${HOME}/.cargo" defunct.
+export CARGO_NET_GIT_FETCH_WITH_CLI=true CARGO_HOME="${BUILD_PREFIX}/.cargo"
+
 # Use a custom temporary directory as home on macOS.
 # (not sure why this is useful, but people use it in bioconda recipes)
 if [ `uname` == Darwin ]; then
-  export HOME=`mktemp -d`
+	export HOME=`mktemp -d`
 fi
 
+# build statically linked binary with Rust
+RUST_BACKTRACE=1
 # Build the package using maturin - should produce *.whl files.
-maturin build -m pybigtools/Cargo.toml --interpreter $PYTHON --release
+maturin build -b pyo3 --interpreter "${PYTHON}" --release --strip
 
 # Install *.whl files using pip
-$PYTHON -m pip install pybigtools/target/wheels/*.whl --no-deps --ignore-installed -vv
+${PYTHON} -m pip install . --no-deps --no-build-isolation -vvv

--- a/recipes/pybigtools/meta.yaml
+++ b/recipes/pybigtools/meta.yaml
@@ -1,12 +1,13 @@
-{% set version = "0.1.1" %}
+{% set name = "pybigtools" %}
+{% set version = "0.1.2" %}
 
 package:
-  name: pybigtools
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: "https://pypi.io/packages/source/p/pybigtools/pybigtools-{{ version }}.tar.gz"
-  sha256: "84ba15588cd37f2a3f6ef09a86bc3e2633cebf5efec8bd5603b2804d392c9861"
+  url: "https://pypi.io/packages/source/p/pybigtools/{{ name }}-{{ version }}.tar.gz"
+  sha256: "0f21bc8b4f2dce67c6e5287af895f5f28a8c6eb123d809e3ab5679e2131dbf58"
 
 build:
   number: 0

--- a/recipes/pybigtools/meta.yaml
+++ b/recipes/pybigtools/meta.yaml
@@ -35,7 +35,7 @@ about:
   license: MIT
   summary: 'pybigtools: Python bindings to the Bigtools Rust library for high-performance BigWig and BigBed I/O'
   license_family: MIT
-  license_file: LICENSE
+  license_file: pybigtools/LICENSE
   doc_url: https://bigtools.readthedocs.io
   dev_url: https://github.com/jackh726/bigtools/
 

--- a/recipes/pybigtools/meta.yaml
+++ b/recipes/pybigtools/meta.yaml
@@ -1,12 +1,12 @@
-{% set version = "0.1.0" %}
+{% set version = "0.1.1" %}
 
 package:
   name: pybigtools
   version: {{ version }}
 
 source:
-  url: https://github.com/jackh726/bigtools/archive/refs/tags/pybigtools@v{{ version }}.tar.gz
-  sha256: "bb1a1f1d1f39ce0b73eafb40e291b1ded26fbb283898371ade3414c008b80cdf"
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  sha256: "84ba15588cd37f2a3f6ef09a86bc3e2633cebf5efec8bd5603b2804d392c9861"
 
 build:
   number: 0

--- a/recipes/pybigtools/meta.yaml
+++ b/recipes/pybigtools/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 source:
-  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  url: "https://pypi.io/packages/source/p/pybigtools/pybigtools-{{ version }}.tar.gz"
   sha256: "84ba15588cd37f2a3f6ef09a86bc3e2633cebf5efec8bd5603b2804d392c9861"
 
 build:

--- a/recipes/pybigtools/meta.yaml
+++ b/recipes/pybigtools/meta.yaml
@@ -10,6 +10,8 @@ source:
 
 build:
   number: 0
+  run_exports:
+    - {{ pin_subpackage('pybigtools', max_pin="x.x") }}
 
 requirements:
   build:

--- a/recipes/pybigtools/meta.yaml
+++ b/recipes/pybigtools/meta.yaml
@@ -17,10 +17,10 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('rust') }}
-    - maturin
   host:
     - pip
     - python
+    - maturin
   run:
     - python
     - numpy
@@ -36,6 +36,7 @@ about:
   license_family: MIT
   license_file: LICENSE
   doc_url: https://bigtools.readthedocs.io
+  dev_url: https://github.com/jackh726/bigtools/
 
 extra:
   identifiers:


### PR DESCRIPTION
Manually updating pybigtools v0.1.0 -> v0.1.1. [EDIT: -> v0.1.2]

`pybigtools` lives in a [monorepo](https://github.com/jackh726/bigtools.git) with `bigtools` and wasn't picked up for autobump, while `bigtools` was.

Changed URL to point to PyPI as source, hoping Bioconda Bot is able to autobump next time.

cc @jackh726 

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
