### PR TITLE
Update dexseq to reinstate htseq-count dependency

### DIFF
--- a/recipes/bioconductor-dexseq/meta.yaml
+++ b/recipes/bioconductor-dexseq/meta.yaml
@@ -55,7 +55,7 @@ requirements:
     - 'bioconductor-s4vectors >=0.40.0,<0.41.0'
     - 'bioconductor-summarizedexperiment >=1.32.0,<1.33.0'
     - 'htseq >=2.0.2,<2.1'
-    - r-baseq
+    - r-base
     - r-hwriter
     - r-rcolorbrewer
     - r-statmod

--- a/recipes/bioconductor-dexseq/meta.yaml
+++ b/recipes/bioconductor-dexseq/meta.yaml
@@ -13,7 +13,7 @@ source:
     - 'https://depot.galaxyproject.org/software/bioconductor-{{ name|lower }}/bioconductor-{{ name|lower }}_{{ version }}_src_all.tar.gz'
   md5: 8e5876f927b0b0cdfc4a402bfb4fb3d6
 build:
-  number: 1
+  number: 2
   rpaths:
     - lib/R/lib/
     - lib/
@@ -54,7 +54,8 @@ requirements:
     - 'bioconductor-rsamtools >=2.18.0,<2.19.0'
     - 'bioconductor-s4vectors >=0.40.0,<0.41.0'
     - 'bioconductor-summarizedexperiment >=1.32.0,<1.33.0'
-    - r-base
+    - 'htseq >=2.0.2,<2.1'
+    - r-baseq
     - r-hwriter
     - r-rcolorbrewer
     - r-statmod
@@ -62,6 +63,8 @@ requirements:
 test:
   commands:
     - '$R -e "library(''{{ name }}'')"'
+    - dexseq_prepare_annotation.py --help
+    - dexseq_count.py --help
 about:
   home: 'https://bioconductor.org/packages/{{ bioc }}/bioc/html/{{ name }}.html'
   license: 'GPL (>= 3)'


### PR DESCRIPTION
I think htseq-count is required for dexseq_count.py.

Hopefully this is OK, I don't know why but it was removed in https://github.com/bioconda/bioconda-recipes/commit/25494d8ab5b1380a3e69445a1bb7e1d251cb3d2f  

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
