### PR TITLE
clermontyping use share folder

### DIFF
--- a/recipes/clermontyping/build.sh
+++ b/recipes/clermontyping/build.sh
@@ -2,7 +2,17 @@
 
 set -xe
 
-mkdir -p ${PREFIX}/bin
+CLERMONTYPING="${PREFIX}/share/${PKG_NAME}-${PKG_VERSION}"
+mkdir -p ${PREFIX}/bin ${CLERMONTYPING}
+
+# Use the share folder of R scripts and reference data
+mv ${SRC_DIR}/bin ${CLERMONTYPING}
+mv ${SRC_DIR}/data ${CLERMONTYPING}
+chmod 755 ${PREFIX}/bin/*
+
+# Edit Wrapper to use Share Folder
+sed -i 's,^MY_PATH=$(dirname "$0"),MY_PATH=$CLERMONTYPING,' $SRC_DIR/clermonTyping.sh
+
+# Copy wrapper into bin
 cp $SRC_DIR/clermonTyping.sh ${PREFIX}/bin/
-mkdir -p ${PREFIX}/bin/bin
-cp $SRC_DIR/bin/* ${PREFIX}/bin/bin
+chmod 755 ${PREFIX}/bin/clermonTyping.sh

--- a/recipes/clermontyping/build.sh
+++ b/recipes/clermontyping/build.sh
@@ -11,7 +11,7 @@ mv ${SRC_DIR}/data ${CLERMONTYPING}
 chmod 755 ${CLERMONTYPING}/bin/*
 
 # Edit Wrapper to use Share Folder
-sed -E -i "s,^(MY_PATH=.*),\1../share/${PKG_NAME}-${PKG_VERSION}," $SRC_DIR/clermonTyping.sh
+sed -E -i "s,^(MY_PATH=.*),\1/../share/${PKG_NAME}-${PKG_VERSION}," $SRC_DIR/clermonTyping.sh
 
 # Copy wrapper into bin
 cp $SRC_DIR/clermonTyping.sh ${PREFIX}/bin/

--- a/recipes/clermontyping/build.sh
+++ b/recipes/clermontyping/build.sh
@@ -11,7 +11,7 @@ mv ${SRC_DIR}/data ${CLERMONTYPING}
 chmod 755 ${CLERMONTYPING}/bin/*
 
 # Edit Wrapper to use Share Folder
-sed -i "s,^MY_PATH=.*,MY_PATH=${CLERMONTYPING}," $SRC_DIR/clermonTyping.sh
+sed -E -i "s,^(MY_PATH=.*),\1../share/${PKG_NAME}-${PKG_VERSION}," $SRC_DIR/clermonTyping.sh
 
 # Copy wrapper into bin
 cp $SRC_DIR/clermonTyping.sh ${PREFIX}/bin/

--- a/recipes/clermontyping/build.sh
+++ b/recipes/clermontyping/build.sh
@@ -11,7 +11,7 @@ mv ${SRC_DIR}/data ${CLERMONTYPING}
 chmod 755 ${CLERMONTYPING}/bin/*
 
 # Edit Wrapper to use Share Folder
-sed -i "s,^MY_PATH=$(dirname \"$0\"),MY_PATH=${CLERMONTYPING}," $SRC_DIR/clermonTyping.sh
+sed -i "s,^MY_PATH=.*,MY_PATH=${CLERMONTYPING}," $SRC_DIR/clermonTyping.sh
 
 # Copy wrapper into bin
 cp $SRC_DIR/clermonTyping.sh ${PREFIX}/bin/

--- a/recipes/clermontyping/build.sh
+++ b/recipes/clermontyping/build.sh
@@ -11,7 +11,7 @@ mv ${SRC_DIR}/data ${CLERMONTYPING}
 chmod 755 ${CLERMONTYPING}/bin/*
 
 # Edit Wrapper to use Share Folder
-sed -i 's,^MY_PATH=$(dirname "$0"),MY_PATH=${CLERMONTYPING},' $SRC_DIR/clermonTyping.sh
+sed -i "s,^MY_PATH=$(dirname \"$0\"),MY_PATH=${CLERMONTYPING}," $SRC_DIR/clermonTyping.sh
 
 # Copy wrapper into bin
 cp $SRC_DIR/clermonTyping.sh ${PREFIX}/bin/

--- a/recipes/clermontyping/build.sh
+++ b/recipes/clermontyping/build.sh
@@ -8,7 +8,7 @@ mkdir -p ${PREFIX}/bin ${CLERMONTYPING}
 # Use the share folder of R scripts and reference data
 mv ${SRC_DIR}/bin ${CLERMONTYPING}
 mv ${SRC_DIR}/data ${CLERMONTYPING}
-chmod 755 ${PREFIX}/bin/*
+chmod 755 ${CLERMONTYPING}/bin/*
 
 # Edit Wrapper to use Share Folder
 sed -i 's,^MY_PATH=$(dirname "$0"),MY_PATH=$CLERMONTYPING,' $SRC_DIR/clermonTyping.sh

--- a/recipes/clermontyping/build.sh
+++ b/recipes/clermontyping/build.sh
@@ -11,7 +11,7 @@ mv ${SRC_DIR}/data ${CLERMONTYPING}
 chmod 755 ${CLERMONTYPING}/bin/*
 
 # Edit Wrapper to use Share Folder
-sed -i 's,^MY_PATH=$(dirname "$0"),MY_PATH=$CLERMONTYPING,' $SRC_DIR/clermonTyping.sh
+sed -i 's,^MY_PATH=$(dirname "$0"),MY_PATH=${CLERMONTYPING},' $SRC_DIR/clermonTyping.sh
 
 # Copy wrapper into bin
 cp $SRC_DIR/clermonTyping.sh ${PREFIX}/bin/

--- a/recipes/clermontyping/meta.yaml
+++ b/recipes/clermontyping/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: '{{sha256}}'
 
 build:
-  number: 0
+  number: 1
   noarch: generic
   run_exports:
     - {{ pin_subpackage('clermontyping', max_pin=None) }}  


### PR DESCRIPTION
Restructured clermontyping to use the share folder for rscripts and a small reference dataset (few megabytes)

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
