### PR TITLE
Update plink2 to 2.00a5.12 final

### DIFF
--- a/recipes/plink2/meta.yaml
+++ b/recipes/plink2/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: plink2
-  version: "2.00a5.10"
+  version: "2.00a5.12"
 
 build:
   number: 0
@@ -8,10 +8,10 @@ build:
       - {{ pin_subpackage('plink2', max_pin=None) }}
 
 source:
-  url: https://s3.amazonaws.com/plink2-assets/alpha5/plink2_linux_x86_64_20240105.zip # [linux]
-  sha256: d841fe0b3fcc42d76b2b08bcfeb95e315156b0b883b353807014a69b4867dc47     # [linux]
-  url: https://s3.amazonaws.com/plink2-assets/alpha5/plink2_mac_20240105.zip   # [osx]
-  sha256: 75d78b9a94a570804a9ab130dd0dd29ff8d1c7851c386239505798cd2126c0f9     # [osx]
+  url: https://s3.amazonaws.com/plink2-assets/alpha5/plink2_linux_x86_64_20240625.zip # [linux]
+  sha256: 7bf73ad7bbd3256a83cd72ed068bee4175bd6052a7bf30a659dbdb696d9d1d9e     # [linux]
+  url: https://s3.amazonaws.com/plink2-assets/alpha5/plink2_mac_20240625.zip   # [osx]
+  sha256: 08e962c59d7f28b4ecc39d0279b859775cc5d2fbb892b7b350a982f4d7de437d     # [osx]
 
 requirements:
   build:
@@ -19,7 +19,7 @@ requirements:
 
 test:
   commands:
-    - plink2 --help | grep "PLINK v2.00a5.10"
+    - plink2 --help | grep "PLINK v2.00a5.12"
 
 about:
   home: https://www.cog-genomics.org/plink2


### PR DESCRIPTION
Update [`plink2`](https://www.cog-genomics.org/plink/2.0): **2.00a5.10** → **2.00a5.12** (released on June 25, 2024)

I simply adapted https://github.com/bioconda/bioconda-recipes/pull/46505 to write this PR