### PR TITLE
fix: disable unused trigger for comment responder

### DIFF
--- a/.github/workflows/CommentResponder.yml
+++ b/.github/workflows/CommentResponder.yml
@@ -1,9 +1,9 @@
 name: CommentResponder
 on:
   status:
-  check_suite:
-    types:
-    - completed
+  # check_suite:
+  #   types:
+  #   - completed
   issue_comment:
     types:
     - created


### PR DESCRIPTION
The comment responder is repeatedly triggering for no reason. I'm not sure if it's caught in a loop of triggering itself, but it keeps running against the latest commit on master. The `check_run` trigger doesn't pass the conditions for any of the bot jobs as of 3 years ago (see comment on line 11).

It's showing up in GitHub Actions as "completed by ghost". I'm not sure if that's because the latest commit was authored by more than one person. Maybe a GitHub Actions bug. In any case, there is no reason to keep this going.