### PR TITLE
Fix mummer hashbang and build on macOS including ARM

### DIFF
--- a/recipes/mummer/build.sh
+++ b/recipes/mummer/build.sh
@@ -49,7 +49,7 @@ done
 
 for i in $binaries; do 
   # fix hashbang lines to use conda's perl
-  sed -i.bak "s/\/usr\/local\/bin\/perl/\/usr\/bin\/env perl/" $MUMMER_HOME/$i
+  sed -i.bak '1 s|^.*$|#!/usr/bin/env perl|g' $MUMMER_HOME/$i
   rm -rf $MUMMER_HOME/$i.bak
   # ensure executable and setup symlink for binary
   chmod +x $MUMMER_HOME/$i

--- a/recipes/mummer/build.sh
+++ b/recipes/mummer/build.sh
@@ -49,7 +49,7 @@ done
 
 for i in $binaries; do 
   # fix hashbang lines to use conda's perl
-  sed -i.bak '1 s|^.*$|#!/usr/bin/env perl|g' $MUMMER_HOME/$i
+  sed -i.bak '1 s|^#!/.*/perl$|#!/usr/bin/env perl|g' $MUMMER_HOME/$i
   rm -rf $MUMMER_HOME/$i.bak
   # ensure executable and setup symlink for binary
   chmod +x $MUMMER_HOME/$i

--- a/recipes/mummer/build.sh
+++ b/recipes/mummer/build.sh
@@ -48,9 +48,11 @@ for i in exact-tandems dnadiff mapview mummerplot nucmer promer run-mummer1 run-
 done
 
 for i in $binaries; do 
-  # fix hashbang lines to use conda's perl
-  sed -i.bak '1 s|^#!/.*/perl$|#!/usr/bin/env perl|g' $MUMMER_HOME/$i
-  rm -rf $MUMMER_HOME/$i.bak
+  if file $MUMMER_HOME/$i | grep "Perl script"; then
+    # fix hashbang lines to use conda's perl
+    sed -i.bak '1 s|^#!/.*/perl$|#!/usr/bin/env perl|g' $MUMMER_HOME/$i
+    rm -rf $MUMMER_HOME/$i.bak
+  fi
   # ensure executable and setup symlink for binary
   chmod +x $MUMMER_HOME/$i
   ln -s "$MUMMER_HOME/$i" "$BINARY_HOME/$i"

--- a/recipes/mummer/build.sh
+++ b/recipes/mummer/build.sh
@@ -48,6 +48,10 @@ for i in exact-tandems dnadiff mapview mummerplot nucmer promer run-mummer1 run-
 done
 
 for i in $binaries; do 
+  # fix hashbang lines to use conda's perl
+  sed -i.bak "s/\/usr\/local\/bin\/perl/\/usr\/bin\/env perl/" $MUMMER_HOME/$i
+  rm -rf $MUMMER_HOME/$i.bak
+  # ensure executable and setup symlink for binary
   chmod +x $MUMMER_HOME/$i
   ln -s "$MUMMER_HOME/$i" "$BINARY_HOME/$i"
 done

--- a/recipes/mummer/meta.yaml
+++ b/recipes/mummer/meta.yaml
@@ -11,6 +11,11 @@ source:
   sha256: {{ sha256 }}
   patches:
     - patches/gnuplot_mouse_clipboardformat.patch
+    - patches/linkloc_explicit.patch  # [osx]
+    - patches/addleafcount_explicit.patch  # [osx]
+    - patches/findmumcand_explicit.patch  # [osx]
+    - patches/findmaxmat_explicit.patch  # [osx]
+    - patches/procmaxmat_explicit.patch  # [osx]
 
 build:
   number: 19

--- a/recipes/mummer/meta.yaml
+++ b/recipes/mummer/meta.yaml
@@ -13,8 +13,7 @@ source:
     - patches/gnuplot_mouse_clipboardformat.patch
 
 build:
-  number: 18
-  skip: True  # [osx]
+  number: 19
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x') }}
 
@@ -24,9 +23,9 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
-    - perl # [not osx]
+    - perl
   run:
-    - perl # [not osx]
+    - perl
 
 test:
   commands:
@@ -52,5 +51,6 @@ about:
 extra:
   additional-platforms:
     - linux-aarch64
+    - osx-arm64
   identifiers:
     - biotools:mummer

--- a/recipes/mummer/patches/addleafcount_explicit.patch
+++ b/recipes/mummer/patches/addleafcount_explicit.patch
@@ -1,0 +1,19 @@
+--- MUMmer3.23/src/kurtz/streesrc/addleafcount.c.old	2024-08-07 13:34:49
++++ MUMmer3.23/src/kurtz/streesrc/addleafcount.c	2024-08-07 13:48:50
+@@ -13,6 +13,16 @@
+ #include "spacedef.h"
+ #include "arraydef.h"
+ 
++void getbranchinfostree(Suffixtree *stree,Uint whichinfo,
++                        Branchinfo *branchinfo,Bref btptr);
++
++Sint depthfirststree(Suffixtree *stree,Reference *startnode,
++                     Sint (*processleaf)(Uint,Bref,void *),
++                     BOOL (*processbranch1)(Bref,void *),
++                     Sint (*processbranch2)(Bref,void *),
++                     BOOL (*stoptraversal)(void *),
++                     void *stopinfo,void *info);
++
+ typedef struct
+ {
+   Suffixtree *stree;                      // suffix tree info

--- a/recipes/mummer/patches/findmaxmat_explicit.patch
+++ b/recipes/mummer/patches/findmaxmat_explicit.patch
@@ -1,0 +1,34 @@
+--- MUMmer3.23/src/kurtz/mm3src/findmaxmat.c.old	2024-08-07 13:55:45
++++ MUMmer3.23/src/kurtz/mm3src/findmaxmat.c	2024-08-07 14:03:39
+@@ -14,7 +14,31 @@
+ #include "debugdef.h"
+ #include "spacedef.h"
+ #include "maxmatdef.h"
++
++void linklocstree(Suffixtree *stree,Location *outloc,Location *inloc);
++
++SYMBOL *scanprefixstree(Suffixtree *stree,Location *outloc,
++                        Location *inloc,SYMBOL *left,
++                        SYMBOL *right,Uint rescanlength);
++
++SYMBOL *findprefixpathstree(Suffixtree *stree,
++                            ArrayPathinfo *path,
++                            Location *outloc,
++                            Location *inloc,
++                            SYMBOL *left,SYMBOL *right,
++                            Uint rescanlength);
+ 
++Sint depthfirststree(Suffixtree *stree,Reference *startnode,
++                     Sint (*processleaf)(Uint,Bref,void *),
++                     BOOL (*processbranch1)(Bref,void *),
++                     Sint (*processbranch2)(Bref,void *),
++                     BOOL (*stoptraversal)(void *),
++                     void *stopinfo,void *info);
++
++SYMBOL *scanprefixfromnodestree(Suffixtree *stree,Location *loc,
++                                Bref btptr,SYMBOL *left,
++                                SYMBOL *right,Uint rescanlength);
++
+ //}
+ 
+ /*EE

--- a/recipes/mummer/patches/findmumcand_explicit.patch
+++ b/recipes/mummer/patches/findmumcand_explicit.patch
@@ -1,0 +1,19 @@
+--- MUMmer3.23/src/kurtz/mm3src/findmumcand.c.old	2024-08-07 13:42:47
++++ MUMmer3.23/src/kurtz/mm3src/findmumcand.c	2024-08-07 13:54:04
+@@ -15,6 +15,16 @@
+ #include "spacedef.h"
+ #include "maxmatdef.h"
+ 
++void linklocstree(Suffixtree *stree,Location *outloc,Location *inloc);
++
++SYMBOL *scanprefixfromnodestree(Suffixtree *stree,Location *loc,
++                                Bref btptr,SYMBOL *left,
++                                SYMBOL *right,Uint rescanlength);
++
++SYMBOL *scanprefixstree(Suffixtree *stree,Location *outloc,
++                                   Location *inloc,SYMBOL *left,
++                                   SYMBOL *right,Uint rescanlength);
++
+ //}
+ 
+ /*EE

--- a/recipes/mummer/patches/linkloc_explicit.patch
+++ b/recipes/mummer/patches/linkloc_explicit.patch
@@ -1,0 +1,12 @@
+--- MUMmer3.23/src/kurtz/streesrc/linkloc.c.old	2024-08-07 12:45:16
++++ MUMmer3.23/src/kurtz/streesrc/linkloc.c	2024-08-07 13:48:38
+@@ -11,6 +11,9 @@
+ #include "debugdef.h"
+ #include "streeacc.h"
+ 
++void getbranchinfostree(Suffixtree *stree,Uint whichinfo,
++                        Branchinfo *branchinfo,Bref btptr);
++
+ void rescanstree(Suffixtree *stree,Location *loc,
+                  Bref btptr,SYMBOL *left,SYMBOL *right)
+ {

--- a/recipes/mummer/patches/procmaxmat_explicit.patch
+++ b/recipes/mummer/patches/procmaxmat_explicit.patch
@@ -1,0 +1,19 @@
+--- MUMmer3.23/src/kurtz/mm3src/procmaxmat.c.old	2024-08-07 14:05:17
++++ MUMmer3.23/src/kurtz/mm3src/procmaxmat.c	2024-08-07 14:07:03
+@@ -19,6 +19,16 @@
+ #include "spacedef.h"
+ #include "streedef.h"
+ #include "maxmatdef.h"
++
++Uint getmaxtextlenstree(void);
++
++Sint constructprogressstree(Suffixtree *stree,SYMBOL *text,
++                            Uint textlen,
++                            void (*progress)(Uint,void *),
++                            void (*finalprogress)(void *),
++                            void *info);
++
++void freestree(Suffixtree *stree);
+ 
+ //}
+ 


### PR DESCRIPTION
Should fix the hashbang (issue #28209; see https://bioconda.github.io/contributor/troubleshooting.html#perl-or-python-not-found), but also tries to re-enable building on macOS plus adding osx-arm64 for use on recent Apple hardware.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
