### PR TITLE
Update pybigtools to 0.1.3

### DIFF
--- a/recipes/pybigtools/build.sh
+++ b/recipes/pybigtools/build.sh
@@ -14,10 +14,19 @@ if [ `uname` == Darwin ]; then
 	export HOME=`mktemp -d`
 fi
 
-# build statically linked binary with Rust
-RUST_BACKTRACE=1
-# Build the package using maturin - should produce *.whl files.
+# Build statically linked binary with Rust
+# Note: This sdist is a bit wonky because it was generated from a monorepo by running maturin sdist
+RUST_BACKTRACE=1 
+
+# Creating the sdist from the monorepo placed pyproject.toml one level above Cargo.toml.
+# The wheels don't seem to install as expected unless pyproject.toml is moved back into the source dir.
+mv pyproject.toml pybigtools/
+
+# Run maturin build to produce *.whl files.
 maturin build -m pybigtools/Cargo.toml -b pyo3 --interpreter "${PYTHON}" --release --strip
 
 # Install *.whl files using pip
-${PYTHON} -m pip install target/wheels/*.whl --no-deps --no-build-isolation --no-cache-dir -vvv
+${PYTHON} -m pip install pybigtools/target/wheels/*.whl --no-deps --no-build-isolation --no-cache-dir -vvv
+
+# Move the LICENSE file to the root dir
+mv pybigtools/LICENSE .

--- a/recipes/pybigtools/meta.yaml
+++ b/recipes/pybigtools/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "pybigtools" %}
-{% set version = "0.1.2" %}
-{% set sha256 = "ecc46cbfac71a4c10b7c14b4b280742db9d6ef6cecd5e595bb361027c47ea670" %}
+{% set version = "0.1.3" %}
+{% set sha256 = "0dd7f2127ff2a96cc4a7cf4dda2ce5b3e5916559640a85aec5966e796244a613" %}
 
 package:
   name: {{ name }}
   version: {{ version }}
 
 source:
-  url: "https://github.com/jackh726/bigtools/archive/refs/tags/{{ name }}@v{{ version }}.tar.gz"
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
   sha256: {{ sha256 }}
 
 build:

--- a/recipes/pybigtools/meta.yaml
+++ b/recipes/pybigtools/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 2
+  number: 0
   run_exports:
     - {{ pin_subpackage('pybigtools', max_pin="x.x") }}
 


### PR DESCRIPTION
Trying to switch to a URL pattern autobump will recognize.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
