### PR TITLE
Update sylph

### DIFF
--- a/recipes/sylph/build.sh
+++ b/recipes/sylph/build.sh
@@ -4,12 +4,7 @@
 # We set CARGO_HOME because we don't pass on HOME to conda-build, thus rendering the default "${HOME}/.cargo" defunct.
 export CARGO_NET_GIT_FETCH_WITH_CLI=true CARGO_HOME="$(pwd)/.cargo"
 
-if [ "$(uname)" == "Darwin" ]; then # x86-64 on macosx
-    # AVX512 build not supported in bioconda osx servers
-    TARGET_CPUS=("x86-64" "x86-64-v2" "x86-64-v3")
-else # x86-64 on Linux
-    TARGET_CPUS=("x86-64" "x86-64-v2" "x86-64-v3" "x86-64-v4")
-fi
+TARGET_CPUS=("x86-64" "x86-64-v2" "x86-64-v3" "x86-64-v4")
 
 for TARGET_CPU in "${TARGET_CPUS[@]}"; do
     # build statically linked binary with Rust

--- a/recipes/sylph/build.sh
+++ b/recipes/sylph/build.sh
@@ -4,5 +4,19 @@
 # We set CARGO_HOME because we don't pass on HOME to conda-build, thus rendering the default "${HOME}/.cargo" defunct.
 export CARGO_NET_GIT_FETCH_WITH_CLI=true CARGO_HOME="$(pwd)/.cargo"
 
-# build statically linked binary with Rust
-RUST_BACKTRACE=1 cargo install --verbose --path . --root $PREFIX
+if [ "$(uname)" == "Darwin" ]; then # x86-64 on macosx
+    # AVX512 build not supported in bioconda osx servers
+    TARGET_CPUS=("x86-64" "x86-64-v2" "x86-64-v3")
+else # x86-64 on Linux
+    TARGET_CPUS=("x86-64" "x86-64-v2" "x86-64-v3" "x86-64-v4")
+fi
+
+for TARGET_CPU in "${TARGET_CPUS[@]}"; do
+    # build statically linked binary with Rust
+    RUST_BACKTRACE=1 RUSTFLAGS="-C target-cpu=${TARGET_CPU}" cargo install --verbose --path . --root $PREFIX
+    mv ${PREFIX}/bin/sylph ${PREFIX}/bin/_sylph_${TARGET_CPU}
+done
+
+
+cp "${RECIPE_DIR}/sylph" "${PREFIX}/bin/sylph"
+chmod +x "${PREFIX}/bin/sylph"

--- a/recipes/sylph/meta.yaml
+++ b/recipes/sylph/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage('sylph', max_pin='x.x') }}
 
@@ -33,4 +33,4 @@ about:
 extra:
   recipe-maintainers:
     - bluenote-1577
-    
+    - fplazaonate

--- a/recipes/sylph/meta.yaml
+++ b/recipes/sylph/meta.yaml
@@ -31,6 +31,9 @@ about:
   license_file: LICENSE
 
 extra:
+  identifiers:
+    - biotools:sylph
+    - doi:10.1101/2023.11.20.567879 
   recipe-maintainers:
     - bluenote-1577
     - fplazaonate

--- a/recipes/sylph/sylph
+++ b/recipes/sylph/sylph
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -eu
+
+SYLPH_VERSION="sylph 0.6.1"
+HAS_SSE2=$([ "$(_sylph_x86-64 --version 2>/dev/null)" = "${SYLPH_VERSION}" ] && echo 0 || echo 1)
+HAS_SSE4_2=$([ "$(_sylph_x86-64-v2 --version 2>/dev/null)" = "${SYLPH_VERSION}" ] && echo 0 || echo 1)
+HAS_AVX2=$([ "$(_sylph_x86-64-v3 --version 2>/dev/null)" = "${SYLPH_VERSION}" ] && echo 0 || echo 1)
+HAS_AVX512=$([ "$(_sylph_x86-64-v4 --version 2>/dev/null)" = "${SYLPH_VERSION}" ] && echo 0 || echo 1)
+
+if [ ${HAS_AVX512} -eq 0 ]; then
+    _sylph_x86-64-v4 "$@"
+elif [ ${HAS_AVX2} -eq 0 ]; then
+    _sylph_x86-64-v3 "$@"
+elif [ ${HAS_SSE4_2} -eq 0 ]; then
+    _sylph_x86-64-v2 "$@"
+elif [ ${HAS_SSE2} -eq 0 ]; then
+    _sylph_x86-64 "$@"
+else
+    echo "Unsupported CPU" && exit 1
+fi


### PR DESCRIPTION
New attempt to fix issue https://github.com/bluenote-1577/sylph/issues/2 where sylph cannot run on machine embedding a CPU without AVX2 support.
This recipes builds binaries for multiple target CPUs and wrapper script automatically choose the most appropriate one at runtime.