### PR TITLE
Update fastahack to 1.0.0 and modernize recipe style

### DIFF
--- a/recipes/fastahack/meta.yaml
+++ b/recipes/fastahack/meta.yaml
@@ -1,21 +1,25 @@
+{% set name = "fastahack" %}
+{% set version = "1.0.0" %}
+
+
 package:
-  name: fastahack
-  version: 2016.07.2
+  name: {{ name }}
+  version: {{ version }}
 
 source:
-  url: https://github.com/ekg/fastahack/archive/bbc645f2f7966cb7b44446200c02627c3168b399.zip
-  md5: d32a9dee44a8da7477631930e92f5095
+  url: https://github.com/ekg/fastahack/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: cc1c04729b0c8ba3647cbb7e15e2b490ce701d73773f30f5892d68c36a1dceae
 
 build:
-  number: 6
+  number: 0
   skip: True # [osx]
+  run_exports:
+    - {{ pin_subpackage("fastahack", max_pin="x") }}
 
 requirements:
   build:
     - make
     - {{ compiler('cxx') }}
-
-  run:
 
 test:
   commands:


### PR DESCRIPTION
While working on a different package, I noted that the bioconda fastahack package was slightly out of date and didn't have the (only) release version of upstream. As such, I've done the very minor patching required to bump to upstream's 1.0.0.

Something interesting I noted while doing this is that, while upstream is a very small executable, debian's package management defines a linked library that can be pulled into different projects, and which is apparently now used by freebayes. Since the library isn't actually defined in the upstream fastahack project itself, I'm dubious about reimplementing debian's work for a corresponding conda package. But I just thought I'd note this here in case someone stumbles across this in the future.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
