### PR TITLE
ci: reenable artifact fetching on successful check suite

### DIFF
--- a/.github/workflows/CommentResponder.yml
+++ b/.github/workflows/CommentResponder.yml
@@ -1,18 +1,13 @@
 name: CommentResponder
 on:
   status:
-  # check_suite:
-  #   types:
-  #   - completed
+  check_suite:
+    types:
+    - completed
   issue_comment:
     types:
     - created
 
-# Re-enable when the bot has been updated to handle azure
-#      (
-#        github.event_name == 'check_suite' &&
-#        github.event.check_suite.conclusion == 'success'
-#      ) ||
 jobs:
   comment:
     runs-on: ubuntu-latest
@@ -21,6 +16,10 @@ jobs:
       (
         github.event_name == 'status' &&
         github.event.state == 'success'
+      ) ||
+      (
+        github.event_name == 'check_suite' &&
+        github.event.check_suite.conclusion == 'success'
       ) ||
       (
         github.event_name == 'issue_comment' &&


### PR DESCRIPTION
This seems to have been disabled with a plan to re-enable it that never happened.

This may cause excessive runs, but there's no way to know without merging it in. I'll keep an eye on it.