### PR TITLE
ci: revert automatic artifact fetching

### DIFF
--- a/.github/workflows/CommentResponder.yml
+++ b/.github/workflows/CommentResponder.yml
@@ -1,12 +1,18 @@
 name: CommentResponder
 on:
   status:
-  check_suite:
-    types:
-    - completed
+  # check_suite:
+  #   types:
+  #   - completed
   issue_comment:
     types:
     - created
+
+    # Runs too many times
+    # (
+    #   github.event_name == 'check_suite' &&
+    #   github.event.check_suite.conclusion == 'success'
+    # ) ||
 
 jobs:
   comment:
@@ -16,10 +22,6 @@ jobs:
       (
         github.event_name == 'status' &&
         github.event.state == 'success'
-      ) ||
-      (
-        github.event_name == 'check_suite' &&
-        github.event.check_suite.conclusion == 'success'
       ) ||
       (
         github.event_name == 'issue_comment' &&


### PR DESCRIPTION
This bot is a little out of control. I guess GitHub considers each CI platform to be its own check suite?

I'll see if I can figure out a way to get it to do what we want, but for now, I don't want to spam all the PRs.