### PR TITLE
Update Maaslin2 version to use latest release from BioC v3.19

### DIFF
--- a/recipes/bioconductor-maaslin2/meta.yaml
+++ b/recipes/bioconductor-maaslin2/meta.yaml
@@ -11,7 +11,7 @@ source:
     - 'https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/Archive/{{ name }}/{{ name }}_{{ version }}.tar.gz'
     - 'https://bioarchive.galaxyproject.org/{{ name }}_{{ version }}.tar.gz'
     - 'https://depot.galaxyproject.org/software/bioconductor-{{ name|lower }}/bioconductor-{{ name|lower }}_{{ version }}_src_all.tar.gz'
-  md5: 0f92778b2d59935191e2ac58621da8f5
+  md5: 65689f289ef30a89d727f676e645719a
   patches:
     - rpath.patch
 build:

--- a/recipes/bioconductor-maaslin2/meta.yaml
+++ b/recipes/bioconductor-maaslin2/meta.yaml
@@ -15,7 +15,7 @@ source:
   patches:
     - rpath.patch
 build:
-  number: 1
+  number: 0
   rpaths:
     - lib/R/lib/
     - lib/

--- a/recipes/bioconductor-maaslin2/meta.yaml
+++ b/recipes/bioconductor-maaslin2/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.16.0" %}
+{% set version = "1.18.0" %}
 {% set name = "Maaslin2" %}
 {% set bioc = "3.18" %}
 

--- a/recipes/bioconductor-maaslin2/meta.yaml
+++ b/recipes/bioconductor-maaslin2/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "1.18.0" %}
 {% set name = "Maaslin2" %}
-{% set bioc = "3.18" %}
+{% set bioc = "3.19" %}
 
 package:
   name: 'bioconductor-{{ name|lower }}'


### PR DESCRIPTION
Update Maaslin2 recipe to pull v1.81.0 which is the latest release from the new release of BioC v3.19.
