### PR TITLE
ci: Fix additional platform script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,9 +23,9 @@ jobs: # a basic unit of work in a run
       - run:
           name: Check for Additional Platforms
           command: |
-            result=$(./scripts/check-for-additional-platforms.sh "origin/master...HEAD" "build_and_test" "${CIRCLE_JOB}")
-            if [[ ${result} != "build" ]]
-            then
+            ./scripts/check-for-additional-platforms.sh "origin/master...HEAD" "build_and_test" "${CIRCLE_JOB}"
+            result=$?
+            if [ $result -eq 0 ]; then
                 echo "No recipes using this platform, skipping rest of job."
                 circleci-agent step halt
             fi
@@ -115,9 +115,9 @@ jobs: # a basic unit of work in a run
       - run:
           name: Check for Additional Platforms
           command: |
-            result=$(./scripts/check-for-additional-platforms.sh "${CIRCLE_SHA1}~1 ${CIRCLE_SHA1}" "build_and_upload" "${CIRCLE_JOB}")
-            if [[ ${result} != "build" ]]
-            then
+            ./scripts/check-for-additional-platforms.sh "${CIRCLE_SHA1}~1 ${CIRCLE_SHA1}" "build_and_upload" "${CIRCLE_JOB}"
+            result=$?
+            if [ $result -eq 0 ]; then
                 echo "No recipes using this platform, skipping rest of job."
                 circleci-agent step halt
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,10 @@ jobs: # a basic unit of work in a run
             if [ $result -eq 0 ]; then
                 echo "No recipes using this platform, skipping rest of job."
                 circleci-agent step halt
+            elif [ $result -eq 200 ]; then
+                echo "Platform found, starting build."
+            else
+                exit $result
             fi
 
       - run:
@@ -120,6 +124,10 @@ jobs: # a basic unit of work in a run
             if [ $result -eq 0 ]; then
                 echo "No recipes using this platform, skipping rest of job."
                 circleci-agent step halt
+            elif [ $result -eq 200 ]; then
+                echo "Platform found, starting build."
+            else
+                exit $result
             fi
 
       - run:

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -229,9 +229,9 @@ jobs:
       - name: Check for Additional Platforms
         id: additional_platforms
         run: |
-          result=$(./scripts/check-for-additional-platforms.sh "origin/master...HEAD" "build_and_test" "${GITHUB_JOB}")
-          if [[ ${result} != "build" ]]
-          then
+          ./scripts/check-for-additional-platforms.sh "origin/master...HEAD" "build_and_test" "${GITHUB_JOB}"
+          result=$?
+          if [ $result -eq 0 ]; then
               echo "No recipes using this platform, skipping rest of job."
               echo "skip_build=true" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -234,6 +234,10 @@ jobs:
           if [ $result -eq 0 ]; then
               echo "No recipes using this platform, skipping rest of job."
               echo "skip_build=true" >> $GITHUB_OUTPUT
+          elif [ $result -eq 200 ]; then
+              echo "Platform found, starting build."
+          else
+              exit $result
           fi
 
       - name: set path

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -122,9 +122,9 @@ jobs:
       - name: Check for Additional Platforms
         id: additional_platforms
         run: |
-          result=$(./scripts/check-for-additional-platforms.sh "${GITHUB_SHA}~1 ${GITHUB_SHA}" "build_and_upload" "${GITHUB_JOB}")
-          if [[ ${result} != "build" ]]
-          then
+          ./scripts/check-for-additional-platforms.sh "${GITHUB_SHA}~1 ${GITHUB_SHA}" "build_and_upload" "${GITHUB_JOB}"
+          result=$?
+          if [ $result -eq 0 ]; then
               echo "No recipes using this platform, skipping rest of job."
               echo "skip_build=true" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -127,6 +127,10 @@ jobs:
           if [ $result -eq 0 ]; then
               echo "No recipes using this platform, skipping rest of job."
               echo "skip_build=true" >> $GITHUB_OUTPUT
+          elif [ $result -eq 200 ]; then
+              echo "Platform found, starting build."
+          else
+              exit $result
           fi
 
       - name: set path

--- a/recipes/sorted_nearest/meta.yaml
+++ b/recipes/sorted_nearest/meta.yaml
@@ -13,7 +13,7 @@ source:
   '{{ hash_type }}': '{{ hash_value }}'
 
 build:
-  number: 3
+  number: 4
   script_env:
     - SETUPTOOLS_SCM_PRETEND_VERSION={{ version }}
   script: "{{ PYTHON }} -m pip install . -vvv --no-deps --no-build-isolation --no-cache-dir"

--- a/recipes/sorted_nearest/meta.yaml
+++ b/recipes/sorted_nearest/meta.yaml
@@ -13,7 +13,7 @@ source:
   '{{ hash_type }}': '{{ hash_value }}'
 
 build:
-  number: 4
+  number: 3
   script_env:
     - SETUPTOOLS_SCM_PRETEND_VERSION={{ version }}
   script: "{{ PYTHON }} -m pip install . -vvv --no-deps --no-build-isolation --no-cache-dir"

--- a/scripts/check-for-additional-platforms.sh
+++ b/scripts/check-for-additional-platforms.sh
@@ -46,7 +46,7 @@ for file in $files; do
     for additional_platform in $additional_platforms; do
     if [ "${current_job}" = "${job_name}-${additional_platform}" ]
     then
-        build=1
+        build=200
         break
     fi
     done

--- a/scripts/check-for-additional-platforms.sh
+++ b/scripts/check-for-additional-platforms.sh
@@ -53,7 +53,4 @@ for file in $files; do
 done
 
 # If no changed recipes apply to this platform, skip remaining steps
-if [[ build -gt 0 ]]
-then
-    echo "build"
-fi
+exit $build


### PR DESCRIPTION
The extra logging added in https://github.com/bioconda/bioconda-recipes/pull/50325 is great, but the CI was using the echoed output. Some broken osx-arm64 builds got merged to master (found them on bulk). 

Updated this to use the exit code instead. I'm not too thrilled with this solution, so open to suggestions.

(draft because I need to test if it will fail with the exit code from the script)