### PR TITLE
Add Snakemake 8 executor plugins for LSF

### DIFF
--- a/recipes/snakemake-executor-plugin-lsf-jobstep/meta.yaml
+++ b/recipes/snakemake-executor-plugin-lsf-jobstep/meta.yaml
@@ -1,0 +1,39 @@
+{% set name = "snakemake-executor-plugin-lsf-jobstep" %}
+{% set version = "0.1.10" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/snakemake_executor_plugin_lsf_jobstep-{{ version }}.tar.gz
+  sha256: 72d29f3cd22061a61f138bba0ab6803b3fb7017f9475276acfa40ad20d23f44d
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python >=3.11,<4.0
+    - poetry-core
+    - pip
+  run:
+    - python >=3.11.0,<4.0.0
+    - snakemake-interface-common >=1.17.1,<2.0.0
+    - snakemake-interface-executor-plugins >=9.0.0,<10.0.0
+
+test:
+  imports:
+    - snakemake_executor_plugin_lsf_jobstep
+
+about:
+  home: https://github.com/BEFH/snakemake-executor-plugin-lsf-jobstep
+  summary: A Snakemake executor plugin for running bjobs jobs inside of LSF jobs (meant for internal use by snakemake-executor-plugin-lsf)
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - BFH

--- a/recipes/snakemake-executor-plugin-lsf/meta.yaml
+++ b/recipes/snakemake-executor-plugin-lsf/meta.yaml
@@ -1,0 +1,41 @@
+{% set name = "snakemake-executor-plugin-lsf" %}
+{% set version = "0.2.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/snakemake_executor_plugin_lsf-{{ version }}.tar.gz
+  sha256: 2e03b98b29cf1469add3114046b5a1662e07879a8606914f4fe4c01f1fd53aea
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python >=3.11,<4.0
+    - poetry-core
+    - pip
+  run:
+    - python >=3.11.0,<4.0.0
+    - snakemake-interface-common >=1.17.1,<2.0.0
+    - snakemake-interface-executor-plugins >=9.0.0,<10.0.0
+    - snakemake-executor-plugin-lsf-jobstep >=0.1.10,<0.2.0
+    - throttler >=1.2.2,<2.0.0
+
+test:
+  imports:
+    - snakemake_executor_plugin_lsf
+
+about:
+  home: https://github.com/befh/snakemake-executor-plugin-lsf
+  summary: A Snakemake executor plugin for submitting jobs to a LSF cluster.
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - BEFH


### PR DESCRIPTION
This adds `snakemake-executor-plugin-lsf-jobstep` and `snakemake-executor-plugin-lsf`, which are necessary for running Snakemake workflows on LSF clusters.