### PR TITLE
Update Binette recipe

### DIFF
--- a/recipes/binette/meta.yaml
+++ b/recipes/binette/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install --no-deps --ignore-installed -vv .
   run_exports:
     - {{ pin_subpackage(name|lower, max_pin="x") }}
@@ -32,7 +32,7 @@ requirements:
     - packaging
     - tqdm
     - networkx >=3
-    - pyfastx
+    - pyfastx >=2
     - pyrodigal >=2
 
 test:


### PR DESCRIPTION
This PR updates the Binette recipe to fix the required `pyfastx` version.

As mentioned in this Binette issue: https://github.com/genotoul-bioinfo/Binette/issues/15.

----

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
