### PR TITLE
update ProtGenerics version to 1.38.0

### DIFF
--- a/recipes/bioconductor-protgenerics/meta.yaml
+++ b/recipes/bioconductor-protgenerics/meta.yaml
@@ -1,6 +1,6 @@
-{% set version = "1.34.0" %}
+{% set version = "1.38.0" %}
 {% set name = "ProtGenerics" %}
-{% set bioc = "3.18" %}
+{% set bioc = "3.20" %}
 
 package:
   name: 'bioconductor-{{ name|lower }}'
@@ -11,7 +11,7 @@ source:
     - 'https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/Archive/{{ name }}/{{ name }}_{{ version }}.tar.gz'
     - 'https://bioarchive.galaxyproject.org/{{ name }}_{{ version }}.tar.gz'
     - 'https://depot.galaxyproject.org/software/bioconductor-{{ name|lower }}/bioconductor-{{ name|lower }}_{{ version }}_src_all.tar.gz'
-  md5: 5d55c00588169aa089bb457e2d94669a
+  md5: 7e7211a9fa758ca6f1b701c86e892895
 build:
   number: 0
   rpaths:


### PR DESCRIPTION
This PR updates ProtGenerics to version 1.38.0 which is needed for qfeatures_1.16
### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
