### PR TITLE
Build vsearch for osx-arm64

### DIFF
--- a/recipes/vsearch/build.sh
+++ b/recipes/vsearch/build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -xe
+
 # Remove configure.ac C(XX)?FLAGS override
 sed -i.bak 's/ *CX\?X\?FLAGS/#\0/p' configure.ac
 # Remove MACOS_DEPLOYMENT_TARGET override

--- a/recipes/vsearch/build.sh
+++ b/recipes/vsearch/build.sh
@@ -7,8 +7,14 @@ sed -i.bak 's/ *CX\?X\?FLAGS/#\0/p' configure.ac
 # Remove MACOS_DEPLOYMENT_TARGET override
 sed -i.bak 's/MACOSX_DEPLOYMENT_TARGET=/#\0/' configure.ac
 sed -i.bak 's/export MACOSX_DEPLOYMENT_TARGET=/#\0/' src/Makefile.am
+
+which m4
 # Set PATH to prioritize conda-installed m4 (for osx)
 export PATH="$PREFIX/bin:$PATH" 
+
+which m4
+
+m4 --version
 
 ./autogen.sh
 ./configure --prefix=$PREFIX

--- a/recipes/vsearch/build.sh
+++ b/recipes/vsearch/build.sh
@@ -5,6 +5,8 @@ sed -i.bak 's/ *CX\?X\?FLAGS/#\0/p' configure.ac
 # Remove MACOS_DEPLOYMENT_TARGET override
 sed -i.bak 's/MACOSX_DEPLOYMENT_TARGET=/#\0/' configure.ac
 sed -i.bak 's/export MACOSX_DEPLOYMENT_TARGET=/#\0/' src/Makefile.am
+# Set PATH to prioritize conda-installed m4 (for osx)
+export PATH="$PREFIX/bin:$PATH" 
 
 ./autogen.sh
 ./configure --prefix=$PREFIX

--- a/recipes/vsearch/build.sh
+++ b/recipes/vsearch/build.sh
@@ -8,15 +8,8 @@ sed -i.bak 's/ *CX\?X\?FLAGS/#\0/p' configure.ac
 sed -i.bak 's/MACOSX_DEPLOYMENT_TARGET=/#\0/' configure.ac
 sed -i.bak 's/export MACOSX_DEPLOYMENT_TARGET=/#\0/' src/Makefile.am
 
-which m4
-# Set PATH to prioritize conda-installed m4 (for osx)
-export PATH="$PREFIX/bin:$PATH" 
-
-which m4
-
-m4 --version
-
+export M4="$BUILD_PREFIX/bin/m4" 
 ./autogen.sh
 ./configure --prefix=$PREFIX
-make
+make -j ${CPU_COUNT}
 make install

--- a/recipes/vsearch/meta.yaml
+++ b/recipes/vsearch/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: '{{ sha256 }}'
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage('vsearch', max_pin="x") }}
 

--- a/recipes/vsearch/meta.yaml
+++ b/recipes/vsearch/meta.yaml
@@ -45,6 +45,7 @@ about:
 extra:
   additional-platforms:
     - linux-aarch64
+    - osx-arm64
   identifiers:
     - biotools:vsearch
     - doi:10.7717/peerj.2584

--- a/recipes/vsearch/meta.yaml
+++ b/recipes/vsearch/meta.yaml
@@ -21,6 +21,7 @@ requirements:
     - '{{ compiler("cxx") }}'
     - automake
     - autoconf
+    - m4
   host:
     - zlib
     - bzip2


### PR DESCRIPTION
no idea if this _should_ even work, but let's try!

[Current error](https://app.circleci.com/pipelines/github/bioconda/bioconda-recipes/122140/workflows/754c2e91-577e-4ba9-91e4-4e721cf3384a/jobs/196176?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link&utm_content=summary) is that it's using the `m4` that comes with macs, not the one from conda. Strange!

>01:20:07 BIOCONDA INFO (ERR) autom4te: error: need GNU m4 1.4 or later: /usr/bin/m4
01:20:07 BIOCONDA INFO (ERR) aclocal: error: /opt/mambaforge/envs/bioconda/conda-bld/vsearch_1720660763326/_build_env/bin/autom4te failed with exit status: 1
01:20:07 BIOCONDA INFO (ERR) autoreconf: error: aclocal failed with exit status: 1

@martin-g, would you be willing to have a look?