### PR TITLE
add gfainject

### DIFF
--- a/recipes/gfainject/build.sh
+++ b/recipes/gfainject/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -euo
+
+set -xe
+
+# build statically linked binary with Rust
+RUST_BACKTRACE=1
+cargo install --verbose --path . --root ${PREFIX}

--- a/recipes/gfainject/meta.yaml
+++ b/recipes/gfainject/meta.yaml
@@ -1,0 +1,38 @@
+{% set name = "gfainject" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/AndreaGuarracino/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 6b41c91a9f53cdea850c43f222386607a02c5eccbf0b7de4482c14a985b3b136 
+
+build:
+  number: 0
+  run_exports:
+      - {{ pin_subpackage(name, max_pin='x.x') }}
+
+requirements:
+  build:
+    - {{ compiler('rust') }}
+
+test:
+  commands:
+    - gfainject --help
+
+about:
+  home: https://github.com/AndreaGuarracino/{{ name }}
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: Inject alignment into pangenome grpahs
+  dev_url: https://github.com/AndreaGuarracino/{{ name }}
+
+extra:
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64
+  recipe-maintainers:
+    - AndreaGuarracino


### PR DESCRIPTION
This is a pangenome tool to inject mappings/alignments (in BAM and PAF formats) into pangenome graphs (in GFA format).