### PR TITLE
cyvcf2: enable osx-arm64 build

### DIFF
--- a/recipes/cyvcf2/meta.yaml
+++ b/recipes/cyvcf2/meta.yaml
@@ -19,6 +19,7 @@ build:
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --no-cache-dir -vvv
   script_env:
     - CFLAGS=-Wno-implicit-function-declaration -Wno-int-conversion  # [osx and py == 38]
+    - M4=$BUILD_PREFIX/bin/m4  # [osx and arm64]
   entry_points:
     - cyvcf2 = cyvcf2.__main__:cli
   run_exports:

--- a/recipes/cyvcf2/meta.yaml
+++ b/recipes/cyvcf2/meta.yaml
@@ -14,7 +14,7 @@ source:
     - patches/setup.py.patch
 
 build:
-  number: 0
+  number: 1
   skip: True  # [py < 37]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --no-cache-dir -vvv
   script_env:
@@ -67,3 +67,4 @@ extra:
     - biotools:cyvcf2
   additional-platforms:
     - linux-aarch64
+    - osx-arm64


### PR DESCRIPTION
`cyvcf2` already has support for ARM on PyPI. This PR also adds ARM support on bioconda