### PR TITLE
[Update] Metabuli 1.0.5

### DIFF
--- a/recipes/metabuli/meta.yaml
+++ b/recipes/metabuli/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "1.0.3" %}
-{% set sha256 = "facfc3c411b4732e80ac4dfaccf1057cf8b86da4a8d4f05667b1f07dbb18077d" %}
+{% set version = "1.0.4" %}
+{% set sha256 = "f86e1ddc831f412761e61a4b483b2d8d4329214e5bbd7145541ef4dceaa0af9b" %}
 
 package:
   name: metabuli

--- a/recipes/metabuli/meta.yaml
+++ b/recipes/metabuli/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "1.0.5" %}
-{% set sha256 = "f86e1ddc831f412761e61a4b483b2d8d4329214e5bbd7145541ef4dceaa0af9b" %}
+{% set sha256 = "c84a4e2436904f0cbea7126abf2a5f665a870735c8af786883e10f3f872bda28" %}
 
 package:
   name: metabuli

--- a/recipes/metabuli/meta.yaml
+++ b/recipes/metabuli/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version|replace("-", ".")  }}
 
 build:
-  number: 1
+  number: 0
   run_exports:
     - {{ pin_subpackage('metabuli', max_pin="x") }}
 

--- a/recipes/metabuli/meta.yaml
+++ b/recipes/metabuli/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.0.4" %}
+{% set version = "1.0.5" %}
 {% set sha256 = "f86e1ddc831f412761e61a4b483b2d8d4329214e5bbd7145541ef4dceaa0af9b" %}
 
 package:


### PR DESCRIPTION
- Fixed a minor reproducibility issue.
- Fixed a performance-harming bug occurring with sequences containing lowercased bases.
- Auto adjustment of --match-per-kmer parameter. 
- Record version info. in db.parameter

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
