### PR TITLE
Add linux-aarch64 and/or osx-arm64 variants to various perl-unicode-*

### DIFF
--- a/recipes/perl-unicode-map/meta.yaml
+++ b/recipes/perl-unicode-map/meta.yaml
@@ -11,7 +11,9 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 7
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x.x") }}
+  number: 8
 
 requirements:
   build:
@@ -35,3 +37,8 @@ about:
   home: http://metacpan.org/pod/Unicode::Map
   license: unknown
   summary: 'An utility to map texts from and to unicode'
+
+extra:
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64

--- a/recipes/perl-unicode-normalize/meta.yaml
+++ b/recipes/perl-unicode-normalize/meta.yaml
@@ -11,7 +11,9 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 5
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x") }}
+  number: 6
 
 requirements:
   build:
@@ -39,3 +41,8 @@ about:
   home: http://metacpan.org/pod/Unicode::Normalize
   license: perl_5
   summary: 'Unicode Normalization Forms'
+
+extra:
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64

--- a/recipes/perl-unicode-utf8/meta.yaml
+++ b/recipes/perl-unicode-utf8/meta.yaml
@@ -11,7 +11,9 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 6
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x.x") }}
+  number: 7
 
 requirements:
   build:
@@ -38,3 +40,8 @@ about:
   home: http://metacpan.org/pod/Unicode::UTF8
   license: perl_5
   summary: 'Encoding and decoding of UTF-8 encoding form'
+
+extra:
+  # osx-arm64 is erroring due to missing perl-encode in conda forge
+  additional-platforms:
+    - linux-aarch64


### PR DESCRIPTION
This pull request adds support for linux-aarch64 and/or osx-arm64 perl-unicode-* where these packages ought to already work.  This is a slice of previous PR request that is timing out due to size of package list.

@martin-g - can you review 