### PR TITLE
Update MarkDups 1.1.5 to use fixed Sambamba package

### DIFF
--- a/recipes/hmftools-mark-dups/1.1.5/build.sh
+++ b/recipes/hmftools-mark-dups/1.1.5/build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+TGT="$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM"
+[ -d "$TGT" ] || mkdir -p "$TGT"
+[ -d "${PREFIX}/bin" ] || mkdir -p "${PREFIX}/bin"
+
+cd "${SRC_DIR}"
+mv mark-dups*.jar $TGT/markdups.jar
+
+cp $RECIPE_DIR/markdups.sh $TGT/markdups
+ln -s $TGT/markdups $PREFIX/bin
+chmod 0755 "${PREFIX}/bin/markdups"

--- a/recipes/hmftools-mark-dups/1.1.5/markdups.sh
+++ b/recipes/hmftools-mark-dups/1.1.5/markdups.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# hmftools MarkDups executable shell script
+# https://github.com/hartwigmedical/hmftools/tree/master/mark-dups
+set -eu -o pipefail
+
+export LC_ALL=en_US.UTF-8
+
+# Find original directory of bash script, resolving symlinks
+# http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in/246128#246128
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+    DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+    SOURCE="$(readlink "$SOURCE")"
+    [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+
+JAR_DIR=$DIR
+ENV_PREFIX="$(dirname $(dirname $DIR))"
+# Use Java installed with Anaconda to ensure correct version
+java="$ENV_PREFIX/bin/java"
+
+# if JAVA_HOME is set (non-empty), use it. Otherwise keep "java"
+if [ -n "${JAVA_HOME:=}" ]; then
+  if [ -e "$JAVA_HOME/bin/java" ]; then
+      java="$JAVA_HOME/bin/java"
+  fi
+fi
+
+# extract memory and system property Java arguments from the list of provided arguments
+# http://java.dzone.com/articles/better-java-shell-script
+default_jvm_mem_opts="-Xms512m -Xmx1g"
+jvm_mem_opts=""
+jvm_prop_opts=""
+pass_args=""
+for arg in "$@"; do
+    case $arg in
+        '-D'*)
+            jvm_prop_opts="$jvm_prop_opts $arg"
+            ;;
+        '-XX'*)
+            jvm_prop_opts="$jvm_prop_opts $arg"
+            ;;
+         '-Xm'*)
+            jvm_mem_opts="$jvm_mem_opts $arg"
+            ;;
+         *)
+	    if [[ ${pass_args} == '' ]] #needed to avoid preceeding space on first arg e.g. ' MarkDuplicates'
+            then 
+                pass_args="$arg" 
+	    else
+                pass_args="$pass_args \"$arg\"" #quotes later arguments to avoid problem with ()s in MarkDuplicates regex arg
+            fi
+            ;;
+    esac
+done
+
+if [ "$jvm_mem_opts" == "" ]; then
+    jvm_mem_opts="$default_jvm_mem_opts"
+fi
+
+pass_arr=($pass_args)
+if [[ ${pass_arr[0]:=} == com.hartwig.* ]]
+then
+    eval "$java" $jvm_mem_opts $jvm_prop_opts -cp "$JAR_DIR/markdups.jar" $pass_args
+else
+    eval "$java" $jvm_mem_opts $jvm_prop_opts -jar "$JAR_DIR/markdups.jar" $pass_args
+fi
+exit

--- a/recipes/hmftools-mark-dups/1.1.5/meta.yaml
+++ b/recipes/hmftools-mark-dups/1.1.5/meta.yaml
@@ -1,0 +1,32 @@
+{% set version = "1.1.5" %}
+{% set sha256 = "59cc87f1e7923b11d5c1b59c3c8fb531ace6d5d39dac61a165d76b4d1c472c10" %}
+
+package:
+  name: hmftools-mark-dups
+  version: '{{ version }}'
+
+source:
+  url: https://github.com/hartwigmedical/hmftools/releases/download/mark-dups-v{{ version }}/mark-dups_v{{ version }}.jar
+  sha256: '{{ sha256 }}'
+
+build:
+  noarch: generic
+  number: 1
+  run_exports:
+    - {{ pin_subpackage('hmftools-mark-dups', max_pin="x.x") }}
+
+requirements:
+  run:
+    - openjdk >=8
+    - sambamba >=1.0.1
+    - samtools >=1.17
+
+test:
+  commands:
+    - 'markdups -version | grep MarkDups'
+
+about:
+  home: https://github.com/hartwigmedical/hmftools/tree/master/mark-dups
+  license: GPL-3.0-only
+  license_family: GPL
+  summary: Mark read duplicates and form consenus sequences


### PR DESCRIPTION
- update MarkDups 1.1.5 recipe to use fixed Sambamba package, see:
  - https://github.com/bioconda/bioconda-recipes/pull/48071
  - https://github.com/bioconda/bioconda-recipes/pull/48074
- the change is applied only to the most recent MarkDups release that is available (1.1.5)
  - MarkDups 1.1.6 has since been deleted from the [hartwigmedical/hmftools releases](https://github.com/hartwigmedical/hmftools/releases?q=mark-dups)
  - I expect the next MarkDups release will be 1.1.6 (re-release) or 1.1.7, and I'll handle accordingly as that happens

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
