### PR TITLE
Update bowtie2 to remove TBB dependencies

### DIFF
--- a/recipes/bowtie2/build.sh
+++ b/recipes/bowtie2/build.sh
@@ -7,7 +7,7 @@ git clone https://github.com/ch4rr0/libsais third_party/libsais
 
 LDFLAGS=""
 make CXX="${CXX}" CXXFLAGS="${CXXFLAGS} -O3" CPP="${CXX} -I${PREFIX}/include" CC="${CC} -L${PREFIX}/lib" \
-	CFLAGS="${CFLAGS} -O3" LDLIBS="-L$PREFIX/lib -lz -lzstd -ltbb -ltbbmalloc -lpthread" \
+	CFLAGS="${CFLAGS} -O3" LDLIBS="-L$PREFIX/lib -lz -lzstd -lpthread" \
 	WITH_ZSTD=1 USE_SRA=1 USE_SAIS_OPENMP=1
 
 binaries="\

--- a/recipes/bowtie2/meta.yaml
+++ b/recipes/bowtie2/meta.yaml
@@ -25,8 +25,6 @@ requirements:
     - libgomp  # [linux]
     - zlib
     - zstd
-    - tbb-devel
-    - tbb
   run:
     - python
     - perl

--- a/recipes/bowtie2/meta.yaml
+++ b/recipes/bowtie2/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 841a6a60111b690c11d1e123cb5c11560b4cd1502b5cee7e394fd50f83e74e13
 
 build:
-  number: 3
+  number: 4
   run_exports:
     - {{ pin_subpackage('bowtie2', max_pin="x") }}
 


### PR DESCRIPTION
TBB concurrency replaced with C++ threads since bowtie 2.4.3
(see: https://bowtie-bio.sourceforge.net/bowtie2/news.shtml)