### PR TITLE
Add recipe for snakeatac_env

### DIFF
--- a/recipes/snaketaca_env/meta.yaml
+++ b/recipes/snaketaca_env/meta.yaml
@@ -1,0 +1,97 @@
+{% set version = "0.1.1" %}
+{% set sha256 = "7d9c753aceadd0cdd2132f510375e191f1bd9de92e29e43d710433ca770e1f03" %}
+
+package:
+  name: snakeatac_env
+  version: {{ version }}
+
+source:
+  - url: https://github.com/sebastian-gregoricchio/snakeATAC/archive/refs/tags/v{{ version }}.tar.gz
+    sha256: {{ sha256 }}
+build:
+  noarch: python
+  number: 0
+
+requirements:
+  host:
+    - python
+    - pip
+    - numpy >=1.22
+    - conda-forge::mpich
+
+  run:
+    - bioconda::bcftools
+    - bioconda::bedtools
+    - bioconda::bioconductor-copywriter
+    - bioconda::bioconductor-shortread
+    - bioinfokit
+    - bioconda::bwa-mem2
+    - bzip2
+    - bioconda::cutadapt
+    - bioconda::deeptools
+    - bioconda::fastqc
+    - bioconda::gatk4
+    - bioconda::macs3
+    - matplotlib-base
+    - bioconda::multiqc >=1.23
+    - conda-forge::pdfcombine
+    - pip
+    - conda-forge::py-bgzip
+    - bioconda::py2bit
+    - bioconda::pybigwig
+    - bioconda::pyfaidx
+    - bioconda::pysam
+    - python
+    - r-colorspace
+    - r-data.table
+    - r-dplyr
+    - r-generics
+    - r-ggplot2
+    - r-ggtext
+    - r-plyr
+    - r-rcolorbrewer
+    - r-reshape2
+    - r-scales
+    - r-snow
+    - r-stringr
+    - r-viridis
+    - bioconda::samtools
+    - scipy
+    - seaborn
+    - bioconda::snakemake >=7.24.0
+    - bioconda::snpsift
+    - bioconda::subread
+    - bioconda::tobias
+    - bioconda::ucsc-bedgraphtobigwig
+    - biopython
+    - docutils
+    - fastcluster
+    - bioconda::logomaker
+    - matplotlib >=3.3.4
+    - numpydoc
+    - pandas
+    - bioconda::pybedtools
+
+
+test:
+  commands:
+    - deeptools --help
+    - samtools --help
+    
+
+about:
+  home: https://github.com/sebastian-gregoricchio/snakeATAC
+  license: https://github.com/sebastian-gregoricchio/snakeATAC/blob/main/LICENSE
+  summary: snakemake based ATACseq pipeline
+
+
+extra:
+  recipe-maintainers:
+    - sebastian-gregoricchio
+  channels:
+    - bioconda
+    - anaconda
+    - conda-forge
+    - defaults
+    - macs3
+    - r


### PR DESCRIPTION
Add recipe for `sankeatac_env`

It corresponds to the environment required to use the [`snakeATAC`](https://github.com/sebastian-gregoricchio/snakeATAC) pipeline. The latter is a pipeline for the analyses of ATAC-seq data.