### PR TITLE
fix: Nextclade sha256sum for 3.3.1 osx_64

### DIFF
--- a/recipes/nextclade/meta.yaml
+++ b/recipes/nextclade/meta.yaml
@@ -11,12 +11,12 @@ source:
   - url: https://github.com/nextstrain/nextclade/releases/download/{{ version }}/{{ name }}-aarch64-unknown-linux-gnu  # [aarch64]
     sha256: 63b38aac186b9b9776761bb1a321b87382044d01c17e6b4a2ba76ca614d04ed1                                           # [aarch64]
   - url: https://github.com/nextstrain/nextclade/releases/download/{{ version }}/{{ name }}-x86_64-apple-darwin        # [osx and x86_64]
-    sha256: 330ad12cd1bb20429f49fd00bcd773c453b66662842913ec35bc9e288ab3db2a                                           # [osx and x86_64]
+    sha256: d8e1604be6a32f34086616ebdf532ec1409d500b5fe72c239b6db2614d75e722                                           # [osx and x86_64]
   - url: https://github.com/nextstrain/nextclade/releases/download/{{ version }}/{{ name }}-aarch64-apple-darwin       # [osx and arm64]
     sha256: b95e2ed966b08dbd481fe48d7aa1019a748d29ef330daad4773d1c98e6b007ba                                           # [osx and arm64]
 
 build:
-  number: 1
+  number: 0
   binary_relocation: False
   run_exports:
   - {{ pin_compatible(name, max_pin='x') }}

--- a/recipes/nextclade/meta.yaml
+++ b/recipes/nextclade/meta.yaml
@@ -16,7 +16,7 @@ source:
     sha256: b95e2ed966b08dbd481fe48d7aa1019a748d29ef330daad4773d1c98e6b007ba                                           # [osx and arm64]
 
 build:
-  number: 0
+  number: 2
   binary_relocation: False
   run_exports:
   - {{ pin_compatible(name, max_pin='x') }}


### PR DESCRIPTION
Update [nextclade](https://bioconda.github.io/recipes/nextclade/README.html): 3.3.1 → 3.3.1.

<img src=https://img.shields.io/conda/dn/bioconda/nextclade.svg />

<table>
<tr>
	<td>Home</td>
	<td><a href="https://github.com/nextstrain/nextclade">https://github.com/nextstrain/nextclade</a></td>
</tr>
<tr>
	<td>Summary</td>
	<td>Viral genome alignment, mutation calling, clade assignment, quality checks and phylogenetic placement</td>
</tr>
<tr>
	<td>Recipe maintainers</td>
	<td>@pvanheus, @corneliusroemer, @ivan-aksamentov</td>
</tr>
</table>

@BiocondaBot please add label

@BiocondaBot please fetch artifacts

Note: this pull request is submitted [automatically](https://github.com/nextstrain/nextclade/blob/master/.github/workflows/bioconda.yml), triggered by [a release](https://github.com/nextstrain/nextclade/releases) in [nextstrain/nextclade](https://github.com/nextstrain/nextclade) repo. If you want to get in touch, please ping recipe maintainers and/or someone from [`@nextstrain/core`](https://github.com/orgs/nextstrain/teams/core/members) team.

