### PR TITLE
Add argNorm recipe

### DIFF
--- a/recipes/argnorm/meta.yaml
+++ b/recipes/argnorm/meta.yaml
@@ -1,0 +1,50 @@
+{% set name = "argnorm" %}
+{% set version = "0.2.0" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  sha256: 8210aaa121272f2bd815498332bd076b9a5322b064c851dfb32d01486921a88c
+
+build:
+  number: 0
+  entry_points:
+    - argnorm=argnorm.cli:main
+  script: "{{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation"
+
+requirements:
+  host:
+    - pandas
+    - pip
+    - pronto
+    - pytest
+    - python
+    - setuptools
+  run:
+    - pandas
+    - pronto
+    - pytest
+    - python
+    - setuptools
+
+test:
+  imports:
+    - argnorm
+    - argnorm.data
+  commands:
+    - argnorm --help
+
+about:
+  home: "https://github.com/BigDataBiology/argNorm"
+  license: MIT
+  license_family: MIT
+  license_file: 
+  summary: "Normalize antibiotic resistance genes (ARGs) abundance tables (e.g., from metagenomics) by using the ARO ontology (developed by CARD)."
+  doc_url: https://argnorm.readthedocs.io/en/latest/
+
+extra:
+  recipe-maintainers:
+    - Vedanth-Ramji

--- a/recipes/argnorm/meta.yaml
+++ b/recipes/argnorm/meta.yaml
@@ -43,7 +43,7 @@ about:
   home: "https://github.com/BigDataBiology/argNorm"
   license: MIT
   license_family: MIT
-  license_file: 
+  license_file: LICENSE
   summary: "Normalize antibiotic resistance genes (ARGs) abundance tables (e.g., from metagenomics) by using the ARO ontology (developed by CARD)."
   doc_url: https://argnorm.readthedocs.io/en/latest/
 

--- a/recipes/argnorm/meta.yaml
+++ b/recipes/argnorm/meta.yaml
@@ -10,11 +10,13 @@ source:
   sha256: 8210aaa121272f2bd815498332bd076b9a5322b064c851dfb32d01486921a88c
 
 build:
+  noarch: python
   number: 0
   entry_points:
     - argnorm=argnorm.cli:main
   script: "{{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation"
-
+  run_exports:
+    - {{ pin_subpackage('argnorm', max_pin='x') }}
 requirements:
   host:
     - pandas


### PR DESCRIPTION
Describe your pull request here

Adding argNorm to bioconda. argNorm is a tool to normalize antibiotic resistance genes (ARGs) by mapping them to the antibiotic resistance ontology created by the CARD database. argNorm also provides drug categorization of drugs that antibiotic resistance genes confer resistance to.
----
