### PR TITLE
Add linux-aarch64 and/or osx-arm64 to various perl-* packages 1 of 2

### DIFF
--- a/recipes/perl-bloom-faster/meta.yaml
+++ b/recipes/perl-bloom-faster/meta.yaml
@@ -1,8 +1,9 @@
+{% set name = "perl-bloom-faster" %}
 {% set version = "1.7" %}
 {% set sha256 = "02cfde4f6aca6f7453edb93ba70d36d08081f5ebad8b023188da6379ff1d4a75" %}
 
 package:
-  name: perl-bloom-faster
+  name: {{ name }}
   version: {{ version }}
 
 source:
@@ -10,7 +11,9 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 6
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x") }}
+  number: 7
 
 requirements:
   build:
@@ -30,3 +33,8 @@ about:
   home: http://metacpan.org/pod/Bloom-Faster
   license: unknown
   summary: 'Perl extension for the c library libbloom.'
+
+extra:
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64

--- a/recipes/perl-class-methodmaker/meta.yaml
+++ b/recipes/perl-class-methodmaker/meta.yaml
@@ -12,7 +12,9 @@ source:
 
 
 build:
-  number: 4
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x") }}
+  number: 5
 
 requirements:
   build:
@@ -43,3 +45,8 @@ about:
   home: http://search.cpan.org/~schwigon/Class-MethodMaker-2.24/
   license: perl_5
   summary: 'Create generic methods for OO Perl'
+
+extra:
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64

--- a/recipes/perl-crypt-openssl-random/0.11/meta.yaml
+++ b/recipes/perl-crypt-openssl-random/0.11/meta.yaml
@@ -7,13 +7,15 @@ package:
   version: {{ version }}
 
 source:
-  url: https://cpan.metacpan.org/authors/id/R/RU/RURBAN/Crypt-OpenSSL-Random-0.11.tar.gz
+  url: https://cpan.metacpan.org/authors/id/R/RU/RURBAN/Crypt-OpenSSL-Random-{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 # If this is a new build for the same version, increment the build
 # number. If you do not include this key, it defaults to 0.
 build:
-  number: 5
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x.x") }}
+  number: 6
 
 requirements:
   build:
@@ -44,6 +46,11 @@ about:
   home: http://sourceforge.net/projects/perl-openssl/
   license: perl_5
   summary: 'OpenSSL/LibreSSL pseudo-random number generator access'
+
+extra:
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64
 
 # See
 # http://docs.continuum.io/conda/build.html for

--- a/recipes/perl-crypt-openssl-rsa/meta.yaml
+++ b/recipes/perl-crypt-openssl-rsa/meta.yaml
@@ -13,7 +13,7 @@ source:
 # If this is a new build for the same version, increment the build
 # number. If you do not include this key, it defaults to 0.
 build:
-  number: 2
+  number: 3
   run_exports:
     weak:
       - {{ name }} ={{ version }}
@@ -47,3 +47,8 @@ about:
 # See
 # https://docs.conda.io/projects/conda-build for
 # more information about meta.yaml
+
+extra:
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64

--- a/recipes/perl-file-copy-recursive/meta.yaml
+++ b/recipes/perl-file-copy-recursive/meta.yaml
@@ -11,7 +11,9 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 3
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x.x") }}
+  number: 4
 
 requirements:
   build:
@@ -37,3 +39,8 @@ about:
   home: https://metacpan.org/pod/File::Copy::Recursive
   license: Perl
   summary: 'Perl extension for recursively copying files and directories'
+
+extra:
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64

--- a/recipes/perl-filesys-df/meta.yaml
+++ b/recipes/perl-filesys-df/meta.yaml
@@ -1,8 +1,9 @@
+{% set name = "perl-filesys-df" %}
 {% set version = "0.92" %}
 {% set sha256 = "fe89cbb427e0e05f1cd97c2dd6d3866ac6b21bc7a85734ede159bdc35479552a" %}
 
 package:
-  name: "perl-filesys-df"
+  name: {{ name }}
   version: {{ version }}
 
 source:
@@ -10,7 +11,9 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 7
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x.x") }}
+  number: 8
 
 requirements:
   build:
@@ -29,3 +32,8 @@ about:
   home: http://metacpan.org/pod/Filesys-Df
   license: unknown
   summary: 'Perl extension for filesystem disk space information.'
+
+extra:
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64

--- a/recipes/perl-heap-simple-xs/meta.yaml
+++ b/recipes/perl-heap-simple-xs/meta.yaml
@@ -1,13 +1,18 @@
+{% set name = "perl-heap-simple-xs" %}
+{% set version = "0.10" %}
+
 package:
-  name: perl-heap-simple-xs
-  version: "0.10"
+  name: {{ name }}
+  version: {{ version }} 
 
 source:
-  url: http://cpan.metacpan.org/authors/id/T/TH/THOSPEL/Heap-Simple-XS-0.10.tar.gz
+  url: http://cpan.metacpan.org/authors/id/T/TH/THOSPEL/Heap-Simple-XS-{{ version }}.tar.gz
   md5: 0611ac7984f6ddc3aaa60c75d2257803
 
 build:
-  number: 6
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x.x") }}
+  number: 7
 
 requirements:
   build:
@@ -28,3 +33,8 @@ about:
   home: http://metacpan.org/pod/Heap::Simple::XS
   license: unknown
   summary: 'An XS implementation of the Heap::Simple interface'
+
+extra:
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64

--- a/recipes/perl-ipc-sharelite/meta.yaml
+++ b/recipes/perl-ipc-sharelite/meta.yaml
@@ -11,7 +11,9 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 5
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x.x") }}
+  number: 6
 
 requirements:
   build:
@@ -33,3 +35,8 @@ about:
   home: http://metacpan.org/pod/IPC::ShareLite
   license: perl_5
   summary: 'Lightweight interface to shared memory'
+
+extra:
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64

--- a/recipes/perl-json-parse/meta.yaml
+++ b/recipes/perl-json-parse/meta.yaml
@@ -11,7 +11,9 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 3
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x.x") }}
+  number: 4
 
 requirements:
   build:
@@ -33,3 +35,8 @@ about:
   home: http://metacpan.org/pod/JSON::Parse
   license: perl_5
   summary: 'Read JSON into a Perl variable'
+
+extra:
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64

--- a/recipes/perl-math-cdf/meta.yaml
+++ b/recipes/perl-math-cdf/meta.yaml
@@ -1,13 +1,18 @@
+{% set name = "perl-math-cdf" %}
+{% set version = "0.1" %}
+
 package:
-  name: perl-math-cdf
-  version: "0.1"
+  name: {{ name }}
+  version: {{ version }}
 
 source:
-  url: http://cpan.metacpan.org/authors/id/C/CA/CALLAHAN/Math-CDF-0.1.tar.gz
+  url: http://cpan.metacpan.org/authors/id/C/CA/CALLAHAN/Math-CDF-{{ version }}.tar.gz
   md5: 7866c7b6b9d27f0ce4b7637334478ab7
 
 build:
-  number: 9
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x.x") }}
+  number: 10
 
 requirements:
   build:
@@ -27,3 +32,8 @@ about:
   home: http://metacpan.org/pod/Math-CDF
   license: Public Domain
   summary: 'Generate probabilities and quantiles from several statistical probability functions'
+
+extra:
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64

--- a/recipes/perl-math-random/meta.yaml
+++ b/recipes/perl-math-random/meta.yaml
@@ -1,13 +1,18 @@
+{% set name = "perl-math-random" %}
+{% set version = "0.72" %}
+
 package:
-  name: perl-math-random
-  version: "0.72"
+  name: {{ name }}
+  version: {{ version }}
 
 source:
-  url: https://cpan.metacpan.org/authors/id/G/GR/GROMMEL/Math-Random-0.72.tar.gz
+  url: https://cpan.metacpan.org/authors/id/G/GR/GROMMEL/Math-Random-{{ version }}.tar.gz
   md5: b0b961e2ae06920801a9c9843c48d0bc
 
 build:
-  number: 6
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x.x") }}
+  number: 7
 
 requirements:
   build:
@@ -29,3 +34,8 @@ about:
   home: http://metacpan.org/pod/Math-Random
   license: unknown
   summary: 'Random Number Generators'
+
+extra:
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64

--- a/recipes/perl-math-random/meta.yaml
+++ b/recipes/perl-math-random/meta.yaml
@@ -13,6 +13,8 @@ build:
   run_exports:
     - {{ pin_subpackage(name, max_pin="x.x") }}
   number: 7
+  # skip osx on x86 - builds fail in CI
+  skip: True # [osx]
 
 requirements:
   build:


### PR DESCRIPTION
This breaks PR #51856 up to smaller pieces to get past build-timeout due to size of package list.
This adds osx-arm64 and linux-aarch64 where the packages would already work but for lack of meta.yaml or historic missing dependency in conda-forge.