### PR TITLE
add recipe for steamboat

### DIFF
--- a/recipes/steamboat/meta.yaml
+++ b/recipes/steamboat/meta.yaml
@@ -20,6 +20,7 @@ requirements:
   host:
     - python >=3.9
     - pip
+    - poetry-core
   run:
     - biopython
     - executor

--- a/recipes/steamboat/meta.yaml
+++ b/recipes/steamboat/meta.yaml
@@ -14,7 +14,7 @@ build:
   script: {{ PYTHON }} -m pip install --no-deps --ignore-installed -vv .
   number: 0
   run_exports:
-    - {{ pin_subpackage(name|lower, max_pin='x.x.x') }}
+    - {{ pin_subpackage(name|lower, max_pin='x') }}
 
 requirements:
   host:

--- a/recipes/steamboat/meta.yaml
+++ b/recipes/steamboat/meta.yaml
@@ -1,0 +1,49 @@
+{% set name = "steamboat" %}
+{% set version = "1.1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/steamboat-binf/steamboat_binf-{{ version }}.tar.gz
+  sha256: dfade01e251d5bbfb117378b9abeaf7231e0fc7a37fc7e37be0933ac9185981c
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install --no-deps --ignore-installed -vv .
+  number: 0
+  run_exports:
+    - {{ pin_subpackage(name|lower, max_pin='x.x.x') }}
+
+requirements:
+  host:
+    - python >=3.8
+    - poetry
+    - pip
+  run:
+    - biopython
+    - executor
+    - pigz
+    - python >=3.8
+    - pyyaml
+    - rich-click >=1.6.0
+
+test:
+  imports:
+    - steamboat
+  commands:
+    - pip check
+    - gisaid-batch --help
+  requires:
+    - pip
+
+about:
+  home: https://github.com/rpetit3/steamboat-py
+  summary: A collection of tools/scripts for microbial bioinformatics
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - rpetit3

--- a/recipes/steamboat/meta.yaml
+++ b/recipes/steamboat/meta.yaml
@@ -18,14 +18,13 @@ build:
 
 requirements:
   host:
-    - python >=3.8
-    - poetry
+    - python >=3.9
     - pip
   run:
     - biopython
     - executor
     - pigz
-    - python >=3.8
+    - python >=3.9
     - pyyaml
     - rich-click >=1.6.0
 

--- a/recipes/steamboat/meta.yaml
+++ b/recipes/steamboat/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "steamboat" %}
-{% set version = "1.1.0" %}
+{% set version = "1.0.0" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
Adds recipe for a python package with tools/scripts for microbial binf

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
