### PR TITLE
disable phone home snpeff

### DIFF
--- a/recipes/snpeff/meta.yaml
+++ b/recipes/snpeff/meta.yaml
@@ -14,7 +14,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 0
+  number: 1
   noarch: generic
   run_exports:
     - {{ pin_compatible('snpeff', max_pin="x.x") }}
@@ -31,6 +31,8 @@ requirements:
 
 test:
   commands:
+    - snpEff -help --debug
+    - snpEff -help
     - snpEff -version
 
 extra:

--- a/recipes/snpeff/meta.yaml
+++ b/recipes/snpeff/meta.yaml
@@ -4,11 +4,6 @@
 {% set version = "5.2" %}
 {% set sha256 = "60ad2eec66c4f086b8cc7812e5654dce2dd500dd218774da490326e6a4e585f7" %}
 
-about:
-  home: 'http://snpeff.sourceforge.net/'
-  license: "LGPLv3"
-  summary: "Genetic variant annotation and effect prediction toolbox"
-
 package:
   name: snpeff
   version: {{ version }}
@@ -34,6 +29,11 @@ test:
     - snpEff -help --debug
     - snpEff -help
     - snpEff -version
+
+about:
+  home: 'http://snpeff.sourceforge.net/'
+  license: "LGPLv3"
+  summary: "Genetic variant annotation and effect prediction toolbox"
 
 extra:
   notes: 'The tool is available as command `snpEff`. Note that the package version is slightly different from upstream, this is to make sure conda will order the package versions correctly.'

--- a/recipes/snpeff/meta.yaml
+++ b/recipes/snpeff/meta.yaml
@@ -26,7 +26,7 @@ requirements:
 
 test:
   commands:
-    - snpEff -help --debug
+    - snpEff -help --dry-run
     - snpEff -version
 
 about:

--- a/recipes/snpeff/meta.yaml
+++ b/recipes/snpeff/meta.yaml
@@ -27,7 +27,6 @@ requirements:
 test:
   commands:
     - snpEff -help --debug
-    - snpEff -help
     - snpEff -version
 
 about:

--- a/recipes/snpeff/snpeff.py
+++ b/recipes/snpeff/snpeff.py
@@ -80,7 +80,7 @@ def jvm_opts(argv):
     if mem_opts == [] and getenv('_JAVA_OPTIONS') is None:
         mem_opts = default_jvm_mem_opts
 
-    return (mem_opts, prop_opts, pass_args, exec_dir, is_debug)
+    return (mem_opts, prop_opts, pass_args, exec_dir, is_dryrun)
 
 
 def main():

--- a/recipes/snpeff/snpeff.py
+++ b/recipes/snpeff/snpeff.py
@@ -16,7 +16,7 @@ from os import X_OK
 
 jar_file = 'snpEff.jar'
 
-# Phone home has been diabled due to usage of an unregistered domain
+# Phone home has been disabled due to usage of an unregistered domain
 # If in the future the "phone home" feature becomes "opt-in" (e.g. -Log)
 # please remove the below to allow users to opt in
 disable_phone_home_opts = ['-noLog']

--- a/recipes/snpeff/snpeff.py
+++ b/recipes/snpeff/snpeff.py
@@ -53,7 +53,7 @@ def jvm_opts(argv):
     prop_opts = []
     pass_args = []
     exec_dir = None
-    is_debug = False
+    is_dryrun = False
 
     for arg in argv:
         if arg.startswith('-D'):
@@ -66,8 +66,8 @@ def jvm_opts(argv):
             exec_dir = arg.split('=')[1].strip('"').strip("'")
             if not os.path.exists(exec_dir):
                 shutil.copytree(real_dirname(sys.argv[0]), exec_dir, symlinks=False, ignore=None)
-        elif arg.startswith('--debug'):
-            is_debug = True
+        elif arg.startswith('--dry-run'):
+            is_dryrun = True
         else:
             pass_args.append(arg)
 
@@ -92,7 +92,7 @@ def main():
     If the exec_dir dies not exist,
     we copy the jar file, lib, and resources to the exec_dir directory.
     """
-    (mem_opts, prop_opts, pass_args, exec_dir, is_debug) = jvm_opts(sys.argv[1:])
+    (mem_opts, prop_opts, pass_args, exec_dir, is_dryrun) = jvm_opts(sys.argv[1:])
     jar_dir = exec_dir if exec_dir else real_dirname(sys.argv[0])
 
     if pass_args != [] and pass_args[0].startswith('eu'):
@@ -104,7 +104,7 @@ def main():
 
     java_args = [java] + mem_opts + prop_opts + [jar_arg] + [jar_path] + pass_args + disable_phone_home_opts
 
-    if is_debug:
+    if is_dryrun:
         sys.exit(print(java_args))
     else:
         sys.exit(subprocess.call(java_args))

--- a/recipes/snpeff/snpeff.py
+++ b/recipes/snpeff/snpeff.py
@@ -16,6 +16,10 @@ from os import X_OK
 
 jar_file = 'snpEff.jar'
 
+# Phone home has been diabled due to usage of an unregistered domain
+# If in the future the "phone home" feature becomes "opt-in" (e.g. -Log)
+# please remove the below to allow users to opt in
+disable_phone_home_opts = ['-noLog']
 
 default_jvm_mem_opts = ['-Xms512m', '-Xmx1g']
 
@@ -49,6 +53,7 @@ def jvm_opts(argv):
     prop_opts = []
     pass_args = []
     exec_dir = None
+    is_debug = False
 
     for arg in argv:
         if arg.startswith('-D'):
@@ -61,6 +66,8 @@ def jvm_opts(argv):
             exec_dir = arg.split('=')[1].strip('"').strip("'")
             if not os.path.exists(exec_dir):
                 shutil.copytree(real_dirname(sys.argv[0]), exec_dir, symlinks=False, ignore=None)
+        elif arg.startswith('--debug'):
+            is_debug = True
         else:
             pass_args.append(arg)
 
@@ -73,7 +80,7 @@ def jvm_opts(argv):
     if mem_opts == [] and getenv('_JAVA_OPTIONS') is None:
         mem_opts = default_jvm_mem_opts
 
-    return (mem_opts, prop_opts, pass_args, exec_dir)
+    return (mem_opts, prop_opts, pass_args, exec_dir, is_debug)
 
 
 def main():
@@ -85,7 +92,7 @@ def main():
     If the exec_dir dies not exist,
     we copy the jar file, lib, and resources to the exec_dir directory.
     """
-    (mem_opts, prop_opts, pass_args, exec_dir) = jvm_opts(sys.argv[1:])
+    (mem_opts, prop_opts, pass_args, exec_dir, is_debug) = jvm_opts(sys.argv[1:])
     jar_dir = exec_dir if exec_dir else real_dirname(sys.argv[0])
 
     if pass_args != [] and pass_args[0].startswith('eu'):
@@ -95,9 +102,12 @@ def main():
 
     jar_path = os.path.join(jar_dir, jar_file)
 
-    java_args = [java] + mem_opts + prop_opts + [jar_arg] + [jar_path] + pass_args
+    java_args = [java] + mem_opts + prop_opts + [jar_arg] + [jar_path] + pass_args + disable_phone_home_opts
 
-    sys.exit(subprocess.call(java_args))
+    if is_debug:
+        sys.exit(print(java_args))
+    else:
+        sys.exit(subprocess.call(java_args))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Currently SneEff phones home to `www.dnaminer.com` (https://github.com/pcingola/SnpEff/blob/master/src/main/java/org/snpeff/logStatsServer/LogStats.java#L37-L42) which is no longer a registered domain. Phoning home can be disabled with `-noLog`.

This PR makes it so that SnpEff is always executed with `-noLog` I have submitted an issue upstream at https://github.com/pcingola/SnpEff/issues/541

I also added a debug feature to the python wrapper just for sanity checks to make sure `-noLog` is being passed

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
