### PR TITLE
Schwarz marek patch unicycler

### DIFF
--- a/recipes/unicycler/meta.yaml
+++ b/recipes/unicycler/meta.yaml
@@ -27,10 +27,12 @@ requirements:
     - zlib
   run:
     - python
-    - spades >=3.15.4,<4
+    - spades >=3.15.4
     - blast
     - racon
     - miniasm
+  run_exports:
+    - {{ pin_subpackage('spades', max_pin='x') }}
 
 test:
   commands:

--- a/recipes/unicycler/meta.yaml
+++ b/recipes/unicycler/meta.yaml
@@ -13,7 +13,7 @@ source:
       - misc.py.patch
 
 build:
-  number: 3
+  number: 4
   skip: True  # [py<34 or osx]
 
 requirements:
@@ -27,7 +27,7 @@ requirements:
     - zlib
   run:
     - python
-    - spades >=3.15.4
+    - spades >=3.15.4,<4
     - blast
     - racon
     - miniasm


### PR DESCRIPTION
spades version 4.0.0 was released recently and current version of recipe installs spades in incompatible version resulting in broken unicycler installation.
```
Dependencies:
  Program       Version   Status  
  spades.py     4.0.0     too new 
```
This edit pins spades to ">=3.15.4,<4".
