### PR TITLE
Update snakemake minimum version for smart-open

### DIFF
--- a/recipes/snakemake/meta.yaml
+++ b/recipes/snakemake/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 75711faa668324f9e6c44a860f2f9645be358763a97ee411bb32f7a8f6dca6b7
 
 build:
-  number: 0
+  number: 1
   noarch: generic
   run_exports:
     - {{ pin_subpackage("snakemake", max_pin="x") }}
@@ -102,7 +102,7 @@ outputs:
         - pyyaml
         - requests >=2.8.1
         - reretry
-        - smart_open >=3.0,<8.0
+        - smart_open >=4.0,<8.0
         - snakemake-interface-executor-plugins >=9.1.0,<10.0.0
         - snakemake-interface-common >=1.17.0,<2.0
         - snakemake-interface-storage-plugins >=3.1.0,<4.0

--- a/recipes/snakemake/meta.yaml
+++ b/recipes/snakemake/meta.yaml
@@ -83,7 +83,7 @@ outputs:
         - pip
         - setuptools
       run:
-        # Keep in sync with snakemake/setup.cfg
+        # Keep in sync with snakemake/setup.cfg 
         - python >=3.11,<3.13
         - appdirs
         - immutables


### PR DESCRIPTION
This raises the minimum required version for smart-open to ">=4". This prevents a bug 
https://github.com/snakemake/snakemake/issues/2765
when using snakemake with the old version of smart-open: 

I have also opened a PR to snakemake, to also set the restriction in "setup.cfg" as well: 
https://github.com/snakemake/snakemake/pull/2833
