### PR TITLE
Update pretextgraph

### DIFF
--- a/recipes/pretextgraph/build.sh
+++ b/recipes/pretextgraph/build.sh
@@ -5,7 +5,7 @@ set -eo pipefail
 if [ `uname` == Darwin ]; then
     meson setup --buildtype=release --prefix=$PREFIX --unity on builddir
 else
-    env CC=clang CXX=clang meson setup --buildtype=release --prefix=$PREFIX --unity on builddir
+    env CC=clang CXX=clang++ meson setup --buildtype=release --prefix=$PREFIX --unity on builddir
 fi
 
 cd builddir

--- a/recipes/pretextgraph/meta.yaml
+++ b/recipes/pretextgraph/meta.yaml
@@ -1,17 +1,22 @@
 {% set name = "PretextGraph" %}
-{% set version = "0.0.6" %}
-{% set sha256 = "94e69e9c99f62d6112a8e48db4cf9ff92102c2704dacff01924cce5799a6807f" %}
+{% set version = "0.0.7" %}
+# {% set sha256 = "cd5b8e32b519c6cdcfa53134ca739b496418b87e57ebbb019f3325a0ec6cd9b9" %}
 
 package:
   name: "{{ name|lower }}"
   version: "{{ version }}"
 
 source:
-  url: https://github.com/wtsi-hpag/{{ name }}/releases/download/{{ version }}/{{ name }}-{{ version }}.tar.xz
-  sha256: {{ sha256 }}
+  # url: https://github.com/wtsi-hpag/{{ name }}/releases/download/{{ version }}/{{ name }}-{{ version }}.tar.xz
+  # url: https://github.com/sanger-tol/PretextGraph/archive/refs/tags/{{ version }}.tar.gz
+  # sha256: {{ sha256 }}
+
+  git_url: https://github.com/sanger-tol/PretextGraph.git
+  git_tag: "{{ version }}"
+  git_submodules: True
 
 build:
-  number: 3
+  number: 4 # use to be 3
 
 requirements:
   build:

--- a/recipes/pretextgraph/meta.yaml
+++ b/recipes/pretextgraph/meta.yaml
@@ -7,7 +7,7 @@ package:
   version: "{{ version }}"
 
 source:
-  url: https://github.com/guanshaoheng/PretextGraph/releases/download/{{ version }}/{{ name|lower }}-{{ version }}.tar.gz
+  url: https://github.com/sanger-tol/PretextGraph/releases/download/{{ version }}/{{ name|lower }}-{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:

--- a/recipes/pretextgraph/meta.yaml
+++ b/recipes/pretextgraph/meta.yaml
@@ -18,7 +18,8 @@ build:
 requirements:
   build:
     - {{ compiler('cxx') }}
-    - clang >=9.0.1 # [linux] 
+    - clang >=11.0.1 # [linux] 
+    - clangxx >=11.0.1 # [linux]
     - meson >=0.57.1
 
 test:

--- a/recipes/pretextgraph/meta.yaml
+++ b/recipes/pretextgraph/meta.yaml
@@ -1,16 +1,11 @@
 {% set name = "PretextGraph" %}
 {% set version = "0.0.7" %}
-# {% set sha256 = "cd5b8e32b519c6cdcfa53134ca739b496418b87e57ebbb019f3325a0ec6cd9b9" %}
 
 package:
   name: "{{ name|lower }}"
   version: "{{ version }}"
 
 source:
-  # url: https://github.com/wtsi-hpag/{{ name }}/releases/download/{{ version }}/{{ name }}-{{ version }}.tar.xz
-  # url: https://github.com/sanger-tol/PretextGraph/archive/refs/tags/{{ version }}.tar.gz
-  # sha256: {{ sha256 }}
-
   git_url: https://github.com/sanger-tol/PretextGraph.git
   git_tag: "{{ version }}"
   git_submodules: True

--- a/recipes/pretextgraph/meta.yaml
+++ b/recipes/pretextgraph/meta.yaml
@@ -1,23 +1,25 @@
 {% set name = "PretextGraph" %}
 {% set version = "0.0.7" %}
+{% set sha256 = "4c99c46105cf4de3f22ab3065b0e5445cdf3caed8f66aafaf08249c365455d37" %}
 
 package:
   name: "{{ name|lower }}"
   version: "{{ version }}"
 
 source:
-  git_url: https://github.com/sanger-tol/PretextGraph.git
-  git_tag: "{{ version }}"
-  git_submodules: True
+  url: https://github.com/guanshaoheng/PretextGraph/releases/download/{{ version }}/{{ name|lower }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
 
 build:
-  number: 4 # use to be 3
+  number: 0 # the build number should be incremented if the same version of the package is built with different build settings
+  run_exports:
+    - {{ pin_subpackage('pretextgraph', max_pin="x.x") }}
 
 requirements:
   build:
     - {{ compiler('cxx') }}
-    - clang>=9.0.1 # [linux] 
-    - meson>=0.57.1
+    - clang >=9.0.1 # [linux] 
+    - meson >=0.57.1
 
 test:
   commands:


### PR DESCRIPTION
Update PretextGraph to 0.0.7

**Fixes and Improvements:**

- Resolved the gap extension issue:
    - Addressed data overflow when calculating `graph->values` by changing the calculation type from u32 to f32.
    - Introduced a new `data_type` for handling different methods of transforming the `bedgraph` file into `Graph->values`:
        - `gap`: Sets the pixel value with number `index` for `Graph->values[index]` containing the gap to `1`.
 - `repeat_density`: Normalizes the value of each bin as a percentage, reflecting the ratio of repeat pairs within that bin. For instance, if the `bin_size=10,000` and `N` base pairs are marked as repeats, the ratio is calculated as `N / 10,000`.
 - `default`: Retains the original calculation method.
- Fixed a **segmentation fault** in `PrintStatus`: Resolved small bugs that caused the program to crash.
- Improved `ProcessLine` function: Added a check to ensure `(u32) nThisBin ` does not become negative. Originally, if a negative value is encountered, it will be set to the maximum allowable value for `u32`. Currently, it will be set as 0.
- **Compilation adjustments**: Since modifications were made in C++, the compiler has been switched to Clang++ to resolve compilation issues.