### PR TITLE
Update UMICollapse to 1.1.0

### DIFF
--- a/recipes/umicollapse/meta.yaml
+++ b/recipes/umicollapse/meta.yaml
@@ -7,7 +7,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 1
+  number: 0
   noarch: generic
 
 source:

--- a/recipes/umicollapse/meta.yaml
+++ b/recipes/umicollapse/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "UMICollapse" %}
-{% set version = "1.0.0" %}
-{% set sha256 = "40685d58f6be844ae4029eff1bf21f886f059da8293902ab390ee872e878edec"%}
+{% set version = "1.1.0" %}
+{% set sha256 = "01b8ff5b6bcc775b277e92f5414e7e94019bfbe47fe0850810ab4e33500992b1"%}
 
 package:
   name: umicollapse
@@ -11,7 +11,7 @@ build:
   noarch: generic
 
 source:
-  url: https://github.com/CharlotteAnne/UMICollapse/archive/refs/tags/v{{ version }}.tar.gz
+  url: https://github.com/siddharthab/UMICollapse/archive/refs/tags/v{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 requirements:

--- a/recipes/umicollapse/meta.yaml
+++ b/recipes/umicollapse/meta.yaml
@@ -1,14 +1,16 @@
-{% set name = "UMICollapse" %}
+{% set name = "umicollapse" %}
 {% set version = "1.1.0" %}
 {% set sha256 = "01b8ff5b6bcc775b277e92f5414e7e94019bfbe47fe0850810ab4e33500992b1"%}
 
 package:
-  name: umicollapse
+  name: {{ name }}
   version: {{ version }}
 
 build:
   number: 0
   noarch: generic
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x") }}
 
 source:
   url: https://github.com/siddharthab/UMICollapse/archive/refs/tags/v{{ version }}.tar.gz


### PR DESCRIPTION
Also changes the source GitHub repo to another fork because the original author is non-responsive.

Some discussion on this in https://github.com/nf-core/rnaseq/issues/1087#issuecomment-2392499060

----

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
