### PR TITLE
Include Nightly Build status in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,12 @@ Please visit https://bioconda.github.io for details.
 
 Please visit the new docs at https://bioconda.github.io/contributor/index.html for details.
 
+## Nightly build status
+The nightly build any recipes that exist on master but were not successfully uploaded to the [bioconda channel](https://anaconda.org/bioconda). Any failure in the nightly build should be resolved with aPR for the affected recipe.
+
+|arch|build status|
+|----|------------|
+|linux-64 |[![Nightly linux-64](https://dev.azure.com/bioconda/bioconda-recipes/_apis/build/status/Nightly%20uploader?branchName=master&jobName=build_and_push_linux&label=Nightly%20linux-64)](https://dev.azure.com/bioconda/bioconda-recipes/_build/latest?definitionId=4)|
+|osx-64 |[![Nightly osx-64](https://dev.azure.com/bioconda/bioconda-recipes/_apis/build/status/Nightly%20uploader?branchName=master&jobName=build_and_push_osx&label=Nightly%20osx-64)](https://dev.azure.com/bioconda/bioconda-recipes/_build/latest?definitionId=4)|
+|osx-arm64|[![Nightly osx-arm64](https://github.com/bioconda/bioconda-recipes/actions/workflows/nightly.yml/badge.svg)](https://github.com/bioconda/bioconda-recipes/actions/workflows/nightly.yml)|
+|linux-aarch64|[![CircleCI](https://dl.circleci.com/insights-snapshot/gh/bioconda/bioconda-recipes/master/Nightly%20(ARM)/badge.svg?window=24h)](https://app.circleci.com/insights/github/bioconda/bioconda-recipes/workflows/Nightly%20(ARM)/overview?branch=master&reporting-window=last-24-hours&insights-snapshot=false)|

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Please visit https://bioconda.github.io for details.
 Please visit the new docs at https://bioconda.github.io/contributor/index.html for details.
 
 ## Nightly build status
-The nightly build any recipes that exist on master but were not successfully uploaded to the [bioconda channel](https://anaconda.org/bioconda). Any failure in the nightly build should be resolved with aPR for the affected recipe.
+The nightly build any recipes that exist on master but were not successfully uploaded to the [bioconda channel](https://anaconda.org/bioconda). Any failure in the nightly build should be resolved with a PR for the affected recipe.
 
 | arch | build status |
 |------|--------------|

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ Please visit the new docs at https://bioconda.github.io/contributor/index.html f
 ## Nightly build status
 The nightly build any recipes that exist on master but were not successfully uploaded to the [bioconda channel](https://anaconda.org/bioconda). Any failure in the nightly build should be resolved with aPR for the affected recipe.
 
-|arch|build status|
-|----|------------|
-|linux-64 |[![Nightly linux-64](https://dev.azure.com/bioconda/bioconda-recipes/_apis/build/status/Nightly%20uploader?branchName=master&jobName=build_and_push_linux&label=Nightly%20linux-64)](https://dev.azure.com/bioconda/bioconda-recipes/_build/latest?definitionId=4)|
-|osx-64 |[![Nightly osx-64](https://dev.azure.com/bioconda/bioconda-recipes/_apis/build/status/Nightly%20uploader?branchName=master&jobName=build_and_push_osx&label=Nightly%20osx-64)](https://dev.azure.com/bioconda/bioconda-recipes/_build/latest?definitionId=4)|
-|osx-arm64|[![Nightly osx-arm64](https://github.com/bioconda/bioconda-recipes/actions/workflows/nightly.yml/badge.svg)](https://github.com/bioconda/bioconda-recipes/actions/workflows/nightly.yml)|
-|linux-aarch64|[![CircleCI](https://dl.circleci.com/insights-snapshot/gh/bioconda/bioconda-recipes/master/Nightly%20(ARM)/badge.svg?window=24h)](https://app.circleci.com/insights/github/bioconda/bioconda-recipes/workflows/Nightly%20(ARM)/overview?branch=master&reporting-window=last-24-hours&insights-snapshot=false)|
+| arch | build status |
+|------|--------------|
+| linux-64 | [![Nightly linux-64](https://dev.azure.com/bioconda/bioconda-recipes/_apis/build/status/Nightly%20uploader?branchName=master&jobName=build_and_push_linux&label=Nightly%20linux-64)](https://dev.azure.com/bioconda/bioconda-recipes/_build/latest?definitionId=4) |
+| osx-64 | [![Nightly osx-64](https://dev.azure.com/bioconda/bioconda-recipes/_apis/build/status/Nightly%20uploader?branchName=master&jobName=build_and_push_osx&label=Nightly%20osx-64)](https://dev.azure.com/bioconda/bioconda-recipes/_build/latest?definitionId=4) |
+| osx-arm64 | [![Nightly osx-arm64](https://github.com/bioconda/bioconda-recipes/actions/workflows/nightly.yml/badge.svg)](https://github.com/bioconda/bioconda-recipes/actions/workflows/nightly.yml) |
+| linux-aarch64 |[![CircleCI](https://dl.circleci.com/insights-snapshot/gh/bioconda/bioconda-recipes/master/Nightly%20(ARM)/badge.svg?window=24h)](https://app.circleci.com/insights/github/bioconda/bioconda-recipes/workflows/Nightly%20(ARM)/overview?branch=master&reporting-window=last-24-hours) |


### PR DESCRIPTION
I check the status of the various nightly builds every day or so to see if any manual intervention is needed. Instead, it would be nice if that status could be seen at a glance. 

Unfortunately, CircleCI's status badge doesn't differentiate between workflows on the same branch, so I used their Insights widget. [This post](https://support.circleci.com/hc/en-us/articles/28238747450907-Understanding-the-3-Different-Status-Badges-in-CircleCI-Builds) suggests there is a way to do it, but I was not able to successfully get a badge for the `Nightly (ARM)` workflow, even by URL-encoding the name.


**Example:**

> ## Nightly build status
> The nightly build any recipes that exist on master but were not successfully uploaded to the [bioconda channel](https://anaconda.org/bioconda). Any failure in the nightly build should be resolved with a PR for the affected recipe.
> 
> | arch | build status |
> |------|--------------|
> | linux-64 | [![Nightly linux-64](https://dev.azure.com/bioconda/bioconda-recipes/_apis/build/status/Nightly%20uploader?branchName=master&jobName=build_and_push_linux&label=Nightly%20linux-64)](https://dev.azure.com/bioconda/bioconda-recipes/_build/latest?definitionId=4) |
> | osx-64 | [![Nightly osx-64](https://dev.azure.com/bioconda/bioconda-recipes/_apis/build/status/Nightly%20uploader?branchName=master&jobName=build_and_push_osx&label=Nightly%20osx-64)](https://dev.azure.com/bioconda/bioconda-recipes/_build/latest?definitionId=4) |
> | osx-arm64 | [![Nightly osx-arm64](https://github.com/bioconda/bioconda-recipes/actions/workflows/nightly.yml/badge.svg)](https://github.com/bioconda/bioconda-recipes/actions/workflows/nightly.yml) |
> | linux-aarch64 |[![CircleCI](https://dl.circleci.com/insights-snapshot/gh/bioconda/bioconda-recipes/master/Nightly%20(ARM)/badge.svg?window=24h)](https://app.circleci.com/insights/github/bioconda/bioconda-recipes/workflows/Nightly%20(ARM)/overview?branch=master&reporting-window=last-24-hours) |
> 