### PR TITLE
fix amrfinderplus pinning in abritamr

### DIFF
--- a/recipes/abritamr/meta.yaml
+++ b/recipes/abritamr/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: "{{ sha256 }}"
 
 build:
-  number: 0
+  number: 1
   noarch: python
   entry_points:
     - abritamr=abritamr.abritamr:main
@@ -29,7 +29,10 @@ requirements:
     - python >=3.9
     - pandas
     - xlsxwriter
-    - ncbi-amrfinderplus =3.10.42
+    # Please review ncbi-amrfinderplus pinning every release
+    # The version should be pinned to the database version used by abritamr
+    # Please see the "changes.txt" file in https://github.com/MDU-PHL/abritamr/blob/master/abritamr/db/amrfinderplus/data/<DATABASE_VERSION>/changes.txt
+    - ncbi-amrfinderplus =3.12.8
     - blast
     - hmmer
 


### PR DESCRIPTION
abritamr packages a prebuilt database that is locked to a specific ncbi-amrfinderplus version. Added a note to review this every new release, and which file to review

```
Database directory: '/usr/local/lib/python3.12/site-packages/abritamr/db/amrfinderplus/data/2024-01-31.1'
Database version: 2024-01-31.1

ESC[1;31m*** ERROR ***ESC[0m
Database requires sofware version at least 3.12.1

HOSTNAME: ?
SHELL: ?
PWD: /home/robert_petit/pytest_workflow_a9fmmcy8/abritamr-test/work/43/5c9ff0c6ef49be3520c78e6dcff64c
PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
Progam name:  amrfinder
Command line: amrfinder -n GCF_001682305.fna -o results/amrfinder.out --plus --threads 4 -d /usr/local/lib/python3.12/site-packages/abritamr/db/amrfinderplus/data/2024-01-31.1
```

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
