### PR TITLE
Add dbghaplo

### DIFF
--- a/recipes/dbghaplo/build.sh
+++ b/recipes/dbghaplo/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -euo
+
+# Add workaround for SSH-based Git connections from Rust/cargo.  See https://github.com/rust-lang/cargo/issues/2078 for details.
+# We set CARGO_HOME because we don't pass on HOME to conda-build, thus rendering the default "${HOME}/.cargo" defunct.
+export CARGO_NET_GIT_FETCH_WITH_CLI=true CARGO_HOME="$(pwd)/.cargo"
+
+# build statically linked binary with Rust
+RUST_BACKTRACE=1 cargo install --verbose --path . --root $PREFIX
+cp scripts/* $PREFIX/bin

--- a/recipes/dbghaplo/build.sh
+++ b/recipes/dbghaplo/build.sh
@@ -5,5 +5,6 @@
 export CARGO_NET_GIT_FETCH_WITH_CLI=true CARGO_HOME="$(pwd)/.cargo"
 
 # build statically linked binary with Rust
-RUST_BACKTRACE=1 cargo install --verbose --path . --root $PREFIX
+cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
+RUST_BACKTRACE=1 cargo install --verbose --locked --no-track --root $PREFIX --path .
 cp scripts/* $PREFIX/bin

--- a/recipes/dbghaplo/meta.yaml
+++ b/recipes/dbghaplo/meta.yaml
@@ -6,7 +6,6 @@ package:
 
 source:
   url: https://github.com/bluenote-1577/dbghaplo/archive/v{{ version }}.tar.gz
-
   sha256: e7e2741afb0c7f12718ec969815d3c8f18ce7ba66517e21c6fcfb3fe4262780b
 
 build:

--- a/recipes/dbghaplo/meta.yaml
+++ b/recipes/dbghaplo/meta.yaml
@@ -17,16 +17,16 @@ build:
 requirements:
   build:
     - {{ compiler("cxx") }}
-    - rust >= 1.70
+    - rust >=1.70
     - make
-    - cmake >= 3.12
+    - cmake >=3.12
   run:
     - python 
     - samtools
     - minimap2
-    - lofreq >= 2.1.5
+    - lofreq >=2.1.5
     - tabix
-    - pysam >= 0.16
+    - pysam >=0.16
 
 test:
   commands:

--- a/recipes/dbghaplo/meta.yaml
+++ b/recipes/dbghaplo/meta.yaml
@@ -31,10 +31,6 @@ requirements:
 test:
   commands:
     - dbghaplo -h
-    - samtools --help
-    - minimap2 --help
-    - lofreq version
-    - tabix --help
     - run_dbghaplo_pipeline -h
     - haplotag_bam -h
 

--- a/recipes/dbghaplo/meta.yaml
+++ b/recipes/dbghaplo/meta.yaml
@@ -41,6 +41,9 @@ test:
 about:
   home: https://github.com/bluenote-1577/dbghaplo
   license: MIT
+  license_file:
+    - LICENSE
+    - THIRDPARTY.yml 
   summary: Haplotyping small sequences from heterogeneous long-read sequencing samples with a SNP-encoded positional de Bruijn Graph.
 
 extra:

--- a/recipes/dbghaplo/meta.yaml
+++ b/recipes/dbghaplo/meta.yaml
@@ -33,7 +33,7 @@ test:
     - dbghaplo -h
     - samtools --help
     - minimap2 --help
-    - lofreq --help
+    - lofreq version
     - tabix --help
     - run_dbghaplo_pipeline -h
     - haplotag_bam -h

--- a/recipes/dbghaplo/meta.yaml
+++ b/recipes/dbghaplo/meta.yaml
@@ -1,0 +1,43 @@
+{% set version="0.0.1" %}
+
+package:
+  name: dbghaplo
+  version: {{ version }}
+
+source:
+  url: https://github.com/bluenote-1577/dbghaplo/archive/v{{ version }}.tar.gz
+
+  sha256: 7e8baecaf2d7ce82ac2a7d4e35e4bb11d6454ad6a97969194c77271d24da777f
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - {{ compiler("cxx") }}
+    - rust >= 1.70
+    - make
+    - cmake >= 3.12
+  run:
+    - python 
+    - samtools
+    - minimap2
+    - lofreq >= 2.1.5
+    - tabix
+    - pysam >= 0.16
+
+test:
+  commands:
+    - dbghaplo -h
+    - samtools --help
+    - minimap2 -h
+    - run_dbghaplo_pipeline -h
+
+about:
+  home: https://github.com/bluenote-1577/dbghaplo
+  license: MIT
+  summary: Haplotyping small sequences from heterogeneous long-read sequencing samples with a SNP-encoded positional de Bruijn Graph.
+
+extra:
+  recipe-maintainers:
+    - bluenote-1577

--- a/recipes/dbghaplo/meta.yaml
+++ b/recipes/dbghaplo/meta.yaml
@@ -16,7 +16,8 @@ build:
 requirements:
   build:
     - {{ compiler("cxx") }}
-    - rust >=1.70
+    - {{ compiler('rust') }} 
+    - cargo-bundle-licenses
     - make
     - cmake >=3.12
   run:

--- a/recipes/dbghaplo/meta.yaml
+++ b/recipes/dbghaplo/meta.yaml
@@ -1,4 +1,4 @@
-{% set version="0.0.1" %}
+{% set version="0.0.2" %}
 
 package:
   name: dbghaplo
@@ -7,10 +7,12 @@ package:
 source:
   url: https://github.com/bluenote-1577/dbghaplo/archive/v{{ version }}.tar.gz
 
-  sha256: 7e8baecaf2d7ce82ac2a7d4e35e4bb11d6454ad6a97969194c77271d24da777f
+  sha256: e7e2741afb0c7f12718ec969815d3c8f18ce7ba66517e21c6fcfb3fe4262780b
 
 build:
   number: 0
+  run_exports:
+    - {{ pin_subpackage('dbghaplo', max_pin="x.x") }}
 
 requirements:
   build:
@@ -30,8 +32,11 @@ test:
   commands:
     - dbghaplo -h
     - samtools --help
-    - minimap2 -h
+    - minimap2 --help
+    - lofreq --help
+    - tabix --help
     - run_dbghaplo_pipeline -h
+    - haplotag_bam -h
 
 about:
   home: https://github.com/bluenote-1577/dbghaplo


### PR DESCRIPTION
Adding dbghaplo, a new tool for long-read haplotyping of highly heterogeneous small sequences.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced the `dbghaplo` package (version 0.0.2) for haplotyping small sequences from long-read sequencing samples.
	- Added a new build script to streamline the installation process.

- **Documentation**
	- Included metadata such as home URL, license, and package summary in the new `meta.yaml` file.

- **Requirements**
	- Specified dependencies for building and running the package, including Rust, CMake, and other tools.

- **Tests**
	- Added test commands to verify package functionality and dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->