### PR TITLE
fix busco patch

### DIFF
--- a/recipes/busco/meta.yaml
+++ b/recipes/busco/meta.yaml
@@ -7,7 +7,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 0
+  number: 1
   noarch: python
   run_exports:
     - {{ pin_subpackage(name, max_pin="x.x") }}

--- a/recipes/busco/meta.yaml
+++ b/recipes/busco/meta.yaml
@@ -17,6 +17,7 @@ source:
   sha256: {{ sha256 }}
   patches:
     - 0001-Add-default-config-path-within-prefix-updated.patch
+    - 0001-Set-conda-distribution.patch
 
 requirements:
   host:


### PR DESCRIPTION
Patch existed but had not been added to meta.yaml so it wasn't patched. 