### PR TITLE
Update MAGUS recipe, bump to v0.2.0

### DIFF
--- a/recipes/magus-msa/meta.yaml
+++ b/recipes/magus-msa/meta.yaml
@@ -33,6 +33,17 @@ requirements:
     - hmmer
 
 test:
+  imports:
+    - magus
+    - magus.align
+    - magus.align.decompose
+    - magus.align.merge
+    - magus.align.merge.graph_build
+    - magus.align.merge.graph_cluster
+    - magus.align.merge.graph_trace
+    - magus.helpers
+    - magus.tasks
+    - magus.tools
   commands:
     - magus --help
 


### PR DESCRIPTION
I have changed the packaging of MAGUS in the recent v0.2.0 release.
The build is still done via `pip install .`, but some of the tests were failing, because they were testing imports that no longer exist.
This commit changes the tests to reflect the new architecture.