### PR TITLE
feat: Prereqs for Bioconductor script

### DIFF
--- a/scripts/bioconductor/missingCranPackages.py
+++ b/scripts/bioconductor/missingCranPackages.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import argparse
+from itertools import chain
 import networkx as nx
 import requests
 from bioconda_utils import utils
@@ -10,7 +11,7 @@ def getRepoData():
     for subdir in ["linux-64", "noarch", "osx-64", "linux-aarch64", "osx-arm64"]:
         for channel in ["conda-forge", "bioconda"]:
             r = requests.get(f"https://conda.anaconda.org/{channel}/{subdir}/repodata.json")
-            for k, v in r.json()["packages"].items():
+            for k, v in chain(r.json()["packages"].items(), r.json()["packages.conda"].items()):
                 if k.startswith("r-"):
                     res.add(v["name"])
     return res

--- a/scripts/bioconductor/missingCranPackages.py
+++ b/scripts/bioconductor/missingCranPackages.py
@@ -9,48 +9,53 @@ def getRepoData():
     res = set()
     for subdir in ["linux-64", "noarch", "osx-64", "linux-aarch64", "osx-arm64"]:
         for channel in ["conda-forge", "bioconda"]:
-            r = requests.get(f"https://conda.anaconda.org/{channel}/{subdir}/repodata.json")
-            js = r.json()['packages']
-            for k, v in r.json()['packages'].items():
-                if k.startswith('r-'):
-                    res.add(v['name'])
+            r = requests.get(
+                f"https://conda.anaconda.org/{channel}/{subdir}/repodata.json"
+            )
+            js = r.json()["packages"]
+            for k, v in r.json()["packages"].items():
+                if k.startswith("r-"):
+                    res.add(v["name"])
     return res
+
 
 def getDag(js):
     dag = nx.DiGraph()
-    for k, v in js['_feedstock_status'].items():
+    for k, v in js["_feedstock_status"].items():
         dag.add_node(k)
-        children = v['immediate_children']
-        dag.add_edges_from(
-            (k, dep)
-            for dep in set(children)
-        )
+        children = v["immediate_children"]
+        dag.add_edges_from((k, dep) for dep in set(children))
     return dag
 
+
 def getCondaForgeMigrationStatus(migration_id):
-    r = requests.get(f"https://raw.githubusercontent.com/regro/cf-graph-countyfair/master/status/migration_json/{migration_id}.json")
+    r = requests.get(
+        f"https://raw.githubusercontent.com/regro/cf-graph-countyfair/master/status/migration_json/{migration_id}.json"
+    )
     js = r.json()
     depDag = getDag(js)
     res = {
-        'in-pr': dict(),
-        'bot-error': dict(),
-        'not-solvable': dict(),
-        'awaiting-parents': dict(),
-        'dag': depDag
+        "in-pr": dict(),
+        "bot-error": dict(),
+        "not-solvable": dict(),
+        "awaiting-parents": dict(),
+        "dag": depDag,
     }
-    for recipe in js['in-pr']:
-        res['in-pr'][recipe] =  f"{recipe}: In PR {js['_feedstock_status'][recipe]['pr_url']}"
-    for recipe in js['bot-error']:
-        status = js['_feedstock_status'][recipe]['pre_pr_migrator_status']
-        segment = status.split('\n')
-        res['bot-error'][recipe] =  f"{recipe}: {segment[0] + ' ' + segment[1]}"
-    for recipe in js['not-solvable']:
-        status = js['_feedstock_status'][recipe]['pre_pr_migrator_status']
-        segment1 = status.split('\n')[0]
-        segment2 = status.split(':')[3].split('\n')[0]
-        res['not-solvable'][recipe] =  f"{recipe}: {segment1 + ' ' + segment2}"
-    for recipe in js['awaiting-parents']:
-        res['awaiting-parents'][recipe] =  f"{recipe}: Awaiting parents"
+    for recipe in js["in-pr"]:
+        res["in-pr"][
+            recipe
+        ] = f"{recipe}: In PR {js['_feedstock_status'][recipe]['pr_url']}"
+    for recipe in js["bot-error"]:
+        status = js["_feedstock_status"][recipe]["pre_pr_migrator_status"]
+        segment = status.split("\n")
+        res["bot-error"][recipe] = f"{recipe}: {segment[0] + ' ' + segment[1]}"
+    for recipe in js["not-solvable"]:
+        status = js["_feedstock_status"][recipe]["pre_pr_migrator_status"]
+        segment1 = status.split("\n")[0]
+        segment2 = status.split(":")[3].split("\n")[0]
+        res["not-solvable"][recipe] = f"{recipe}: {segment1 + ' ' + segment2}"
+    for recipe in js["awaiting-parents"]:
+        res["awaiting-parents"][recipe] = f"{recipe}: Awaiting parents"
     return res
 
 
@@ -61,60 +66,78 @@ def printMissingCRAN(recipe_folder, migration_id, format):
     for r in recipes:
         if "bioconductor" not in r:
             continue
-        d = utils.load_meta_fast(r)[0]  # a dictionary with keys requirements, build, etc.
-        if d['requirements']['run'] is None:
+        d = utils.load_meta_fast(r)[
+            0
+        ]  # a dictionary with keys requirements, build, etc.
+        if d["requirements"]["run"] is None:
             continue
-        for dep in d['requirements']['run']:
-            if dep.startswith('r-'):
-                dependencies.add(dep.split(' ')[0])
+        for dep in d["requirements"]["run"]:
+            if dep.startswith("r-"):
+                dependencies.add(dep.split(" ")[0])
 
-    CHECKBOX = '- [ ]'
+    CHECKBOX = "- [ ]"
     # Find packages waiting for a migration
     if migration_id:
         cf = getCondaForgeMigrationStatus(migration_id)
-        dag = cf['dag']
+        dag = cf["dag"]
 
         # Update dependencies based on DAG from conda-forge migration data
-        awaiting_parents = set.intersection(dependencies, set(cf['awaiting-parents'].keys()))
+        awaiting_parents = set.intersection(
+            dependencies, set(cf["awaiting-parents"].keys())
+        )
         for recipe in awaiting_parents:
             dependencies = set.union(dependencies, nx.algorithms.ancestors(dag, recipe))
         # Now that we expanded dependencies, get the new list of awaiting parents
-        awaiting_parents = set.intersection(dependencies, set(cf['awaiting-parents'].keys()))
-        in_pr = set.intersection(dependencies, set(cf['in-pr'].keys()))
-        bot_error = set.intersection(dependencies, set(cf['bot-error'].keys()))
-        not_solvable = set.intersection(dependencies, set(cf['not-solvable'].keys()))
-        if format == 'markdown':
-            print("## Awaiting migration of {} packages ##".format(len(in_pr) + len(bot_error) + len(not_solvable)))
+        awaiting_parents = set.intersection(
+            dependencies, set(cf["awaiting-parents"].keys())
+        )
+        in_pr = set.intersection(dependencies, set(cf["in-pr"].keys()))
+        bot_error = set.intersection(dependencies, set(cf["bot-error"].keys()))
+        not_solvable = set.intersection(dependencies, set(cf["not-solvable"].keys()))
+        if format == "markdown":
+            print(
+                "## Awaiting migration of {} packages ##".format(
+                    len(in_pr) + len(bot_error) + len(not_solvable)
+                )
+            )
             print("### In PR ({} packages) ###".format(len(in_pr)))
             for recipe in in_pr:
-                print(CHECKBOX, cf['in-pr'][recipe])
+                print(CHECKBOX, cf["in-pr"][recipe])
             print("### Bot Error ({} packages) ###".format(len(bot_error)))
             for recipe in bot_error:
-                print(CHECKBOX, cf['bot-error'][recipe])
+                print(CHECKBOX, cf["bot-error"][recipe])
             print("### Not Solvable ({} packages) ###".format(len(not_solvable)))
             for recipe in not_solvable:
-                print(CHECKBOX, cf['not-solvable'][recipe])
-            print("### Awaiting Parents ({} packages) ###".format(len(awaiting_parents)))
+                print(CHECKBOX, cf["not-solvable"][recipe])
+            print(
+                "### Awaiting Parents ({} packages) ###".format(len(awaiting_parents))
+            )
             for recipe in awaiting_parents:
-                print(CHECKBOX, cf['awaiting-parents'][recipe], "(", nx.algorithms.ancestors(dag, recipe), ")")
+                print(
+                    CHECKBOX,
+                    cf["awaiting-parents"][recipe],
+                    "(",
+                    nx.algorithms.ancestors(dag, recipe),
+                    ")",
+                )
         else:
-            print('In PR:')
+            print("In PR:")
             for recipe in in_pr:
                 print(recipe)
-            print('Bot Error:')
+            print("Bot Error:")
             for recipe in bot_error:
                 print(recipe)
-            print('Not Solvable:')
+            print("Not Solvable:")
             for recipe in not_solvable:
                 print(recipe)
-            print('Awaiting Parents:')
+            print("Awaiting Parents:")
             for recipe in awaiting_parents:
                 print(recipe)
 
     # Find missing packages
     repo = getRepoData()
     missing = dependencies - repo
-    if format == 'markdown':
+    if format == "markdown":
         print("## Missing {} packages ##".format(len(missing)))
         for recipe in missing:
             print(CHECKBOX, recipe)
@@ -123,15 +146,33 @@ def printMissingCRAN(recipe_folder, migration_id, format):
         for recipe in missing:
             print(recipe)
 
+
 def main():
-    parser = argparse.ArgumentParser(description="""Print a list of missing CRAN dependencies for Bioconductor packages.""")
-    parser.add_argument("recipe_folder", default="recipes", help="Location of the recipes folder (default: %(default)s)", nargs='?')
-    parser.add_argument("--migration_id", help="See conda-forge status page. If populated, will report packages held up in a conda-forge migration (default: None)", nargs='?')
-    parser.add_argument('--format', dest='format', default="plain", help="Format of results: ['plain', 'markdown'] (default: %(default)s)", nargs='?')
+    parser = argparse.ArgumentParser(
+        description="""Print a list of missing CRAN dependencies for Bioconductor packages."""
+    )
+    parser.add_argument(
+        "recipe_folder",
+        default="recipes",
+        help="Location of the recipes folder (default: %(default)s)",
+        nargs="?",
+    )
+    parser.add_argument(
+        "--migration_id",
+        help="See conda-forge status page. If populated, will report packages held up in a conda-forge migration (default: None)",
+        nargs="?",
+    )
+    parser.add_argument(
+        "--format",
+        dest="format",
+        default="plain",
+        help="Format of results: ['plain', 'markdown'] (default: %(default)s)",
+        nargs="?",
+    )
     args = parser.parse_args()
 
     printMissingCRAN(args.recipe_folder, args.migration_id, args.format)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/scripts/bioconductor/missingCranPackages.py
+++ b/scripts/bioconductor/missingCranPackages.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python
 import argparse
-import networkx as nx
-from datetime import datetime, timedelta
+import json
+import os
 import requests
-from bioconda_utils import utils, graph
+from bioconda_utils import utils
 
 
 def getRepoData():
     res = set()
-    for subdir in ["linux-64", "noarch", "osx-64"]:
+    for subdir in ["linux-64", "noarch", "osx-64", "linux-aarch64", "osx-arm64"]:
         for channel in ["conda-forge", "bioconda"]:
             r = requests.get(f"https://conda.anaconda.org/{channel}/{subdir}/repodata.json")
             js = r.json()['packages']
@@ -18,13 +18,31 @@ def getRepoData():
     return res
 
 
-def printMissingCRAN(config_path, recipe_folder):
-    config = utils.load_config(config_path)
-    recipes = utils.get_recipes(recipe_folder)
+def getCondaForgeMigrationStatus(migration_id):
+    r = requests.get(f"https://raw.githubusercontent.com/regro/cf-graph-countyfair/master/status/migration_json/{migration_id}.json")
+    js = r.json()
+    res = {
+        'in-pr': dict(),
+        'bot-error': dict(),
+        'not-solvable': dict(),
+    }
+    for recipe in js['in-pr']:
+        res['in-pr'][recipe] =  f"{recipe}: In PR {js['_feedstock_status'][recipe]['pr_url']}"
+    for recipe in js['bot-error']:
+        status = js['_feedstock_status'][recipe]['pre_pr_migrator_status']
+        segment = status.split('\n')
+        res['bot-error'][recipe] =  f"{recipe}: {segment[0] + ' ' + segment[1]}"
+    for recipe in js['not-solvable']:
+        status = js['_feedstock_status'][recipe]['pre_pr_migrator_status']
+        segment1 = status.split('\n')[0]
+        segment2 = status.split(':')[3].split('\n')[0]
+        res['not-solvable'][recipe] =  f"{recipe}: {segment1 + ' ' + segment2}"
+    return res
 
-    repo = getRepoData()
 
+def printMissingCRAN(recipe_folder, migration_id, format):
     # Construct a set of all dependencies (ignoring versions)
+    recipes = utils.get_recipes(recipe_folder)
     dependencies = set()
     for r in recipes:
         if "bioconductor" not in r:
@@ -36,19 +54,55 @@ def printMissingCRAN(config_path, recipe_folder):
             if dep.startswith('r-'):
                 dependencies.add(dep.split(' ')[0])
 
-    missing = dependencies - repo
-    print("Missing {} packages!".format(len(missing)))
-    for m in missing:
-        print(m)
+    CHECKBOX = '- [ ]'
+    # Find packages waiting for a migration
+    if migration_id:
+        cf = getCondaForgeMigrationStatus(migration_id)
+        in_pr = set.intersection(dependencies, set(cf['in-pr'].keys()))
+        bot_error = set.intersection(dependencies, set(cf['bot-error'].keys()))
+        not_solvable = set.intersection(dependencies, set(cf['not-solvable'].keys()))
+        if format == 'markdown':
+            print("## Awaiting migration of {} packages ##".format(len(in_pr) + len(bot_error) + len(not_solvable)))
+            print("### In PR ({} packages) ###".format(len(in_pr)))
+            for recipe in in_pr:
+                print(CHECKBOX, cf['in-pr'][recipe])
+            print("### Bot Error ({} packages) ###".format(len(bot_error)))
+            for recipe in bot_error:
+                print(CHECKBOX, cf['bot-error'][recipe])
+            print("### Not Solvable ({} packages) ###".format(len(not_solvable)))
+            for recipe in not_solvable:
+                print(CHECKBOX, cf['not-solvable'][recipe])
+        else:
+            print('In PR:')
+            for recipe in in_pr:
+                print(recipe)
+            print('Bot Error:')
+            for recipe in bot_error:
+                print(recipe)
+            print('Not Solvable:')
+            for recipe in not_solvable:
+                print(recipe)
 
+    # Find missing packages
+    repo = getRepoData()
+    missing = dependencies - repo
+    if format == 'markdown':
+        print("## Missing {} packages ##".format(len(missing)))
+        for recipe in missing:
+            print(CHECKBOX, recipe)
+    else:
+        print("Missing:")
+        for recipe in missing:
+            print(recipe)
 
 def main():
     parser = argparse.ArgumentParser(description="""Print a list of missing CRAN dependencies for Bioconductor packages.""")
-    parser.add_argument("config_path", default="config.yml", help="Location of config.yml (default: %(default)s", nargs='?')
     parser.add_argument("recipe_folder", default="recipes", help="Location of the recipes folder (default: %(default)s)", nargs='?')
+    parser.add_argument("--migration_id", help="See conda-forge status page. If populated, will report packages held up in a conda-forge migration (default: None)", nargs='?')
+    parser.add_argument('--format', dest='format', default="plain", help="Format of results: ['plain', 'markdown'] (default: %(default)s)", nargs='?')
     args = parser.parse_args()
 
-    printMissingCRAN(args.config_path, args.recipe_folder)
+    printMissingCRAN(args.recipe_folder, args.migration_id, args.format)
 
 
 if __name__ == '__main__':

--- a/scripts/bioconductor/missingCranPackages.py
+++ b/scripts/bioconductor/missingCranPackages.py
@@ -97,7 +97,7 @@ def printMissingCRAN(recipe_folder, migration_id, format):
         if format == "markdown":
             print(
                 "## Awaiting migration of {} packages ##".format(
-                    len(in_pr) + len(bot_error) + len(not_solvable)
+                    len(in_pr) + len(bot_error) + len(not_solvable) + len(awaiting_parents)
                 )
             )
             print("### In PR ({} packages) ###".format(len(in_pr)))
@@ -117,7 +117,7 @@ def printMissingCRAN(recipe_folder, migration_id, format):
                     CHECKBOX,
                     cf["awaiting-parents"][recipe],
                     "(",
-                    nx.algorithms.ancestors(dag, recipe),
+                    ", ".join([r for r in nx.algorithms.ancestors(dag, recipe) if r in set.union(in_pr, bot_error, not_solvable, awaiting_parents)]),
                     ")",
                 )
         else:

--- a/scripts/bioconductor/missingCranPackages.py
+++ b/scripts/bioconductor/missingCranPackages.py
@@ -38,18 +38,18 @@ def getCondaForgeMigrationStatus(migration_id):
         "dag": depDag,
     }
     for recipe in js["in-pr"]:
-        res["in-pr"][recipe] = f"{recipe}: In PR {js['_feedstock_status'][recipe]['pr_url']}"
+        res["in-pr"][recipe] = f"`{recipe}`: In PR {js['_feedstock_status'][recipe]['pr_url']}"
     for recipe in js["bot-error"]:
         status = js["_feedstock_status"][recipe]["pre_pr_migrator_status"]
         segment = status.split("\n")
-        res["bot-error"][recipe] = f"{recipe}: {segment[0] + ' ' + segment[1]}"
+        res["bot-error"][recipe] = f"`{recipe}`: {segment[0] + ' ' + segment[1]}"
     for recipe in js["not-solvable"]:
         status = js["_feedstock_status"][recipe]["pre_pr_migrator_status"]
         segment1 = status.split("\n")[0]
         segment2 = status.split(":")[3].split("\n")[0]
-        res["not-solvable"][recipe] = f"{recipe}: {segment1 + ' ' + segment2}"
+        res["not-solvable"][recipe] = f"`{recipe}`: {segment1 + ' ' + segment2}"
     for recipe in js["awaiting-parents"]:
-        res["awaiting-parents"][recipe] = f"{recipe}: Awaiting parents"
+        res["awaiting-parents"][recipe] = f"`{recipe}`: Awaiting parents"
     return res
 
 

--- a/scripts/bioconductor/missingCranPackages.py
+++ b/scripts/bioconductor/missingCranPackages.py
@@ -9,10 +9,7 @@ def getRepoData():
     res = set()
     for subdir in ["linux-64", "noarch", "osx-64", "linux-aarch64", "osx-arm64"]:
         for channel in ["conda-forge", "bioconda"]:
-            r = requests.get(
-                f"https://conda.anaconda.org/{channel}/{subdir}/repodata.json"
-            )
-            js = r.json()["packages"]
+            r = requests.get(f"https://conda.anaconda.org/{channel}/{subdir}/repodata.json")
             for k, v in r.json()["packages"].items():
                 if k.startswith("r-"):
                     res.add(v["name"])
@@ -29,9 +26,7 @@ def getDag(js):
 
 
 def getCondaForgeMigrationStatus(migration_id):
-    r = requests.get(
-        f"https://raw.githubusercontent.com/regro/cf-graph-countyfair/master/status/migration_json/{migration_id}.json"
-    )
+    r = requests.get(f"https://raw.githubusercontent.com/regro/cf-graph-countyfair/master/status/migration_json/{migration_id}.json")
     js = r.json()
     depDag = getDag(js)
     res = {
@@ -42,9 +37,7 @@ def getCondaForgeMigrationStatus(migration_id):
         "dag": depDag,
     }
     for recipe in js["in-pr"]:
-        res["in-pr"][
-            recipe
-        ] = f"{recipe}: In PR {js['_feedstock_status'][recipe]['pr_url']}"
+        res["in-pr"][recipe] = f"{recipe}: In PR {js['_feedstock_status'][recipe]['pr_url']}"
     for recipe in js["bot-error"]:
         status = js["_feedstock_status"][recipe]["pre_pr_migrator_status"]
         segment = status.split("\n")
@@ -66,9 +59,7 @@ def printMissingCRAN(recipe_folder, migration_id, format):
     for r in recipes:
         if "bioconductor" not in r:
             continue
-        d = utils.load_meta_fast(r)[
-            0
-        ]  # a dictionary with keys requirements, build, etc.
+        d = utils.load_meta_fast(r)[0]  # a dictionary with keys requirements, build, etc.
         if d["requirements"]["run"] is None:
             continue
         for dep in d["requirements"]["run"]:
@@ -82,15 +73,11 @@ def printMissingCRAN(recipe_folder, migration_id, format):
         dag = cf["dag"]
 
         # Update dependencies based on DAG from conda-forge migration data
-        awaiting_parents = set.intersection(
-            dependencies, set(cf["awaiting-parents"].keys())
-        )
+        awaiting_parents = set.intersection(dependencies, set(cf["awaiting-parents"].keys()))
         for recipe in awaiting_parents:
             dependencies = set.union(dependencies, nx.algorithms.ancestors(dag, recipe))
         # Now that we expanded dependencies, get the new list of awaiting parents
-        awaiting_parents = set.intersection(
-            dependencies, set(cf["awaiting-parents"].keys())
-        )
+        awaiting_parents = set.intersection(dependencies, set(cf["awaiting-parents"].keys()))
         in_pr = set.intersection(dependencies, set(cf["in-pr"].keys()))
         bot_error = set.intersection(dependencies, set(cf["bot-error"].keys()))
         not_solvable = set.intersection(dependencies, set(cf["not-solvable"].keys()))
@@ -109,9 +96,7 @@ def printMissingCRAN(recipe_folder, migration_id, format):
             print("### Not Solvable ({} packages) ###".format(len(not_solvable)))
             for recipe in not_solvable:
                 print(CHECKBOX, cf["not-solvable"][recipe])
-            print(
-                "### Awaiting Parents ({} packages) ###".format(len(awaiting_parents))
-            )
+            print("### Awaiting Parents ({} packages) ###".format(len(awaiting_parents)))
             for recipe in awaiting_parents:
                 print(
                     CHECKBOX,


### PR DESCRIPTION
This script originally output missing CRAN packages, but I've added an option to output conda-forge packages stuck in migration. Also added an option to output a checklist in markdown format, which includes the first couple of pertinent lines from the bot output. (Inspired by https://github.com/bioconda/bioconda-recipes/issues/49778)


Example output from `python ./scripts/bioconductor/missingCranPackages.py --format markdown --migration_id r-base44_and_m2w64-ucrt`
```
## Awaiting migration of 105 packages ##
### In PR (27 packages) ###
- [ ] `r-strawr`: In PR https://github.com/conda-forge/r-strawr-feedstock/pull/4
- [ ] `r-rttf2pt1`: In PR https://github.com/conda-forge/r-rttf2pt1-feedstock/pull/19
- [ ] `r-dplr`: In PR https://github.com/conda-forge/r-dplr-feedstock/pull/14
- [ ] `r-logistf`: In PR https://github.com/conda-forge/r-logistf-feedstock/pull/14
- [ ] `r-cairo`: In PR https://github.com/conda-forge/r-cairo-feedstock/pull/36
- [ ] `r-infotheo`: In PR https://github.com/conda-forge/r-infotheo-feedstock/pull/13
- [ ] `r-primme`: In PR https://github.com/conda-forge/r-primme-feedstock/pull/17
- [ ] `r-ckmeans.1d.dp`: In PR https://github.com/conda-forge/r-ckmeans.1d.dp-feedstock/pull/10
- [ ] `r-rcppalgos`: In PR https://github.com/conda-forge/r-rcppalgos-feedstock/pull/16
- [ ] `r-rmariadb`: In PR https://github.com/conda-forge/r-rmariadb-feedstock/pull/25
- [ ] `r-msqc`: In PR https://github.com/conda-forge/r-msqc-feedstock/pull/7
- [ ] `r-vim`: In PR https://github.com/conda-forge/r-vim-feedstock/pull/18
- [ ] `r-bayesm`: In PR https://github.com/conda-forge/r-bayesm-feedstock/pull/14
- [ ] `r-pdftools`: In PR https://github.com/conda-forge/r-pdftools-feedstock/pull/48
- [ ] `r-backbone`: In PR https://github.com/conda-forge/r-backbone-feedstock/pull/16
- [ ] `r-bold`: In PR https://github.com/conda-forge/r-bold-feedstock/pull/17
- [ ] `r-glmmtmb`: In PR https://github.com/conda-forge/r-glmmtmb-feedstock/pull/27
- [ ] `r-locfit`: In PR https://github.com/conda-forge/r-locfit-feedstock/pull/20
- [ ] `r-rcurl`: In PR https://github.com/conda-forge/r-rcurl-feedstock/pull/33
- [ ] `r-rmixmod`: In PR https://github.com/conda-forge/r-rmixmod-feedstock/pull/17
- [ ] `r-mixtools`: In PR https://github.com/conda-forge/r-mixtools-feedstock/pull/14
- [ ] `r-hdf5r`: In PR https://github.com/conda-forge/r-hdf5r-feedstock/pull/34
- [ ] `r-rcppparallel`: In PR https://github.com/conda-forge/r-rcppparallel-feedstock/pull/30
- [ ] `r-git2r`: In PR https://github.com/conda-forge/r-git2r-feedstock/pull/44
- [ ] `r-envstats`: In PR https://github.com/conda-forge/r-envstats-feedstock/pull/15
- [ ] `r-scs`: In PR https://github.com/conda-forge/r-scs-feedstock/pull/5
- [ ] `r-wrswor`: In PR https://github.com/conda-forge/r-wrswor-feedstock/pull/2
### Bot Error (12 packages) ###
- [ ] `r-rjsoncons`: bot error (<a href="https://github.com/regro/cf-scripts/actions/runs/10471726786">bot CI job</a>): main: Error running migrate-feedstock in container - JSON could not parse stdout:
- [ ] `r-nycflights13`: bot error (<a href="https://github.com/regro/cf-scripts/actions/runs/10471726786">bot CI job</a>): main: Error running migrate-feedstock in container - JSON could not parse stdout:
- [ ] `r-pspline`: bot error (<a href="https://github.com/regro/cf-scripts/actions/runs/10473752058">bot CI job</a>): main: Error running migrate-feedstock in container - JSON could not parse stdout:
- [ ] `r-sparsemvn`: bot error (<a href="https://github.com/regro/cf-scripts/actions/runs/10473752058">bot CI job</a>): main: Error running migrate-feedstock in container - JSON could not parse stdout:
- [ ] `r-magick`: bot error (<a href="https://github.com/regro/cf-scripts/actions/runs/10470019435">bot CI job</a>): main: Error running check-solvable in container - error ValueError raised:
- [ ] `r-rebus.base`: bot error (<a href="https://github.com/regro/cf-scripts/actions/runs/10470019435">bot CI job</a>): main: Error running migrate-feedstock in container - JSON could not parse stdout:
- [ ] `r-rtriangle`: bot error (<a href="https://github.com/regro/cf-scripts/actions/runs/10470019435">bot CI job</a>): main: Error running migrate-feedstock in container - JSON could not parse stdout:
- [ ] `r-maptree`: bot error (<a href="https://github.com/regro/cf-scripts/actions/runs/10468254743">bot CI job</a>): main: Error running migrate-feedstock in container - JSON could not parse stdout:
- [ ] `r-anylib`: bot error (<a href="https://github.com/regro/cf-scripts/actions/runs/10470019435">bot CI job</a>): main: Error running migrate-feedstock in container - JSON could not parse stdout:
- [ ] `r-common`: bot error (<a href="https://github.com/regro/cf-scripts/actions/runs/10471726786">bot CI job</a>): main: Error running migrate-feedstock in container - JSON could not parse stdout:
- [ ] `r-superheat`: bot error (<a href="https://github.com/regro/cf-scripts/actions/runs/10473752058">bot CI job</a>): main: Error running migrate-feedstock in container - JSON could not parse stdout:
- [ ] `r-isa2`: bot error (<a href="https://github.com/regro/cf-scripts/actions/runs/10463453441">bot CI job</a>): main: Error running migrate-feedstock in container - JSON could not parse stdout:
### Not Solvable (10 packages) ###
- [ ] `r-rmpi`: not solvable (<a href='https://github.com/regro/cf-scripts/actions/runs/10464511121'>bot CI job</a>) @ main  No candidates were found for openmpi 5.*.
- [ ] `r-tkrplot`: not solvable (<a href='https://github.com/regro/cf-scripts/actions/runs/10471726786'>bot CI job</a>) @ main  No candidates were found for tcl *.
- [ ] `r-harmony`: not solvable (<a href='https://github.com/regro/cf-scripts/actions/runs/10470019435'>bot CI job</a>) @ main  No candidates were found for libwinpthread-git *.
- [ ] `r-spdep`: not solvable (<a href='https://github.com/regro/cf-scripts/actions/runs/10473752058'>bot CI job</a>) @ main  r-sf * cannot be installed because there are no viable options
- [ ] `r-pmcmrplus`: not solvable (<a href='https://github.com/regro/cf-scripts/actions/runs/10461481144'>bot CI job</a>) @ main  r-ksamples >=1.2.7 cannot be installed because there are no viable options
- [ ] `r-transformr`: not solvable (<a href='https://github.com/regro/cf-scripts/actions/runs/10471726786'>bot CI job</a>) @ main  r-sf * cannot be installed because there are no viable options
- [ ] `r-protolite`: not solvable (<a href='https://github.com/regro/cf-scripts/actions/runs/10473752058'>bot CI job</a>) @ main  r-sf * cannot be installed because there are no viable options
- [ ] `r-gstat`: not solvable (<a href='https://github.com/regro/cf-scripts/actions/runs/10473752058'>bot CI job</a>) @ main  r-sf >=0.7_2 cannot be installed because there are no viable options
- [ ] `r-rjags`: not solvable (<a href='https://github.com/regro/cf-scripts/actions/runs/10470019435'>bot CI job</a>) @ main //conda.anaconda.org/conda-forge/linux-ppc64le/repodata.json.zst
- [ ] `r-gamlss`: not solvable (<a href='https://github.com/regro/cf-scripts/actions/runs/10473752058'>bot CI job</a>) @ main  r-gamlss.dist >=4.3.1 cannot be installed because there are no viable options
### Awaiting Parents (56 packages) ###
- [ ] `r-lambertw`: Awaiting parents ( r-lamw, r-rcppparallel )
- [ ] `r-ggrastr`: Awaiting parents ( r-cairo )
- [ ] `r-flatxml`: Awaiting parents ( r-rcurl )
- [ ] `r-stringfish`: Awaiting parents ( r-rcppparallel )
- [ ] `r-hrbrthemes`: Awaiting parents ( r-rttf2pt1, r-extrafont )
- [ ] `r-gprofiler2`: Awaiting parents ( r-rcurl )
- [ ] `r-fda`: Awaiting parents ( r-hdrcde, r-rainbow, r-locfit, r-rcurl, r-fds )
- [ ] `r-r2jags`: Awaiting parents ( r-rjags )
- [ ] `r-rebus.unicode`: Awaiting parents ( r-rebus.base )
- [ ] `r-smoothwin`: Awaiting parents ( r-rcppparallel, r-rfast )
- [ ] `r-densestbayes`: Awaiting parents ( r-rstantools, r-rstan, r-stanheaders, r-rcppparallel )
- [ ] `r-waffle`: Awaiting parents ( r-rttf2pt1, r-extrafont )
- [ ] `r-logr`: Awaiting parents ( r-common )
- [ ] `r-dicer`: Awaiting parents ( r-infotheo )
- [ ] `r-taxize`: Awaiting parents ( r-bold )
- [ ] `r-summarytools`: Awaiting parents ( r-magick )
- [ ] `r-rstantools`: Awaiting parents ( r-rcppparallel )
- [ ] `r-eva`: Awaiting parents ( r-envstats )
- [ ] `r-rstan`: Awaiting parents ( r-stanheaders, r-rcppparallel )
- [ ] `r-plsvarsel`: Awaiting parents ( r-msqc )
- [ ] `r-opencpu`: Awaiting parents ( r-protolite )
- [ ] `r-remacor`: Awaiting parents ( r-envstats )
- [ ] `r-tidytidbits`: Awaiting parents ( r-rttf2pt1, r-extrafont )
- [ ] `r-webchem`: Awaiting parents ( r-rcurl )
- [ ] `r-tiledb`: Awaiting parents ( r-nycflights13 )
- [ ] `r-qs`: Awaiting parents ( r-rcppparallel, r-stringfish )
- [ ] `r-compositions`: Awaiting parents ( r-bayesm )
- [ ] `r-textstem`: Awaiting parents ( r-rcppparallel, r-quanteda )
- [ ] `r-agricolae`: Awaiting parents ( r-spdep )
- [ ] `r-rebus`: Awaiting parents ( r-rebus.datetimes, r-rebus.base, r-rebus.numbers, r-rebus.unicode )
- [ ] `r-lamw`: Awaiting parents ( r-rcppparallel )
- [ ] `r-animation`: Awaiting parents ( r-magick )
- [ ] `r-stanheaders`: Awaiting parents ( r-rcppparallel )
- [ ] `r-qdaptools`: Awaiting parents ( r-rcurl )
- [ ] `r-bestnormalize`: Awaiting parents ( r-rcppparallel, r-lamw, r-lambertw )
- [ ] `r-ggalt`: Awaiting parents ( r-rttf2pt1, r-extrafont )
- [ ] `r-ggimage`: Awaiting parents ( r-magick )
- [ ] `r-extrafont`: Awaiting parents ( r-rttf2pt1 )
- [ ] `r-hdrcde`: Awaiting parents ( r-locfit )
- [ ] `r-rainbow`: Awaiting parents ( r-hdrcde, r-locfit )
- [ ] `r-xml2r`: Awaiting parents ( r-rcurl )
- [ ] `r-rebus.numbers`: Awaiting parents ( r-rebus.base )
- [ ] `r-robcompositions`: Awaiting parents ( r-vim, r-rcurl, r-hdrcde, r-fda, r-rainbow, r-fds, r-locfit )
- [ ] `r-gganimate`: Awaiting parents ( r-transformr )
- [ ] `r-gprofiler`: Awaiting parents ( r-rcurl )
- [ ] `r-varfrompdb`: Awaiting parents ( r-xml2r, r-rcurl )
- [ ] `r-fds`: Awaiting parents ( r-hdrcde, r-rainbow, r-locfit, r-rcurl )
- [ ] `r-reldist`: Awaiting parents ( r-rstantools, r-densestbayes, r-rstan, r-stanheaders, r-rcppparallel )
- [ ] `r-mvoutlier`: Awaiting parents ( r-vim, r-rcurl, r-hdrcde, r-fda, r-rainbow, r-fds, r-robcompositions, r-locfit )
- [ ] `r-quanteda`: Awaiting parents ( r-rcppparallel )
- [ ] `r-cvxr`: Awaiting parents ( r-scs )
- [ ] `r-rebus.datetimes`: Awaiting parents ( r-rebus.base )
- [ ] `r-paralleldist`: Awaiting parents ( r-rcppparallel )
- [ ] `r-survivalanalysis`: Awaiting parents ( r-rttf2pt1, r-tidytidbits, r-extrafont )
- [ ] `r-copula`: Awaiting parents ( r-pspline )
- [ ] `r-rfast`: Awaiting parents ( r-rcppparallel )
## Missing 8 packages ##
- [ ] r-tidydr
- [ ] r-mwcsr
- [ ] r-microbiomestat
- [ ] r-tca
- [ ] r-dashboardthemes
- [ ] r-mashr
- [ ] r-shinycyjs
- [ ] r-rbeta2009
```