### PR TITLE
add gafpack

### DIFF
--- a/recipes/gafpack/build.sh
+++ b/recipes/gafpack/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -euo
+
+set -xe
+
+# build statically linked binary with Rust
+export RUST_BACKTRACE=1
+cargo install --verbose --path . --root ${PREFIX} --no-track

--- a/recipes/gafpack/meta.yaml
+++ b/recipes/gafpack/meta.yaml
@@ -1,0 +1,38 @@
+{% set name = "gafpack" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/pangenome/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 0b78d8047132965c7b0a9b0f3dc26682c1251d08507ebdd98583d9c1b563c758 
+
+build:
+  number: 0
+  run_exports:
+      - {{ pin_subpackage(name, max_pin='x.x') }}
+
+requirements:
+  build:
+    - {{ compiler('rust') }}
+
+test:
+  commands:
+    - gfainject --help
+
+about:
+  home: https://github.com/pangenome/{{ name }}
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: Convert alignments to pangenome variation graphs to coverage maps
+  dev_url: https://github.com/pangenome/{{ name }}
+
+extra:
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64
+  recipe-maintainers:
+    - AndreaGuarracino

--- a/recipes/gafpack/meta.yaml
+++ b/recipes/gafpack/meta.yaml
@@ -20,7 +20,7 @@ requirements:
 
 test:
   commands:
-    - gfainject --help
+    - gafpack --help
 
 about:
   home: https://github.com/pangenome/{{ name }}


### PR DESCRIPTION
[`gafpack`](https://github.com/pangenome/gafpack) is a tool to convert alignments to pangenome variation graphs to coverage maps (vectors). These vectors can be used together with [`odgi`](https://github.com/pangenome/odgi), [`pggb`](https://github.com/pangenome/pggb), and [`cosigt`](https://github.com/davidebolo1993/cosigt) to perform pangenome-based genotyping.