### PR TITLE
ci: disable status trigger for bioconda bot comments

### DIFF
--- a/.github/workflows/CommentResponder.yml
+++ b/.github/workflows/CommentResponder.yml
@@ -1,28 +1,14 @@
 name: CommentResponder
 on:
-  status:
-  # check_suite:
-  #   types:
-  #   - completed
   issue_comment:
     types:
     - created
-
-    # Runs too many times
-    # (
-    #   github.event_name == 'check_suite' &&
-    #   github.event.check_suite.conclusion == 'success'
-    # ) ||
 
 jobs:
   comment:
     runs-on: ubuntu-latest
     name: bioconda-bot comment
     if: >-
-      (
-        github.event_name == 'status' &&
-        github.event.state == 'success'
-      ) ||
       (
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&


### PR DESCRIPTION
CodeRabbit has been enabled, but it seems to be causing a side effect of extra `No artifacts found on the most recent builds. Either the builds failed, the artifacts have been removed due to age, or the recipe was blacklisted/skipped.` comments.

All our CI checks use "checks" and do not update "status". (see [GitHub docs](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/about-status-checks#types-of-status-checks-on-github)) Now coderabbit seems to be setting "status" which is causing extra Comment Responder runs.

I'm removing the `status` trigger since it has not actually been doing anything and the comment bot was only trigger by special bot comments as desired.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Simplified the workflow configuration for handling issue comments by removing unnecessary event triggers. Now focuses solely on comments related to pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->