### PR TITLE
Update: Metabuli 1.0.8

### DIFF
--- a/recipes/metabuli/meta.yaml
+++ b/recipes/metabuli/meta.yaml
@@ -1,12 +1,12 @@
-{% set version = "1.0.5" %}
-{% set sha256 = "c84a4e2436904f0cbea7126abf2a5f665a870735c8af786883e10f3f872bda28" %}
+{% set version = "1.0.8" %}
+{% set sha256 = "4c131a81beb46bd1784a826025955274063abc79dd6e7cee44c143da1ea23d59" %}
 
 package:
   name: metabuli
   version: {{ version }}
 
 build:
-  number: 2
+  number: 1
   run_exports:
     - {{ pin_subpackage('metabuli', max_pin="x") }}
 

--- a/recipes/metabuli/meta.yaml
+++ b/recipes/metabuli/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 1
+  number: 0
   run_exports:
     - {{ pin_subpackage('metabuli', max_pin="x") }}
 

--- a/recipes/metabuli/meta.yaml
+++ b/recipes/metabuli/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "1.0.8" %}
-{% set sha256 = "4c131a81beb46bd1784a826025955274063abc79dd6e7cee44c143da1ea23d59" %}
+{% set sha256 = "cc7e496ff82f00b56ef59aa2a04fa572a2025225b0558e0df144f166fade82d4" %}
 
 package:
   name: metabuli


### PR DESCRIPTION
### Metabuli v1.0.8
- Added `extract` module: It extracts reads classified under a specific taxon at any ranks. It can be used after running `classify`.

### Metabuli v1.0.7
Metabuli became faster than v1.0.6
- **Dataset**
  - Query: SRR24315757_1.fastq, SRR24315757_2.fastq
    - 22,107,398 paired-end reads
    - 6,632,219,400 nt in total
  - DB: GTDB
    - Complete Genome or Chromosome level assemblies
    - CheckM completeness > 90 and contamination < 5
    - 36,203 genomes from 8,465 species

- **Windows: ~8.3 times faster**
  - Machine: Intel(R) Core(TM) i9-9900 CPU, 32GB RAM
  - `--max-ram`: 32
  - `--threads`: 8
  - v1.0.6: 825s for the first 587,593 reads (2.7% of all). Total time not measured
  - v1.0.7:  100s for the first 587,593 reads. 1h 7m 22s in total
- **MacOS: ~1.7 times faster**
  - Machine: MacBook Pro 14-inch 2023, M2 Pro chip, 32GB RAM
  - `--max-ram`: 32
  - `--threads`: 8
  - v1.0.6: 71m 34s
  - v1.0.7: 42m 58s
- **Linux: ~1.3 times faster**
  - Machine: A server with 64-core AMD EPYC 7742 CPU and 1 TB of RAM
  - `--max-ram` : 128
  - `--threads` : 32
    - v1.0.6: 13m 34s 
    - v1.0.7: 9m 58s 
  - `--threads` : 64
    - v1.0.6: 9m 36s
    - v1.0.7: 7m 19s
    

### Metabuli v1.0.6
Windows OS is supported

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated `metabuli` package to version 1.0.8, providing users with the latest enhancements and improvements.

- **Bug Fixes**
	- Adjusted the build number for better package management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->