### PR TITLE
Update isoquant to 3.5.0

### DIFF
--- a/recipes/isoquant/meta.yaml
+++ b/recipes/isoquant/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "IsoQuant" %}
-{% set version = "3.4.2" %}
-{% set sha256 = "7cff391e0d9e9d61d4fce6a1218270cf72e8dd034d7cfdd154b4c5b4055e17b4" %}
+{% set version = "3.5.0" %}
+{% set sha256 = "80771cc4fbe8d222b5dfa45be392942b2fdd356ebbb1d99e26d251c37bba085d" %}
 
 package:
   name: {{ name | lower }}

--- a/recipes/isoquant/meta.yaml
+++ b/recipes/isoquant/meta.yaml
@@ -24,6 +24,7 @@ requirements:
     - biopython >=1.76
     - gffutils >=0.10.1
     - minimap2 >=2.18
+    - numpy >=1.18.1
     - packaging
     - pandas >=1.0.1
     - pybedtools >=0.8.1
@@ -31,6 +32,8 @@ requirements:
     - pysam >=0.15
     - pyyaml >=5.4
     - samtools >=1.14
+    - scipy >=1.4.1
+    - seaborn >=0.10.0
     - simplejson >=3.17.0
     - six >=1.14.0
 
@@ -48,7 +51,7 @@ about:
   license_family: GPL2
   license_file: LICENSE
   dev_url: "https://github.com/ablab/IsoQuant"
-  doc_url: "https://github.com/ablab/IsoQuant/blob/master/README.md"
+  doc_url: "https://ablab.github.io/IsoQuant"
 
 extra:
   identifiers:


### PR DESCRIPTION
Updates IsoQuant to 3.5.0

Adds a few more requirements, so should be preferred over 
https://github.com/bioconda/bioconda-recipes/pull/49779