### PR TITLE
Update matchms dependencies

### DIFF
--- a/recipes/matchms/meta.yaml
+++ b/recipes/matchms/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: f727d116fdbc8c6ed0ada94f2fc857a40b33ea27333265fe540221e744b61296
 
 build:
-  number: 0
+  number: 1
   script: "{{ PYTHON }} -m pip install . --no-deps --no-build-isolation --no-cache-dir -vvv"
   noarch: python
   run_exports:
@@ -19,26 +19,26 @@ build:
 requirements:
   host:
     - pip
-    - python >=3.9,<3.13
+    - python >=3.10,<3.13
     - poetry-core
   run:
     - deprecated >=1.2.14
     - lxml >=4.9.3,<5
     - matplotlib-base >=3.7
-    - networkx >=3.0
-    - numba >=0.57.1,<0.60
-    - numpy >1.22,<1.27
+    - networkx >=3.4.2
+    - numba >=0.60.0
+    - numpy >=2.0.0
     - pickydict >=0.4.0
     - pyteomics >=4.6
-    - python >=3.9,<3.13
+    - python >=3.10,<3.13
     - pyyaml >=6.0.1
-    - rdkit >=2023.9.6
+    - rdkit >=2024.3.5
     - requests >=2.31.0
-    - scipy >=1.11
-    - sparsestack >=0.4.1
+    - scipy >=1.14.1
+    - sparsestack >=0.6.0
     - tqdm >=4.65.0
     - pillow !=9.4.0
-    - pandas >=2.0.3
+    - pandas >=2.2.3
     - pubchempy
 
 test:


### PR DESCRIPTION
This PR updates the matchms dependencies to be in line with the [pyproject.toml](https://github.com/matchms/matchms/blob/8fec6bba9c2009ac76720b82cf42e8e2889f7bbf/pyproject.toml) file in the repo.
