### PR TITLE
Update STAR-Fusion

### DIFF
--- a/recipes/star-fusion/meta.yaml
+++ b/recipes/star-fusion/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   noarch: generic
   run_exports:
     - {{ pin_subpackage('star-fusion', max_pin="x") }}
@@ -35,7 +35,7 @@ requirements:
     - perl-uri
     - python
     - samtools <1.10
-    - star ==2.7.8a
+    - star ==2.7.11a
     - trinity <2.9
 
 test:


### PR DESCRIPTION
According to the STAR-Fusion [release notes](https://github.com/STAR-Fusion/STAR-Fusion/releases/tag/STAR-Fusion-v1.13.0), this version of STAR-Fusion uses STAR `v2.7.11a`.
