### PR TITLE
trnascan-se: add aarch64/arm64 build

### DIFF
--- a/recipes/trnascan-se/build.sh
+++ b/recipes/trnascan-se/build.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+export M4="${BUILD_PREFIX}/bin/m4"
 export INCLUDE_PATH=${PREFIX}/include
 export LIBRARY_PATH=${PREFIX}/lib
 export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib"

--- a/recipes/trnascan-se/build.sh
+++ b/recipes/trnascan-se/build.sh
@@ -7,7 +7,10 @@ export CFLAGS="${CFLAGS} -O3 -I${PREFIX}/include ${LDFLAGS}"
 
 sed -i.bak '1 s|^.*$|#!/usr/bin/env perl|g' tRNAscan-SE.src
 sed -i.bak '1 s|^.*$|#!/usr/bin/env perl|g' src/instman.pl
+rm -rf *.bak
+rm -rf src/*.bak
 
+autoreconf -if
 ./configure CC="${CC}" CFLAGS="${CFLAGS}" --prefix="${PREFIX}"
 
 make

--- a/recipes/trnascan-se/meta.yaml
+++ b/recipes/trnascan-se/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "tRNAscan-SE" %}
 {% set version = "2.0.12" %}
-{% set sha256 = "96fa4af507cd918c1c623763d9260bd6ed055d091662b44314426f6bbf447251" %}
+{% set sha256 = "4b255c2c5e0255381194166f857ab2ea21c55aa7de409e201333ba615aa3dc61" %}
 
 package:
   name: {{ name|lower }}
@@ -12,7 +12,7 @@ build:
     - {{ pin_subpackage('trnascan-se', max_pin="x") }}
 
 source:
-  url: http://trna.ucsc.edu/software/trnascan-se-{{ version }}.tar.gz
+  url: https://github.com/UCSC-LoweLab/tRNAscan-SE/archive/refs/tags/v{{ version }}.tar.gz
   sha256: {{ sha256 }}
   patches:
     - patches/libdir.patch

--- a/recipes/trnascan-se/meta.yaml
+++ b/recipes/trnascan-se/meta.yaml
@@ -7,7 +7,9 @@ package:
   version: {{ version }}
 
 build:
-  number: 0
+  number: 1
+  run_exports:
+    - {{ pin_subpackage('trnascan-se', max_pin="x") }}
 
 source:
   url: http://trna.ucsc.edu/software/trnascan-se-{{ version }}.tar.gz
@@ -21,6 +23,7 @@ requirements:
     - make
     - autoconf
     - automake
+    - libtool
   host:
     - perl
   run:
@@ -32,13 +35,18 @@ test:
     - tRNAscan-SE -h
 
 about:
-  home: "http://lowelab.ucsc.edu/tRNAscan-SE/"
-  license: GPLv3
+  home: "https://lowelab.ucsc.edu/tRNAscan-SE/"
+  license: "GPL-3.0-or-later"
+  license_family: GPL3
   license_file: LICENSE
   summary: tRNA detection in large-scale genomic sequences
-  doc_url: "http://lowelab.ucsc.edu/tRNAscan-SE/help.html"
+  doc_url: "https://lowelab.ucsc.edu/tRNAscan-SE/help.html"
+  dev_url: "https://github.com/UCSC-LoweLab/tRNAscan-SE"
 
 extra:
   identifiers:
     - biotools:trnascan-se
     - doi:10.1093/nar/gkab688
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64


### PR DESCRIPTION
Describe your pull request here

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated package metadata with enhanced security and licensing information.
	- Added support for additional platforms: `linux-aarch64` and `osx-arm64`.
	- Included `libtool` as a new host dependency.
	- Introduced a `run_exports` section for improved package management.
	- Updated the source URL to point to a GitHub repository.

- **Bug Fixes**
	- Removed backup files created during script executions to streamline the build process.

- **Documentation**
	- Updated URLs to use HTTPS for improved security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->