### PR TITLE
Downgrade Philosopher for compatibility with FragPipe

### DIFF
--- a/recipes/fragpipe/meta.yaml
+++ b/recipes/fragpipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "FragPipe" %}
 {% set version = "20.0" %}
-{% set philosopher_version = "5.1.0" %}
+{% set philosopher_version = "5.0.0" %}
 
 # These keys were generated ONLY for the testing of this bioconda package.
 # Users must generate their own key by agreeing to the terms at https://msfragger-upgrader.nesvilab.org/upgrader/ and https://msfragger.arsci.com/ionquant/.
@@ -12,7 +12,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 1
+  number: 2
   noarch: generic
   run_exports:
     - {{ pin_subpackage('fragpipe', max_pin="x.x") }}
@@ -22,7 +22,7 @@ source:
     sha256: 0d77db85ae26c190a915823e1c68238f3a19533810734b008564b2a8d85d1bd6
     folder: fragpipe_source
   - url: https://github.com/Nesvilab/philosopher/releases/download/v{{ philosopher_version }}/philosopher_v{{ philosopher_version }}_linux_amd64.zip
-    sha256: cf15a2d6321ecb530170b2410f5873f89e283b52d5f1ab0f27eebc124f4f4a1a
+    sha256: b0f6a6d22ca72efd54d1143142648e110b211eccaba20fe169ee65509da02fad
     folder: philosopher_source
 
 requirements:


### PR DESCRIPTION
Philosopher 5.1.0 is actually incompatible with FragPipe 20.0, which becomes apparent in certain configurations. This downgrades Philosopher to 5.0.0.

In the near future, we can upgrade both FragPipe and Philosopher to 21.* and 5.1.0 in tandem.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
