### PR TITLE
Update: Musgy - Fix issue with sed on macos m1

### DIFF
--- a/recipes/mugsy/meta.yaml
+++ b/recipes/mugsy/meta.yaml
@@ -11,6 +11,8 @@ source:
 build:
   noarch: generic
   number: 5
+  run_exports:
+    - {{ pin_subpackage('mugsy', max_pin="x") }}
 
 requirements:
   run:

--- a/recipes/mugsy/meta.yaml
+++ b/recipes/mugsy/meta.yaml
@@ -10,11 +10,12 @@ source:
 
 build:
   noarch: generic
-  number: 4
+  number: 5
 
 requirements:
   run:
     - perl
+    - sed
 
 about:
   home: http://mugsy.sourceforge.net


### PR DESCRIPTION
Attempt to fix sed issue on macos m1

On macos m1, an error is produced during install of mugys:

```
stderr: sed: 1: "/Users/XXXX/miniforge3 ...": command a expects \ followed by text
```

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
