### PR TITLE
Update stranger with setuptools and change dev url

### DIFF
--- a/recipes/stranger/meta.yaml
+++ b/recipes/stranger/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: f27c705b53e27098907f6ff8710ee817408baf75ea26720423bfbf1a2383f013
 
 build:
-  number: 0
+  number: 1
   noarch: python
   entry_points:
     - stranger = stranger.__main__:base_command
@@ -30,6 +30,7 @@ requirements:
     - coloredlogs
     - python >=3.6.0
     - pyyaml
+    - setuptools
 
 test:
   imports:
@@ -46,5 +47,5 @@ about:
   license: MIT
   license_family: MIT
   summary: "Annotate VCF files with str variants"
-  doc_url: "https://github.com/moonso/stranger"
-  dev_url: "https://github.com/moonso/stranger"
+  doc_url: "https://github.com/Clinical-Genomics/stranger"
+  dev_url: "https://github.com/Clinical-Genomics/stranger"


### PR DESCRIPTION
The noarch version of the tool results in 

```
Traceback (most recent call last):
  File "/home/felix/.local/bin/mambaforge/envs/stranger9.2/bin/stranger", line 6, in <module>
    from stranger.__main__ import base_command
  File "/home/felix/.local/bin/mambaforge/envs/stranger9.2/lib/python3.13/site-packages/stranger/__main__.py", line 14, in <module>
    from stranger.cli import cli as base_command
  File "/home/felix/.local/bin/mambaforge/envs/stranger9.2/lib/python3.13/site-packages/stranger/cli.py", line 11, in <module>
    from stranger.resources import repeats_json_path
  File "/home/felix/.local/bin/mambaforge/envs/stranger9.2/lib/python3.13/site-packages/stranger/resources/__init__.py", line 1, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```

Not entirely sure this is the correct way to fix it, but adding setuptools to my local conda environment fixed the issue. 

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
