### PR TITLE
Update ToulligQC to v2.5.2

### DIFF
--- a/recipes/toulligqc/meta.yaml
+++ b/recipes/toulligqc/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "toulligqc" %}
-{% set version = "2.5" %}
+{% set version = "2.5.2" %}
 
 package:
   name: "{{ name|lower }}"
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 8c8f5406e8f8dbfaa260ef446b08875a337ef3201dbaad6c8a4e0fa5cbf42f85
+  sha256: df12bbd9383857c33a997e44913625a430579e116763c069f38af9de4701d945
 
 build:
   number: 0


### PR DESCRIPTION
There is a v2.6 but due to some package dependencies (pod5), conda build fails.
We have published a new pypi package for v2.5.2 but there was no update to v2.5.2 in bioconda
