### PR TITLE
Update Metabinner (Make scripts/auxilirary tools available on path)

### DIFF
--- a/recipes/metabinner/build.sh
+++ b/recipes/metabinner/build.sh
@@ -6,3 +6,8 @@ chmod a+x run_metabinner.sh
 cp run_metabinner.sh $PREFIX/bin/
 cp -r auxiliary $PREFIX/bin/
 cp -r scripts $PREFIX/bin/
+
+## Original build by author just placed directories in bin, not scripts themsleves
+## To ensure backwards compatibility, we additionally symlink the scripts to the bin directory
+ln -s $PREFIX/bin/auxiliary/* $PREFIX/bin/
+ln -s $PREFIX/bin/scripts/* $PREFIX/bin/

--- a/recipes/metabinner/meta.yaml
+++ b/recipes/metabinner/meta.yaml
@@ -7,7 +7,7 @@ source:
   sha256: 087a28aeb8fe218a3a2a6dd53b3bc5cad4cf33353fde3eebb8ee992461a99119
 
 build:
-  number: 0
+  number: 1
   noarch: generic
 
 requirements:
@@ -30,10 +30,12 @@ requirements:
 
 test:
   commands:
-    - which run_metabinner.sh 
-    
+    - "gen_coverage_file.sh 2> /dev/null | grep 'Usage: bash gen_coverage_file.sh'"
+    - which gen_kmer.py
+    - Filter_tooshort.py --help
+    - "run_metabinner.sh 2> /dev/null | grep 'Usage: bash run_metabinner.sh'"
+
 about:
   home: "https://github.com/ziyewang/MetaBinner"
   license: BSD
   summary: "Ensemble binning method to recover individual genomes from complex microbial communities"
-

--- a/recipes/metabinner/meta.yaml
+++ b/recipes/metabinner/meta.yaml
@@ -9,6 +9,8 @@ source:
 build:
   number: 1
   noarch: generic
+  run_exports:
+    - { { pin_subpackage("metabinner", max_pin="x.x") } }
 
 requirements:
   run:

--- a/recipes/metabinner/meta.yaml
+++ b/recipes/metabinner/meta.yaml
@@ -10,7 +10,7 @@ build:
   number: 1
   noarch: generic
   run_exports:
-    - { { pin_subpackage("metabinner", max_pin="x.x") } }
+    - {{ pin_subpackage("metabinner", max_pin="x") }}
 
 requirements:
   run:


### PR DESCRIPTION
When trying to follow the tutorial, I noticed many of the auxiliary/preparation scripts were not available on the path because only the directory was copied to the `bin/`, not the scripts themselves. 

This updates the recipe so the build is backwards compatible - i.e., the directories are still copied in the bin but the scripts are also symlinked into the `bin/` so they are easily available to the user.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
