### PR TITLE
ci: specify macos version to control architecture

### DIFF
--- a/.github/workflows/Bulk.yml
+++ b/.github/workflows/Bulk.yml
@@ -77,7 +77,7 @@ jobs:
   build-osx:
     name: Bulk OSX Builds
     if: "contains(github.event.head_commit.message, '[ci run]')"
-    runs-on: macOS-latest
+    runs-on: macos-13
     strategy:
       fail-fast: false
       max-parallel: 4

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -165,7 +165,7 @@ jobs:
 
   build-osx:
     name: OSX Tests
-    runs-on: macOS-latest
+    runs-on: macos-13
     strategy:
       fail-fast: true
       max-parallel: 4

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -71,7 +71,7 @@ jobs:
   build-osx:
     name: OSX Upload
     if: github.repository == 'bioconda/bioconda-recipes'
-    runs-on: macOS-latest
+    runs-on: macos-13
     strategy:
       fail-fast: false
       max-parallel: 4

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -65,7 +65,7 @@ jobs:
   build-osx:
     name: OSX Tests
     if: github.repository == 'bioconda/bioconda-recipes'
-    runs-on: macOS-latest
+    runs-on: macos-13
     strategy:
       fail-fast: false
       max-parallel: 4


### PR DESCRIPTION
GitHub Actions changes are being rolled out to change `macos-latest` to use `macos-14` which has ARM architecture. Specify `macos-13` to continue to build and test on x86-64.

NOTE: This really only affects the `bulk` branch because the other workflows are currently disabled on GitHub Actions and run on Azure instead. I'm updating those disabled workflow files now in case we decide to reuse them in the future.

https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources