### PR TITLE
Add support for osx-arm64

### DIFF
--- a/recipes/panacus/build.sh
+++ b/recipes/panacus/build.sh
@@ -1,7 +1,9 @@
 #!/bin/bash -euo
 
-RUST_BACKTRACE=1 CARGO_HOME="${BUILD_PREFIX}/.cargo" cargo install --no-track --verbose --root "${PREFIX}" --path .
-
 mkdir -p $PREFIX/bin
+
+RUST_BACKTRACE=1
+cargo install --no-track --verbose --root "${PREFIX}" --path .
+
 cp $BUILD_PREFIX/.cargo/bin/panacus $PREFIX/bin 
 cp scripts/panacus-visualize.py $PREFIX/bin/panacus-visualize

--- a/recipes/panacus/build.sh
+++ b/recipes/panacus/build.sh
@@ -3,5 +3,5 @@
 RUST_BACKTRACE=1 CARGO_HOME="${BUILD_PREFIX}/.cargo" cargo build --release
 
 mkdir -p $PREFIX/bin
-cp target/release/panacus $PREFIX/bin 
-cp scripts/panacus-visualize.py $PREFIX/bin/panacus-visualize
+cp $PREFIX/target/release/panacus $PREFIX/bin 
+cp $PREFIX/scripts/panacus-visualize.py $PREFIX/bin/panacus-visualize

--- a/recipes/panacus/build.sh
+++ b/recipes/panacus/build.sh
@@ -3,5 +3,5 @@
 RUST_BACKTRACE=1 CARGO_HOME="${BUILD_PREFIX}/.cargo" cargo build --release
 
 mkdir -p $PREFIX/bin
-cp $PREFIX/target/release/panacus $PREFIX/bin 
-cp $PREFIX/scripts/panacus-visualize.py $PREFIX/bin/panacus-visualize
+cp $BUILD_PREFIX/target/release/panacus $PREFIX/bin 
+cp $BUILD_PREFIX/scripts/panacus-visualize.py $PREFIX/bin/panacus-visualize

--- a/recipes/panacus/build.sh
+++ b/recipes/panacus/build.sh
@@ -2,8 +2,6 @@
 
 mkdir -p $PREFIX/bin
 
-RUST_BACKTRACE=1
-cargo install --no-track --verbose --root "${PREFIX}" --path .
+RUST_BACKTRACE=1 cargo install --no-track --verbose --root "${PREFIX}" --path .
 
-cp $BUILD_PREFIX/.cargo/bin/panacus $PREFIX/bin 
 cp scripts/panacus-visualize.py $PREFIX/bin/panacus-visualize

--- a/recipes/panacus/build.sh
+++ b/recipes/panacus/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -euo
 
-RUST_BACKTRACE=1 CARGO_HOME="${BUILD_PREFIX}/.cargo" cargo build --release
+RUST_BACKTRACE=1 CARGO_HOME="${BUILD_PREFIX}/.cargo" cargo install --no-track --verbose --root "${PREFIX}" --path .
 
 mkdir -p $PREFIX/bin
-cp $BUILD_PREFIX/target/release/panacus $PREFIX/bin 
-cp $BUILD_PREFIX/scripts/panacus-visualize.py $PREFIX/bin/panacus-visualize
+cp $BUILD_PREFIX/.cargo/bin/panacus $PREFIX/bin 
+cp scripts/panacus-visualize.py $PREFIX/bin/panacus-visualize

--- a/recipes/panacus/meta.yaml
+++ b/recipes/panacus/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: e4709c5e3e4b5c445789406a0ebf06a2052e24bc5fcc3b540cacf8064c2ab478
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage(name, max_pin="x.x") }}
 

--- a/recipes/panacus/meta.yaml
+++ b/recipes/panacus/meta.yaml
@@ -43,6 +43,8 @@ about:
   summary: panacus is a tool for computing counting statistics for GFA files
 
 extra:
+  additional-platforms:
+    - osx-arm64
   recipe-maintainers:
     - danydoerr
     - heringerp

--- a/recipes/panacus/meta.yaml
+++ b/recipes/panacus/meta.yaml
@@ -32,7 +32,6 @@ requirements:
     - seaborn
 
 test:
-  native_and_emulated
   commands:
     - panacus --help
     - panacus-visualize --help

--- a/recipes/panacus/meta.yaml
+++ b/recipes/panacus/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: e4709c5e3e4b5c445789406a0ebf06a2052e24bc5fcc3b540cacf8064c2ab478
 
 build:
-  number: 1
+  number: 2
   run_exports:
     - {{ pin_subpackage(name, max_pin="x.x") }}
 
@@ -18,6 +18,7 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - {{ compiler('rust') }}
     - cmake
     - make
     - rust >=1.68
@@ -31,6 +32,7 @@ requirements:
     - seaborn
 
 test:
+  native_and_emulated
   commands:
     - panacus --help
     - panacus-visualize --help

--- a/recipes/panacus/meta.yaml
+++ b/recipes/panacus/meta.yaml
@@ -19,6 +19,7 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('rust') }}
     - cmake
+    - make
   run:
     - python
     - matplotlib-base
@@ -26,7 +27,7 @@ requirements:
     - pandas
     - scikit-learn
     - scipy
-    - seaborn
+    - seaborn-base
 
 test:
   commands:
@@ -38,7 +39,8 @@ about:
   license: MIT
   license_family: MIT
   license_file: LICENSE
-  summary: panacus is a tool for computing counting statistics for GFA files
+  summary: "panacus is a tool for computing counting statistics for GFA files."
+  dev_url: https://github.com/marschall-lab/{{ name }}
 
 extra:
   additional-platforms:

--- a/recipes/panacus/meta.yaml
+++ b/recipes/panacus/meta.yaml
@@ -17,11 +17,8 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
-    - {{ compiler('cxx') }}
     - {{ compiler('rust') }}
     - cmake
-    - make
-    - rust >=1.68
   run:
     - python
     - matplotlib-base
@@ -46,6 +43,7 @@ about:
 extra:
   additional-platforms:
     - osx-arm64
+    - linux-aarch64
   recipe-maintainers:
     - danydoerr
     - heringerp


### PR DESCRIPTION
Panacus compiles and runs on osx-arm64. This update brings panacus also to this plattform. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Expanded compatibility of the `panacus` tool to include macOS systems with ARM64 architecture and Linux systems with ARM64 architecture.
	- Added a development URL for easier access to the development repository.

- **Chores**
	- Incremented the build number for the `panacus` recipe.
	- Updated the build requirement to use the Rust compiler.
	- Replaced the `seaborn` dependency with `seaborn-base`.
	- Clarified the summary description for the `panacus` tool.
	- Adjusted paths in the installation process for the `panacus` executable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->