### PR TITLE
Build iqtree2 with cmaple feature, reduce pkg size from 8MB to 3MB

### DIFF
--- a/recipes/iqtree/build.sh
+++ b/recipes/iqtree/build.sh
@@ -27,14 +27,12 @@ cmake -S . -B build -DCMAKE_INSTALL_PREFIX="${PREFIX}" -DCMAKE_BUILD_TYPE=Releas
 	-DBUILD_GMOCK=OFF -DINSTALL_GTEST=OFF \
 	-Wno-dev -Wno-deprecated --no-warn-unused-cli
 
-case $(uname -m) in
-aarch64)
+# Detect if we are running on CircleCI's arm.medium VM
+# If CPU_COUNT is 4, we are on CircleCI's arm.large VM
+JOBS=${CPU_COUNT}
+if [[ "$(uname -m)" == "aarch64" ]] && [[ "${CPU_COUNT}" -lt 4 ]]; then
 	JOBS=1 # CircleCI's arm.medium VM runs out of memory with higher values
-	;;
-*)
-	JOBS=${CPU_COUNT}
-	;;
-esac
+fi
 
 VERBOSE=1 cmake --build build --target install -j "${JOBS}"
 

--- a/recipes/iqtree/build.sh
+++ b/recipes/iqtree/build.sh
@@ -12,6 +12,8 @@ if [ "$(uname)" == Darwin ]; then
 	export CMAKE_C_COMPILER="clang"
 	export CMAKE_CXX_COMPILER="clang++"
 	export CXXFLAGS="${CXXFLAGS} -mmacosx-version-min=11"
+        # `which` is required, as full paths needed
+        # see https://github.com/bioconda/bioconda-recipes/pull/49360#discussion_r1686187284
 	CC=$(which "$CC")
 	CXX=$(which "$CXX")
 	AR=$(which "$AR")

--- a/recipes/iqtree/build.sh
+++ b/recipes/iqtree/build.sh
@@ -6,7 +6,7 @@ export LIBPATH="-L${PREFIX}/lib"
 export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib"
 export CFLAGS="${CFLAGS} -O3 -w"
 export CPPFLAGS="${CPPFLAGS} -I${PREFIX}/include -w"
-export CXXFLAGS="${CXXFLAGS} -std=c++14 -w"
+export CXXFLAGS="${CXXFLAGS} -w"
 
 if [ "$(uname)" == Darwin ]; then
 	export CMAKE_C_COMPILER="clang"
@@ -21,8 +21,10 @@ if [ "$(uname)" == Darwin ]; then
 fi
 
 cmake -S . -B build -DCMAKE_INSTALL_PREFIX="${PREFIX}" -DCMAKE_BUILD_TYPE=Release \
+	-GNinja \
 	-DUSE_LSD2=ON -DIQTREE_FLAGS=omp -DUSE_CMAPLE=ON \
 	-DCMAKE_CXX_FLAGS="${CXXFLAGS}" "${DCMAKE_ARGS[@]}" \
+	-DBUILD_GMOCK=OFF -DINSTALL_GTEST=OFF \
 	-Wno-dev -Wno-deprecated --no-warn-unused-cli
 
 case $(uname -m) in
@@ -37,4 +39,13 @@ esac
 VERBOSE=1 cmake --build build --target install -j "${JOBS}"
 
 chmod 755 "${PREFIX}/bin/iqtree2"
-cp -f "${PREFIX}"/bin/iqtree2 "${PREFIX}"/bin/iqtree
+
+# Use symlink to not duplicate the binary, saving space
+ln -s "${PREFIX}"/bin/iqtree2 "${PREFIX}"/bin/iqtree
+
+# Remove example data files
+for file in "${PREFIX}/example"* "${PREFIX}/models.nex"; do
+    if [ -f "$file" ]; then
+        rm "$file"
+    fi
+done

--- a/recipes/iqtree/build.sh
+++ b/recipes/iqtree/build.sh
@@ -12,10 +12,11 @@ if [ "$(uname)" == Darwin ]; then
 	export CMAKE_C_COMPILER="clang"
 	export CMAKE_CXX_COMPILER="clang++"
 	export CXXFLAGS="${CXXFLAGS} -mmacosx-version-min=11"
-	CC=$(which "$CC")
-	CXX=$(which "$CXX")
-	AR=$(which "$AR")
-	RANLIB=$(which "$RANLIB")
+        # Comment out the `which`'s to see if they are really necessary
+	# CC=$(which "$CC")
+	# CXX=$(which "$CXX")
+	# AR=$(which "$AR")
+	# RANLIB=$(which "$RANLIB")
 	DCMAKE_ARGS=(-DCMAKE_C_COMPILER="${CC}" -DCMAKE_CXX_COMPILER="${CXX}"
 		-DCMAKE_CXX_COMPILER_AR="${AR}" -DCMAKE_CXX_COMPILER_RANLIB="${RANLIB}")
 fi

--- a/recipes/iqtree/build.sh
+++ b/recipes/iqtree/build.sh
@@ -6,7 +6,7 @@ export LIBPATH="-L${PREFIX}/lib"
 export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib"
 export CFLAGS="${CFLAGS} -O3"
 export CPPFLAGS="${CPPFLAGS} -I${PREFIX}/include"
-export CXXFLAGS="${CXXFLAGS} -std=c++14"
+export CXXFLAGS="${CXXFLAGS} -std=c++17"
 
 if [ "$(uname)" == Darwin ]; then
 	export CMAKE_C_COMPILER="clang"

--- a/recipes/iqtree/build.sh
+++ b/recipes/iqtree/build.sh
@@ -28,12 +28,12 @@ cmake -S . -B build -DCMAKE_INSTALL_PREFIX="${PREFIX}" -DCMAKE_BUILD_TYPE=Releas
 	-Wno-dev -Wno-deprecated --no-warn-unused-cli
 
 case $(uname -m) in
-	aarch64) 
-		JOBS=1 # CircleCI's arm.medium VM runs out of memory with higher values 
-		;;
-	*)
-		JOBS=${CPU_COUNT}
-		;;
+aarch64)
+	JOBS=1 # CircleCI's arm.medium VM runs out of memory with higher values
+	;;
+*)
+	JOBS=${CPU_COUNT}
+	;;
 esac
 
 VERBOSE=1 cmake --build build --target install -j "${JOBS}"
@@ -44,8 +44,8 @@ chmod 755 "${PREFIX}/bin/iqtree2"
 ln -s "${PREFIX}"/bin/iqtree2 "${PREFIX}"/bin/iqtree
 
 # Remove example data files
-for file in "${PREFIX}/example"* "${PREFIX}/models.nex"; do
-    if [ -f "$file" ]; then
-        rm "$file"
-    fi
+for file in "${PREFIX}/example"* "${PREFIX}/models.nex" "${PREFIX}/bin/iqtree2-aa"; do
+	if [ -f "$file" ]; then
+		rm "$file"
+	fi
 done

--- a/recipes/iqtree/build.sh
+++ b/recipes/iqtree/build.sh
@@ -6,7 +6,7 @@ export LIBPATH="-L${PREFIX}/lib"
 export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib"
 export CFLAGS="${CFLAGS} -O3 -w"
 export CPPFLAGS="${CPPFLAGS} -I${PREFIX}/include -w"
-export CXXFLAGS="${CXXFLAGS} -std=c++14"
+export CXXFLAGS="${CXXFLAGS} -std=c++14 -w"
 
 if [ "$(uname)" == Darwin ]; then
 	export CMAKE_C_COMPILER="clang"

--- a/recipes/iqtree/build.sh
+++ b/recipes/iqtree/build.sh
@@ -12,11 +12,17 @@ if [ "$(uname)" == Darwin ]; then
 	export CMAKE_C_COMPILER="clang"
 	export CMAKE_CXX_COMPILER="clang++"
 	export CXXFLAGS="${CXXFLAGS} -mmacosx-version-min=11"
+	CC=$(which "$CC")
+	CXX=$(which "$CXX")
+	AR=$(which "$AR")
+	RANLIB=$(which "$RANLIB")
+	DCMAKE_ARGS=(-DCMAKE_C_COMPILER="${CC}" -DCMAKE_CXX_COMPILER="${CXX}"
+		-DCMAKE_CXX_COMPILER_AR="${AR}" -DCMAKE_CXX_COMPILER_RANLIB="${RANLIB}")
 fi
 
 cmake -S . -B build -DCMAKE_INSTALL_PREFIX="${PREFIX}" -DCMAKE_BUILD_TYPE=Release \
-	-DUSE_LSD2=ON -DIQTREE_FLAGS=omp -DCMAKE_CXX_COMPILER="${CXX}" \
-	-DCMAKE_CXX_FLAGS="${CXXFLAGS}" -DUSE_CMAPLE=ON \
+	-DUSE_LSD2=ON -DIQTREE_FLAGS=omp -DUSE_CMAPLE=ON \
+	-DCMAKE_CXX_FLAGS="${CXXFLAGS}" "${DCMAKE_ARGS[@]}" \
 	-Wno-dev -Wno-deprecated --no-warn-unused-cli
 
 case $(uname -m) in
@@ -28,7 +34,7 @@ case $(uname -m) in
 		;;
 esac
 
-cmake --build build --target install -j 1
+VERBOSE=1 cmake --build build --target install -j "${JOBS}"
 
 chmod 755 "${PREFIX}/bin/iqtree2"
 cp -f "${PREFIX}"/bin/iqtree2 "${PREFIX}"/bin/iqtree

--- a/recipes/iqtree/build.sh
+++ b/recipes/iqtree/build.sh
@@ -6,7 +6,7 @@ export LIBPATH="-L${PREFIX}/lib"
 export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib"
 export CFLAGS="${CFLAGS} -O3"
 export CPPFLAGS="${CPPFLAGS} -I${PREFIX}/include"
-export CXXFLAGS="${CXXFLAGS} -std=c++17"
+export CXXFLAGS="${CXXFLAGS} -std=c++14"
 
 if [ "$(uname)" == Darwin ]; then
 	export CMAKE_C_COMPILER="clang"

--- a/recipes/iqtree/build.sh
+++ b/recipes/iqtree/build.sh
@@ -4,8 +4,8 @@ set -ex
 export INCLUDES="-I${PREFIX}/include"
 export LIBPATH="-L${PREFIX}/lib"
 export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib"
-export CFLAGS="${CFLAGS} -O3"
-export CPPFLAGS="${CPPFLAGS} -I${PREFIX}/include"
+export CFLAGS="${CFLAGS} -O3 -w"
+export CPPFLAGS="${CPPFLAGS} -I${PREFIX}/include -w"
 export CXXFLAGS="${CXXFLAGS} -std=c++14"
 
 if [ "$(uname)" == Darwin ]; then
@@ -28,7 +28,7 @@ case $(uname -m) in
 		;;
 esac
 
-cmake --build build --target install -j ${JOBS}
+cmake --build build --target install -j 1
 
 chmod 755 "${PREFIX}/bin/iqtree2"
 cp -f "${PREFIX}"/bin/iqtree2 "${PREFIX}"/bin/iqtree

--- a/recipes/iqtree/build.sh
+++ b/recipes/iqtree/build.sh
@@ -11,6 +11,7 @@ export CXXFLAGS="${CXXFLAGS} -std=c++17"
 if [ "$(uname)" == Darwin ]; then
 	export CMAKE_C_COMPILER="clang"
 	export CMAKE_CXX_COMPILER="clang++"
+	export CXXFLAGS="${CXXFLAGS} -mmacosx-version-min=11"
 fi
 
 cmake -S . -B build -DCMAKE_INSTALL_PREFIX="${PREFIX}" -DCMAKE_BUILD_TYPE=Release \

--- a/recipes/iqtree/build.sh
+++ b/recipes/iqtree/build.sh
@@ -12,11 +12,10 @@ if [ "$(uname)" == Darwin ]; then
 	export CMAKE_C_COMPILER="clang"
 	export CMAKE_CXX_COMPILER="clang++"
 	export CXXFLAGS="${CXXFLAGS} -mmacosx-version-min=11"
-        # Comment out the `which`'s to see if they are really necessary
-	# CC=$(which "$CC")
-	# CXX=$(which "$CXX")
-	# AR=$(which "$AR")
-	# RANLIB=$(which "$RANLIB")
+	CC=$(which "$CC")
+	CXX=$(which "$CXX")
+	AR=$(which "$AR")
+	RANLIB=$(which "$RANLIB")
 	DCMAKE_ARGS=(-DCMAKE_C_COMPILER="${CC}" -DCMAKE_CXX_COMPILER="${CXX}"
 		-DCMAKE_CXX_COMPILER_AR="${AR}" -DCMAKE_CXX_COMPILER_RANLIB="${RANLIB}")
 fi

--- a/recipes/iqtree/build.sh
+++ b/recipes/iqtree/build.sh
@@ -15,7 +15,8 @@ fi
 
 cmake -S . -B build -DCMAKE_INSTALL_PREFIX="${PREFIX}" -DCMAKE_BUILD_TYPE=Release \
 	-DUSE_LSD2=ON -DIQTREE_FLAGS=omp -DCMAKE_CXX_COMPILER="${CXX}" \
-	-DCMAKE_CXX_FLAGS="${CXXFLAGS}" -Wno-dev -Wno-deprecated --no-warn-unused-cli
+	-DCMAKE_CXX_FLAGS="${CXXFLAGS}" -DUSE_CMAPLE=ON \
+	-Wno-dev -Wno-deprecated --no-warn-unused-cli
 
 case $(uname -m) in
 	aarch64) 

--- a/recipes/iqtree/conda_build_config.yaml
+++ b/recipes/iqtree/conda_build_config.yaml
@@ -1,4 +1,0 @@
-c_compiler_version:            # [arm64]
-  - 17                         # [arm64]
-cxx_compiler_version:          # [arm64]
-  - 17                         # [arm64]

--- a/recipes/iqtree/conda_build_config.yaml
+++ b/recipes/iqtree/conda_build_config.yaml
@@ -1,0 +1,4 @@
+c_compiler:
+  - clangxx  # [arm64]
+c_compiler_version:
+  - 17  # [arm64]

--- a/recipes/iqtree/conda_build_config.yaml
+++ b/recipes/iqtree/conda_build_config.yaml
@@ -1,4 +1,4 @@
-c_compiler:
-  - clangxx  # [arm64]
-c_compiler_version:
-  - 17  # [arm64]
+c_compiler_version:            # [arm64]
+  - 17                         # [arm64]
+cxx_compiler_version:          # [arm64]
+  - 17                         # [arm64]

--- a/recipes/iqtree/meta.yaml
+++ b/recipes/iqtree/meta.yaml
@@ -21,12 +21,11 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - make
     - cmake
+    - ninja
   host:
     - libgomp  # [linux]
     - llvm-openmp  # [osx]
-    - ld64  # [osx]
     - boost-cpp
     - eigen
 test:

--- a/recipes/iqtree/meta.yaml
+++ b/recipes/iqtree/meta.yaml
@@ -29,8 +29,6 @@ requirements:
     - ld64  # [osx]
     - boost-cpp
     - eigen
-    - zlib
-
 test:
   commands:
     - iqtree

--- a/recipes/iqtree/meta.yaml
+++ b/recipes/iqtree/meta.yaml
@@ -19,6 +19,7 @@ source:
 
 requirements:
   build:
+    - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - make
     - cmake

--- a/recipes/iqtree/meta.yaml
+++ b/recipes/iqtree/meta.yaml
@@ -30,9 +30,15 @@ requirements:
     - boost-cpp
     - eigen
 test:
+  source_files:
+    - cmaple/example/input.fa
   commands:
     - iqtree
     - iqtree2
+    # Mulled builds don't work with source_files
+    - iqtree --pathogen-force -s cmaple/example/input.fa  # [osx]
+    # Test that the CMAPLE submodule is working
+    - grep -v "not compiled with CMAPLE integrated" cmaple/example/input.fa.log  # [osx]
 
 about:
   home: "http://www.iqtree.org"
@@ -56,6 +62,8 @@ extra:
     - doi:10.1038/nmeth.4285
     - doi:10.1093/molbev/msx281
     - doi:10.1093/sysbio/syae008
+    # cmaple
+    - doi:10.1093/molbev/msae134
     - usegalaxy-eu:{{ name|lower }}
   recipe-maintainers:
     - corneliusroemer

--- a/recipes/iqtree/meta.yaml
+++ b/recipes/iqtree/meta.yaml
@@ -1,22 +1,19 @@
 {% set name = "IQTREE" %}
-{% set version = "2.3.5" %}
-{% set sha256 = "8e323e0b7c46e97901d3500f11e810703e0e5d25848188047eca9602d03fa6b1" %}
+{% set version = "v2.3.5" %}
 
 package:
   name: {{ name|lower }}
-  version: {{ version | replace("-", "_") }}
+  version: {{ version | replace("-", "_") | replace("v", "") }}
 
 build:
-  number: 1
+  number: 2
   run_exports:
     - {{ pin_subpackage('iqtree', max_pin="x") }}
 
 source:
-  - url: https://github.com/iqtree/iqtree2/archive/refs/tags/v{{ version }}.tar.gz
-    sha256: {{ sha256 }}
-  - url: https://github.com/tothuhien/lsd2/archive/refs/tags/v.2.4.1.tar.gz
-    sha256: 3d0921c96edb8f30498dc8a27878a76d785516043fbede4a72eefd84b5955458
-    folder: lsd2
+  - git_url: https://github.com/iqtree/iqtree2.git
+    git_rev: {{ version }}
+    sha256: unused
 
 requirements:
   build:
@@ -56,3 +53,5 @@ extra:
     - doi:10.1093/molbev/msx281
     - doi:10.1093/sysbio/syae008
     - usegalaxy-eu:{{ name|lower }}
+  recipe-maintainers:
+    - corneliusroemer

--- a/recipes/iqtree/meta.yaml
+++ b/recipes/iqtree/meta.yaml
@@ -43,6 +43,9 @@ about:
   doc_url: "http://www.iqtree.org/doc"
 
 extra:
+  skip-lints:
+    # uses submodules
+    - uses_vcs_url
   additional-platforms:
     - linux-aarch64
     - osx-arm64

--- a/recipes/iqtree/meta.yaml
+++ b/recipes/iqtree/meta.yaml
@@ -11,6 +11,10 @@ build:
     - {{ pin_subpackage('iqtree', max_pin="x") }}
 
 source:
+  # using git_url rather than tarball due to use of 2 submodules by iqtree (lsd2, cmaple)
+  # Previously, the submodules were specified as source tarballs themselves
+  # But the submodules weren't updated when iqtree was, hence switch to git_url
+  # see discussion https://github.com/bioconda/bioconda-recipes/pull/49360/files#r1686415630
   git_url: https://github.com/iqtree/iqtree2.git
   git_rev: v{{ version }}
   sha256: unused

--- a/recipes/iqtree/meta.yaml
+++ b/recipes/iqtree/meta.yaml
@@ -1,9 +1,9 @@
 {% set name = "IQTREE" %}
-{% set version = "v2.3.5" %}
+{% set version = "2.3.5" %}
 
 package:
   name: {{ name|lower }}
-  version: {{ version | replace("-", "_") | replace("v", "") }}
+  version: {{ version | replace("-", "_") }}
 
 build:
   number: 2
@@ -12,7 +12,7 @@ build:
 
 source:
   git_url: https://github.com/iqtree/iqtree2.git
-  git_rev: {{ version }}
+  git_rev: v{{ version }}
   sha256: unused
   patches:
   - "patch"

--- a/recipes/iqtree/meta.yaml
+++ b/recipes/iqtree/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "IQTREE" %}
-{% set version = "v2.3.5" %}
+{% set version = "v2.3.5.cmaple" %}
 
 package:
   name: {{ name|lower }}

--- a/recipes/iqtree/meta.yaml
+++ b/recipes/iqtree/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version | replace("-", "_") | replace("v", "") }}
 
 build:
-  number: 2
+  number: 0
   run_exports:
     - {{ pin_subpackage('iqtree', max_pin="x") }}
 

--- a/recipes/iqtree/meta.yaml
+++ b/recipes/iqtree/meta.yaml
@@ -1,12 +1,12 @@
 {% set name = "IQTREE" %}
-{% set version = "v2.3.5.cmaple" %}
+{% set version = "v2.3.5" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version | replace("-", "_") | replace("v", "") }}
 
 build:
-  number: 0
+  number: 2
   run_exports:
     - {{ pin_subpackage('iqtree', max_pin="x") }}
 

--- a/recipes/iqtree/meta.yaml
+++ b/recipes/iqtree/meta.yaml
@@ -11,9 +11,11 @@ build:
     - {{ pin_subpackage('iqtree', max_pin="x") }}
 
 source:
-  - git_url: https://github.com/iqtree/iqtree2.git
-    git_rev: {{ version }}
-    sha256: unused
+  git_url: https://github.com/iqtree/iqtree2.git
+  git_rev: {{ version }}
+  sha256: unused
+  patches:
+  - "patch"
 
 requirements:
   build:

--- a/recipes/iqtree/patch
+++ b/recipes/iqtree/patch
@@ -1,0 +1,25 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ca5ebac7..f88c4410 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -204,16 +204,16 @@ if (WIN32)
+ elseif (APPLE)
+     message("Target OS     : Mac OS X")
+ 	if(OSX_NATIVE_ARCHITECTURE STREQUAL "arm64")
+-		add_definitions("--target=arm64-apple-macos10.5")
+-        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --target=arm64-apple-macos12.0.1")
++		add_definitions("--target=arm64-apple-macos11")
++        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --target=arm64-apple-macos11")
+ 	else()
+ 		# to be compatible back to Mac OS X 10.7
+     	if (IQTREE_FLAGS MATCHES "oldmac")
+         	add_definitions("-mmacosx-version-min=10.5")
+         	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -mmacosx-version-min=10.5")
+     	else()
+-        	add_definitions("--target=x86_64-apple-macos10.7")
+-        	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --target=x86_64-apple-macos10.7")
++		add_definitions("--target=x86_64-apple-macos10.13")
++		set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --target=x86_64-apple-macos10.13")
+     	endif()
+ 	endif()
+     SET(CMAKE_FIND_LIBRARY_SUFFIXES .a ${CMAKE_FIND_LIBRARY_SUFFIXES})


### PR DESCRIPTION
- Compiling iqtree2 with cmaple feature
- Soft-link iqtree alias to iqtree2 to half disk space usage (previously was copied), saves 3MB
- Use 4 CPUs for CircleCI's large arm runners, when used, halfs build time -> better resource usage
- Remove example files (saves 2MB disk space), these shouldn't be packaged, they aren't included in env anyways
- Add actual functional test (on osx only due to mulled-tests not working with `source_files`, but better than nothing)
- Use ninja instead of make with cmake
- Silence warnings -> build log is finally not 10k lines
----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
