### PR TITLE
ci: update GHA artifact location

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -135,14 +135,8 @@ jobs:
         with:
           name: linux-packages
           path: |
-            /tmp/artifacts/packages
+            /tmp/artifacts
 
-      - name: Archive images 
-        uses: actions/upload-artifact@v4
-        with:
-          name: docker-images
-          path: |
-            /tmp/artifacts/images
 
   build-osx-64:
     name: OSX-64 Tests
@@ -214,7 +208,7 @@ jobs:
         with:
           name: osx-packages
           path: |
-            /tmp/artifacts/packages
+            /tmp/artifacts
 
   # Disabled due to concurrency limits on GHA for OSX. osx-arm64 builds are on CircleCI.
   # build_and_test-osx-arm64:

--- a/recipes/lima/meta.yaml
+++ b/recipes/lima/meta.yaml
@@ -31,5 +31,5 @@ extra:
     - armintoepfer
     - pb-dseifert
   skip-lints:
-    #repackaged binary
+    #repackaged binary 
     - should_be_noarch_generic


### PR DESCRIPTION
The expected artifact directory structure changed slightly from last time GHA was used.

Use Lima as an example since it was merged to master but not uploaded.