### PR TITLE
LOCIDEX BUILD #1 v0.1.1 -> updated pyrodigal >=3.0 due to new feature for locidex

### DIFF
--- a/recipes/locidex/meta.yaml
+++ b/recipes/locidex/meta.yaml
@@ -12,7 +12,7 @@ source:
   
 
 build:
-  number: 0
+  number: 1
   noarch: python
   run_exports:
     - {{ pin_subpackage(name, max_pin="x") }}
@@ -31,7 +31,7 @@ requirements:
     - numba >=0.57.1
     - pytables >=3.8
     - six >=1.16
-    - pyrodigal
+    - pyrodigal >=3.0
     - biopython >=1.83
     - mafft
     - blast >=2.9.0


### PR DESCRIPTION
Submitting build 1. 

Updated pyrodigal >=3.0 requirement as `locidex` calls an option called `GeneFinder` that only exists in version 3 of pyrodigal