### PR TITLE
Update pgscatalog.match to 0.3.3

### DIFF
--- a/recipes/pgscatalog.match/meta.yaml
+++ b/recipes/pgscatalog.match/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pgscatalog.match" %}
-{% set version = "0.3.2" %}
+{% set version = "0.3.3" %}
 
 package:
   name: {{ name|lower }}

--- a/recipes/pgscatalog.match/meta.yaml
+++ b/recipes/pgscatalog.match/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 
 build:
-  number: 1
+  number: 0
   noarch: python
   entry_points:
     - pgscatalog-match = pgscatalog.match.cli.match_cli:run_match

--- a/recipes/pgscatalog.match/meta.yaml
+++ b/recipes/pgscatalog.match/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 316feb3337298ac54a2b8aa5baa68bb9144acc1f38795cce628d8cd9b2e3b7c1
 
 build:
-  number: 0
+  number: 1
   noarch: python
   entry_points:
     - pgscatalog-match = pgscatalog.match.cli.match_cli:run_match
@@ -29,15 +29,18 @@ requirements:
     - python >=3.10
     - polars 0.20.30
     - pyarrow >=15.0.0,<16.0.0
-    - pgscatalog.core >=0.2.1,<0.3.0
+    - pgscatalog.core >=0.3.0,<0.4.0
 
 test:
   imports:
     - pgscatalog.match
   commands:
+    - pip check
     - pgscatalog-match --help
     - pgscatalog-matchmerge --help
     - pgscatalog-intersect --help
+  requires:
+    - pip
 
 about:
   home: https://github.com/PGScatalog/pygscatalog

--- a/recipes/pgscatalog.match/meta.yaml
+++ b/recipes/pgscatalog.match/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pgscatalog.match" %}
-{% set version = "0.3.1" %}
+{% set version = "0.3.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/pgscatalog_match-{{ version }}.tar.gz
-  sha256: 316feb3337298ac54a2b8aa5baa68bb9144acc1f38795cce628d8cd9b2e3b7c1
+  sha256: d927fa227917d3e03fb06370dfadc6a5fe4b85f0008f303909f0d7b2d1c48c61
 
 build:
   number: 1


### PR DESCRIPTION
* https://github.com/bioconda/bioconda-recipes/pull/51216 had inconsistent dependencies across `pyproject.toml` and `meta.yaml` but passed CI/CD checks

  * Adding `pip check` to the tests section prevent this from happening again 

* Also the patch release fixed some broken tests

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
