### PR TITLE
Update eva-sub-cli to 0.4

### DIFF
--- a/recipes/eva-sub-cli/build.sh
+++ b/recipes/eva-sub-cli/build.sh
@@ -3,11 +3,10 @@
 BIOVALIDATOR_VERSION=2.2.1
 
 EVA_SUB_CLI="${PREFIX}/share/${PKG_NAME}-${PKG_VERSION}"
-mkdir -p ${PREFIX}/bin ${EVA_SUB_CLI}
+mkdir -p ${EVA_SUB_CLI}
 
 # Install eva-sub-cli
 $PYTHON -m pip install .
-cp bin/* ${PREFIX}/bin
 echo "Done with eva-sub-cli"
 
 cd ${EVA_SUB_CLI}

--- a/recipes/eva-sub-cli/meta.yaml
+++ b/recipes/eva-sub-cli/meta.yaml
@@ -28,6 +28,7 @@ requirements:
     - requests
     - jsonschema
     - unzip
+    - setuptools-scm
   run:
     - nextflow >=21.10.0
     - python >=3.8

--- a/recipes/eva-sub-cli/meta.yaml
+++ b/recipes/eva-sub-cli/meta.yaml
@@ -12,6 +12,8 @@ source:
 build:
   number: 0
   noarch: generic
+  script_env:
+    - SETUPTOOLS_SCM_PRETEND_VERSION={{ version }}
   run_exports:
     - {{ pin_subpackage(name, max_pin="x.x") }}
 

--- a/recipes/eva-sub-cli/meta.yaml
+++ b/recipes/eva-sub-cli/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "eva-sub-cli" %}
-{% set version = "0.3" %}
+{% set version = "0.4" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/EBIvariation/eva-sub-cli/archive/v{{version}}.tar.gz
-  sha256: bf5e00ffd7f4a290350011ceb626f818111f8646975e5dd7247910555971e1bd
+  sha256: be4d4109d9879ad94ccc01a3bd534ff6077775f126977dfb3f2d6fd9cfb251ba
 
 build:
   number: 0
@@ -20,7 +20,7 @@ requirements:
     - nextflow >=21.10.0
     - python >=3.8
     - nodejs >=10.19.1
-    - vcf-validator >=0.9.6
+    - vcf-validator >=0.9.7
     - ebi-eva-common-pyutils >=0.6.1
     - pyyaml
     - jinja2
@@ -32,7 +32,7 @@ requirements:
     - nextflow >=21.10.0
     - python >=3.8
     - nodejs >=10.19.1
-    - vcf-validator >=0.9.6
+    - vcf-validator >=0.9.7
     - ebi-eva-common-pyutils >=0.6.1
     - pyyaml
     - jinja2


### PR DESCRIPTION
Update eva-sub-cli to 0.4 and update build script. Supersedes #50762.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
