### PR TITLE
Update PhaBOX to 2.1.5

### DIFF
--- a/recipes/phabox/meta.yaml
+++ b/recipes/phabox/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "PhaBOX" %}
-{% set version = "2.1.4" %}
+{% set version = "2.1.5" %}
 
 package:
   name: "{{ name|lower }}"
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/KennthShang/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 963d71ac1e600f5a41cd8ff22a66a34921190e7b8afe449aa5ca3fd10fabba40
+  sha256: 875124cd1568fcb706662e7f86ff7e1ef79b38944156c8c5d0b1b329d983d73a
 
 build:
   number: 0
@@ -42,6 +42,7 @@ requirements:
     - blast >=2.16.0
     - diamond <=0.9.14
     - mcl >=22.282
+    - accelerate >=1.0.1
     
 test:
   commands:


### PR DESCRIPTION
- added new packages accelerate that maybe required on some system.
- fix some bugs in the phabox2 scripts.