### PR TITLE
Updated ToulligQC to v2.5.4

### DIFF
--- a/recipes/toulligqc/meta.yaml
+++ b/recipes/toulligqc/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "toulligqc" %}
-{% set version = "2.5.3" %}
+{% set version = "2.5.4" %}
 
 package:
   name: "{{ name|lower }}"
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 254f1f21227a15e51612523cc642fe58660e519661d61cb09d88270be9259965
+  sha256: 27524706a9483b9fd38b1122b8622214126b02fa13cb2c198c6686346bd7c880
 
 build:
   number: 0

--- a/recipes/toulligqc/meta.yaml
+++ b/recipes/toulligqc/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "toulligqc" %}
-{% set version = "2.5.2" %}
+{% set version = "2.5.3" %}
 
 package:
   name: "{{ name|lower }}"
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: df12bbd9383857c33a997e44913625a430579e116763c069f38af9de4701d945
+  sha256: 2254f1f21227a15e51612523cc642fe58660e519661d61cb09d88270be9259965
 
 build:
   number: 0
@@ -21,19 +21,18 @@ build:
 requirements:
   host:
     - pip
-    - python >=3.8
+    - python >=3.11.0
   run:
-    - h5py >=2.10
-    - matplotlib-base >=3.1.2
-    - numpy >=1.17.4
-    - scipy >=1.3.3
-    - pandas >=0.25.3
-    - plotly >=4.5.0
-    - pysam
-    - python >=3.8
-    - seaborn >=0.10
-    - scikit-learn >=0.22
-    - tqdm
+    - h5py >=3.7.0
+    - matplotlib >=3.6.3
+    - numpy >=1.24.2
+    - scipy >=1.10.1
+    - pandas >=1.5.3
+    - plotly >=5.15.0
+    - pysam >=0.21.0
+    - python >=3.11.0
+    - scikit-learn >=1.2.1
+    - tqdm >=4.64.1
 
 test:
   imports:

--- a/recipes/toulligqc/meta.yaml
+++ b/recipes/toulligqc/meta.yaml
@@ -20,7 +20,6 @@ build:
 
 requirements:
   host:
-    - pip
     - python >=3.10.0
   run:
     - h5py >=3.7.0

--- a/recipes/toulligqc/meta.yaml
+++ b/recipes/toulligqc/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - python >=3.11.0
   run:
     - h5py >=3.7.0
-    - matplotlib >=3.6.3
+    - matplotlib-base >=3.6.3
     - numpy >=1.24.2
     - scipy >=1.10.1
     - pandas >=1.5.3

--- a/recipes/toulligqc/meta.yaml
+++ b/recipes/toulligqc/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 2254f1f21227a15e51612523cc642fe58660e519661d61cb09d88270be9259965
+  sha256: 254f1f21227a15e51612523cc642fe58660e519661d61cb09d88270be9259965
 
 build:
   number: 0

--- a/recipes/toulligqc/meta.yaml
+++ b/recipes/toulligqc/meta.yaml
@@ -21,7 +21,7 @@ build:
 requirements:
   host:
     - pip
-    - python >=3.11.0
+    - python >=3.10.0
   run:
     - h5py >=3.7.0
     - matplotlib-base >=3.6.3
@@ -30,7 +30,7 @@ requirements:
     - pandas >=1.5.3
     - plotly >=5.15.0
     - pysam >=0.21.0
-    - python >=3.11.0
+    - python >=3.10.0
     - scikit-learn >=1.2.1
     - tqdm >=4.64.1
 


### PR DESCRIPTION
There is a v2.6 but due to some package dependencies (pod5), conda build fails.
We have published a new pypi package for v2.5.4 but there was no update to v2.5.4 in bioconda.