### PR TITLE
Update csvtk to v0.31.0

### DIFF
--- a/recipes/csvtk/meta.yaml
+++ b/recipes/csvtk/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.30.0" %}
+{% set version = "0.31.0" %}
 # This package should be migrated to conda-forge due to general utility
 # In that case it needs to be built from source
 package:
@@ -6,19 +6,19 @@ package:
   version: {{ version }}
 
 build:
-  number: 2
+  number: 0
   run_exports:
     - {{ pin_subpackage('csvtk', max_pin='x.x') }}
   
 source:
   - url: https://github.com/shenwei356/csvtk/releases/download/v{{ version }}/csvtk_darwin_amd64.tar.gz # [osx and x86_64]
-    md5: c415255e265ba0cd547806fdbda05652 # [osx and x86_64]
+    md5: 5a23d000a1fc068360e1aeb439f3ae25 # [osx and x86_64]
   - url: https://github.com/shenwei356/csvtk/releases/download/v{{ version }}/csvtk_darwin_arm64.tar.gz # [arm64]
-    md5: dd8a84c301d378ab7ff28c85d37fbefa # [arm64]
+    md5: 6aa24ce286910e83d95d28a21905f1d8 # [arm64]
   - url: https://github.com/shenwei356/csvtk/releases/download/v{{ version }}/csvtk_linux_amd64.tar.gz # [linux and x86_64]
-    md5: 8f5877d4fbea89609d64bd2679956476 # [linux and x86_64]
+    md5: 09bc8c3288f028239c94d4c935ac7a6f # [linux and x86_64]
   - url: https://github.com/shenwei356/csvtk/releases/download/v{{ version }}/csvtk_linux_arm64.tar.gz # [aarch64]
-    md5: 2a6dd840291d23971ff538eaf3de00ec # [aarch64]
+    md5: f7a5b8839459d7d55685056331670eec # [aarch64]
 
 test:
   commands:


### PR DESCRIPTION
Describe your pull request here

### Changes

- [csvtk v0.31.0](https://github.com/shenwei356/csvtk/releases/tag/v0.31.0) [![Github Releases (by Release)](https://img.shields.io/github/downloads/shenwei356/csvtk/v0.31.0/total.svg)](https://github.com/shenwei356/csvtk/releases/tag/v0.31.0)
    - `csvtk sort/join`:
        - faster speed and lower memory.
    - `csvtk sort`:
        - do not panic for empty input. [#287](https://github.com/shenwei356/csvtk/issues/287)
    - `csvtk summary`:
        - fix the order of columns. [#282](https://github.com/shenwei356/csvtk/issues/282)
    - `csvtk rename2`:
        - fix `-n/--start-num`. [#286](https://github.com/shenwei356/csvtk/issues/286)
        - add flag `--nr-width`.
    - `csvtk replace`:
        - fix implementing `{nr}`. [#286](https://github.com/shenwei356/csvtk/issues/286)
    - `csvtk csv2json`:
        - fix values with double quotes and new line symbols. [#291](https://github.com/shenwei356/csvtk/issues/291)
    - `csvtk split`:
        - support customize output file prefix and subdirectory from prefix of keys. [#288](https://github.com/shenwei356/csvtk/issues/288)
    - `csvtk spread`:
        - add a new alias "scatter" to "spread". [#265](https://github.com/shenwei356/csvtk/issues/265)
    - `csvtk grep`:
        - do not show progress.
    - `csvtk fix-quotes`:
        - new flag `-b, --buffer-size`.
    - `csvtk plot`:
        - new flag `--scale` for scaling the image width/height, tick, axes, line/point and font sizes proportionally, adviced by @tseemann.
    - `csvtk plot line`:
        - only add legend for more than one group. [#279](https://github.com/shenwei356/csvtk/issues/279)
        - sort points by X for plotting lines. [#280](https://github.com/shenwei356/csvtk/issues/280)
    - `csvtk hist`:
        - new flags: `--line-width`.
    - `csvtk box`:
        - plots of different groups have different colors now.
        - new flags: `--line-width`, `--point-size`, and `color-index`.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
