### PR TITLE
CI updates: remove caching, remove old docker image, mac vars

### DIFF
--- a/azure-pipeline-master.yml
+++ b/azure-pipeline-master.yml
@@ -21,23 +21,10 @@ jobs:
           wget https://raw.githubusercontent.com/bioconda/bioconda-common/master/{common,install-and-set-up-conda,configure-conda}.sh
         displayName: Fetch bioconda install script
 
-      - task: Cache@2
-        inputs:
-          path: "/opt/mambaforge"
-          key: '"$(Agent.OS)" | install-and-set-up-conda.sh | configure-conda.sh | common.sh'
-          cacheHitVar: CACHE_RESTORED
-        displayName: Restore cache
-
       - script: bash install-and-set-up-conda.sh
-        condition: ne(variables.CACHE_RESTORED, 'true')
         displayName: Install bioconda-utils
 
       # We reconfigure conda to use the right channel setup.
-      # This has to be done after the cache is restored, because
-      # the channel setup is not cached as it resides in the home directory.
-      # We could use a system-wide (and therefore cached) channel setup,
-      # but mamba does not support that at the time of implementation
-      # (it ignores settings made by --system).
       - script: bash configure-conda.sh
         displayName: Configure conda
 
@@ -49,8 +36,6 @@ jobs:
           export OSTYPE="linux-gnu"
           export CI="true"
 
-          docker pull quay.io/dpryan79/mulled_container:latest
-
           bioconda-utils handle-merged-pr recipes config.yml \
             --repo bioconda/bioconda-recipes \
             --git-range $(Build.SourceVersion)~1 $(Build.SourceVersion) \
@@ -60,7 +45,6 @@ jobs:
           #  --git-range $(Build.SourceVersion)~1 $(Build.SourceVersion) \
           #  --docker --mulled-test --anaconda-upload --mulled-upload-target biocontainers
 
-          docker rmi quay.io/dpryan79/mulled_container:latest
         env:
           QUAY_LOGIN: $(QUAY_LOGIN)
           QUAY_OAUTH_TOKEN: $(QUAY_OAUTH_TOKEN)
@@ -87,28 +71,11 @@ jobs:
           wget https://raw.githubusercontent.com/bioconda/bioconda-common/master/{common,install-and-set-up-conda,configure-conda}.sh
         displayName: Fetch bioconda install script
 
-      - bash: |
-          sudo mkdir -p /opt
-          sudo chown -R $USER /opt
-        displayName: Ensure cache has path to restore to
-
-      - task: Cache@2
-        inputs:
-          path: "/opt/mambaforge"
-          key: '"$(Agent.OS)" | install-and-set-up-conda.sh | configure-conda.sh | common.sh'
-          cacheHitVar: CACHE_RESTORED
-        displayName: Restore cache
 
       - script: bash install-and-set-up-conda.sh
-        condition: ne(variables.CACHE_RESTORED, 'true')
         displayName: Install bioconda-utils
 
       # We reconfigure conda to use the right channel setup.
-      # This has to be done after the cache is restored, because
-      # the channel setup is not cached as it resides in the home directory.
-      # We could use a system-wide (and therefore cached) channel setup,
-      # but mamba does not support that at the time of implementation
-      # (it ignores settings made by --system).
       - script: bash configure-conda.sh
         displayName: Configure conda
 
@@ -118,6 +85,9 @@ jobs:
           conda activate bioconda
           export OSTYPE="darwin"
           export CI="true"
+
+          # Get MACOSX vars
+          source common.sh
 
           bioconda-utils handle-merged-pr recipes config.yml \
             --repo bioconda/bioconda-recipes \

--- a/azure-pipeline-nightly.yml
+++ b/azure-pipeline-nightly.yml
@@ -30,28 +30,10 @@ jobs:
           wget https://raw.githubusercontent.com/bioconda/bioconda-common/master/{common,install-and-set-up-conda,configure-conda}.sh
         displayName: Fetch bioconda install script
 
-      - bash: |
-          sudo mkdir -p /opt
-          sudo chown -R $USER /opt
-        displayName: Ensure cache has path to restore to
-
-      - task: Cache@2
-        inputs:
-          path: "/opt/mambaforge"
-          key: '"$(Agent.OS)" | install-and-set-up-conda.sh | configure-conda.sh | common.sh'
-          cacheHitVar: CACHE_RESTORED
-        displayName: Restore cache
-
       - script: bash install-and-set-up-conda.sh
-        condition: ne(variables.CACHE_RESTORED, 'true')
         displayName: Install bioconda-utils
 
       # We reconfigure conda to use the right channel setup.
-      # This has to be done after the cache is restored, because
-      # the channel setup is not cached as it resides in the home directory.
-      # We could use a system-wide (and therefore cached) channel setup,
-      # but mamba does not support that at the time of implementation
-      # (it ignores settings made by --system).
       - script: bash configure-conda.sh
         displayName: Configure conda
 
@@ -68,7 +50,6 @@ jobs:
           set -e
           eval "$(conda shell.bash hook)"
           conda activate bioconda
-          docker pull quay.io/dpryan79/mulled_container:latest
 
           export OSTYPE="linux-gnu"
           export CI="true"
@@ -77,7 +58,6 @@ jobs:
           bioconda-utils build recipes config.yml \
               --docker --mulled-test --anaconda-upload --mulled-upload-target biocontainers \
               --prelint --exclude bioconda-repodata-patches
-          docker rmi quay.io/dpryan79/mulled_container:latest
         env:
           QUAY_OAUTH_TOKEN: $(QUAY_OAUTH_TOKEN)
           ANACONDA_TOKEN: $(ANACONDA_TOKEN)
@@ -102,28 +82,10 @@ jobs:
           wget https://raw.githubusercontent.com/bioconda/bioconda-common/master/{common,install-and-set-up-conda,configure-conda}.sh
         displayName: Fetch bioconda install script
 
-      - bash: |
-          sudo mkdir -p /opt
-          sudo chown -R $USER /opt
-        displayName: Ensure cache has path to restore to
-
-      - task: Cache@2
-        inputs:
-          path: "/opt/mambaforge"
-          key: '"$(Agent.OS)" | install-and-set-up-conda.sh | configure-conda.sh | common.sh'
-          cacheHitVar: CACHE_RESTORED
-        displayName: Restore cache
-
       - script: bash install-and-set-up-conda.sh
-        condition: ne(variables.CACHE_RESTORED, 'true')
         displayName: Install bioconda-utils
 
       # We reconfigure conda to use the right channel setup.
-      # This has to be done after the cache is restored, because
-      # the channel setup is not cached as it resides in the home directory.
-      # We could use a system-wide (and therefore cached) channel setup,
-      # but mamba does not support that at the time of implementation
-      # (it ignores settings made by --system).
       - script: bash configure-conda.sh
         displayName: Configure conda
 
@@ -133,6 +95,10 @@ jobs:
           conda activate bioconda
           export OSTYPE="darwin"
           export CI="true"
+
+          # Get MACOSX vars
+          source common.sh
+
           bioconda-utils build recipes config.yml \
               --anaconda-upload \
               --prelint

--- a/azure-pipeline.yml
+++ b/azure-pipeline.yml
@@ -23,28 +23,10 @@ stages:
               wget https://raw.githubusercontent.com/bioconda/bioconda-common/master/{common,install-and-set-up-conda,configure-conda}.sh
             displayName: Fetch bioconda install script
 
-          - bash: |
-              sudo mkdir -p /opt
-              sudo chown -R $USER /opt
-            displayName: Ensure cache has path to restore to
-
-          - task: Cache@2
-            inputs:
-              path: "/opt/mambaforge"
-              key: '"$(Agent.OS)" | install-and-set-up-conda.sh | configure-conda.sh | common.sh'
-              cacheHitVar: CACHE_RESTORED
-            displayName: Restore cache
-
           - script: bash install-and-set-up-conda.sh
-            condition: ne(variables.CACHE_RESTORED, 'true')
             displayName: Install bioconda-utils
 
           # We reconfigure conda to use the right channel setup.
-          # This has to be done after the cache is restored, because
-          # the channel setup is not cached as it resides in the home directory.
-          # We could use a system-wide (and therefore cached) channel setup,
-          # but mamba does not support that at the time of implementation
-          # (it ignores settings made by --system).
           - script: bash configure-conda.sh
             displayName: Configure conda
 
@@ -73,28 +55,10 @@ stages:
               wget https://raw.githubusercontent.com/bioconda/bioconda-common/master/{common,install-and-set-up-conda,configure-conda}.sh
             displayName: Fetch bioconda install script
 
-          - bash: |
-              sudo mkdir -p /opt
-              sudo chown -R $USER /opt
-            displayName: Ensure cache has path to restore to
-
-          - task: Cache@2
-            inputs:
-              path: "/opt/mambaforge"
-              key: '"$(Agent.OS)" | install-and-set-up-conda.sh | configure-conda.sh | common.sh'
-              cacheHitVar: CACHE_RESTORED
-            displayName: Restore cache
-
           - script: bash install-and-set-up-conda.sh
-            condition: ne(variables.CACHE_RESTORED, 'true')
             displayName: Install bioconda-utils
 
           # We reconfigure conda to use the right channel setup.
-          # This has to be done after the cache is restored, because
-          # the channel setup is not cached as it resides in the home directory.
-          # We could use a system-wide (and therefore cached) channel setup,
-          # but mamba does not support that at the time of implementation
-          # (it ignores settings made by --system).
           - script: bash configure-conda.sh
             displayName: Configure conda
 
@@ -102,13 +66,11 @@ stages:
               set -e
               eval "$(conda shell.bash hook)"
               conda activate bioconda
-              docker pull quay.io/dpryan79/mulled_container:latest
               export OSTYPE="linux-gnu"
               export CI="true"
               bioconda-utils build recipes config.yml \
                   --docker --mulled-test \
                   --git-range origin/"$SYSTEM_PULLREQUEST_TARGETBRANCH" HEAD
-              docker rmi quay.io/dpryan79/mulled_container:latest
             displayName: Test
 
           - bash: |
@@ -154,28 +116,10 @@ stages:
               wget https://raw.githubusercontent.com/bioconda/bioconda-common/master/{common,install-and-set-up-conda,configure-conda}.sh
             displayName: Fetch setup scripts
 
-          - bash: |
-              sudo mkdir -p /opt
-              sudo chown -R $USER /opt
-            displayName: Ensure cache has path to restore to
-
-          - task: Cache@2
-            inputs:
-              path: "/opt/mambaforge"
-              key: '"$(Agent.OS)" | install-and-set-up-conda.sh | configure-conda.sh | common.sh'
-              cacheHitVar: CACHE_RESTORED
-            displayName: Restore cache
-
           - script: bash install-and-set-up-conda.sh
-            condition: ne(variables.CACHE_RESTORED, 'true')
             displayName: Install bioconda-utils
 
           # We reconfigure conda to use the right channel setup.
-          # This has to be done after the cache is restored, because
-          # the channel setup is not cached as it resides in the home directory.
-          # We could use a system-wide (and therefore cached) channel setup,
-          # but mamba does not support that at the time of implementation
-          # (it ignores settings made by --system).
           - script: bash configure-conda.sh
             displayName: Configure conda
 
@@ -185,6 +129,10 @@ stages:
               conda activate bioconda
               export OSTYPE="darwin"
               export CI="true"
+
+              # Get MACOSX vars
+              source common.sh
+
               bioconda-utils build recipes config.yml \
                   --git-range origin/"$SYSTEM_PULLREQUEST_TARGETBRANCH" HEAD
             displayName: Test


### PR DESCRIPTION
- Remove caching from CI (causing more issues than it solves and not saving much time)
- Remove old quay.io/dpryan79/mulled_container image which is no longer used
- Source `common.sh` to include MACOSX environment variables (needed for new pinnings)