### PR TITLE
 Add srahunter/meta.yaml

### DIFF
--- a/recipes/srahunter/meta.yaml
+++ b/recipes/srahunter/meta.yaml
@@ -1,0 +1,41 @@
+package:
+  name: srahunter
+  version: 0.0.2
+
+source:
+  url:    https://github.com/GitEnricoNeko/SRAHunter/archive/refs/tags/0.0.2.tar.gz
+  sha256: bb84b58e9176504476fd48b39139b04504d3964e503d8bb154156888fc013854
+build:
+  entry_points:
+    - srahunter=scripts.cli:main
+  noarch: python
+  script: {{ PYTHON }} -m pip install . --no-build-isolation --no-deps -vvv
+  number: 0
+
+requirements:
+  host:
+    - python >=3.6
+    - pip
+  run:
+    - datavzrd
+    - entrez-direct
+    - python >=3.6
+    - pandas >=2.0.2
+    - psutil >=5.7
+    - pyfiglet
+    - requests >=2.31.0
+    - tqdm >=4.66.1
+    - sra-tools
+
+test:
+  commands:
+    - pip check
+    - srahunter --help
+  requires:
+    - pip
+
+about:
+  home: https://github.com/GitEnricoNeko/SRAHunter
+  license: MIT
+  license_file: LICENSE
+  summary: "SRAHunter is a tool for processing SRA accession numbers."

--- a/recipes/srahunter/meta.yaml
+++ b/recipes/srahunter/meta.yaml
@@ -4,7 +4,7 @@ package:
 
 source:
   url:    https://github.com/GitEnricoNeko/SRAHunter/archive/refs/tags/0.0.2.tar.gz
-  sha256: bb84b58e9176504476fd48b39139b04504d3964e503d8bb154156888fc013854
+  sha256: c7f4e0af7012e9bdeb787116d1a157cdb6431464dbba16306e7b770ebc220032
 build:
   entry_points:
     - srahunter=scripts.cli:main

--- a/recipes/srahunter/meta.yaml
+++ b/recipes/srahunter/meta.yaml
@@ -1,6 +1,9 @@
+{% set name = "SRAHunter" %}
+{% set version = "0.0.2" %}
+
 package:
-  name: srahunter
-  version: 0.0.2
+  name: {{ name|lower }}
+  version: {{ version }}
 
 source:
   url:    https://github.com/GitEnricoNeko/SRAHunter/archive/refs/tags/0.0.2.tar.gz

--- a/recipes/srahunter/meta.yaml
+++ b/recipes/srahunter/meta.yaml
@@ -11,6 +11,8 @@ build:
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-build-isolation --no-deps -vvv
   number: 0
+  run_exports:
+    - {{ pin_subpackage('srahunter', max_pin="x") }}
 
 requirements:
   host:

--- a/recipes/srahunter/meta.yaml
+++ b/recipes/srahunter/meta.yaml
@@ -1,4 +1,4 @@
-{% set name = "SRAHunter" %}
+{% set name = "srahunter" %}
 {% set version = "0.0.2" %}
 
 package:
@@ -6,8 +6,8 @@ package:
   version: {{ version }}
 
 source:
-  url:    https://github.com/GitEnricoNeko/SRAHunter/archive/refs/tags/0.0.2.tar.gz
-  sha256: c7f4e0af7012e9bdeb787116d1a157cdb6431464dbba16306e7b770ebc220032
+  url:    https://github.com/GitEnricoNeko/srahunter/archive/refs/tags/{{version}}.tar.gz
+  sha256: 635dbea61296fc84857b8290fb8858b5dbc26301031d8fce3a5de2e340c78740
 build:
   entry_points:
     - srahunter=scripts.cli:main
@@ -40,7 +40,7 @@ test:
     - pip
 
 about:
-  home: https://github.com/GitEnricoNeko/SRAHunter
+  home: https://github.com/GitEnricoNeko/srahunter
   license: MIT
   license_file: LICENSE
-  summary: "SRAHunter is a tool for processing SRA accession numbers."
+  summary: "srahunter is a tool for processing SRA accession numbers."


### PR DESCRIPTION
added new file:   srahunter/meta.yaml

Dear Bioconda team,
I'm Bortoletto Enrico from university of Padova (Italy), I developed a new tool useful for automatizing the download of data and metadata from SRA.
Specifically SRAHunter is a tool designed to facilitate the downloading and processing of data and metadata from the Sequence Read Archive (SRA) of the National Center for Biotechnology Information ([NCBI](https://www.ncbi.nlm.nih.gov/)). This Python package includes three modules : a module for automatized download of fastq files from SRA (srahunter download), a module for main SRA associated metadata retrieval (srahunter metadata), and a module to retrieve the full associated metadata to an accession number (srahunter fullmetadata).
Sincerely,
Bortoletto Enrico  

----

<table>
  <tr>
    <td>PyPI link</td>
    <td><a href="https://pypi.org/manage/project/srahunter/releases/">srahunter pypi</a></td>
  </tr>
  <tr>
    <td>Github page</td>
    <td><a href="https://github.com/GitEnricoNeko/SRAHunter">srahunter github</a></td>
  </tr>
  <tr>
    <td>maintainers</td>
    <td> @GitEnricoNeko , @r-frizzo </td>
  </tr>
</table>

