### PR TITLE
Add linux-aarch64 and osx-arm64 support to rpsbproc

### DIFF
--- a/recipes/rpsbproc/build.sh
+++ b/recipes/rpsbproc/build.sh
@@ -156,7 +156,7 @@ cd "$NCBI_CXX_TOOLKIT"
 # Run GNU Make
 cd "$RESULT_PATH/build"
 echo "RUNNING MAKE" >&2
-make -j -f Makefile.flat rpsbproc.exe >&2
+make -j 4 -f Makefile.flat rpsbproc.exe >&2
 
 # Copy compiled binaries to the Conda $PREFIX
 mkdir -p "$PREFIX/bin"

--- a/recipes/rpsbproc/build.sh
+++ b/recipes/rpsbproc/build.sh
@@ -156,7 +156,7 @@ cd "$NCBI_CXX_TOOLKIT"
 # Run GNU Make
 cd "$RESULT_PATH/build"
 echo "RUNNING MAKE" >&2
-make -j1 -f Makefile.flat rpsbproc.exe >&2
+make -j -f Makefile.flat rpsbproc.exe >&2
 
 # Copy compiled binaries to the Conda $PREFIX
 mkdir -p "$PREFIX/bin"

--- a/recipes/rpsbproc/build.sh
+++ b/recipes/rpsbproc/build.sh
@@ -125,9 +125,11 @@ CONFIGURE_FLAGS="$CONFIGURE_FLAGS --without-dll --with-static-exe"
 # Platform-specific flags
 if [[ "$(uname)" = "Linux" ]]; then
 	# --with(out)-64:
-	#   Compile in 64-bit mode instead of 32-bit.
+	#   Compile in 64-bit mode instead of 32-bit on x86_64 platforms.
 	#   Flag not available for osx build.
-	CONFIGURE_FLAGS="$CONFIGURE_FLAGS --with-64"
+        if [[ "$(arch)" = "x86_64" ]]; then
+	    CONFIGURE_FLAGS="$CONFIGURE_FLAGS --with-64"
+	fi
 	# --with(out)-openmp:
 	#   Enable OpenMP extensions for all projects.
 	#   Does not work without hacks for OSX

--- a/recipes/rpsbproc/meta.yaml
+++ b/recipes/rpsbproc/meta.yaml
@@ -24,7 +24,7 @@ source:
       - update_configsub.patch
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage(name, max_pin="x.x") }}
 

--- a/recipes/rpsbproc/meta.yaml
+++ b/recipes/rpsbproc/meta.yaml
@@ -81,3 +81,6 @@ about:
 extra:
   identifiers:
     - doi:10.1002/cpbi.90
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64

--- a/recipes/rpsbproc/meta.yaml
+++ b/recipes/rpsbproc/meta.yaml
@@ -83,4 +83,5 @@ extra:
     - doi:10.1002/cpbi.90
   additional-platforms:
     - linux-aarch64
-    - osx-arm64
+    # osx-arm64 is encountering issues with Xcode and make during builds
+    # - osx-arm64


### PR DESCRIPTION
Fix compile flags in build.sh to enable linux-aarch64. Add linux-aarch64 and osx-arm64 to additional platforms.
