### PR TITLE
Use binary for tower-cli, add macOS-arm64

### DIFF
--- a/recipes/tower-cli/build.sh
+++ b/recipes/tower-cli/build.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
-mkdir -p $PREFIX/bin
-mv $SRC_DIR/tw $PREFIX/bin/tw
-chmod 755 $PREFIX/bin/tw
+#!/usr/bin/env bash
+ls "${SRC_DIR}"
+chmod +x "${SRC_DIR}/tw"
+mkdir -p "${PREFIX}/bin"
+mv "${SRC_DIR}"/tw ${PREFIX}/bin/tw

--- a/recipes/tower-cli/build.sh
+++ b/recipes/tower-cli/build.sh
@@ -1,11 +1,4 @@
 #!/bin/bash
-
-TGT="$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM"
-[ -d "$TGT" ] || mkdir -p "$TGT"
-[ -d "${PREFIX}/bin" ] || mkdir -p "${PREFIX}/bin"
-
-cp -p "$SRC_DIR"/*.jar "$TGT"
-
-cp $RECIPE_DIR/tw.sh $TGT/tw
-ln -s $TGT/tw $PREFIX/bin
-chmod 0755 "${PREFIX}/bin/tw"
+mkdir -p $PREFIX/bin
+mv $SRC_DIR/tw $PREFIX/bin/tw
+chmod 755 $PREFIX/bin/tw

--- a/recipes/tower-cli/meta.yaml
+++ b/recipes/tower-cli/meta.yaml
@@ -1,20 +1,27 @@
-{% set name = "tw"%}
 {% set version = "0.9.2" %}
-{% set sha = "c9ebabdfe7aaeea0ce823c39819b0091503e6e8bf751281f90b620d20d365cec" %}
 
 package:
   name: tower-cli
   version: {{ version }}
 
 build:
-  number: 0
-  noarch: generic
+  number: 1
   run_exports:
     - {{ pin_subpackage("tower-cli", max_pin="x.x") }}
     
 source:
-  - url: https://github.com/seqeralabs/tower-cli/releases/download/v{{ version }}/tw.jar
-    sha256: {{ sha }}
+  - url: https://github.com/seqeralabs/tower-cli/releases/download/v{{ version }}/tw-linux-x86_64 # [linux]
+    sha256: 55217d07e4615e12a46bb3d86057975113636c26f3f9ee57f5d79290d3c1606d # [linux]
+    fn: tw # [linux]
+  - url: https://github.com/seqeralabs/tower-cli/releases/download/v{{ version }}/tw-osx-x86_64 # [osx]
+    sha256: e96c036401c21b4c9b0379a4099192161d94f7567ea16313e7147d6f75828394 # [osx] 
+    fn: tw # [osx]
+  - url: https://github.com/seqeralabs/tower-cli/releases/download/v{{ version }}/tw-osx-arm64 # [arm64]
+    sha256: 31ffa200aea3e70533222cab08a212080b889d933ac7ee2b8ece22c51d3e8c1a # [arm64]
+    fn: tw # [arm64]
+  - url: https://github.com/seqeralabs/tower-cli/releases/download/{{ version }}/tw-windows-x86_64.exe # [win]
+    sha256: 97c6aed555e1450bb5e32e0e031fe7416caec271925a64f48a4a14b420b3e457 # [win]
+    fn: tw # [win]
 
 requirements:
   run:

--- a/recipes/tower-cli/meta.yaml
+++ b/recipes/tower-cli/meta.yaml
@@ -11,7 +11,7 @@ build:
     
 source:
   - url: https://github.com/seqeralabs/tower-cli/releases/download/v{{ version }}/tw-linux-x86_64 # [linux]
-    sha256: 55217d07e4615e12a46bb3d86057975113636c26f3f9ee57f5d79290d3c1606d # [linux]
+    sha256: 1b96696219d922aaa1a5e09f4a018b34c38806c134234b7f9bde19c92f04ab64 # [linux]
     fn: tw # [linux]
   - url: https://github.com/seqeralabs/tower-cli/releases/download/v{{ version }}/tw-osx-x86_64 # [osx]
     sha256: e96c036401c21b4c9b0379a4099192161d94f7567ea16313e7147d6f75828394 # [osx] 
@@ -20,7 +20,7 @@ source:
     sha256: 31ffa200aea3e70533222cab08a212080b889d933ac7ee2b8ece22c51d3e8c1a # [arm64]
     fn: tw # [arm64]
   - url: https://github.com/seqeralabs/tower-cli/releases/download/{{ version }}/tw-windows-x86_64.exe # [win]
-    sha256: 97c6aed555e1450bb5e32e0e031fe7416caec271925a64f48a4a14b420b3e457 # [win]
+    sha256: c51f2f9b146f4d4d074770e5eb8684188a7358aa61032f1822a0e7d681a4f05c # [win]
     fn: tw # [win]
 
 requirements:


### PR DESCRIPTION
This PR replaces tower-cli with pre-built binary instead of jar.

This _might_ fix https://github.com/seqeralabs/tower-cli/issues/388 but the macOS security rules around binaries are opaque to say the least so I'm not hopeful.

But if it works, it will add macOS arm64 support.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
