### PR TITLE
Bump up abnumber to 0.3.3

### DIFF
--- a/recipes/abnumber/meta.yaml
+++ b/recipes/abnumber/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.3.2" %} # Remember to update sha256 below
+{% set version = "0.3.3" %} # Remember to update sha256 below
 
 package:
   name: abnumber
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/prihoda/abnumber/archive/v{{ version }}.tar.gz
-  sha256: '1e00d010a05b2b7fe93660346f8b0bc36d7058e2655c3f779d84c85b52022ebc'
+  sha256: 'bddaf761fa35b2afc83344b5e27aa84377baf42e888dfdfe78f97540db41187a'
 
 build:
   noarch: python

--- a/recipes/abnumber/meta.yaml
+++ b/recipes/abnumber/meta.yaml
@@ -10,6 +10,8 @@ source:
 
 build:
   noarch: python
+  run_exports:
+    - {{ pin_subpackage('abnumber', max_pin="x.x") }}
   number: 0
   script: {{ PYTHON }} -m pip install . --ignore-installed --no-deps -vv
 


### PR DESCRIPTION
Bump up abnumber to latest release 0.3.3: https://github.com/prihoda/AbNumber/releases/tag/v0.3.3