### PR TITLE
Add hmftools-peach 2.0.0

### DIFF
--- a/recipes/hmftools-peach/build.sh
+++ b/recipes/hmftools-peach/build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+TGT="$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM"
+[ -d "$TGT" ] || mkdir -p "$TGT"
+[ -d "${PREFIX}/bin" ] || mkdir -p "${PREFIX}/bin"
+
+cd "${SRC_DIR}"
+mv peach*.jar $TGT/peach.jar
+
+cp $RECIPE_DIR/peach.sh $TGT/peach
+ln -s $TGT/peach $PREFIX/bin
+chmod 0755 "${PREFIX}/bin/peach"

--- a/recipes/hmftools-peach/meta.yaml
+++ b/recipes/hmftools-peach/meta.yaml
@@ -1,0 +1,30 @@
+{% set version = "2.0.0" %}
+{% set sha256 = "52ffd5dc9bd6018adc5854cbe10cdb2cc364e99099af2f9c8dbc7fdd80fab83e" %}
+
+package:
+  name: hmftools-peach
+  version: '{{ version }}'
+
+source:
+  url: https://github.com/hartwigmedical/hmftools/releases/download/peach-v{{ version }}/peach_v{{ version }}.jar
+  sha256: '{{ sha256 }}'
+
+build:
+  noarch: generic
+  number: 0
+  run_exports:
+    - {{ pin_subpackage("hmftools-peach", max_pin="x.x") }}
+
+requirements:
+  run:
+    - openjdk >=8
+
+test:
+  commands:
+    - 'peach -version | grep Peach'
+
+about:
+  home: https://github.com/hartwigmedical/hmftools/blob/master/peach/README.md
+  license: GPL-3.0-only
+  license_family: GPL3
+  summary: Infer haplotypes for interpretation in a pharmacogenomic context

--- a/recipes/hmftools-peach/peach.sh
+++ b/recipes/hmftools-peach/peach.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# hmftools PEACH executable shell script
+# https://github.com/hartwigmedical/hmftools/tree/master/peach
+set -eu -o pipefail
+
+export LC_ALL=en_US.UTF-8
+
+# Find original directory of bash script, resolving symlinks
+# http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in/246128#246128
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+    DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+    SOURCE="$(readlink "$SOURCE")"
+    [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+
+JAR_DIR=$DIR
+ENV_PREFIX="$(dirname $(dirname $DIR))"
+# Use Java installed with Anaconda to ensure correct version
+java="$ENV_PREFIX/bin/java"
+
+# if JAVA_HOME is set (non-empty), use it. Otherwise keep "java"
+if [ -n "${JAVA_HOME:=}" ]; then
+  if [ -e "$JAVA_HOME/bin/java" ]; then
+      java="$JAVA_HOME/bin/java"
+  fi
+fi
+
+# extract memory and system property Java arguments from the list of provided arguments
+# http://java.dzone.com/articles/better-java-shell-script
+default_jvm_mem_opts="-Xms512m -Xmx1g"
+jvm_mem_opts=""
+jvm_prop_opts=""
+pass_args=""
+for arg in "$@"; do
+    case $arg in
+        '-D'*)
+            jvm_prop_opts="$jvm_prop_opts $arg"
+            ;;
+        '-XX'*)
+            jvm_prop_opts="$jvm_prop_opts $arg"
+            ;;
+         '-Xm'*)
+            jvm_mem_opts="$jvm_mem_opts $arg"
+            ;;
+         *)
+	    if [[ ${pass_args} == '' ]] #needed to avoid preceeding space on first arg e.g. ' MarkDuplicates'
+            then
+                pass_args="$arg"
+	    else
+                pass_args="$pass_args \"$arg\"" #quotes later arguments to avoid problem with ()s in MarkDuplicates regex arg
+            fi
+            ;;
+    esac
+done
+
+if [ "$jvm_mem_opts" == "" ]; then
+    jvm_mem_opts="$default_jvm_mem_opts"
+fi
+
+pass_arr=($pass_args)
+if [[ ${pass_arr[0]:=} == org* ]]
+then
+    eval "$java" $jvm_mem_opts $jvm_prop_opts -cp "$JAR_DIR/peach.jar" $pass_args
+else
+    eval "$java" $jvm_mem_opts $jvm_prop_opts -jar "$JAR_DIR/peach.jar" $pass_args
+fi
+exit


### PR DESCRIPTION
Add recipe for hmftools-peach 2.0.0

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `build.sh` script for automated installation and setup of the `hmftools-peach` package.
	- Added `meta.yaml` file with package metadata, versioning, and requirements, including OpenJDK.
	- Launched `peach.sh` script to execute the PEACH tool with enhanced configuration and error handling.

- **Documentation**
	- Updated metadata for the `hmftools-peach` package, including project homepage and licensing information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->