### PR TITLE
Add Linux aarch64 to bioconductor-bambu

### DIFF
--- a/recipes/bioconductor-bambu/meta.yaml
+++ b/recipes/bioconductor-bambu/meta.yaml
@@ -13,7 +13,7 @@ source:
     - 'https://depot.galaxyproject.org/software/bioconductor-{{ name }}/bioconductor-{{ name }}_{{ version }}_src_all.tar.gz'
   md5: 900e0e67c251f12989154113c54d2b32
 build:
-  number: 0
+  number: 1
   rpaths:
     - lib/R/lib/
     - lib/
@@ -74,3 +74,6 @@ about:
   description: 'bambu is a R package for multi-sample transcript discovery and quantification using long read RNA-Seq data. You can use bambu after read alignment to obtain expression estimates for known and novel transcripts and genes. The output from bambu can directly be used for visualisation and downstream analysis such as differential gene expression or transcript usage.'
   license_file: LICENSE
 
+extra:
+  additional-platforms:
+    - linux-aarch64


### PR DESCRIPTION


Adds linux-aarch64 to the package.