### PR TITLE
Update pgenlib to 0.91.0 and enable arm64/aarch64 builds

### DIFF
--- a/recipes/pgenlib/meta.yaml
+++ b/recipes/pgenlib/meta.yaml
@@ -1,16 +1,16 @@
 {% set name = "pgenlib" %}
-{% set version = "0.90.2" %}
+{% set version = "0.91.0" %}
 
 package:
   name: "{{ name|lower }}"
   version: "{{ version }}"
 
 source:
-  url: "https://pypi.io/packages/source/P/Pgenlib/Pgenlib-{{ version }}.tar.gz"
-  sha256: 09825be43ffb25bc68b6e243b98989a5bc35a8aa22cd749fd9f602d778dd6bd0
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  sha256: 32992274214d2e6735b721544abfd0ae0c76906c4193120f7091065b88f68dfa
 
 build:
-  number: 1
+  number: 0
   script: "{{ PYTHON }} -m pip install . -vvv --no-deps --no-build-isolation"
   run_exports:
     - {{ pin_subpackage('pgenlib', max_pin="x.x") }}
@@ -21,12 +21,13 @@ requirements:
   host:
     - python
     - pip
-    - cython
-    - numpy
+    - cython 
+    - numpy >=2.0.0  # [py >= 39]
+    - numpy  # [py < 39]
     - zlib
   run:
     - python
-    - {{ pin_compatible('numpy') }}
+    - numpy >=1.19.0
 
 test:
   imports:
@@ -46,3 +47,6 @@ extra:
     - chrchang
   identifiers:
     - doi:10.1186/s13742-015-0047-8
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64


### PR DESCRIPTION
Update [`pgenlib`](https://github.com/chrchang/plink-ng/tree/master/2.0/Python#readme): **0.90.2** → **0.91.0** (released on Jun 18, 2024)

`pgenlib` v0.91.0 adds numpy 2.0 as a build dependency for versions of python >= 3.9 (see https://github.com/chrchang/plink-ng/pull/272)

This PR also drops `pin_compatible` per https://github.com/conda-forge/conda-forge.github.io/issues/2156 and enables builds on macOS ARM and linux aarch64