### PR TITLE
Add neodisambiguate for multi-species read disambiguation (xenografts, etc.)

### DIFF
--- a/recipes/neodisambiguate/build.sh
+++ b/recipes/neodisambiguate/build.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-set -eu -o pipefail
-
-mkdir -p $PREFIX/bin
-cp $RECIPE_DIR/neodisambiguate ${PREFIX}/bin/neodisambiguate
-chmod +x ${PREFIX}/bin/neodisambiguate

--- a/recipes/neodisambiguate/build.sh
+++ b/recipes/neodisambiguate/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -eu -o pipefail
+
+mkdir -p $PREFIX/bin
+cp $RECIPE_DIR/neodisambiguate ${PREFIX}/bin/neodisambiguate
+chmod +x ${PREFIX}/bin/neodisambiguate

--- a/recipes/neodisambiguate/meta.yaml
+++ b/recipes/neodisambiguate/meta.yaml
@@ -10,13 +10,13 @@ source:
 
 build:
   noarch: generic
-  number: 1
+  number: 0
   run_exports:
     - {{ pin_subpackage('neodisambiguate', max_pin="x") }}
 
 requirements:
   run:
-    - openjdk>=8
+    - openjdk >= 8
 
 test:
   commands:

--- a/recipes/neodisambiguate/meta.yaml
+++ b/recipes/neodisambiguate/meta.yaml
@@ -6,13 +6,17 @@ package:
 
 source:
   url: https://github.com/clintval/neodisambiguate/releases/download/{{ version }}/neodisambiguate
-  sha256: 4180053d07dc4817eb2c89636e5fe111360c1a00f9260d6c61fa44980f50c04e
+  sha256: 175f80595162de99c9f0813da773d48cf9883eb2772d434ec61bb237968b1729
 
 build:
   noarch: generic
   number: 0
   run_exports:
     - {{ pin_subpackage('neodisambiguate', max_pin="x") }}
+  script: |
+    mkdir -p "${PREFIX}/bin"
+    cp neodisambiguate "${PREFIX}/bin/"
+    chmod +x "${PREFIX}/bin/neodisambiguate"
 
 requirements:
   run:

--- a/recipes/neodisambiguate/meta.yaml
+++ b/recipes/neodisambiguate/meta.yaml
@@ -16,7 +16,7 @@ build:
 
 requirements:
   run:
-    - openjdk >= 8
+    - openjdk >=8
 
 test:
   commands:

--- a/recipes/neodisambiguate/meta.yaml
+++ b/recipes/neodisambiguate/meta.yaml
@@ -1,0 +1,31 @@
+{% set version="1.0.0" %}
+
+package:
+  name: neodisambiguate
+  version: {{ version }}
+
+source:
+  url: https://github.com/clintval/neodisambiguate/releases/download/{{ version }}/neodisambiguate
+  sha256: 4180053d07dc4817eb2c89636e5fe111360c1a00f9260d6c61fa44980f50c04e
+
+build:
+  noarch: generic
+  number: 1
+  run_exports:
+    - {{ pin_subpackage('neodisambiguate', max_pin="x") }}
+
+requirements:
+  run:
+    - openjdk>=8
+
+test:
+  commands:
+    - 'neodisambiguate --help 2>&1 | grep "neodisambiguate"'
+    - 'neodisambiguate --version 2>&1 | grep "neodisambiguate"'
+
+about:
+  home: https://github.com/clintval/neodisambiguate
+  license: MIT
+  license_family: MIT
+  summary: Disambiguate reads that were mapped to multiple references.
+  doc_url: https://github.com/clintval/neodisambiguate


### PR DESCRIPTION
This PR adds a new tool ([`neodisambiguate`](https://github.com/clintval/neodisambiguate)) for multi-species read disambiguation.

This type of NGS analysis is commonly used in patient-derived xenograft experiments. e.g.:

- https://pubmed.ncbi.nlm.nih.gov/27990269/

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
