### PR TITLE
epik: updates boost-cpp to strict version 1.85

### DIFF
--- a/recipes/epik/meta.yaml
+++ b/recipes/epik/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage('epik', max_pin="x.x") }}
 
@@ -22,11 +22,11 @@ requirements:
     - cmake
     - llvm-openmp  # [osx]
   host:
-    - boost-cpp >=1.67
+    - boost-cpp =1.85
     - zlib
     - rapidjson
   run:
-    - boost-cpp >=1.67
+    - boost-cpp =1.85
     - llvm-openmp # [osx]
     - python
     - click


### PR DESCRIPTION
This PR is brother to PR #49000 . See details there.
It just fixes version of boost-cpp to attempt to solve an issue that cannot be detected in the bioconda CI.