### PR TITLE
Add camisim

### DIFF
--- a/recipes/camisim/build.sh
+++ b/recipes/camisim/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cp metagenome_from_profile.py ${PREFIX}/bin
+chmod 755 ${PREFIX}/bin/metagenome_from_profile.py

--- a/recipes/camisim/build.sh
+++ b/recipes/camisim/build.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 
 cp metagenome_from_profile.py ${PREFIX}/bin
+cp metagenomesimulation.py ${PREFIX}/bin
 chmod 755 ${PREFIX}/bin/metagenome_from_profile.py
+chmod 755 ${PREFIX}/bin/metagenomesimulation.py

--- a/recipes/camisim/meta.yaml
+++ b/recipes/camisim/meta.yaml
@@ -1,0 +1,48 @@
+
+{% set version = "1.3" %}
+{% set name = "CAMISIM" %}
+{% set sha256 = "92c9e234c99cd776c0d33612a3ac1e26fa5c4209be3af40f8f11918a9dc74706" %}
+{% set user = "CAMI-challenge" %}
+
+package:
+  name: {{ name | lower }}
+  version: {{ version }}
+
+build:
+  number: 1
+  noarch: python
+
+source:
+  url: https://github.com/{{ user }}/{{ name }}/archive/refs/tags/{{ version }}.tar.gz 
+  sha256: {{ sha256 }}
+
+requirements:
+
+  host:
+    - python 3.9
+  run:
+    - python 3.9
+    - scikit-learn
+    - joblib
+    - numpy
+    - biopython
+    - matplotlib
+    - biom-format
+    - ete3
+    - samtools
+
+test:
+  commands:
+    - metagenome_from_profile.py --help
+
+about:
+  home: https://github.com/CAMI-challenge/CAMISIM
+  license: MIT
+  license_file: LICENSE
+  summary: "CAMISIM is a software to model abundance distributions of microbial communities and to simulate corresponding shotgun metagenome datasets"
+  dev_url: https://github.com/CAMI-challenge/CAMISIM
+  doc_url: https://github.com/CAMI-challenge/CAMISIM
+
+extra:
+  recipe-maintainers:
+    - paulzierep


### PR DESCRIPTION
First try to add camisim to bioconda. Using the python scripts not the nextflow pipline. It seems currently only the python scripts are supported: https://github.com/CAMI-challenge/CAMISIM/issues/184

The initial build only includes `metagenome_from_profile.py` and `metagenomesimulation.py` - the main entry points to the pipeline.