### PR TITLE
Update dnaio dependency for cutadapt

### DIFF
--- a/recipes/cutadapt/meta.yaml
+++ b/recipes/cutadapt/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: da3b45775b07334d2e2580a7b154d19ea7e872f0da813bb1ac2a4da712bfc223
 
 build:
-  number: 1
+  number: 2
   script: "{{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vvv"
   skip: True  # [py < 38]
   run_exports:
@@ -26,7 +26,7 @@ requirements:
   run:
     - python
     - xopen >=1.6.0
-    - dnaio >=1.2.0
+    - dnaio >=1.2.2
 
 test:
   imports:


### PR DESCRIPTION
ping @marcelm 

This updates the dnaio dependency to 1.2.2 which fixes a bug in the uBAM reader. This will make a new biocontainer available without the bug.