### PR TITLE
Change incorrect license to LGPL-2.1 form Apache-2.0

### DIFF
--- a/recipes/jronn/meta.yaml
+++ b/recipes/jronn/meta.yaml
@@ -30,7 +30,7 @@ test:
 about:
   home: https://biojava.org/
   dev_url: https://github.com/biojava/biojava/tree/master/biojava-protein-disorder
-  license: Apache-2.0
+  license: LGPL-2.1
   summary: "JRONN is based on the C implementation of RONN algorithm."
   description: >-
     JRONN is a Java implementation of RONN. JRONN is based on RONN and uses the

--- a/recipes/jronn/meta.yaml
+++ b/recipes/jronn/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 0
+  number: 1
   noarch: generic
   run_exports:
     - {{ pin_subpackage('jronn', max_pin="x.x") }}


### PR DESCRIPTION
JRONN was incorrectly given an Apache-2.0 license, but Biojava tools are released under LGPL-2.1.
Updated the license in the meta.yaml.
