### PR TITLE
Update Sambamba recipe to use release binary rather than test binary

### DIFF
--- a/recipes/sambamba/build.sh
+++ b/recipes/sambamba/build.sh
@@ -10,8 +10,12 @@ fi
 
 sed -e "/^CC=/d" Makefile > Makefile.new
 mv Makefile.new Makefile
-make CC=${CC} LIBRARY_PATH=${PREFIX}/lib prefix=${PREFIX}
+
+# Running this make target compiles an unoptimised binary so must be done prior to release compile
 make test CC=${CC}
+
+make CC=${CC} LIBRARY_PATH=${PREFIX}/lib prefix=${PREFIX}
 make install prefix=${PREFIX}
+
 # The binaries are versioned for some reason
 mv ${PREFIX}/bin/sambamba-* ${PREFIX}/bin/sambamba

--- a/recipes/sambamba/meta.yaml
+++ b/recipes/sambamba/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipes/sambamba/meta.yaml
+++ b/recipes/sambamba/meta.yaml
@@ -11,6 +11,8 @@ source:
 
 build:
   number: 1
+  run_exports:
+    - {{ pin_subpackage(name, max_pin='x.x') }}
 
 requirements:
   build:


### PR DESCRIPTION
### Background

- Sambamba recompiles the output binary for both the `make` and `make test` targets
- the `make` target but not `make test` target applies optimisation
- the current command ordering in `build.sh` means that the unoptimised binary is inadvertently distributed
- I have observed a ~8x slowdown for `sambamba merge` when using the Conda package compared to manually compiled

The following issues are also likely related:

- https://github.com/biod/sambamba/issues/503
- https://github.com/biod/sambamba/issues/447

### Changes

- adjust command ordering so that the optimised binary is distributed

### Other

- please do not merge until I have been able to confirm slowdown is resolved with in the new build artefacts

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
