### PR TITLE
Update el_gato to 1.18.0

### DIFF
--- a/recipes/el_gato/meta.yaml
+++ b/recipes/el_gato/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "el_gato" %}
-{% set version = "1.15.2" %}
-{% set hash = "ef930f7e0e2940f7d28820fbfc19b2262d1898c82d8699ca47dbc4c851eb11ad" %}
+{% set version = "1.18.0" %}
+{% set hash = "b00d812d047053823275e62d7f01ed88aaffa906471e073443bb18e85c905995" %}
 {% set user = "appliedbinf" %}
 
 package:

--- a/recipes/el_gato/meta.yaml
+++ b/recipes/el_gato/meta.yaml
@@ -30,6 +30,7 @@ requirements:
     - ispcr >=33.0
     - nextflow
     - fpdf2
+    - packaging
 
 test:
   commands:


### PR DESCRIPTION
Updates el_gato to version 1.18.0 and adds packaging dependency.

Replaces #49528