### PR TITLE
Add Locityper

### DIFF
--- a/recipes/locityper/build.sh
+++ b/recipes/locityper/build.sh
@@ -7,8 +7,6 @@ fi
 
 export C_INCLUDE_PATH="$BUILD_PREFIX/include:$C_INCLUDE_PATH"
 export LIBRARY_PATH="$BUILD_PREFIX/lib:$LIBRARY_PATH"
-# export CFLAGS="-L$BUILD_PREFIX/lib"
-# export RUSTFLAGS="-L$BUILD_PREFIX/lib -lz"
 
 git clone https://github.com/smarco/WFA2-lib WFA2
 cargo install --no-track --verbose --root "${PREFIX}" --path .

--- a/recipes/locityper/build.sh
+++ b/recipes/locityper/build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash -euo
+
+if [ "$(uname)" == "Darwin" ]; then
+    export HOME="/Users/distiller"
+    export HOME=`pwd`
+fi
+
+export C_INCLUDE_PATH="$BUILD_PREFIX/include"
+export LIBRARY_PATH="$BUILD_PREFIX/lib"
+# export CFLAGS="-L$BUILD_PREFIX/lib"
+# export RUSTFLAGS="-L$BUILD_PREFIX/lib -lz"
+
+git clone https://github.com/smarco/WFA2-lib WFA2
+cargo install --no-track --verbose --root "${PREFIX}" --path .
+

--- a/recipes/locityper/build.sh
+++ b/recipes/locityper/build.sh
@@ -5,8 +5,8 @@ if [ "$(uname)" == "Darwin" ]; then
     export HOME=`pwd`
 fi
 
-export C_INCLUDE_PATH="$BUILD_PREFIX/include"
-export LIBRARY_PATH="$BUILD_PREFIX/lib"
+export C_INCLUDE_PATH="$BUILD_PREFIX/include:$C_INCLUDE_PATH"
+export LIBRARY_PATH="$BUILD_PREFIX/lib:$LIBRARY_PATH"
 # export CFLAGS="-L$BUILD_PREFIX/lib"
 # export RUSTFLAGS="-L$BUILD_PREFIX/lib -lz"
 

--- a/recipes/locityper/meta.yaml
+++ b/recipes/locityper/meta.yaml
@@ -30,7 +30,7 @@ test:
         - locityper version
 
 about:
-    summary: Targeted genotyper for complex polymorphic loci from short and long WGS.
+    summary: Targeted genotyper for complex polymorphic loci from short and long read WGS.
     home: https://github.com/tprodanov/locityper
     license: MIT
     license_file: LICENSE

--- a/recipes/locityper/meta.yaml
+++ b/recipes/locityper/meta.yaml
@@ -20,8 +20,10 @@ requirements:
     - cmake
     - make
     - clangdev
+    - llvm-openmp
   host:
     - clangdev
+    - llvm-openmp
   run:
     - samtools >=1.18
     - jellyfish >=1.0

--- a/recipes/locityper/meta.yaml
+++ b/recipes/locityper/meta.yaml
@@ -17,6 +17,8 @@ requirements:
   build:
     - {{ compiler('rust') }}
     - {{ compiler('cxx') }}
+    - cmake
+    - make
   run:
     - samtools >=1.18
     - jellyfish >=1.0

--- a/recipes/locityper/meta.yaml
+++ b/recipes/locityper/meta.yaml
@@ -19,6 +19,9 @@ requirements:
     - {{ compiler('cxx') }}
     - cmake
     - make
+    - libclang
+  host:
+    - libclang
   run:
     - samtools >=1.18
     - jellyfish >=1.0

--- a/recipes/locityper/meta.yaml
+++ b/recipes/locityper/meta.yaml
@@ -21,9 +21,6 @@ requirements:
     - make
     - clangdev
     - llvm-openmp
-  host:
-    - clangdev
-    - llvm-openmp
   run:
     - samtools >=1.18
     - jellyfish >=1.0

--- a/recipes/locityper/meta.yaml
+++ b/recipes/locityper/meta.yaml
@@ -5,6 +5,11 @@ package:
   name: {{ name|lower }}
   version: {{ version }}
 
+build:
+  number: 0
+  run_exports:
+    - {{ pin_subpackage("locityper", max_pin="x.x") }}
+
 source:
   url: https://github.com/tprodanov/{{name}}/archive/refs/tags/{{version}}.tar.gz
   sha256: 2e7290d6a6a63f594906de02a30e3f1f1e495bbb5f99640ac66708ac37c1113e

--- a/recipes/locityper/meta.yaml
+++ b/recipes/locityper/meta.yaml
@@ -19,9 +19,9 @@ requirements:
     - {{ compiler('cxx') }}
     - cmake
     - make
-    - libclang
+    - clangdev
   host:
-    - libclang
+    - clangdev
   run:
     - samtools >=1.18
     - jellyfish >=1.0

--- a/recipes/locityper/meta.yaml
+++ b/recipes/locityper/meta.yaml
@@ -1,8 +1,7 @@
-{% set name = "Locityper" %}
 {% set version = "0.13.4" %}
 
 package:
-  name: {{ name|lower }}
+  name: locityper
   version: {{ version }}
 
 build:
@@ -11,7 +10,7 @@ build:
     - {{ pin_subpackage("locityper", max_pin="x.x") }}
 
 source:
-  url: https://github.com/tprodanov/{{name}}/archive/refs/tags/{{version}}.tar.gz
+  url: https://github.com/tprodanov/locityper/archive/refs/tags/v{{ version }}.tar.gz
   sha256: 2e7290d6a6a63f594906de02a30e3f1f1e495bbb5f99640ac66708ac37c1113e
 
 requirements:

--- a/recipes/locityper/meta.yaml
+++ b/recipes/locityper/meta.yaml
@@ -1,0 +1,33 @@
+{% set name = "Locityper" %}
+{% set version = "0.13.4" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/tprodanov/{{name}}/archive/refs/tags/{{version}}.tar.gz
+  sha256: 2e7290d6a6a63f594906de02a30e3f1f1e495bbb5f99640ac66708ac37c1113e
+
+requirements:
+  build:
+    - {{ compiler('rust') }}
+    - {{ compiler('cxx') }}
+  run:
+    - samtools >=1.18
+    - jellyfish >=1.0
+    - minimap2 >=2.25
+    - strobealign >=0.12
+    - python
+    - pysam
+
+test:
+    commands:
+        - locityper version
+
+about:
+    summary: Targeted genotyper for complex polymorphic loci from short and long WGS.
+    home: https://github.com/tprodanov/locityper
+    license: MIT
+    license_file: LICENSE
+          


### PR DESCRIPTION
Add recipe for Locityper `v0.13.4`.
[Locityper](https://github.com/tprodanov/locityper) is a targeted genotyper for complex polymorphic genes/loci based on short and long-read whole genome sequencing.