### PR TITLE
Update Plink2 to Alpha 5.10 final (5 Jan)

### DIFF
--- a/recipes/plink2/meta.yaml
+++ b/recipes/plink2/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: plink2
-  version: "2.00a5"
+  version: "2.00a5.10"
 
 build:
   number: 0
@@ -8,10 +8,10 @@ build:
       - {{ pin_subpackage('plink2', max_pin=None) }}
 
 source:
-  url: https://s3.amazonaws.com/plink2-assets/alpha5/plink2_linux_x86_64_20230923.zip # [linux]
-  sha256: f0537f5b90315028de0f3c6be3aaa384a2aa7cd74b0d4d5b6f4d2916c262db40     # [linux]
-  url: https://s3.amazonaws.com/plink2-assets/alpha5/plink2_mac_20230923.zip   # [osx]
-  sha256: 4a4264ff57abe7191a9244617d86069c370336aa726ced9a6369c0d8318e1f7c     # [osx]
+  url: https://s3.amazonaws.com/plink2-assets/alpha5/plink2_linux_x86_64_20240105.zip # [linux]
+  sha256: d841fe0b3fcc42d76b2b08bcfeb95e315156b0b883b353807014a69b4867dc47     # [linux]
+  url: https://s3.amazonaws.com/plink2-assets/alpha5/plink2_mac_20240105.zip   # [osx]
+  sha256: 75d78b9a94a570804a9ab130dd0dd29ff8d1c7851c386239505798cd2126c0f9     # [osx]
 
 requirements:
   build:
@@ -19,7 +19,7 @@ requirements:
 
 test:
   commands:
-    - plink2 --help | grep "PLINK v2.00a5"
+    - plink2 --help | grep "PLINK v2.00a5.10"
 
 about:
   home: https://www.cog-genomics.org/plink2


### PR DESCRIPTION
Updating plink2 to the latest stable build (https://www.cog-genomics.org/plink/2.0/)