### PR TITLE
Update polap to v0.2.6

### DIFF
--- a/recipes/polap/meta.yaml
+++ b/recipes/polap/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "polap" %}
-{% set version = "0.2.4" %}
-{% set sha256 = "4463d4a71a8a3273108a0ab2dff0a4c37a565c05af6ee17ee83dc62404294caf" %}
+{% set version = "0.2.6" %}
+{% set sha256 = "6d9b5ffc26ce6feeaa6119d0dda57e07af9e9def55e5510b0ddf237699b15948" %}
 
 package:
   name: "{{ name }}"
@@ -30,7 +30,7 @@ requirements:
     - sra-tools
     - csvtk
     - gfastats
-    - jellyfish
+    - kmer-jellyfish
     - clustalw
     - samtools
     - assembly-stats


### PR DESCRIPTION
Fix a bug and a bioconda package name.
- A bug in polap is fixed.
- kmer-jellyfish replaces jellyfish, which has duplicates in conda-forge channel as well.