### PR TITLE
Update vcflib

### DIFF
--- a/recipes/vcflib/build.sh
+++ b/recipes/vcflib/build.sh
@@ -41,6 +41,6 @@ cmake -S . -B build \
 	-DCMAKE_BUILD_TYPE=Release \
 	-DCMAKE_INSTALL_PREFIX="${PREFIX}" \
 	-DCMAKE_CXX_FLAGS="${CXXFLAGS}" \
-	-DEXTRA_FLAGS=""
+	-DEXTRA_FLAGS="" # Disable march=native to build a generic executable
 
 cmake --build build/ --target install -j 4 -v

--- a/recipes/vcflib/build.sh
+++ b/recipes/vcflib/build.sh
@@ -40,6 +40,7 @@ cmake -S . -B build \
 	-DZIG=ON -DOPENMP=ON -DWFA_GITMODULE=OFF \
 	-DCMAKE_BUILD_TYPE=Release \
 	-DCMAKE_INSTALL_PREFIX="${PREFIX}" \
-	-DCMAKE_CXX_FLAGS="${CXXFLAGS}"
+	-DCMAKE_CXX_FLAGS="${CXXFLAGS}" \
+	-DEXTRA_FLAGS=""
 
 cmake --build build/ --target install -j 4 -v

--- a/recipes/vcflib/build.sh
+++ b/recipes/vcflib/build.sh
@@ -41,6 +41,6 @@ cmake -S . -B build \
 	-DCMAKE_BUILD_TYPE=Release \
 	-DCMAKE_INSTALL_PREFIX="${PREFIX}" \
 	-DCMAKE_CXX_FLAGS="${CXXFLAGS}" \
-	-DEXTRA_FLAGS="" # Disable march=native to build a generic executable
+	-DEXTRA_FLAGS="" # Disable march=native to build a generic executable, see https://github.com/vcflib/vcflib/issues/401
 
 cmake --build build/ --target install -j 4 -v

--- a/recipes/vcflib/meta.yaml
+++ b/recipes/vcflib/meta.yaml
@@ -25,7 +25,7 @@ source:
   folder: zig-macos-x86_64-0.10.1  # [osx]
 
 build:
-  number: 6
+  number: 7
   run_exports:
     - {{ pin_subpackage('vcflib', max_pin="x") }}
 


### PR DESCRIPTION
Current version of vcflib does not work with CPUs that do not support AVX extensions.
This new recipe disables march=native optimisations by unsetting the EXTRA_FLAGS variable in CMakeLists.txt

https://github.com/vcflib/vcflib/blob/master/CMakeLists.txt#L73