### PR TITLE
PATCH: include pysam in libdeflate repodata-patches

### DIFF
--- a/recipes/bioconda-repodata-patches/gen_patch_json.py
+++ b/recipes/bioconda-repodata-patches/gen_patch_json.py
@@ -172,7 +172,7 @@ def _gen_new_index(repodata, subdir):
             _pin_looser(fn, record, 'htslib', min_lower_bound='1.10', upper_bound='1.21')
 
         # future libdeflate versions are compatible until they bump their soversion; relax dependencies accordingly
-        if record_name in ['htslib', 'staden_io_lib', 'fastp'] and has_dep(record, 'libdeflate'):
+        if record_name in ['htslib', 'staden_io_lib', 'fastp', 'pysam'] and has_dep(record, 'libdeflate'):
             # skip deps that allow anything <1.3, which contained an incompatible library filename
             # TODO adjust the replacement (exclusive) upper bound each time a compatible new libdeflate is released
             _pin_looser(fn, record, 'libdeflate', min_lower_bound='1.3', upper_bound='1.21')

--- a/recipes/bioconda-repodata-patches/meta.yaml
+++ b/recipes/bioconda-repodata-patches/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: bioconda-repodata-patches
-  version: 20240416  # ensure that this is the "current" date, and always higher than the latest version in master
+  version: 20240525  # ensure that this is the "current" date, and always higher than the latest version in master
 
 source:
   path: .


### PR DESCRIPTION
The current build of `pysam` contains a max pin of 1.19 for `libdeflate`, which conflicts with a lot of packages in the QIIME 2 ecosystem. However, it appears as though `pysam` is compatible with the newer version of `libdeflate` - this just needs to be reflected in the bioconda build (see this related [PR](https://github.com/bioconda/bioconda-recipes/pull/40675) and [comment](https://github.com/pysam-developers/pysam/issues/1114#issuecomment-1521641722)).
