### PR TITLE
UPDATE: remove old dendropy pin

### DIFF
--- a/recipes/busco/meta.yaml
+++ b/recipes/busco/meta.yaml
@@ -30,7 +30,6 @@ requirements:
     - biopython >=1.79
     - prodigal
     - sepp >=4.3.10
-    - dendropy <4.6.0  # necessary temporarily until SEPP updates their codebase or recipe
     - metaeuk >=6.a5d39d9 # needed for gff bug fix
     - pandas
     - bbmap
@@ -47,7 +46,6 @@ requirements:
     - r-ggplot2 >=2.2.1
     - prodigal
     - sepp >=4.3.10
-    - dendropy <4.6.0  # necessary temporarily until SEPP updates their codebase or recipe
     - metaeuk >=6.a5d39d9 # needed for gff bug fix
     - pandas
     - bbmap

--- a/recipes/busco/meta.yaml
+++ b/recipes/busco/meta.yaml
@@ -7,7 +7,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 0
+  number: 1
   noarch: python
   run_exports:
     - {{ pin_subpackage(name, max_pin="x.x") }}


### PR DESCRIPTION
As of sepp 4.5.5, there is no longer a dependency on dendropy 4.5.2 (builds are currently up on [bioconda](https://anaconda.org/bioconda/sepp/files)) - so this max pin can be dropped, which will allow for greater compatibility of busco with other more modern packages.