### PR TITLE
Update telseq/meta.yaml: add samtools to decode CRAM file

### DIFF
--- a/recipes/telseq/meta.yaml
+++ b/recipes/telseq/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: aac2477f0d01390d1603afe09cadf0f7ba0fb8864c579289dcbe363ca9bbfa1a
 
 build:
-  number: 7
+  number: 8
 
 requirements:
   build:
@@ -23,6 +23,7 @@ requirements:
   run:
     - bamtools
     - zlib
+    - samtools >=1.20 # for CRAM files
 
 test:
   commands:

--- a/recipes/telseq/meta.yaml
+++ b/recipes/telseq/meta.yaml
@@ -10,6 +10,9 @@ source:
 
 build:
   number: 8
+  run_exports:
+    - {{ pin_subpackage('telseq', max_pin="x") }}
+
 
 requirements:
   build:


### PR DESCRIPTION
telseq cannot read CRAM files. Samtools is added to read CRAM Files ( see: https://github.com/zd1/telseq/issues/26#issuecomment-704019482 )
