### PR TITLE
Add FirstBaseReadDepthFinder 0.1.0

### DIFF
--- a/recipes/firstbasereaddepthfinder/meta.yaml
+++ b/recipes/firstbasereaddepthfinder/meta.yaml
@@ -1,0 +1,39 @@
+{% set version = "0.1.0" %}
+
+package:
+  name: firstbasereaddepthfinder
+  version: {{ version }}
+
+source:
+  url: https://github.com/gozdekb/FirstBaseReadDepthFinder/archive/refs/tags/v0.1.0.tar.gz
+  sha256: cf421dae08bf202e9a6755552bb5b20a63867d634c39f8d13c57efbdeaaa4424
+
+build:
+  number: 0
+  noarch: generic
+  script: R CMD INSTALL --build .
+
+requirements:
+  host:
+    - r-base
+    - r-tidyverse
+    - r-janitor
+    - r-openxlsx
+  run:
+    - r-base
+    - r-tidyverse
+    - r-janitor
+    - r-openxlsx
+
+test:
+  commands:
+    - "Rscript -e 'library(\"FirstBaseReadDepthFinder\")'"
+
+about:
+  home: https://github.com/gozdekb/FirstBaseReadDepthFinder
+  license: None
+  summary: 'The FirstBaseReadDepthFinder R package is designed to analyze amplicon-based NGS data to find read depths at the first bases of amplicons. This package is particularly useful for researchers and bioinformaticians working with amplicon sequencing data, providing insights into the sequencing coverage of multiple SAM files at the same time.'
+
+extra:
+  recipe-maintainers:
+    - gozdekb


### PR DESCRIPTION
## Background
This PR adds a new package called `FirstBaseReadDepthFinder` for analyzing amplicon-based NGS data to find read depths at the first base of amplicons. It's particularly useful for researchers and bioinformaticians working with amplicon sequencing data.

## Content
- Added `meta.yaml` for the `FirstBaseReadDepthFinder` package version 0.1.0.
- This package includes dependencies on `r-base`, `r-tidyverse`, `r-janitor`, and `r-openxlsx`.

## Testing
The recipe has been locally tested to ensure correct build and installation.

## Notes for Reviewers
- The package is open source and is provided for educational or informational purposes.
- This is my first contribution to Bioconda, and I look forward to your feedback to improve the submission.