### PR TITLE
Update PACU SNP (new build) - added missing bedtools dependency, increased build number

### DIFF
--- a/recipes/pacu_snp/meta.yaml
+++ b/recipes/pacu_snp/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   entry_points:
     - PACU=pacu.run_pacu:main
     - PACU_map=pacu.map_to_ref:main
@@ -29,6 +29,7 @@ requirements:
   run:
     - bcftools >=1.17
     - beautifulsoup4 >=4.12.2
+    - bedtools >=2.31.0
     - biopython >=1.84
     - bowtie2 >=2.5.1
     - figtree >=1.4.4


### PR DESCRIPTION
I have added a missing dependency and increased the build number.