### PR TITLE
Update vcflib 

### DIFF
--- a/recipes/vcflib/build.sh
+++ b/recipes/vcflib/build.sh
@@ -40,7 +40,6 @@ cmake -S . -B build \
 	-DZIG=ON -DOPENMP=ON -DWFA_GITMODULE=OFF \
 	-DCMAKE_BUILD_TYPE=Release \
 	-DCMAKE_INSTALL_PREFIX="${PREFIX}" \
-	-DCMAKE_CXX_FLAGS="${CXXFLAGS}" \
-	-DEXTRA_FLAGS="" # Disable march=native to build a generic executable, see https://github.com/vcflib/vcflib/issues/401
+	-DCMAKE_CXX_FLAGS="${CXXFLAGS}"
 
 cmake --build build/ --target install -j 4 -v

--- a/recipes/vcflib/build.sh
+++ b/recipes/vcflib/build.sh
@@ -12,10 +12,10 @@ else
 	export PATH="$(pwd)/zig-linux-${ARCH}-0.10.1:${PATH}"
 fi
 
-export INCLUDES="-I${PREFIX}/include -I. -Ihtslib -Itabixpp -I\$(INC_DIR)"
-export LIBPATH="-L${PREFIX}/lib -L. -Lhtslib -Ltabixpp"
+export INCLUDES="-I${PREFIX}/include -I. -Ihtslib -Itabixpp -Iwfa2 -I\$(INC_DIR)"
+export LIBPATH="-L${PREFIX}/lib -L. -Lhtslib -Ltabixpp -Lwfa2"
 export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib -lhts -ltabixpp -lpthread -lz -lm -llzma -lbz2 -fopenmp -lwfa2"
-export CXXFLAGS="${CXXFLAGS} -O3 -D_FILE_OFFSET_BITS=64"
+export CXXFLAGS="${CXXFLAGS} -O3 -D_FILE_OFFSET_BITS=64 -I${PREFIX}/include"
 
 sed -i.bak 's/CFFFLAGS:= -O3/CFFFLAGS=-O3 -D_FILE_OFFSET_BITS=64 -std=c++0x/' contrib/smithwaterman/Makefile
 sed -i.bak 's/CFLAGS/CXXFLAGS/g' contrib/smithwaterman/Makefile
@@ -27,11 +27,14 @@ sed -i.bak 's/g++/$(CXX) $(CXXFLAGS)/g' contrib/multichoose/Makefile
 sed -i.bak 's/g++/$(CXX) $(CXXFLAGS)/g' contrib/intervaltree/Makefile
 
 # MacOSX Build fix: https://github.com/chapmanb/homebrew-cbl/issues/14
-if [ "${OS}" == "Darwin" ]; then
+if [[ `uname` == "Darwin" ]]; then
 	sed -i.bak 's/LDFLAGS=-Wl,-s/LDFLAGS=/' contrib/smithwaterman/Makefile
+	sed -i.bak 's/-std=c++0x/-std=c++14 -stdlib=libc++/g' contrib/intervaltree/Makefile
 	export LDFLAGS="${LDFLAGS} -Wl,-rpath,${PREFIX}/lib"
 	export CXXFLAGS="${CXXFLAGS} -D_LIBCPP_ENABLE_CXX17_REMOVED_FEATURES"
-	sed -i.bak 's/-std=c++0x/-std=c++11 -stdlib=libc++/g' contrib/intervaltree/Makefile
+	export CONFIG_ARGS="-DCMAKE_FIND_FRAMEWORK=NEVER -DCMAKE_FIND_APPBUNDLE=NEVER"
+else
+        export CONFIG_ARGS=""
 fi
 
 pkg-config --list-all
@@ -39,7 +42,12 @@ pkg-config --list-all
 cmake -S . -B build \
 	-DZIG=ON -DOPENMP=ON -DWFA_GITMODULE=OFF \
 	-DCMAKE_BUILD_TYPE=Release \
+	-DBUILD_SHARED_LIBS=ON \
+	-DCMAKE_INSTALL_LIBDIR=lib \
 	-DCMAKE_INSTALL_PREFIX="${PREFIX}" \
-	-DCMAKE_CXX_FLAGS="${CXXFLAGS}"
+	-DCMAKE_CXX_COMPILER="${CXX}" \
+	-DCMAKE_CXX_FLAGS="${CXXFLAGS}" \
+	-DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON \
+	"${CONFIG_ARGS}"
 
-cmake --build build/ --target install -j 4 -v
+cmake --build build/ --target install -j "${CPU_COUNT}" -v

--- a/recipes/vcflib/march_native.patch
+++ b/recipes/vcflib/march_native.patch
@@ -1,0 +1,16 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 7e90114..2280e33 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -69,11 +69,6 @@ if(NOT CMAKE_BUILD_TYPE)
+           "Choose the type of build, options are: Release|Debug|RelWithDebInfo (for distros)." FORCE)
+ endif()
+ 
+-if (${CMAKE_BUILD_TYPE} MATCHES Release)
+-  set(EXTRA_FLAGS "-march=native -D_FILE_OFFSET_BITS=64")
+-  # set(CMAKE_CXX_FLAGS_RELEASE "-DNDEBUG") # reset CXX_FLAGS to replace -O3 with -Ofast
+-endif()
+-
+ if ((${CMAKE_BUILD_TYPE} MATCHES Release) OR (${CMAKE_BUILD_TYPE} MATCHES RelWithDebInfo))
+   set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${EXTRA_FLAGS}")
+   set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${EXTRA_FLAGS}")

--- a/recipes/vcflib/meta.yaml
+++ b/recipes/vcflib/meta.yaml
@@ -54,6 +54,7 @@ requirements:
     - eigen
     - jsoncpp
     - wfa2-lib
+    - wget
 
 test:
   requires:
@@ -67,11 +68,13 @@ test:
     - "vcfuniq test.vcf"
 
 about:
-  home: https://github.com/vcflib/vcflib
+  home: "https://github.com/vcflib/vcflib"
   license: MIT
   license_family: MIT
   license_file: LICENSE
-  summary: Command-line tools for manipulating VCF files
+  summary: "Command-line tools for manipulating VCF files."
+  dev_url: "https://github.com/vcflib/vcflib"
+  doc_url: "https://github.com/vcflib/vcflib/blob/v{{ version }}/README.md"
 
 extra:
   additional-platforms:
@@ -82,3 +85,25 @@ extra:
     - biotools:vcflib
     - doi:10.1371/journal.pcbi.1009123
     - usegalaxy-eu:vcfsort
+    - usegalaxy-eu:vcfallelicprimitives
+    - usegalaxy-eu:vcfbreakcreatemulti
+    - usegalaxy-eu:vcffilter2
+    - usegalaxy-eu:vcfcheck
+    - usegalaxy-eu:vcfcombine
+    - usegalaxy-eu:vcfaddinfo
+    - usegalaxy-eu:vcf2tsv
+    - usegalaxy-eu:vcfleftalign
+    - usegalaxy-eu:vcfhethom
+    - usegalaxy-eu:vcfrandomsample
+    - usegalaxy-eu:vcfbedintersect
+    - usegalaxy-eu:vcfgenotypes
+    - usegalaxy-eu:vcffixup
+    - usegalaxy-eu:vcfgeno2haplo
+    - usegalaxy-eu:vcfvcfintersect
+    - usegalaxy-eu:vcfanno
+    - usegalaxy-eu:vcfannotate
+    - usegalaxy-eu:vcfcommonsamples
+    - usegalaxy-eu:vcfflatten2
+    - usegalaxy-eu:vcfdistance
+    - usegalaxy-eu:vcfannotategenotypes
+    - usegalaxy-eu:vcfselectsamples

--- a/recipes/vcflib/meta.yaml
+++ b/recipes/vcflib/meta.yaml
@@ -14,6 +14,7 @@ source:
     - shared_lib.patch
     - backport_pr_394.patch  # TODO remove once PR https://github.com/vcflib/vcflib/pull/394 is merged and released
     - tabix.patch
+    - march_native.patch  # Disable march=native to build a generic executable, see https://github.com/vcflib/vcflib/issues/401
 - url: https://ziglang.org/download/0.10.1/zig-linux-x86_64-0.10.1.tar.xz  # [linux and x86_64]
   sha256: 6699f0e7293081b42428f32c9d9c983854094bd15fee5489f12c4cf4518cc380  # [linux and x86_64]
   folder: zig-linux-x86_64-0.10.1  # [linux and x86_64]
@@ -25,7 +26,7 @@ source:
   folder: zig-macos-x86_64-0.10.1  # [osx]
 
 build:
-  number: 7
+  number: 8
   run_exports:
     - {{ pin_subpackage('vcflib', max_pin="x") }}
 

--- a/recipes/vcflib/pkg-config.patch
+++ b/recipes/vcflib/pkg-config.patch
@@ -1,18 +1,18 @@
 Author: Andreas Tille <tille@debian.org> modified for bioconda by Jon Puritz <jpuritz@gmail.com>
-Description: Add pkg-config file to simplify building of freebayes
+Description: Add pkg-config file to simplify building of freebayes.
 Forwarded: not-needed
 --- a/dev/null
 +++ b/libvcflib/libvcflib.pc
 @@ -0,0 +1,12 @@
-+prefix=/usr
++prefix=${PREFIX}
 +exec_prefix=${prefix}
 +libdir=${exec_prefix}/lib
-+includedir=${prefix}/include/vcflib
++includedir=${prefix}/include
 +
 +Name: libvcflib
 +Version: 1.0
 +Requires:
 +Description: C++ library for parsing and manipulating VCF files
 +Libs: -L${libdir} -lvcflib
-+Cflags: -I${includedir}
++Cflags: -I${includedir}/vcflib
 +


### PR DESCRIPTION
My previous attempt to disable "march=native" by unsetting EXTRA_FLAGS from the command line failed.
I guess this is because variable set via the command line are defined before those in CMakeLists.txt.
https://github.com/bioconda/bioconda-recipes/pull/50531

This new recipe directy remove EXTRA_FLAGS  from the CMakeLists.txt
I have built this recipe and I have I checked that the "march=native" flag does not appear anymore.
