### PR TITLE
ci: nightly builds for linux-aarch64 and osx-arm64

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -239,6 +239,54 @@ jobs: # a basic unit of work in a run
               --skiplist-leafs
             conda clean -y --all
 
+  nightly_build:
+    parameters:
+      os:
+        type: executor
+      runner:
+        type: integer
+    executor: << parameters.os >>
+    steps:
+      - add_ssh_keys:
+          fingerprints:
+            - 1e:85:74:42:35:5f:c5:a2:35:c2:ec:b7:80:c0:7c:40
+
+      - checkout
+
+      - run:
+          name: Fetch bioconda install script
+          command: wget https://raw.githubusercontent.com/bioconda/bioconda-common/bulk/{common,install-and-set-up-conda,configure-conda}.sh
+
+      - run:
+          name: Install bioconda-utils
+          command: |
+            sudo mkdir -p /opt/
+            sudo chmod o+rwx /opt
+            bash install-and-set-up-conda.sh
+
+      - run:
+          name: Setup PATH
+          command:
+            echo 'export PATH=/opt/mambaforge/bin:"$PATH"' >> "$BASH_ENV"
+
+      - run:
+          name: Configure conda
+          command: bash configure-conda.sh
+
+      # For now, do not upload ARM images to biocontainers: --mulled-upload-target biocontainers
+      - run:
+          name: Build and push leftover packages
+          command: |
+          set -e
+          eval "$(conda shell.bash hook)"
+          conda activate bioconda
+          source common.sh
+
+          # build and push all leftover packages
+          bioconda-utils build recipes config.yml \
+              --docker --mulled-test  --docker-base-image "quay.io/bioconda/bioconda-utils-build-env-cos7-$(arch):${BIOCONDA_UTILS_TAG#v}" \
+              --anaconda-upload \
+              --prelint --exclude bioconda-repodata-patches
 
 workflows:
   build and test (ARM):
@@ -267,7 +315,6 @@ workflows:
                 - osx-arm64
                 - linux-aarch64
 
-
   Bulk branch (ARM):
     jobs:
       - bulk_build:
@@ -280,3 +327,21 @@ workflows:
                 # - osx-arm64 Bulk is on GitHub Actions
                 - linux-aarch64
               runner: [0, 1, 2, 3, 4, 5]
+
+  Nightly (ARM):
+     triggers:
+      - schedule:
+         cron: "0 0 * * *"
+         filters:
+           branches:
+              only: master
+    jobs:
+      - nightly_build:
+          filters:
+            branches:
+              only: master
+          matrix:
+            parameters:
+              os:
+                # - osx-arm64 Nightly is on GitHub Actions
+                - linux-aarch64

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,76 +1,17 @@
 name: Nightly Uploader
 on:
   schedule:
-    - cron: '12 2 * * *'
+    - cron: "0 0 * * *"
 jobs:
-  build-linux:
-    name: Linux Upload
+  nightly-osx-arm:
+    name: Nightly OSX-ARM64 Builds
     if: github.repository == 'bioconda/bioconda-recipes'
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      max-parallel: 13
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: set path
-        run: echo "/opt/mambaforge/bin" >> $GITHUB_PATH
-
-      - name: Fetch conda install script
-        run: |
-          wget https://raw.githubusercontent.com/bioconda/bioconda-common/master/{install-and-set-up-conda,configure-conda,common}.sh
-
-      - name: Restore cache
-        id: cache
-        uses: actions/cache@v3
-        with:
-          path: /opt/mambaforge
-          key: ${{ runner.os }}--bulk--${{ hashFiles('**/install-and-set-up-conda.sh') }}
-
-      - name: Set up bioconda-utils
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: bash install-and-set-up-conda.sh
-
-      # This script can be used to reconfigure conda to use the right channel setup.
-      # This has to be done after the cache is restored, because
-      # the channel setup is not cached as it resides in the home directory.
-      # We could use a system-wide (and therefore cached) channel setup,
-      # but mamba does not support that at the time of implementation
-      # (it ignores settings made with --system).
-      - name: Configure conda
-        run: bash configure-conda.sh
-
-      - name: Build and upload
-        env:
-          QUAY_LOGIN: ${{ secrets.QUAY_LOGIN }}
-          QUAY_OAUTH_TOKEN: ${{ secrets.QUAY_OAUTH_TOKEN }}
-          ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
-          INVOLUCRO_AUTH: ${{ secrets.INVOLUCRO_AUTH }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Mimic circleci
-          OSTYPE: "linux-gnu"
-          CI: "true"
-        run: |
-          set -ex
-          eval "$(conda shell.bash hook)"
-          conda activate bioconda
-          docker pull quay.io/dpryan79/mulled_container:latest
-          bioconda-utils build recipes config.yml \
-              --docker --mulled-test --anaconda-upload --mulled-upload-target biocontainers \
-              --prelint
-          docker rmi quay.io/dpryan79/mulled_container:latest
-
-  build-osx:
-    name: OSX Tests
-    if: github.repository == 'bioconda/bioconda-recipes'
-    runs-on: macos-13
+    runs-on: macOS-14 # M1
     strategy:
       fail-fast: false
       max-parallel: 4
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -81,27 +22,13 @@ jobs:
         run: |
           wget https://raw.githubusercontent.com/bioconda/bioconda-common/master/{install-and-set-up-conda,configure-conda,common}.sh
 
-      - name: Restore cache
-        id: cache
-        uses: actions/cache@v3
-        with:
-          path: /opt/mambaforge
-          key: ${{ runner.os }}--bulk--${{ hashFiles('**/install-and-set-up-conda.sh') }}
-
       - name: Set up bioconda-utils
-        if: steps.cache.outputs.cache-hit != 'true'
         run: bash install-and-set-up-conda.sh
 
-      # This script can be used to reconfigure conda to use the right channel setup.
-      # This has to be done after the cache is restored, because
-      # the channel setup is not cached as it resides in the home directory.
-      # We could use a system-wide (and therefore cached) channel setup,
-      # but mamba does not support that at the time of implementation
-      # (it ignores settings made with --system).
       - name: Configure conda
         run: bash configure-conda.sh
 
-      - name: Build and Test
+      - name: Build and push leftover packages
         env:
           QUAY_LOGIN: ${{ secrets.QUAY_LOGIN }}
           QUAY_OAUTH_TOKEN: ${{ secrets.QUAY_OAUTH_TOKEN }}
@@ -116,9 +43,11 @@ jobs:
           eval "$(conda shell.bash hook)"
           conda activate bioconda
 
-          # The SDK isn't actually cached, so reinstall it
+          source common.sh
+          # Sets up OSX SDK
           run_conda_forge_build_setup
 
+          # build and push all leftover packages
           bioconda-utils build recipes config.yml \
               --anaconda-upload \
-              --prelint
+              --prelint --exclude bioconda-repodata-patches


### PR DESCRIPTION
We have a nightly build on Azure for linux-64 and osx-64. It's for picking up and rebuilding/uploading recipes that failed to upload when a PR is merged into master.

CircleCI for linux-aarch64 since that's the only CI option right now. This should be able to finish within the 1 hour limit as long as there are not too many catch-up builds needed.

GitHub Actions for osx-arm64 to avoid blocking any PR build/upload jobs and it has a longer timeout than CircleCI as a bonus. (I repurposed the existing nightly config file which has been disabled since switching to Azure.)