### PR TITLE
Update rna-seqc to 2.4.2

### DIFF
--- a/recipes/rna-seqc/build.sh
+++ b/recipes/rna-seqc/build.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -eu -o pipefail
 
-cd ./travis/build/broadinstitute/rnaseqc
 export CFLAGS="${CFLAGS} -fcommon"
 
+cd rnaseqc
 pushd SeqLib/bwa
 sed -i.bak '/^DFLAGS=/s/$/ $(LDFLAGS)/' Makefile
 make CC="$CC" CFLAGS="$CFLAGS" LDFLAGS="$LDFLAGS"
@@ -30,3 +30,6 @@ make \
 mkdir -p $PREFIX/bin
 cp rnaseqc $PREFIX/bin
 
+# Install python scripts
+cd python
+$PYTHON setup.py install

--- a/recipes/rna-seqc/build.sh
+++ b/recipes/rna-seqc/build.sh
@@ -29,7 +29,3 @@ make \
 
 mkdir -p $PREFIX/bin
 cp rnaseqc $PREFIX/bin
-
-# Install python scripts
-cd python
-$PYTHON setup.py install

--- a/recipes/rna-seqc/build.sh
+++ b/recipes/rna-seqc/build.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -eu -o pipefail
 
-export CFLAGS="${CFLAGS} -fcommon"
+export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib"
+export CFLAGS="${CFLAGS} -O3 -fcommon"
 
 cd rnaseqc
 pushd SeqLib/bwa
@@ -19,7 +20,7 @@ popd
 
 make \
     CC="$CXX" \
-    CPPFLAGS="-I$PREFIX/include -fcommon" \
+    CPPFLAGS="${CPPFLAGS} -O3 -I$PREFIX/include -fcommon" \
     SeqLib/lib/libseqlib.a
 
 make \
@@ -28,4 +29,5 @@ make \
     LIBRARY_PATHS="-L$PREFIX/lib -Wl,-rpath $PREFIX/lib"
 
 mkdir -p $PREFIX/bin
+chmod 0755 rnaseqc
 cp rnaseqc $PREFIX/bin

--- a/recipes/rna-seqc/meta.yaml
+++ b/recipes/rna-seqc/meta.yaml
@@ -11,14 +11,14 @@ source:
 
 build:
   number: 1
+  run_exports:
+    - {{ pin_subpackage("rna-seqc", max_pin="x.x") }}
 
 requirements:
   build:
     - make
     - {{ compiler('cxx') }}
     - {{ compiler('c') }}
-    run_exports:
-      - {{ pin_subpackage("rna-seqc", max_pin="x.x") }}
   host:
     - curl
     - bzip2

--- a/recipes/rna-seqc/meta.yaml
+++ b/recipes/rna-seqc/meta.yaml
@@ -31,16 +31,9 @@ requirements:
     - boost-cpp
     - xz
     - zlib
-    - numpy
-    - pandas
-    - matplotlib-base
-    - seaborn
-    - nbformat
 test:
   commands:
     - rnaseqc --version
-  imports:
-    - rnaseqc
 
 about:
   home: https://github.com/broadinstitute/rnaseqc

--- a/recipes/rna-seqc/meta.yaml
+++ b/recipes/rna-seqc/meta.yaml
@@ -17,6 +17,8 @@ requirements:
     - make
     - {{ compiler('cxx') }}
     - {{ compiler('c') }}
+    run_exports:
+      - {{ pin_subpackage("rna-seqc", max_pin="x.x") }}
   host:
     - curl
     - bzip2
@@ -39,6 +41,8 @@ requirements:
 test:
   commands:
     - rnaseqc --version
+  imports:
+    - rnaseqc
 
 about:
   home: https://github.com/broadinstitute/rnaseqc

--- a/recipes/rna-seqc/meta.yaml
+++ b/recipes/rna-seqc/meta.yaml
@@ -38,7 +38,7 @@ test:
 about:
   home: https://github.com/broadinstitute/rnaseqc
   license_url: https://raw.githubusercontent.com/broadinstitute/rnaseqc/master/LICENSE
-  license_file: LICENSE
+  license_file: rnaseqc/LICENSE
   license: BSD 3-clause
   license_family: BSD
   summary: Fast, efficient RNA-Seq metrics for quality control and process optimization

--- a/recipes/rna-seqc/meta.yaml
+++ b/recipes/rna-seqc/meta.yaml
@@ -27,19 +27,23 @@ requirements:
     - zlib
   run:
     - curl
-    - bzip2
     - boost-cpp
-    - xz
-    - zlib
+
 test:
   commands:
     - rnaseqc --version
 
 about:
-  home: https://github.com/broadinstitute/rnaseqc
+  home: "https://github.com/broadinstitute/rnaseqc"
   license_url: https://raw.githubusercontent.com/broadinstitute/rnaseqc/master/LICENSE
   license_file: rnaseqc/LICENSE
-  license: BSD 3-clause
+  license: "BSD-3-Clause"
   license_family: BSD
-  summary: Fast, efficient RNA-Seq metrics for quality control and process optimization
+  summary: "Fast, efficient RNA-Seq metrics for quality control and process optimization."
+  dev_url: "https://github.com/broadinstitute/rnaseqc"
+  doc_url: "https://github.com/getzlab/rnaseqc/blob/v{{ version }}/README.md"
 
+extra:
+  identifiers:
+    - biotools:rna-seqc
+    - doi:10.1093/bioinformatics/btab135

--- a/recipes/rna-seqc/meta.yaml
+++ b/recipes/rna-seqc/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "2.3.5" %}
-{% set sha256sum = "44e81f01f2b661a7621f34e3b645f5727bc7143841f1df053723e23ba298d2c6" %}
+{% set version = "2.4.2" %}
+{% set sha256sum = "b214151408696430aead56921b255e2b09efe5f6087a68446deae399227a1303" %}
 
 package:
   name: rna-seqc
@@ -10,7 +10,7 @@ source:
   sha256: '{{ sha256sum }}'
 
 build:
-  number: 6
+  number: 1
 
 requirements:
   build:
@@ -29,14 +29,21 @@ requirements:
     - boost-cpp
     - xz
     - zlib
+    - numpy
+    - pandas
+    - matplotlib-base
+    - seaborn
+    - nbformat
+    - pip:
+        - agutil
 test:
   commands:
     - rnaseqc --version
 
 about:
-  home: https://github.com/broadinstitute/rnaseqc 
+  home: https://github.com/broadinstitute/rnaseqc
   license_url: https://raw.githubusercontent.com/broadinstitute/rnaseqc/master/LICENSE
-  # license_file: LICENSE  # not distributed :-/
+  license_file: LICENSE
   license: BSD 3-clause
   license_family: BSD
   summary: Fast, efficient RNA-Seq metrics for quality control and process optimization

--- a/recipes/rna-seqc/meta.yaml
+++ b/recipes/rna-seqc/meta.yaml
@@ -2,17 +2,17 @@
 {% set sha256sum = "b214151408696430aead56921b255e2b09efe5f6087a68446deae399227a1303" %}
 
 package:
-  name: rna-seqc
-  version: '{{ version }}'
+  name: "rna-seqc"
+  version: {{ version }}
 
 source:
   url: 'https://github.com/broadinstitute/rnaseqc/releases/download/v{{ version }}/rnaseqc.v{{ version }}.full_source.tar.gz'
-  sha256: '{{ sha256sum }}'
+  sha256: {{ sha256sum }}
 
 build:
-  number: 1
+  number: 0
   run_exports:
-    - {{ pin_subpackage("rna-seqc", max_pin="x.x") }}
+    - {{ pin_subpackage("rna-seqc", max_pin="x") }}
 
 requirements:
   build:
@@ -36,8 +36,6 @@ requirements:
     - matplotlib-base
     - seaborn
     - nbformat
-    - pip:
-        - agutil
 test:
   commands:
     - rnaseqc --version


### PR DESCRIPTION
This PR updates RNA-seqc to its current version. It additionally installs the python scripts too.