### PR TITLE
Updated ToulligQc to v2.5.4

### DIFF
--- a/recipes/toulligqc/meta.yaml
+++ b/recipes/toulligqc/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "toulligqc" %}
-{% set version = "2.5.3" %}
+{% set version = "2.5.4" %}
 
 package:
   name: "{{ name|lower }}"
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 254f1f21227a15e51612523cc642fe58660e519661d61cb09d88270be9259965
+  sha256: 27524706a9483b9fd38b1122b8622214126b02fa13cb2c198c6686346bd7c880
 
 build:
   number: 0


### PR DESCRIPTION
There is a v2.6 but due to some package dependencies (pod5), conda build fails.
We have published a new pypi package for v2.5.4 but there was no update to v2.5.4 in bioconda.