### PR TITLE
CI: Don't rename image filename

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -125,8 +125,6 @@ jobs:
                 docker save "${1}" | gzip -c > "${1##*/}.tar.gz"
                 echo "Finished compressing docker image ${1} ."
                 ' --
-            # There's no : allowed in artifact names, replace it with ---
-            for f in /tmp/artifacts/images/*:* ; do mv -- "$f" "${f//:/---}"; done
           fi
           ) || true
 

--- a/recipes/libgff/meta.yaml
+++ b/recipes/libgff/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage('libgff', max_pin='x') }}
 
@@ -28,7 +28,7 @@ requirements:
 test:
   commands:
     - "ls ${PREFIX}/lib/libgff.a"
- 
+
 about:
   home: https://github.com/COMBINE-lab/libgff
   license: MIT

--- a/recipes/libgff/meta.yaml
+++ b/recipes/libgff/meta.yaml
@@ -28,7 +28,7 @@ requirements:
 test:
   commands:
     - "ls ${PREFIX}/lib/libgff.a"
-
+ 
 about:
   home: https://github.com/COMBINE-lab/libgff
   license: MIT


### PR DESCRIPTION
Remove the line that gets rid of `:` in the filename since bioconda-utils uses that to get the image version.