### PR TITLE
Add missing run_exports for kseqpp

### DIFF
--- a/recipes/kseqpp/meta.yaml
+++ b/recipes/kseqpp/meta.yaml
@@ -11,6 +11,8 @@ source:
 
 build:
   number: 0
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x") }}
 
 requirements:
   host:


### PR DESCRIPTION
There is already an autobumped PR #46145 for this version. This PR adds the missing `run_exports`.
