### PR TITLE
Update parm to v0.0.4

### DIFF
--- a/recipes/parm/meta.yaml
+++ b/recipes/parm/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "0.0.3" %}
-{% set sha256 = "c04f8ec7d0d595e6dee291115aa1626371f17a36e125724d1576e7d4b829d8c7" %}
+{% set version = "0.0.4" %}
+{% set sha256 = "d816519a21c3d26dd35c659ec25eccf0b48cae50fec80f705e0bd1a36c04361e" %}
 
 package:
   name: parm
@@ -24,7 +24,7 @@ requirements:
     - python >=3.10.8
     - pytorch
     - biopython
-    - numpy
+    - numpy >=1.26.0
     - pandas
     - matplotlib-base
     - logomaker


### PR DESCRIPTION
## What's Changed
* Add preprint citation to goodbye message
* Fix a bug when no attribution_range was set to `parm plot`
* Some functions are better commented now, to make it easier to understand them when using PARM within Python


**Full Changelog**: https://github.com/vansteensellab/PARM/compare/v0.0.3...v0.0.4