### PR TITLE
Update pgscatalog.core to 0.3.1

### DIFF
--- a/recipes/pgscatalog.core/meta.yaml
+++ b/recipes/pgscatalog.core/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pgscatalog.core" %}
-{% set version = "0.2.2" %}
+{% set version = "0.3.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/pgscatalog_core-{{ version }}.tar.gz
-  sha256: 1a716fdaa6972c86b7a8c2a8141a738cbd5f9e6a98941877631f4187415a0a7f
+  sha256: 612cc10afc4bea0dc5edfc6b279fc92b76e6833a9152e5bd63a7f98da4a125ad
 
 build:
   entry_points:
@@ -33,6 +33,7 @@ requirements:
     - xopen >=1.8.0,<2.0.0
     - tqdm >=4.66.1,<5.0.0
     - natsort >=8.4.0,<9.0.0
+    - pydantic >=2.9.0,<3.0.0
     # for xopen
     - python-zlib-ng
 test:

--- a/recipes/pgscatalog.core/meta.yaml
+++ b/recipes/pgscatalog.core/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - python >=3.10
     - httpx >=0.26.0,<0.27.0
     - tenacity >=8.2.3,<9.0.0
-    - pyliftover >=0.4.0,<0.5.0
+    - pyliftover >=0.4.1,<0.5.0
     - xopen >=1.8.0,<2.0.0
     - tqdm >=4.66.1,<5.0.0
     - natsort >=8.4.0,<9.0.0


### PR DESCRIPTION
Bump pgscatalog.core from `0.2.2` -> `0.3.1`

`0.3.x` added pydantic as a dependency, which broke autobump

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
