### PR TITLE
Add recipe for PACU snp

### DIFF
--- a/recipes/pacu_snp/meta.yaml
+++ b/recipes/pacu_snp/meta.yaml
@@ -52,6 +52,8 @@ about:
   summary: PACU is a workflow for whole genome sequencing based phylogeny of Illumina and ONT R9/R10 data.
 
 test:
+  imports:
+    - pacu
   commands:
     - PACU -h
     - PACU_map -h

--- a/recipes/pacu_snp/meta.yaml
+++ b/recipes/pacu_snp/meta.yaml
@@ -9,6 +9,8 @@ source:
 build:
   noarch: python
   number: 0
+  run_exports:
+    - pacu_snp 
 
 requirements:
   host:

--- a/recipes/pacu_snp/meta.yaml
+++ b/recipes/pacu_snp/meta.yaml
@@ -9,8 +9,9 @@ source:
 build:
   noarch: python
   number: 0
-  run_exports:
-    - pacu_snp 
+  entry_points:
+    - PACU=pacu.run_pacu:main
+    - PACU_map=pacu.map_to_ref:main
 
 requirements:
   host:

--- a/recipes/pacu_snp/meta.yaml
+++ b/recipes/pacu_snp/meta.yaml
@@ -1,9 +1,11 @@
+{% set version = "0.0.3" %}
+
 package:
   name: pacu_snp
-  version: 0.0.3
+  version: {{ version }}
 
 source:
-  url: https://github.com/BioinformaticsPlatformWIV-ISP/PACU/archive/refs/tags/v0.0.3.tar.gz
+  url: https://github.com/BioinformaticsPlatformWIV-ISP/PACU/archive/refs/tags/v{{ version }}.tar.gz
   sha256: 2c13baf3595e219b663e7c2f2be51aeea3e920c690c2c6158789613ec6f91464
 
 build:
@@ -12,14 +14,19 @@ build:
   entry_points:
     - PACU=pacu.run_pacu:main
     - PACU_map=pacu.map_to_ref:main
+  run_exports:
+    - {{ pin_subpackage("pacu_snp", max_pin="x.x") }}
 
 requirements:
   host:
     - python >=3.9
-    - pip
+    - setuptools
+    - biopython >=1.84
+    - pyyaml >=6.0.1
   run:
     - bcftools >=1.17
     - beautifulsoup4 >=4.12.2
+    - biopython >=1.84
     - bowtie2 >=2.5.1
     - figtree >=1.4.4
     - gubbins >=3.3.1
@@ -28,6 +35,7 @@ requirements:
     - minimap2 >=2.26
     - pandas >=2.1.0
     - pyvcf3 >=1.0.3
+    - pyyaml >=6.0.1
     - samtools >=1.17
     - seqkit >=2.3.1
     - snakemake ==7.32.4
@@ -40,9 +48,11 @@ about:
   home: https://github.com/BioinformaticsPlatformWIV-ISP/PACU
   license: GPL-3.0
   license_family: GPL
+  license_file: LICENSE
   summary: PACU is a workflow for whole genome sequencing based phylogeny of Illumina and ONT R9/R10 data.
 
 test:
   commands:
     - PACU -h
     - PACU_map -h
+

--- a/recipes/pacu_snp/meta.yaml
+++ b/recipes/pacu_snp/meta.yaml
@@ -5,8 +5,8 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/BioinformaticsPlatformWIV-ISP/PACU/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 2c13baf3595e219b663e7c2f2be51aeea3e920c690c2c6158789613ec6f91464
+  url: https://files.pythonhosted.org/packages/19/07/fe374dabd76bf3bbccd52180812c97154ab5846f5c9fc8774b4e953227bd/pacu_snp-{{ version }}.tar.gz
+  sha256: a4e9934f6b218a48784389fdc3f2af4fe4fe7225f69a90278a83976bfa02fc78
 
 build:
   noarch: python
@@ -16,10 +16,12 @@ build:
     - PACU_map=pacu.map_to_ref:main
   run_exports:
     - {{ pin_subpackage("pacu_snp", max_pin="x.x") }}
+  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 
 requirements:
   host:
     - python >=3.9
+    - pip
     - setuptools
     - biopython >=1.84
     - pyyaml >=6.0.1

--- a/recipes/pacu_snp/meta.yaml
+++ b/recipes/pacu_snp/meta.yaml
@@ -1,0 +1,45 @@
+package:
+  name: pacu_snp
+  version: 0.0.3
+
+source:
+  url: https://github.com/BioinformaticsPlatformWIV-ISP/PACU/archive/refs/tags/v0.0.3.tar.gz
+  sha256: 2c13baf3595e219b663e7c2f2be51aeea3e920c690c2c6158789613ec6f91464
+
+build:
+  noarch: python
+  number: 0
+
+requirements:
+  host:
+    - python >=3.9
+    - pip
+  run:
+    - bcftools >=1.17
+    - beautifulsoup4 >=4.12.2
+    - bowtie2 >=2.5.1
+    - figtree >=1.4.4
+    - gubbins >=3.3.1
+    - iqtree >=2.2.5
+    - matplotlib-base >=3.8.0
+    - minimap2 >=2.26
+    - pandas >=2.1.0
+    - pyvcf3 >=1.0.3
+    - samtools >=1.17
+    - seqkit >=2.3.1
+    - snakemake ==7.32.4
+    - snp-dists >=0.8.2
+    - trimmomatic >=0.39
+    - upsetplot >=0.8.0
+    - yattag >=1.15.1
+
+about:
+  home: https://github.com/BioinformaticsPlatformWIV-ISP/PACU
+  license: GPL-3.0
+  license_family: GPL
+  summary: PACU is a workflow for whole genome sequencing based phylogeny of Illumina and ONT R9/R10 data.
+
+test:
+  commands:
+    - PACU -h
+    - PACU_map -h

--- a/recipes/pacu_snp/meta.yaml
+++ b/recipes/pacu_snp/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://files.pythonhosted.org/packages/19/07/fe374dabd76bf3bbccd52180812c97154ab5846f5c9fc8774b4e953227bd/pacu_snp-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/p/pacu_snp/pacu_snp-{{ version }}.tar.gz
   sha256: a4e9934f6b218a48784389fdc3f2af4fe4fe7225f69a90278a83976bfa02fc78
 
 build:


### PR DESCRIPTION
A recipe for the PACU SNP phylogeny workflow.
PACU is a workflow for whole genome sequencing based phylogeny of Illumina and ONT R9/R10 data for bacteria.

More information is available on the [GitHub page](https://github.com/BioinformaticsPlatformWIV-ISP/PACU) or in the corresponding [publication](https://pubmed.ncbi.nlm.nih.gov/38441926/).

----

This is my first pull request for bioconda. I followed the instructions as best I could, but please let me know if I need to change anything. 
