### PR TITLE
Update: Patches difcover, adds missing R script

### DIFF
--- a/recipes/difcover/0001-Replaces-fname-char-with-std-string.patch
+++ b/recipes/difcover/0001-Replaces-fname-char-with-std-string.patch
@@ -1,0 +1,42 @@
+From e0f4ac49aa6f6d3446eed5183ea585f7bea31c34 Mon Sep 17 00:00:00 2001
+From: nikostr <nikostr@users.noreply.github.com>
+Date: Fri, 31 May 2024 21:50:45 +0200
+Subject: [PATCH] Replaces fname char with std::string
+
+
+diff --git a/dif_cover_scripts/from_unionbed_to_ratio_per_window_CC0 b/dif_cover_scripts/from_unionbed_to_ratio_per_window_CC0
+old mode 100644
+new mode 100755
+index ee868ce..6c0a513
+Binary files a/dif_cover_scripts/from_unionbed_to_ratio_per_window_CC0 and b/dif_cover_scripts/from_unionbed_to_ratio_per_window_CC0 differ
+diff --git a/dif_cover_scripts/from_unionbed_to_ratio_per_window_CC0.cpp b/dif_cover_scripts/from_unionbed_to_ratio_per_window_CC0.cpp
+index 88aa296..40152a5 100644
+--- a/dif_cover_scripts/from_unionbed_to_ratio_per_window_CC0.cpp
++++ b/dif_cover_scripts/from_unionbed_to_ratio_per_window_CC0.cpp
+@@ -20,7 +20,7 @@ int main( int argc , char** argv ) {
+ 
+ 
+    int opt, a=1, A=max_cov, b=1, B=max_cov, v=1000, l=0; //!!! Default values for parameters !!!!
+-   char fname[1000], fff[1000];
++   char fff[1000];
+  
+    while ((opt = getopt(argc, argv, "a:A:b:B:v:l:")) != -1) {
+         switch (opt) {
+@@ -54,12 +54,12 @@ int main( int argc , char** argv ) {
+         exit(EXIT_FAILURE);
+     }
+ 
+-   strncat(fname,argv[optind],strlen(argv[optind]));
++   std::string fname(argv[optind]);
+    //printf ("fname=%s\n",fname);
+      
+    std::ifstream unionbed_file( fname ) ;
+    if (!unionbed_file) {
+-	fprintf(stderr, "Can't open union.bed file %s\n",fname);	
++	fprintf(stderr, "Can't open union.bed file %s\n",fname.c_str());
+         exit(EXIT_FAILURE);
+     }
+  
+-- 
+2.44.0
+

--- a/recipes/difcover/build.sh
+++ b/recipes/difcover/build.sh
@@ -6,5 +6,5 @@ rm from_unionbed_to_ratio_per_window_CC0
 make CXX="${GXX} ${LDFLAGS}"
 
 mkdir -p "${PREFIX}/bin"
-cp from_unionbed_to_ratio_per_window_CC0 *.sh "${PREFIX}/bin"
+cp from_unionbed_to_ratio_per_window_CC0 *.R *.sh "${PREFIX}/bin"
 chmod +x ${PREFIX}/bin/*.sh

--- a/recipes/difcover/meta.yaml
+++ b/recipes/difcover/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 0
+  number: 1
   skip: True  # [osx]
   run_exports:
     - {{ pin_subpackage("difcover", max_pin="x") }}
@@ -13,6 +13,8 @@ build:
 source:
   url: https://github.com/timnat/DifCover/archive/refs/tags/v{{ version }}.tar.gz
   sha256: 52f950f35bfcd6c863127bae937da1158dd16da5c1a0e85f523561504d300447
+  patches:
+    - 0001-Replaces-fname-char-with-std-string.patch
 
 requirements:
   build:


### PR DESCRIPTION
This PR addresses this issue: https://github.com/timnat/DifCover/pull/4

It also fixes a missing file in the original DifCover build script.



<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
