### PR TITLE
BUG specify pronto version for argnorm

### DIFF
--- a/recipes/argnorm/meta.yaml
+++ b/recipes/argnorm/meta.yaml
@@ -21,15 +21,15 @@ requirements:
   host:
     - pandas
     - pip
-    - pronto>=2.5.6
+    - pronto >=2.5.6
     - pytest
-    - python>=3.7
+    - python >=3.7
     - setuptools
   run:
     - pandas
-    - pronto>=2.5.6
+    - pronto >=2.5.6
     - pytest
-    - python>=3.7
+    - python >=3.7
     - setuptools
 
 test:

--- a/recipes/argnorm/meta.yaml
+++ b/recipes/argnorm/meta.yaml
@@ -21,15 +21,15 @@ requirements:
   host:
     - pandas
     - pip
-    - pronto
+    - pronto>=2.5.6
     - pytest
-    - python
+    - python>=3.7
     - setuptools
   run:
     - pandas
-    - pronto
+    - pronto>=2.5.6
     - pytest
-    - python
+    - python>=3.7
     - setuptools
 
 test:

--- a/recipes/argnorm/meta.yaml
+++ b/recipes/argnorm/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   entry_points:
     - argnorm=argnorm.cli:main
   script: "{{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation"


### PR DESCRIPTION
Explicitly specify pronto version as current conda installation downloads older version of pronto