### PR TITLE
pin Diamond to 2.1.8

### DIFF
--- a/recipes/bakta/meta.yaml
+++ b/recipes/bakta/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: python -m pip install --no-deps --ignore-installed .
   entry_points:
     - bakta = bakta.main:main

--- a/recipes/bakta/meta.yaml
+++ b/recipes/bakta/meta.yaml
@@ -37,7 +37,7 @@ requirements:
     - infernal >=1.1.4
     - piler-cr
     - pyhmmer >=0.10.4
-    - diamond >=2.1.8
+    - diamond ==2.1.8
     - blast >=2.14.0
     - ncbi-amrfinderplus >=3.11.26
     - circos >=0.69.8


### PR DESCRIPTION
Temporarily pin Diamond to v2.1.8 due to a known upstream bug https://github.com/bbuchfink/diamond/issues/785.

