### PR TITLE
Add osx-arm as build target for dysgu

### DIFF
--- a/recipes/dysgu/meta.yaml
+++ b/recipes/dysgu/meta.yaml
@@ -85,6 +85,7 @@ about:
 extra:
   additional-platforms:
     - linux-aarch64
+    - osx-arm64
   container:
       extended-base: True
   recipe-maintainers:


### PR DESCRIPTION
Updated the meta.yaml to add osx-arm