### PR TITLE
Update kissplice 2.6.5

### DIFF
--- a/recipes/kissplice/build.sh
+++ b/recipes/kissplice/build.sh
@@ -1,13 +1,5 @@
 #!/bin/bash
 
-mkdir -p ${PREFIX}/bin
-
-export CXXFLAGS="$CXXFLAGS -fcommon -I$PREFIX/include"
-export CFLAGS="$CFLAGS -fcommon -I$PREFIX/include"
-
-# Unfortunately this is not written to pass on appropriate flags
-cmake -DCMAKE_INSTALL_PREFIX=${PREFIX} -DCMAKE_LIBRARY_PATH=$PREFIX/lib $DCMAKE_INCLUDE_PATH=$PREFIX/include -DUSER_GUIDE=OFF .
-
-# make commands
-make -j1 VERBOSE=1
-make install
+cmake -S . -B build/ -DCMAKE_INSTALL_PREFIX=${PREFIX}
+cmake --build build/
+cmake --install build/

--- a/recipes/kissplice/meta.yaml
+++ b/recipes/kissplice/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "kissplice" %}
-{% set version = "2.6.2" %}
+{% set version = "2.6.5" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: "https://gitlab.inria.fr/erable/{{ name }}/-/archive/{{ version }}/{{ name }}-{{ version }}.tar.gz"
-  sha256: "e2a4f8108c7668a8e50263d105889004f9f18b24f7a20f13ddb7dc903389f3e6"
+  sha256: "79fa50c8fdd83d5b1235fe5ac9293cd9aa241bb86b7badb3b524edd96b781380"
 
 build:
   number: 0


### PR DESCRIPTION
New upstream version, and simplify build.sh to use modern cmake commands.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
