### PR TITLE
Update OPAL meta.yaml

### DIFF
--- a/recipes/cami-opal/meta.yaml
+++ b/recipes/cami-opal/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps -vvv
   run_exports:

--- a/recipes/cami-opal/meta.yaml
+++ b/recipes/cami-opal/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - numpy >=1.24.2
     - matplotlib-base >=3.7.1
     - pandas >=1.5.3
-    - jinja2 <3.0.1
+    - jinja2 >=3.1.2
     - bokeh ==3.1.0
     - seaborn >=0.12.2
     - docker-py >=6.1.2


### PR DESCRIPTION
This tool failed with the current build with:
```
Traceback (most recent call last):
  File "/home/paul/miniconda3/envs/opal/bin/opal.py", line 242, in <module>
    main()
  File "/home/paul/miniconda3/envs/opal/bin/opal.py", line 235, in main
    html.create_html(pd_rankings, ranks_scored, pd_metrics, labels, sample_ids_list, plots_list, output_dir, args.desc)
  File "/home/paul/miniconda3/envs/opal/lib/python3.10/site-packages/cami_opal/html_opal.py", line 636, in create_html
    select_sample, select_rank, heatmap_legend_div, mytable1 = create_metrics_table(pd_metrics, labels, sample_ids_list)
  File "/home/paul/miniconda3/envs/opal/lib/python3.10/site-packages/cami_opal/html_opal.py", line 505, in create_metrics_table
    html.write(mydf_metrics.style.apply(get_heatmap_colors, df_metrics=mydf_metrics, axis=1).format(precision=3).set_table_styles(this_style).to_html())
  File "/home/paul/miniconda3/envs/opal/lib/python3.10/site-packages/pandas/core/frame.py", line 1442, in style
    from pandas.io.formats.style import Styler
  File "/home/paul/miniconda3/envs/opal/lib/python3.10/site-packages/pandas/io/formats/style.py", line 44, in <module>
    jinja2 = import_optional_dependency("jinja2", extra="DataFrame.style requires jinja2.")
  File "/home/paul/miniconda3/envs/opal/lib/python3.10/site-packages/pandas/compat/_optional.py", line 164, in import_optional_dependency
    raise ImportError(msg)
ImportError: Pandas requires version '3.1.2' or newer of 'jinja2' (version '3.0.0' currently installed).
```

Pinning `jinja2 >=3.1.2` fixes it.