### PR TITLE
Add `cosigt`

### DIFF
--- a/recipes/cosigt/build.sh
+++ b/recipes/cosigt/build.sh
@@ -4,4 +4,4 @@ mkdir -p $PREFIX/bin
 go mod init cosigt
 go mod tidy
 go get -d ./...
-CGO_ENABLED=0 go build cosigt -o $PREFIX/bin/cosigt .
+CGO_ENABLED=0 go build -o $PREFIX/bin/cosigt .

--- a/recipes/cosigt/build.sh
+++ b/recipes/cosigt/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+mkdir -p $PREFIX/bin
+go mod init cosigt
+go mod tidy
+go get -d ./...
+CGO_ENABLED=0 go build cosigt -o $PREFIX/bin/cosigt .

--- a/recipes/cosigt/meta.yaml
+++ b/recipes/cosigt/meta.yaml
@@ -23,7 +23,7 @@ test:
 about:
   home: https://github.com/davidebolo1993/{{ name }}
   summary: Cosigt (COsine SImilarity-based GenoTyper)
-  dev_url: home: https://github.com/davidebolo1993/{{ name }}
+  dev_url: https://github.com/davidebolo1993/{{ name }}
 
 extra:
   additional-platforms:

--- a/recipes/cosigt/meta.yaml
+++ b/recipes/cosigt/meta.yaml
@@ -7,6 +7,8 @@ package:
 
 build:
   number: 0
+  run_exports:
+      - {{ pin_subpackage(name, max_pin='x.x') }}
 
 source:
   - url: https://github.com/davidebolo1993/{{ name }}/archive/tags/v{{ version }}.tar.gz

--- a/recipes/cosigt/meta.yaml
+++ b/recipes/cosigt/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "cosigt" %}
-{% set version = "0.1.0" %}
+{% set version = "0.1.1" %}
 
 package:
   name: {{ name }}
@@ -10,7 +10,7 @@ build:
 
 source:
   - url: https://github.com/davidebolo1993/{{ name }}/archive/tags/v{{ version }}.tar.gz
-    sha256: 746abd43417a43341cc00779319088f8a0cb7e1ef595df200fb48b1fd8dbae9b
+    sha256: fdd20dd9127516d21316ff72ac278e17a2bbba49a8a465488378e6fad9ae7b93
 
 requirements:
   build:
@@ -22,6 +22,9 @@ test:
 
 about:
   home: https://github.com/davidebolo1993/{{ name }}
+  license: 'GNU General Public License v3 (GPLv3)'
+  license_family: GPL3
+  license_file: LICENSE
   summary: Cosigt (COsine SImilarity-based GenoTyper)
   dev_url: https://github.com/davidebolo1993/{{ name }}
 

--- a/recipes/cosigt/meta.yaml
+++ b/recipes/cosigt/meta.yaml
@@ -1,0 +1,33 @@
+{% set name = "cosigt" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+build:
+  number: 0
+
+source:
+  - url: https://github.com/davidebolo1993/{{ name }}/archive/tags/v{{ version }}.tar.gz
+    sha256: 746abd43417a43341cc00779319088f8a0cb7e1ef595df200fb48b1fd8dbae9b
+
+requirements:
+  build:
+    - {{ compiler('go') }}
+
+test:
+  commands:
+    - cosigt -h
+
+about:
+  home: https://github.com/davidebolo1993/{{ name }}
+  summary: Pangenome-based genotyping
+  dev_url: home: https://github.com/davidebolo1993/{{ name }}
+
+extra:
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64
+  recipe-maintainers:
+    - AndreaGuarracino

--- a/recipes/cosigt/meta.yaml
+++ b/recipes/cosigt/meta.yaml
@@ -11,7 +11,7 @@ build:
       - {{ pin_subpackage(name, max_pin='x.x') }}
 
 source:
-  - url: https://github.com/davidebolo1993/{{ name }}/archive/tags/v{{ version }}.tar.gz
+  - url: https://github.com/davidebolo1993/{{ name }}/archive/tags/{{ version }}.tar.gz
     sha256: fdd20dd9127516d21316ff72ac278e17a2bbba49a8a465488378e6fad9ae7b93
 
 requirements:

--- a/recipes/cosigt/meta.yaml
+++ b/recipes/cosigt/meta.yaml
@@ -12,7 +12,7 @@ build:
 
 source:
   - url: https://github.com/davidebolo1993/{{ name }}/archive/tags/{{ version }}.tar.gz
-    sha256: fdd20dd9127516d21316ff72ac278e17a2bbba49a8a465488378e6fad9ae7b93
+    sha256: 7db68d7e02424fba7248db4ddd0853f1c634b31e62906037765f1f481e63635d
 
 requirements:
   build:

--- a/recipes/cosigt/meta.yaml
+++ b/recipes/cosigt/meta.yaml
@@ -22,7 +22,7 @@ test:
 
 about:
   home: https://github.com/davidebolo1993/{{ name }}
-  summary: Pangenome-based genotyping
+  summary: Cosigt (COsine SImilarity-based GenoTyper)
   dev_url: home: https://github.com/davidebolo1993/{{ name }}
 
 extra:


### PR DESCRIPTION
Cosigt computes the cosine similarity between pangenome-based coverage vectors that can be used to genotype read samples.