### PR TITLE
fix issue with sistr container

### DIFF
--- a/recipes/sistr_cmd/build.sh
+++ b/recipes/sistr_cmd/build.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
-python -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir  -vvv
+python -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vvv
+${PREFIX}}/bin/sistr_init

--- a/recipes/sistr_cmd/build.sh
+++ b/recipes/sistr_cmd/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 python -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vvv
-${PREFIX}}/bin/sistr_init
+${PREFIX}/bin/sistr_init

--- a/recipes/sistr_cmd/meta.yaml
+++ b/recipes/sistr_cmd/meta.yaml
@@ -6,18 +6,15 @@ package:
   version: "{{ version }}"
 
 source:
-  #url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  #sha256: f68de3f90c2d744db1f282db82f9e4094626c1448a5dbf834ff853c760975bb5
   url: https://github.com/phac-nml/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
   sha256: 5acffbaeb345bb6bdea4fae3317e651c254b114b37762eeb284c5bfa928329a2
   
 
 build:
-  number: 0
+  number: 1
   noarch: python
   run_exports:
     - {{ pin_subpackage(name, max_pin="x") }}
-  #script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir  -vvv
   entry_points:
     - sistr=sistr.sistr_cmd:main
     - sistr_init=sistr.sistr_cmd:setup_sistr_dbs
@@ -62,4 +59,3 @@ extra:
     - usegalaxy-eu:sistr_cmd
     - doi:10.1371/journal.pone.0147101
     - biotools:SISTR
-


### PR DESCRIPTION
sistr container tries to write in the container, as it adds a few MB of database files. This should add the data

```
    File "/usr/local/lib/python3.12/site-packages/sistr/sistr_cmd.py", line 368, in main
      setup_sistr_dbs()
    File "/usr/local/lib/python3.12/site-packages/sistr/sistr_cmd.py", line 222, in setup_sistr_dbs
      download_to_file(SISTR_DB_URL, tmp_file)
    File "/usr/local/lib/python3.12/site-packages/sistr/sistr_cmd.py", line 187, in download_to_file
      with open(file, 'wb') as f:
           ^^^^^^^^^^^^^^^^
  OSError: [Errno 30] Read-only file system: '/usr/local/lib/python3.12/site-packages/sistr/data.tar.gz'
```

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
