### PR TITLE
Add recipe for cyrcular

### DIFF
--- a/recipes/cyrcular/build.sh
+++ b/recipes/cyrcular/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -xeuo
+
+# Make sure bindgen passes on our compiler flags.
+export BINDGEN_EXTRA_CLANG_ARGS="${CPPFLAGS} ${CFLAGS} ${LDFLAGS}"
+
+cargo install --no-track --locked --root "${PREFIX}" --path .

--- a/recipes/cyrcular/meta.yaml
+++ b/recipes/cyrcular/meta.yaml
@@ -1,0 +1,49 @@
+{% set version = "0.3.0" %}
+{% set sha256 = "eba1dea2e13601b5bc18183fff7d5bf3c07e9ed98f62272453a5473e7bbd36c" %}
+
+package:
+  name: cyrcular
+  version: {{ version }}
+
+source:
+  url: https://github.com/tedil/cyrcular/archive/v{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  skip: True  # [osx]
+  number: 0
+  run_exports:
+    - {{ pin_subpackage("cyrcular", max_pin="x.x") }}
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - {{ compiler('rust') }}
+    - cmake
+    - make
+    - pkg-config
+  host:
+    - clangdev
+    - openssl
+    - zlib
+    - xz
+    - bzip2
+    - gsl
+    - libcblas
+    - blis
+
+test:
+  commands:
+    - cyrcular -h
+
+about:
+  home: https://github.com/tedil/cyrcular
+  license: MIT
+  license_family: MIT
+  summary: Tool for calling circles from nanopore reads
+  dev_url: https://github.com/tedil/cyrcular
+
+extra:
+  additional-platforms:
+    - linux-aarch64

--- a/recipes/cyrcular/meta.yaml
+++ b/recipes/cyrcular/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "0.3.0" %}
-{% set sha256 = "eba1dea2e13601b5bc18183fff7d5bf3c07e9ed98f62272453a5473e7bbd36c" %}
+{% set sha256 = "eba1dea2e13601b5bc18183fff7d5bf3c07e9ed98f62272453a5473e7bbd36cb" %}
 
 package:
   name: cyrcular


### PR DESCRIPTION
This PR adds a recipe for [cyrcular](https://github.com/tedil/cyrcular/tree/v0.3.0), a circular DNA calling tool optimized for nanopore sequencing data.