### PR TITLE
Update pgscatalog-utils to 1.4.0

### DIFF
--- a/recipes/pgscatalog-utils/meta.yaml
+++ b/recipes/pgscatalog-utils/meta.yaml
@@ -1,5 +1,6 @@
+
 {% set name = "pgscatalog-utils" %}
-{% set version = "1.3.1" %}
+{% set version = "1.4.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,14 +8,14 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/pgscatalog_utils-{{ version }}.tar.gz
-  sha256: 7816a0de184e385a1afeec153a5079f751ccda578d702af91391be389c0f09a7
+  sha256: 3f0c771a0a27e234de77e9713a9d436cbaa5451f1cf03ec85431fc602a778ddf
 
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vvv --no-deps --no-build-isolation --no-cache-dir
   number: 0
   run_exports:
-    - {{ pin_subpackage('pgscatalog-utils', max_pin='x.x') }}  
+    - {{ pin_subpackage('pgscatalog-utils', max_pin='x') }}  
 
 requirements:
   host:
@@ -23,9 +24,9 @@ requirements:
     - pip
   run:
     - python >=3.10.0,<4.0.0
-    - pgscatalog.calc >=0.2.1,<0.3.0
-    - pgscatalog.core >=0.2.1,<0.3.0
-    - pgscatalog.match >=0.2.1,<0.3.0
+    - pgscatalog.calc >=0.3.0,<0.4.0
+    - pgscatalog.core >=0.3.0,<0.4.0
+    - pgscatalog.match >=0.3.0,<0.4.0
 
 test:
   imports:

--- a/recipes/pgscatalog-utils/meta.yaml
+++ b/recipes/pgscatalog-utils/meta.yaml
@@ -15,7 +15,7 @@ build:
   script: {{ PYTHON }} -m pip install . -vvv --no-deps --no-build-isolation --no-cache-dir
   number: 0
   run_exports:
-    - {{ pin_subpackage('pgscatalog-utils', max_pin='x') }}  
+    - {{ pin_subpackage('pgscatalog-utils', max_pin='x.x') }}
 
 requirements:
   host:

--- a/recipes/pgscatalog-utils/meta.yaml
+++ b/recipes/pgscatalog-utils/meta.yaml
@@ -13,7 +13,7 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vvv --no-deps --no-build-isolation --no-cache-dir
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage('pgscatalog-utils', max_pin='x.x') }}
 
@@ -34,6 +34,7 @@ test:
     - pgscatalog.calc
     - pgscatalog.core
   commands:
+    - pip check
     - pgscatalog-download --help 
     - pgscatalog-combine --help
     - pgscatalog-match --help
@@ -41,6 +42,8 @@ test:
     - pgscatalog-relabel --help
     - pgscatalog-aggregate --help
     - pgscatalog-ancestry-adjust --help
+  requires:
+    - pip
 
 about:
   home: https://github.com/PGScatalog/pygscatalog

--- a/recipes/pgscatalog-utils/meta.yaml
+++ b/recipes/pgscatalog-utils/meta.yaml
@@ -25,8 +25,8 @@ requirements:
   run:
     - python >=3.10.0,<4.0.0
     - pgscatalog.calc >=0.3.0,<0.4.0
-    - pgscatalog.core >=0.3.0,<0.4.0
-    - pgscatalog.match >=0.3.0,<0.4.0
+    - pgscatalog.core >=0.3.1,<0.4.0
+    - pgscatalog.match >=0.3.2,<0.4.0
 
 test:
   imports:


### PR DESCRIPTION
Dependencies received a minor version bump, so need to manually update

Not sure how https://github.com/bioconda/bioconda-recipes/pull/51234 is passing CI/CD 🤔 `pyproject.toml` specifies different dependencies:

```
...
"pgscatalog.calc" = "^0.3.0"
"pgscatalog.core" =  "^0.3.1"
"pgscatalog.match" =  "^0.3.2"
```

to the `meta.yaml` (which is fixed in this PR)

TODO: 

- [ ] fix match dependency 

----

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
