### PR TITLE
Build pysam for linux-aarch64

### DIFF
--- a/recipes/pysam/arm_hwcap.patch
+++ b/recipes/pysam/arm_hwcap.patch
@@ -1,0 +1,15 @@
+Conda-forge's build environment on ARM uses sysroot_linux-aarch64 2.17, which
+is based on glibc 2.17 so <sys/auxv.h> does not define HWCAP_* values on ARM.
+Work around this by including the kernel header to get the desired values.
+
+--- a/htslib/htscodecs/htscodecs/rANS_static4x16pr.c	2023-10-10 02:54:16
++++ b/htslib/htscodecs/htscodecs/rANS_static4x16pr.c	2024-03-06 00:01:14
+@@ -1011,6 +1011,8 @@
+ 
+ #if defined(__linux__) || defined(__FreeBSD__)
+ #include <sys/auxv.h>
++// Ensure ARM HWCAP_* values are defined even on old glibc
++#include <asm/hwcap.h>
+ #elif defined(_WIN32)
+ #include <processthreadsapi.h>
+ #endif

--- a/recipes/pysam/meta.yaml
+++ b/recipes/pysam/meta.yaml
@@ -7,9 +7,11 @@ package:
 source:
   url: https://github.com/pysam-developers/pysam/archive/v{{ version }}.tar.gz
   sha256: 61b3377c5f889ddc6f6979912c3bb960d7e08407dada9cb38f13955564ea036f
+  patches:
+    - arm_hwcap.patch
 
 build:
-  number: 0
+  number: 1
   skip: True # [py2k]
   binary_relocation: False # [linux]
   run_exports:
@@ -31,12 +33,6 @@ requirements:
     - openssl  # [not osx]
   run:
     - python
-    - zlib
-    - xz
-    - bzip2
-    - libdeflate
-    - libcurl
-    - openssl  # [not osx]
 
 about:
   home: https://github.com/pysam-developers/pysam
@@ -44,6 +40,8 @@ about:
   summary: "Pysam is a Python module for reading and manipulating SAM/BAM/VCF/BCF files. It's a lightweight wrapper of the htslib C-API, the same one that powers samtools, bcftools, and tabix."
 
 extra:
+  additional-platforms:
+    - linux-aarch64
   identifiers:
     - biotools:pysam
     - doi:10.1093/bioinformatics/btp352


### PR DESCRIPTION
* Add additional-platforms entry

* Work around old sysroot_linux-aarch64 version (as per the htslib recipe)
Avoid 2.17's missing HWCAP_* values by including the kernel header.

* Remove run requirements for shared libraries
These will be inferred from the library dependencies, as appropriate. In particular, this will omit the spurious zlib package dependency: only libzlib is required.

----

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
