### PR TITLE
ENH add chardet version specification to argnorm

### DIFF
--- a/recipes/argnorm/meta.yaml
+++ b/recipes/argnorm/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 1
+  number: 2
   entry_points:
     - argnorm=argnorm.cli:main
   script: "{{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation"

--- a/recipes/argnorm/meta.yaml
+++ b/recipes/argnorm/meta.yaml
@@ -25,12 +25,14 @@ requirements:
     - pytest
     - python >=3.7
     - setuptools
+    - chardet >=5.2.0
   run:
     - pandas
     - pronto >=2.5.6
     - pytest
     - python >=3.7
     - setuptools
+    - chardet >=5.2.0
 
 test:
   imports:


### PR DESCRIPTION
Specify chardet as requirement due to error during installation with pronto.