### PR TITLE
Treekin

### DIFF
--- a/recipes/treekin/meta.yaml
+++ b/recipes/treekin/meta.yaml
@@ -31,7 +31,7 @@ requirements:
   run:
     - mlapack
     - lapack <3.9
-    - libgfortran =3
+    - {{ compiler('fortran') }}
 
 test:
   commands:

--- a/recipes/treekin/meta.yaml
+++ b/recipes/treekin/meta.yaml
@@ -10,7 +10,7 @@ build:
   skip: True # [osx]
   number: 5
   run_exports:
-    - {{ pin_subpackage('myrecipe', max_pin="x.x") }}
+    - {{ pin_subpackage(name, max_pin="x.x") }}
 
 source:
   url: https://github.com/ViennaRNA/Treekin/releases/download/v{{ version }}/Treekin-{{ version }}.tar.gz 

--- a/recipes/treekin/meta.yaml
+++ b/recipes/treekin/meta.yaml
@@ -9,6 +9,8 @@ package:
 build:
   skip: True # [osx]
   number: 5
+  run_exports:
+    - {{ pin_subpackage('myrecipe', max_pin="x.x") }}
 
 source:
   url: https://github.com/ViennaRNA/Treekin/releases/download/v{{ version }}/Treekin-{{ version }}.tar.gz 

--- a/recipes/treekin/meta.yaml
+++ b/recipes/treekin/meta.yaml
@@ -8,7 +8,7 @@ package:
 
 build:
   skip: True # [osx]
-  number: 4
+  number: 5
 
 source:
   url: https://github.com/ViennaRNA/Treekin/releases/download/v{{ version }}/Treekin-{{ version }}.tar.gz 
@@ -29,6 +29,7 @@ requirements:
   run:
     - mlapack
     - lapack <3.9
+    - libgfortran =3
 
 test:
   commands:


### PR DESCRIPTION
Add runtime dependency libgfortran3 to meta,yaml file. This resolves the runtime error "treekin: error while loading shared libraries: libgfortran.so.3: cannot open shared object file: No such file or directory". 

Further clean up might be needed, including adding libgfortran as dependency during build.

