### PR TITLE
update metav recipes

### DIFF
--- a/recipes/metav/meta.yaml
+++ b/recipes/metav/meta.yaml
@@ -26,6 +26,8 @@ requirements:
     - python >=3.5
     - trimmomatic >=0.39
     - bowtie2 >=2.3.0
+    - samtools >=1.14
+    - salmon >=1.10.0
     - trinity >=2.15.1
     - diamond >=2.0.9
 

--- a/recipes/metav/meta.yaml
+++ b/recipes/metav/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 5a1bd914c3c180f2c73c77bb093fa7706853e6f8b718425dc1667a9f44356c6f
 
 build:
-  number: 0
+  number: 1
   noarch: python
   run_exports:
     - {{ pin_subpackage('metav', max_pin="x") }}


### PR DESCRIPTION
add two software dependencies (samtools >=1.14, salmon >=1.10.0) for metav to resolve the running bug when [Trinity](https://github.com/trinityrnaseq/trinityrnaseq) is called.