### PR TITLE
Update TRTools to 6.1.0

### DIFF
--- a/recipes/trtools/meta.yaml
+++ b/recipes/trtools/meta.yaml
@@ -90,3 +90,5 @@ extra:
   identifiers:
     - biotools:trtools
     - doi:10.1093/bioinformatics/btaa736
+  additional-platforms:
+    - osx-arm64

--- a/recipes/trtools/meta.yaml
+++ b/recipes/trtools/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "trtools" %}
-{% set version = "6.0.2" %}
+{% set version = "6.1.0" %}
 
 package:
   name: "{{ name|lower }}"
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 7bdb476951a4ec748df20058a31da3d1def14554cd9a67f85d3c61bf63f8f303
+  sha256: 3a177cf19060945eff4044f16d5ebdc66364e72a8a3c9bd725086ba10003df96
 
 build:
   noarch: python
@@ -20,6 +20,7 @@ build:
     - associaTR=trtools.associaTR:run
     - prancSTR = trtools.prancSTR:run
     - simTR = trtools.simTR:run
+    - annotaTR = trtools.annotaTR:run
   script: "{{ PYTHON }} -m pip install . --no-deps --no-build-isolation --no-cache-dir -vvv"
   number: 0
   run_exports:
@@ -32,7 +33,7 @@ requirements:
     - pip >=20.3
   run:
     - python >=3.7.1,<4.0
-    - cyvcf2 >=0.30.4
+    - cyvcf2 >=0.30.27
     - matplotlib-base >=3.1.2
     - numpy >=1.17.3
     - pandas >=1.2.0
@@ -42,6 +43,7 @@ requirements:
     - statsmodels >=0.10.2
     - pyfaidx >=0.5.6
     - ART >=2016.06.05
+    - pgenlib >=0.90.1
 
 test:
   imports:
@@ -54,6 +56,7 @@ test:
     - trtools.statSTR
     - trtools.prancSTR
     - trtools.simTR
+    - trtools.annotaTR
     - trtools.utils
   requires:
     - bcftools
@@ -69,6 +72,7 @@ test:
     - qcSTR --help
     - prancSTR --help
     - simTR --help
+    - annotaTR --help
 
 about:
   home: https://github.com/gymreklab/TRTools

--- a/recipes/trtools/meta.yaml
+++ b/recipes/trtools/meta.yaml
@@ -92,3 +92,4 @@ extra:
     - doi:10.1093/bioinformatics/btaa736
   additional-platforms:
     - osx-arm64
+    - linux-aarch64


### PR DESCRIPTION
Closes https://github.com/bioconda/bioconda-recipes/pull/51983

Update [trtools](https://bioconda.github.io/recipes/trtools/README.html): 6.0.2 → 6.1.0

Please merge this PR instead of https://github.com/bioconda/bioconda-recipes/pull/51983. We've updated a dependency, added a dependency, and added an entrypoint.