### PR TITLE
Fix pgscatalog-utils patch update 1.4.2

### DIFF
--- a/recipes/pgscatalog-utils/meta.yaml
+++ b/recipes/pgscatalog-utils/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vvv --no-deps --no-build-isolation --no-cache-dir
-  number: 1
+  number: 0
   run_exports:
     - {{ pin_subpackage('pgscatalog-utils', max_pin='x.x') }}  
 

--- a/recipes/pgscatalog-utils/meta.yaml
+++ b/recipes/pgscatalog-utils/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pgscatalog-utils" %}
-{% set version = "1.4.1" %}
+{% set version = "1.4.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/pgscatalog_utils-{{ version }}.tar.gz
-  sha256: e54e67f9a372e91a7cc640528c66a9989258bc5ae61e7d6972a5b8ef4e1aa2da
+  sha256: a6393687b1b38a1926f999434c6c459f03a4e625ca6a66075b55b82ce1cc186b
 
 build:
   noarch: python
@@ -24,7 +24,7 @@ requirements:
   run:
     - python >=3.10.0,<4.0.0
     - pgscatalog.calc >=0.3.0,<0.4.0
-    - pgscatalog.core >=0.3.1,<0.4.0
+    - pgscatalog.core >=0.3.2,<0.4.0
     - pgscatalog.match >=0.3.3,<0.4.0
 
 test:


### PR DESCRIPTION
`pip check` was failing on the autobump

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
