### PR TITLE
Add linux-aarch64 and osx-arm64 to multiple bioconductor-* packages.

### DIFF
--- a/recipes/bioconductor-bambu/meta.yaml
+++ b/recipes/bioconductor-bambu/meta.yaml
@@ -13,7 +13,7 @@ source:
     - 'https://depot.galaxyproject.org/software/bioconductor-{{ name }}/bioconductor-{{ name }}_{{ version }}_src_all.tar.gz'
   md5: 900e0e67c251f12989154113c54d2b32
 build:
-  number: 0
+  number: 1
   rpaths:
     - lib/R/lib/
     - lib/

--- a/recipes/bioconductor-bambu/meta.yaml
+++ b/recipes/bioconductor-bambu/meta.yaml
@@ -74,3 +74,6 @@ about:
   description: 'bambu is a R package for multi-sample transcript discovery and quantification using long read RNA-Seq data. You can use bambu after read alignment to obtain expression estimates for known and novel transcripts and genes. The output from bambu can directly be used for visualisation and downstream analysis such as differential gene expression or transcript usage.'
   license_file: LICENSE
 
+extra:
+  additional-platforms:
+    - linux-aarch64

--- a/recipes/bioconductor-biobase/meta.yaml
+++ b/recipes/bioconductor-biobase/meta.yaml
@@ -42,6 +42,7 @@ about:
 extra:
   additional-platforms:
     - linux-aarch64
+    - osx-arm64
   identifiers:
     - biotools:biobase
 

--- a/recipes/bioconductor-biocparallel/meta.yaml
+++ b/recipes/bioconductor-biocparallel/meta.yaml
@@ -54,6 +54,7 @@ about:
 extra:
   additional-platforms:
     - linux-aarch64
+    - osx-arm64
   identifiers:
     - biotools:biocparallel
     - doi:10.1214/14-STS476

--- a/recipes/bioconductor-biostrings/meta.yaml
+++ b/recipes/bioconductor-biostrings/meta.yaml
@@ -52,6 +52,7 @@ about:
 extra:
   additional-platforms:
     - linux-aarch64
+    - osx-arm64
   identifiers:
     - biotools:biostrings
     - doi:10.1038/nmeth.3252

--- a/recipes/bioconductor-delayedarray/meta.yaml
+++ b/recipes/bioconductor-delayedarray/meta.yaml
@@ -54,6 +54,7 @@ about:
 extra:
   additional-platforms:
     - linux-aarch64
+    - osx-arm64
   parent_recipe:
     name: bioconductor-delayedarray
     path: recipes/bioconductor-delayedarray

--- a/recipes/bioconductor-genomicalignments/meta.yaml
+++ b/recipes/bioconductor-genomicalignments/meta.yaml
@@ -58,6 +58,7 @@ about:
 extra:
   additional-platforms:
     - linux-aarch64
+    - osx-arm64
   identifiers:
     - biotools:genomicalignments
   parent_recipe:

--- a/recipes/bioconductor-iranges/meta.yaml
+++ b/recipes/bioconductor-iranges/meta.yaml
@@ -44,6 +44,7 @@ about:
 extra:
   additional-platforms:
     - linux-aarch64
+    - osx-arm64
   identifiers:
     - biotools:iranges
   parent_recipe:

--- a/recipes/bioconductor-rsamtools/meta.yaml
+++ b/recipes/bioconductor-rsamtools/meta.yaml
@@ -66,6 +66,7 @@ about:
 extra:
   additional-platforms:
     - linux-aarch64
+    - osx-arm64
   identifiers:
     - biotools:rsamtools
     - doi:10.1038/nmeth.3252

--- a/recipes/bioconductor-s4vectors/meta.yaml
+++ b/recipes/bioconductor-s4vectors/meta.yaml
@@ -42,6 +42,7 @@ about:
 extra:
   additional-platforms:
     - linux-aarch64
+    - osx-arm64
   identifiers:
     - biotools:s4vectors
     - doi:10.1038/nmeth.3252


### PR DESCRIPTION
Add osx-arm64 as a build target to several targets in bioconductor-* recipes.
Add linux-aarch64 to bioconductor-bambu - alas osx-arm64 does not work at this time due to missing r-xml support in conda forge.