### PR TITLE
kraken2: add missing requirements

### DIFF
--- a/recipes/kraken2/Makefile.patch
+++ b/recipes/kraken2/Makefile.patch
@@ -1,10 +1,12 @@
-diff --git a/Makefile b/Makefile2
-index 0ffbe01..447f22d 100644
---- a/src/Makefile
-+++ b/src/Makefile
-@@ -1,4 +1,4 @@
+--- kraken2_org/src/Makefile	2024-06-05 16:08:08.900991340 +0200
++++ kraken2/src/Makefile	2024-06-05 16:14:20.038219436 +0200
+@@ -1,7 +1,7 @@
 -CXX = g++
-+#CXX = g++
++# CXX = g++
  KRAKEN2_SKIP_FOPENMP ?= -fopenmp
  CXXFLAGS = $(KRAKEN2_SKIP_FOPENMP) -Wall -std=c++11 -O3
- CXXFLAGS += -DLINEAR_PROBING
+-CXXFLAGS += -DLINEAR_PROBING
++CXXFLAGS += -DLINEAR_PROBING $(LDFLAGS)
+ 
+ .PHONY: all clean install
+ 

--- a/recipes/kraken2/build.sh
+++ b/recipes/kraken2/build.sh
@@ -8,6 +8,12 @@ outdir=${PREFIX}/share/${PKG_NAME}-${PKG_VERSION}-${PKG_BUILDNUM}
 mkdir -p "${outdir}/libexec" "${PREFIX}/bin"
 
 chmod u+x install_kraken2.sh
+
+#install_name_tool error fix
+if [[ "$(uname)" == Darwin ]]; then
+    export LDFLAGS="$LDFLAGS -headerpad_max_install_names"
+fi
+
 ./install_kraken2.sh "${outdir}/libexec"
 for bin in kraken2 kraken2-build kraken2-inspect; do
     chmod +x "${outdir}/libexec/$bin"

--- a/recipes/kraken2/meta.yaml
+++ b/recipes/kraken2/meta.yaml
@@ -30,6 +30,11 @@ requirements:
     - zlib
   run:
     - blast
+    - perl
+    - wget
+    - tar
+    - rsync
+    - zlib
 
 test:
   commands:

--- a/recipes/kraken2/meta.yaml
+++ b/recipes/kraken2/meta.yaml
@@ -41,7 +41,6 @@ test:
     - kraken2 --version
     - kraken2-build --version
     - kraken2-inspect --version
-    - rsync --version
 
 about:
   home: "https://ccb.jhu.edu/software/kraken2/"

--- a/recipes/kraken2/meta.yaml
+++ b/recipes/kraken2/meta.yaml
@@ -13,7 +13,7 @@ source:
     - Makefile.patch
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -35,6 +35,7 @@ test:
     - kraken2 --version
     - kraken2-build --version
     - kraken2-inspect --version
+    - rsync --version
 
 about:
   home: "https://ccb.jhu.edu/software/kraken2/"

--- a/recipes/kraken2/meta.yaml
+++ b/recipes/kraken2/meta.yaml
@@ -14,6 +14,7 @@ source:
 
 build:
   number: 1
+  run_exports: '{{ pin_subpackage("kraken2", max_pin="x.x") }}'
 
 requirements:
   build:


### PR DESCRIPTION
`kraken2-build` needs `rsync` (and likely wget as well). 



----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
