### PR TITLE
Update shiver

### DIFF
--- a/build-fail-blacklist
+++ b/build-fail-blacklist
@@ -419,9 +419,6 @@ recipes/intervalstats
 recipes/oligotyping
 recipes/oligotyping/2.0
 
-# missing file
-recipes/shiver
-
 # missing binary
 recipes/semeta
 

--- a/recipes/cnvkit/meta.yaml
+++ b/recipes/cnvkit/meta.yaml
@@ -1,37 +1,43 @@
-{% set version="0.9.10" %}
+{% set name = "cnvkit" %}
+{% set version = "0.9.11" %}
+
 package:
-  name: cnvkit
+  name: {{ name }}
   version: {{ version }}
 
 source:
   url: https://github.com/etal/cnvkit/archive/v{{ version }}.tar.gz
-  sha256: 56739496f1f59511661107e662d81e5fd8af413571e853b0a1b34d882a19349a
+  sha256: 1763936427184270108fd51219ebc82f542e28339bdec587579b8745f61179a8
 
 build:
   noarch: python
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  entry_points:
+    - cnvkit.py = cnvlib.cnvkit:main
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --no-cache-dir -vvv
+  run_exports:
+    - {{ pin_subpackage('cnvkit', max_pin="x.x") }}
 
 requirements:
   host:
-    - python >=3.5
+    - python >=3.8
     - pip
   run:
-    - python >=3.5
+    - python >=3.8
     - bioconductor-dnacopy
-    - biopython >=1.62
-    - joblib <1.0
-    - matplotlib-base >=1.3.1
+    - biopython >=1.80
+    - matplotlib-base >=3.5.2
     - networkx >=2.4
-    - numpy >=1.9
-    - pandas >=0.23.3
-    - pomegranate >=0.9.0
-    - pyfaidx >=0.4.7
-    - pysam >=0.16.0
+    - numpy >=1.24.2
+    - pandas >=1.5.3
+    - pomegranate >=0.14.8,<=0.14.9
+    - pyfaidx >=0.7.1
+    - pysam >=0.20.0
     - r-base >=3.4.1
     - r-cghflasso
-    - reportlab >=3.0
-    - scipy >=0.15.0
+    - reportlab >=3.6.12
+    - scikit-learn >=1.1.0
+    - scipy >=1.10.1
 
 test:
   imports:
@@ -45,9 +51,30 @@ test:
 about:
   home: https://github.com/etal/cnvkit
   license: Apache-2.0
+  license_family: APACHE
+  license_file: LICENSE
   summary: Copy number variant detection from high-throughput sequencing
+  dev_url: https://github.com/etal/cnvkit
+  doc_url: https://cnvkit.readthedocs.io/en/stable/
 
 extra:
   identifiers:
     - biotools:cnvkit
     - doi:10.1371/journal.pcbi.1004873
+    - usegalaxy-eu:cnvkit_access
+    - usegalaxy-eu:cnvkit_antitarget
+    - usegalaxy-eu:cnvkit_autobin
+    - usegalaxy-eu:cnvkit_batch
+    - usegalaxy-eu:cnvkit_call
+    - usegalaxy-eu:cnvkit_coverage
+    - usegalaxy-eu:cnvkit_diagram
+    - usegalaxy-eu:cnvkit_fix
+    - usegalaxy-eu:cnvkit_heatmap
+    - usegalaxy-eu:cnvkit_reference
+    - usegalaxy-eu:cnvkit_scatter
+    - usegalaxy-eu:cnvkit_segment
+    - usegalaxy-eu:cnvkit_target
+    - usegalaxy-eu:cnvkit_breaks
+    - usegalaxy-eu:cnvkit_genemetrics
+    - usegalaxy-eu:cnvkit_segmetrics
+    - usegalaxy-eu:cnvkit_sex

--- a/recipes/shiver/meta.yaml
+++ b/recipes/shiver/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.5.7" %} # put in correct version here
+{% set version = "1.7.0" %} # put in correct version here
 {% set name = "shiver" %}
 
 package:
@@ -6,9 +6,7 @@ package:
   version: {{ version }}
 source:
   url: https://github.com/ChrisHIV/{{ name|lower }}/archive/v{{ version }}.tar.gz
-  sha256: 64973462bfc10c725ef5f21e85532ef8dd58d26795b2cee326a77f690d31ebf0
-  patches:
-    - python2-python3.patch
+  sha256: 461752a23a284d6bf4fc186a4e263b5efd28e792b484813d237e3d749b3fbf2f
 build:
   number: 1
 

--- a/recipes/shiver/meta.yaml
+++ b/recipes/shiver/meta.yaml
@@ -9,6 +9,7 @@ source:
   sha256: 461752a23a284d6bf4fc186a4e263b5efd28e792b484813d237e3d749b3fbf2f
 build:
   number: 0
+  noarch: python
 
 
 requirements:

--- a/recipes/shiver/meta.yaml
+++ b/recipes/shiver/meta.yaml
@@ -10,6 +10,8 @@ source:
 build:
   number: 0
   noarch: generic
+  run_exports:
+    - {{ pin_subpackage('shiver', max_pin="x") }}
 
 
 requirements:

--- a/recipes/shiver/meta.yaml
+++ b/recipes/shiver/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 461752a23a284d6bf4fc186a4e263b5efd28e792b484813d237e3d749b3fbf2f
 build:
   number: 0
-  noarch: python
+  noarch: generic
 
 
 requirements:

--- a/recipes/shiver/meta.yaml
+++ b/recipes/shiver/meta.yaml
@@ -8,7 +8,7 @@ source:
   url: https://github.com/ChrisHIV/{{ name|lower }}/archive/v{{ version }}.tar.gz
   sha256: 461752a23a284d6bf4fc186a4e263b5efd28e792b484813d237e3d749b3fbf2f
 build:
-  number: 1
+  number: 0
 
 
 requirements:


### PR DESCRIPTION
Updates shiver to latest version (v1.7.0) and removes python2 patch as no longer necessary
