### PR TITLE
Fix: python scripts path specification

### DIFF
--- a/recipes/poolsnp/build.sh
+++ b/recipes/poolsnp/build.sh
@@ -24,10 +24,16 @@ cp PoolSNP.sh ${PREFIX}/bin
 chmod +x ${PREFIX}/bin/PoolSNP.sh
 
 for script in $SCRIPTS_DIR/*; do
-    cp $script ${PREFIX}/bin/$(basename $script)
+
     cp $script ${PREFIX}/bin/scripts/
-    chmod +x ${PREFIX}/bin/$(basename $script)
     chmod +x ${PREFIX}/bin/scripts/$(basename $script)
+
+    # The main script PoolSNP.sh relies on the scripts being in the same directory as it
+    # Modifying PoolSNP.sh to update the path to the scripts
+    script_name=$(basename $script)
+
+    sed -i.bak "s|${script_name}|\\\$(which ${script_name})|g" ${PREFIX}/bin/PoolSNP.sh
+
 done
 
 cp -r ${TEST_DATA_DIR} ${PREFIX}/share/PoolSNP/TestData

--- a/recipes/poolsnp/meta.yaml
+++ b/recipes/poolsnp/meta.yaml
@@ -19,7 +19,7 @@ requirements:
     - parallel
   
 build:
-  number: 0
+  number: 1
   noarch: generic
   run_exports:
     - {{ pin_subpackage('poolsnp', max_pin='x.x') }}


### PR DESCRIPTION
The PoolSNP package comprises of a main bash script `PoolSNP.sh` that calls on python scripts for different subtasks. However, these python scripts need to be placed in a `scripts/` folder that is in the same directory as the shell script. 

When `PoolSNP.sh` is invoked from a different directory, the shell script looks for the python scripts in the execution directory hence failing with a non-zero exit status. This PR modifies the `PoolSNP.sh` script to call on the python scripts installed in the conda `bin/` directory.
----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
