### PR TITLE
perl-text-roman

### DIFF
--- a/recipes/perl-text-roman/build.sh
+++ b/recipes/perl-text-roman/build.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# If it has Build.PL use that, otherwise use Makefile.PL
+if [ -f Build.PL ]; then
+    perl Build.PL
+    ./Build
+    ./Build test
+    # Make sure this goes in site
+    ./Build install --installdirs site
+elif [ -f Makefile.PL ]; then
+    # Make sure this goes in site
+    perl Makefile.PL INSTALLDIRS=site
+    make
+    make test
+    make install
+else
+    echo 'Unable to find Build.PL or Makefile.PL. You need to modify build.sh.'
+    exit 1
+fi
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/recipes/perl-text-roman/meta.yaml
+++ b/recipes/perl-text-roman/meta.yaml
@@ -1,0 +1,25 @@
+package:
+  name: perl-text-roman
+  version: "3.5"
+
+source:
+  url: https://cpan.metacpan.org/authors/id/S/SY/SYP/Text-Roman-3.5.tar.gz
+  md5: 1f6b09c0cc1f4425b565ff787a39fd83
+
+build:
+  noarch: generic
+  number: 2
+
+requirements:
+  build:
+    - make
+  host:
+    - perl
+    - perl-module-build
+  run:
+    - perl
+
+about:
+  home: https://metacpan.org/pod/Text::Roman
+  license: perl_5
+  summary: 'converts between arabic and roman numerals'


### PR DESCRIPTION
I created  a recipe for the Perl Text::Roman module available in cpan using the bioconda perl-text-glob recipe as template.  It was not available in conda channels. I need this perl module for a conda recipe about a pipeline I developed recently to investigate genome collinearity (https://github.com/PombertLab/SYNY).

I tested the perl-text-roman recipe locally with conda build and it seems to work fine. It is my first time contributing to bioconda so hopefully I did not make any mistake. 

Best regards,
JF

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
