### PR TITLE
hybran: update to version 1.8

### DIFF
--- a/recipes/hybran/meta.yaml
+++ b/recipes/hybran/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.7.1" %}
+{% set version = "1.8" %}
 
 package:
   name: hybran
@@ -6,11 +6,11 @@ package:
 
 source:
   url: https://gitlab.com/LPCDRP/hybran/-/archive/{{ version }}/hybran-{{ version }}.tar.gz
-  sha256: 'c256e88009d0a2cc3fffcb021613392f6a71ee6905bfe1a1d806b962b5243017'
+  sha256: 'cd46ec155109e59ddadf6942a54edcd9c350c6571ae81524eab44d4b695cbbdb'
 
 build:
   noarch: python
-  number: 1
+  number: 0
   script: python -m pip install --no-deps --ignore-installed .
   run_exports:
     - {{ pin_subpackage('hybran', max_pin=None) }}
@@ -20,7 +20,7 @@ requirements:
     - python >=3.9
     - pip
   run:
-    - biopython >=1.80, <1.82
+    - biopython >=1.80
     - blast
     - cd-hit
     - diamond
@@ -28,8 +28,10 @@ requirements:
     - eggnog-mapper
     - emboss
     - entrez-direct
+    - intervaltree
     - mcl
     - multiprocess
+    - networkx
     - prokka >=1.14
     - python >=3.9
     - ratt
@@ -44,4 +46,4 @@ about:
   dev_url: https://gitlab.com/LPCDRP/hybran
   license: GPLv3
   license_file: LICENSE
-  summary: Hybrid reference transfer and ab initio prokaryotic genome annotation
+  summary: Comparative prokaryotic genome annotation


### PR DESCRIPTION
New dependencies in this version. Also, we've restored compatibility with latest biopython versions and so I've removed the version pinning.