### PR TITLE
hybran: limit biopython dependency to <1.82 due to breaking change

### DIFF
--- a/recipes/hybran/meta.yaml
+++ b/recipes/hybran/meta.yaml
@@ -12,6 +12,8 @@ build:
   noarch: python
   number: 1
   script: python -m pip install --no-deps --ignore-installed .
+  run_exports:
+    - {{ pin_subpackage('hybran', max_pin=None) }}
 
 requirements:
   host:

--- a/recipes/hybran/meta.yaml
+++ b/recipes/hybran/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
@@ -18,7 +18,7 @@ requirements:
     - python >=3.9
     - pip
   run:
-    - biopython >=1.80
+    - biopython >=1.80, <1.82
     - blast
     - cd-hit
     - diamond


### PR DESCRIPTION
A deprecation snuck up:

https://github.com/biopython/biopython/blob/master/DEPRECATED.rst#bioseqfeature

> The `location_operator` argument was removed from the SeqFeature initializer in Release 1.82.
