### PR TITLE
ci: Fix platform script echo

### DIFF
--- a/recipes/sorted_nearest/meta.yaml
+++ b/recipes/sorted_nearest/meta.yaml
@@ -13,7 +13,7 @@ source:
   '{{ hash_type }}': '{{ hash_value }}'
 
 build:
-  number: 3
+  number: 4
   script_env:
     - SETUPTOOLS_SCM_PRETEND_VERSION={{ version }}
   script: "{{ PYTHON }} -m pip install . -vvv --no-deps --no-build-isolation --no-cache-dir"

--- a/recipes/sorted_nearest/meta.yaml
+++ b/recipes/sorted_nearest/meta.yaml
@@ -13,7 +13,7 @@ source:
   '{{ hash_type }}': '{{ hash_value }}'
 
 build:
-  number: 4
+  number: 3
   script_env:
     - SETUPTOOLS_SCM_PRETEND_VERSION={{ version }}
   script: "{{ PYTHON }} -m pip install . -vvv --no-deps --no-build-isolation --no-cache-dir"

--- a/scripts/check-for-additional-platforms.sh
+++ b/scripts/check-for-additional-platforms.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -x
+# Do not set -x, this script outputs a value with echo
 
 # Check to see if any changed recipes have specified the key
 # extra:additional-platforms, and if so, if they match the platform of the
@@ -24,8 +24,6 @@ files=`git diff --name-only --diff-filter AMR ${git_range} | grep -v 'template' 
 build=0
 
 for file in $files; do
-    echo "Going to check '${file}' for additional-platforms."
-
     # To create a properly-formatted yaml that yq can parse, comment out jinja2
     # variable setting with {% %} and remove variable use with {{ }}.
     additional_platforms=$(cat $file \


### PR DESCRIPTION
The extra logging added in https://github.com/bioconda/bioconda-recipes/pull/50325 is great, but the CI was using the echoed output to determine if it should build without failing the job. Some broken osx-arm64 recipes (no build) got merged to master (found them on bulk). 

I want to find a better solution (see https://github.com/bioconda/bioconda-recipes/pull/50388), but for now, I think we need this script working again, so just reverting the problematic area.