### PR TITLE
Remove unnecessary run constraints from sambamba

### DIFF
--- a/recipes/sambamba/meta.yaml
+++ b/recipes/sambamba/meta.yaml
@@ -18,17 +18,19 @@ build:
 
 requirements:
   build:
-    - make
     - {{ compiler('c') }}
+    - llvm
+    - make
     - python
   host:
-    - ldc >=1.17.0
     - bzip2
-    - zlib
-    - xz
+    - ldc >=1.17.0
     - lz4-c
-  run:
-    - {{ pin_compatible('ldc', max_pin='x.x') }}
+    - xz
+    - zlib
+  ignore_run_exports:
+    - bzip2
+    - xz
 
 test:
   commands:

--- a/recipes/sambamba/meta.yaml
+++ b/recipes/sambamba/meta.yaml
@@ -15,6 +15,9 @@ build:
   number: 2
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x') }}
+  ignore_run_exports:
+    - bzip2
+    - xz
 
 requirements:
   build:
@@ -27,9 +30,6 @@ requirements:
     - lz4-c
     - xz
     - zlib
-  ignore_run_exports:
-    - bzip2
-    - xz
 
 test:
   commands:

--- a/recipes/sambamba/meta.yaml
+++ b/recipes/sambamba/meta.yaml
@@ -12,14 +12,13 @@ source:
     - 0001-fix-osx-compile.patch
 
 build:
-  number: 1
+  number: 2
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x') }}
 
 requirements:
   build:
     - {{ compiler('c') }}
-    - llvm
     - make
     - python
   host:


### PR DESCRIPTION
Addressing the following lints:

```
16:53:04 BIOCONDA INFO (OUT) WARNING (sambamba): dso library package conda-forge/linux-64::ldc==1.38.0=h8d30b7e_2 in requirements/run but it is not used (i.e. it is overdepending or perhaps statically linked? If that is what you want then add it to `build/ignore_run_exports`)
16:53:04 BIOCONDA INFO (OUT) WARNING (sambamba): run-exports library package conda-forge/linux-64::bzip2==1.0.8=hd590300_5 in requirements/run but it is not used (i.e. it is overdepending or perhaps statically linked? If that is what you want then add it to `build/ignore_run_exports`)
16:53:04 BIOCONDA INFO (OUT) WARNING (sambamba): run-exports library package conda-forge/linux-64::xz==5.2.6=h166bdaf_0 in requirements/run but it is not used (i.e. it is overdepending or perhaps statically linked? If that is what you want then add it to `build/ignore_run_exports`)
```

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
