### PR TITLE
Update snakemake pinned dependency to match setup.cfg

### DIFF
--- a/recipes/snakemake/meta.yaml
+++ b/recipes/snakemake/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: c64e0ddfe2af6c06f0c50f5451b8cffad0775a829364754e40da418b4c1118d6
 
 build:
-  number: 0
+  number: 1
   noarch: generic
   run_exports:
     - {{ pin_subpackage("snakemake", max_pin="x") }}

--- a/recipes/snakemake/meta.yaml
+++ b/recipes/snakemake/meta.yaml
@@ -102,7 +102,7 @@ outputs:
         - pyyaml
         - requests >=2.8.1
         - reretry
-        - smart_open >=3.0,<4.0
+        - smart_open >=3.0,<8.0
         - snakemake-interface-executor-plugins >=9.1.0,<10.0.0
         - snakemake-interface-common >=1.17.0,<2.0
         - snakemake-interface-storage-plugins >=3.1.0,<4.0


### PR DESCRIPTION
This PR ensures we use the newest version of smart-open, which was pinned incorrectly here.

It fixes (https://github.com/snakemake/snakemake/issues/2765) which was caused by a bug in smart-open version 3.