### PR TITLE
art: enable osx-arm64 build

### DIFF
--- a/recipes/art/build.sh
+++ b/recipes/art/build.sh
@@ -8,7 +8,11 @@ export CPATH=${PREFIX}/include
 
 mkdir -p $PREFIX/bin
 
-./configure --prefix=$PREFIX
+if [[ "$HOST" == "arm64-apple-"* ]]; then
+    ./configure --prefix=$PREFIX --host=arm
+else
+    ./configure --prefix=$PREFIX
+fi
 make -j ${CPU_COUNT}
 make install
 

--- a/recipes/art/meta.yaml
+++ b/recipes/art/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 11
+  number: 12
   run_exports:
     - {{ pin_subpackage(name, max_pin=None) }}
 
@@ -40,3 +40,4 @@ about:
 extra:
   additional-platforms:
     - linux-aarch64
+    - osx-arm64


### PR DESCRIPTION
Enable osx-arm64 builds for ART

For some reason, I had to manually check the host and alter the `./configure` command to cross-compile for ARM ([as suggested here](https://stackoverflow.com/a/54070358/16815703)). I hope that's ok.