### PR TITLE
Fix pypi urls for bot autobump: setuptools changed some source paths

### DIFF
--- a/recipes/galaxy-data/meta.yaml
+++ b/recipes/galaxy-data/meta.yaml
@@ -14,6 +14,8 @@ build:
   noarch: python
   number: 0
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+  run_exports:
+    -{{ pin_subpackage('galaxy-files', max_pin="x") }}
 
 requirements:
   host:

--- a/recipes/galaxy-data/meta.yaml
+++ b/recipes/galaxy-data/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "24.1.1" %}
-{% set sha256 = "be4d1ba81589cc5e6d4fb38829c1770483cff6c380b7647aa80b7bc90737f573" %}
+{% set version = "22.1.1" %}
+{% set sha256 = "27d1fc4ccc0d05adbb49fced1b0bcf59497a702c8bf51e39b058449dc0644cfe" %}
 {% set galaxy_version = version.split(".")[:2]|join(".") %}
 
 package:
@@ -7,22 +7,19 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/g/galaxy-data/galaxy_data-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/g/galaxy-data/galaxy-data-{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:
   noarch: python
   number: 0
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
-  run_exports:
-    -{{ pin_subpackage('galaxy-data', max_pin="x") }}
 
 requirements:
   host:
     - pip
     - python >=3.6
   run:
-    - galaxy-files >={{ galaxy_version }}
     - galaxy-objectstore >={{ galaxy_version }}
     - galaxy-util >={{ galaxy_version }}
     - galaxy_sequence_utils

--- a/recipes/galaxy-data/meta.yaml
+++ b/recipes/galaxy-data/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "22.1.1" %}
-{% set sha256 = "27d1fc4ccc0d05adbb49fced1b0bcf59497a702c8bf51e39b058449dc0644cfe" %}
+{% set version = "24.1.1" %}
+{% set sha256 = "be4d1ba81589cc5e6d4fb38829c1770483cff6c380b7647aa80b7bc90737f573" %}
 {% set galaxy_version = version.split(".")[:2]|join(".") %}
 
 package:
@@ -7,7 +7,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/g/galaxy-data/galaxy-data-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/g/galaxy-data/galaxy_data-{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:

--- a/recipes/galaxy-data/meta.yaml
+++ b/recipes/galaxy-data/meta.yaml
@@ -15,7 +15,7 @@ build:
   number: 0
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
   run_exports:
-    -{{ pin_subpackage('galaxy-files', max_pin="x") }}
+    -{{ pin_subpackage('galaxy-data', max_pin="x") }}
 
 requirements:
   host:

--- a/recipes/galaxy-data/meta.yaml
+++ b/recipes/galaxy-data/meta.yaml
@@ -22,6 +22,7 @@ requirements:
     - pip
     - python >=3.6
   run:
+    - galaxy-files >={{ galaxy_version }}
     - galaxy-objectstore >={{ galaxy_version }}
     - galaxy-util >={{ galaxy_version }}
     - galaxy_sequence_utils

--- a/recipes/galaxy-files/meta.yaml
+++ b/recipes/galaxy-files/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "24.0.0" %}
-{% set sha256 = "d00dab002d94a6463bb93d6c7fab4d5dce921e7ab54de5ca59c615faa1a14038" %}
+{% set version = "24.1.1" %}
+{% set sha256 = "d3c23617eed928515fd492fd97588790b1c095fdd298b5f5584307f34846c4ca" %}
 {% set galaxy_version = version.split(".")[:2]|join(".") %}
 
 package:
@@ -7,7 +7,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/g/galaxy-files/galaxy-files-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/g/galaxy-files/galaxy_files-{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:

--- a/recipes/galaxy-objectstore/meta.yaml
+++ b/recipes/galaxy-objectstore/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "24.0.0" %}
-{% set sha256 = "0cd30eff8285b83320b3eb5677bb93e3d368a8e771747c906861f88ca5036cd6" %}
+{% set version = "24.1.1" %}
+{% set sha256 = "0a38e7fedc5c9300507d441c17d745957e1c8a0c65d1b7efde62361bf024eff1" %}
 {% set galaxy_version = version.split(".")[:2]|join(".") %}
 
 package:
@@ -7,7 +7,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/g/galaxy-objectstore/galaxy-objectstore-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/g/galaxy-objectstore/galaxy_objectstore-{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:

--- a/recipes/galaxy_sequence_utils/meta.yaml
+++ b/recipes/galaxy_sequence_utils/meta.yaml
@@ -21,7 +21,7 @@ build:
   number: 1
   preserve_egg_dir: True
   run_exports:
-    -{{ pin_subpackage('galaxy-files', max_pin="x") }}
+    -{{ pin_subpackage(name, max_pin="x") }}
   entry_points:
     - gx-fastq-to-tabular=galaxy_utils.sequence.scripts.fastq_to_tabular:main
     - gx-fastq-groomer=galaxy_utils.sequence.scripts.fastq_groomer:main

--- a/recipes/galaxy_sequence_utils/meta.yaml
+++ b/recipes/galaxy_sequence_utils/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "galaxy_sequence_utils" %}
 {% set version = "1.1.5" %}
+{% set sha256 = "c32bd91f6ff11ad6e8b62f8de309d695ef5c33a782afbf5122c1db7144ef1162" %}
 
 package:
   name: {{ name|lower }}
@@ -12,8 +13,8 @@ about:
   summary: Sequence Utilities from the Galaxy project
 
 source:
-  url: https://files.pythonhosted.org/packages/f9/f2/39a48c3cc1635e4086a743c80f782bb216f069316437028d909448c2356a/galaxy_sequence_utils-1.1.5.tar.gz
-  sha256: c32bd91f6ff11ad6e8b62f8de309d695ef5c33a782afbf5122c1db7144ef1162
+  url: https://pypi.io/packages/source/g/galaxy-sequence-utils/galaxy_sequence_utils-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
 
 build:
   noarch: python

--- a/recipes/galaxy_sequence_utils/meta.yaml
+++ b/recipes/galaxy_sequence_utils/meta.yaml
@@ -20,6 +20,8 @@ build:
   noarch: python
   number: 1
   preserve_egg_dir: True
+  run_exports:
+    -{{ pin_subpackage('galaxy-files', max_pin="x") }}
   entry_points:
     - gx-fastq-to-tabular=galaxy_utils.sequence.scripts.fastq_to_tabular:main
     - gx-fastq-groomer=galaxy_utils.sequence.scripts.fastq_groomer:main

--- a/recipes/galaxy_sequence_utils/meta.yaml
+++ b/recipes/galaxy_sequence_utils/meta.yaml
@@ -18,7 +18,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   preserve_egg_dir: True
   entry_points:
     - gx-fastq-to-tabular=galaxy_utils.sequence.scripts.fastq_to_tabular:main

--- a/recipes/jms-metabolite-services/meta.yaml
+++ b/recipes/jms-metabolite-services/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "jms-metabolite-services" %}
-{% set version = "0.5.7" %}
+{% set version = "0.5.8" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/jms-metabolite-services-{{ version }}.tar.gz
-  sha256: 39cad5a790ebd876ecce7f093769fb7495bbb44e74953c428d81055e5f7feac9
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/jms_metabolite_services-{{ version }}.tar.gz
+  sha256: 0067d4804ebf10aed93556be6e2f7113173b9f5a50c36ea81ef6a2d0254772e7
 
 build:
   noarch: python

--- a/recipes/jms-metabolite-services/meta.yaml
+++ b/recipes/jms-metabolite-services/meta.yaml
@@ -14,7 +14,7 @@ build:
   script: {{ PYTHON }} -m pip install . -vv
   number: 0
   run_exports:
-      - {{ pin_subpackage('jms-metabolite-services', max_pin="x.x") }}
+    - {{ pin_subpackage('jms-metabolite-services', max_pin="x.x") }}
 
 
 requirements:

--- a/recipes/khipu-metabolomics/meta.yaml
+++ b/recipes/khipu-metabolomics/meta.yaml
@@ -10,13 +10,13 @@ source:
   sha256: 98bc3a78ece5def5041506f3219b0a549b3eb95c05b75817d91eabf94f0810ac
 
 build:
-  entry_points:
-    - khipu=khipu.command_line:main
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
   number: 0
   run_exports:
     - {{ pin_subpackage('khipu-metabolomics', max_pin="x.x") }}
+  entry_points:
+    - khipu=khipu.command_line:main
 
 requirements:
   host:

--- a/recipes/khipu-metabolomics/meta.yaml
+++ b/recipes/khipu-metabolomics/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "khipu-metabolomics" %}
-{% set version = "2.1.0" %}
+{% set version = "2.0.1" %}
 
 package:
   name: {{ name|lower }}

--- a/recipes/khipu-metabolomics/meta.yaml
+++ b/recipes/khipu-metabolomics/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "khipu-metabolomics" %}
-{% set version = "0.7.5" %}
+{% set version = "2.1.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/khipu_metabolomics-{{ version }}.tar.gz
-  sha256: 5c89c28d30fccefb1e468d8fbcb3637bd452f002438291f7eb910a762ceb99f1
+  sha256: 98bc3a78ece5def5041506f3219b0a549b3eb95c05b75817d91eabf94f0810ac
 
 build:
   entry_points:

--- a/recipes/khipu-metabolomics/meta.yaml
+++ b/recipes/khipu-metabolomics/meta.yaml
@@ -24,12 +24,14 @@ requirements:
     - pip
   run:
     - python >=3.7
+    - intervaltree
     - isocor
     - mass2chem
     - matplotlib
     - numpy
     - networkx
     - pandas
+    - requests
     - scipy
     - treelib
 test:

--- a/recipes/khipu-metabolomics/meta.yaml
+++ b/recipes/khipu-metabolomics/meta.yaml
@@ -24,10 +24,14 @@ requirements:
     - pip
   run:
     - python >=3.7
+    - isocor
     - mass2chem
-    - treelib
+    - matplotlib
+    - numpy
     - networkx
     - pandas
+    - scipy
+    - treelib
 test:
   imports:
     - khipu

--- a/recipes/khipu-metabolomics/meta.yaml
+++ b/recipes/khipu-metabolomics/meta.yaml
@@ -40,6 +40,7 @@ test:
     - khipu --help
   requires:
     - pip
+    - requests
 
 about:
   home: https://github.com/shuzhao-li/khipu

--- a/recipes/khipu-metabolomics/meta.yaml
+++ b/recipes/khipu-metabolomics/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/khipu-metabolomics-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/khipu_metabolomics-{{ version }}.tar.gz
   sha256: 5c89c28d30fccefb1e468d8fbcb3637bd452f002438291f7eb910a762ceb99f1
 
 build:


### PR DESCRIPTION
Related to #48971 

Setuptools changed some sdist paths, making autobump fail for recipes that use the pre-change path.

I went through all packages that have been received Pypi updates since the setuptools change at the end of Dec 2023.
 and contained vulnerable paths (containing hyphen `-`).


----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
