### PR TITLE
Add recipe for vgorient

### DIFF
--- a/recipes/vgorient/meta.yaml
+++ b/recipes/vgorient/meta.yaml
@@ -6,24 +6,18 @@ package:
   version: "{{ version }}"
 
 source:
-  url: https://github.com/whelixw/vgOrient/archive/refs/tags/v0.1.1.tar.gz
+  url: https://github.com/whelixw/vgOrient/archive/refs/tags/v{{ version }}.tar.gz
   sha256: 99bef68d2545179da8206a573e55f4294a903024ef943ee97e723fdb8bc3668f
 
 build:
   noarch: python
   number: 0
   run_exports:
-    - {{ pin_subpackage('vgorient') }}
+    - {{ pin_subpackage('vgorient', max_pin="x.x") }}
   script:
     - mkdir -p $PREFIX/bin
-    - cp cut_and_rot.py $PREFIX/bin/
-    - cp VG_diterative.py $PREFIX/bin/
-    - cp kmer_jaccard.py $PREFIX/bin/
-    - cp jaccard_dit_wrapper.py $PREFIX/bin/
-    - chmod +x $PREFIX/bin/cut_and_rot.py
-    - chmod +x $PREFIX/bin/VG_diterative.py
-    - chmod +x $PREFIX/bin/kmer_jaccard.py
-    - chmod +x $PREFIX/bin/jaccard_dit_wrapper.py
+    - cp -rf *.py $PREFIX/bin/
+    - chmod +x $PREFIX/bin/cut_and_rot.py $PREFIX/bin/VG_diterative.py $PREFIX/bin/kmer_jaccard.py $PREFIX/bin/jaccard_dit_wrapper.py
 
 requirements:
   host:
@@ -49,10 +43,9 @@ about:
   summary: "Scripts for processing mitochondrial graphs."
   description: |
     MitoGraphs is a collection of scripts for analyzing and processing mitochondrial genome graphs using various bioinformatics tools.
-  doc_url: "https://github.com/whelixw/vgOrient#readme"
+  doc_url: "https://github.com/whelixw/vgOrient/blob/v{{ version }}/README.md"
   dev_url: "https://github.com/whelixw/vgOrient"
 
 extra:
   recipe-maintainers:
     - whelixw
-

--- a/recipes/vgorient/meta.yaml
+++ b/recipes/vgorient/meta.yaml
@@ -1,0 +1,58 @@
+{% set name = "vgorient" %}
+{% set version = "0.1.1" %}
+
+package:
+  name: "{{ name }}"
+  version: "{{ version }}"
+
+source:
+  url: https://github.com/whelixw/vgOrient/archive/refs/tags/v0.1.1.tar.gz
+  sha256: 99bef68d2545179da8206a573e55f4294a903024ef943ee97e723fdb8bc3668f
+
+build:
+  noarch: python
+  number: 0
+  run_exports:
+    - {{ pin_subpackage('vgorient') }}
+  script:
+    - mkdir -p $PREFIX/bin
+    - cp cut_and_rot.py $PREFIX/bin/
+    - cp VG_diterative.py $PREFIX/bin/
+    - cp kmer_jaccard.py $PREFIX/bin/
+    - cp jaccard_dit_wrapper.py $PREFIX/bin/
+    - chmod +x $PREFIX/bin/cut_and_rot.py
+    - chmod +x $PREFIX/bin/VG_diterative.py
+    - chmod +x $PREFIX/bin/kmer_jaccard.py
+    - chmod +x $PREFIX/bin/jaccard_dit_wrapper.py
+
+requirements:
+  host:
+    - python >=3.8,<3.12
+  run:
+    - python >=3.8,<3.12
+    - vg
+    - biopython >=1.83
+    - networkx >=3.3
+    - numpy >=1.26.4
+
+test:
+  commands:
+    - cut_and_rot.py --help
+    - VG_diterative.py --help
+    - kmer_jaccard.py --help
+    - jaccard_dit_wrapper.py --help
+
+about:
+  home: "https://github.com/whelixw/vgOrient"
+  license: "MIT"
+  license_family: "MIT"
+  summary: "Scripts for processing mitochondrial graphs."
+  description: |
+    MitoGraphs is a collection of scripts for analyzing and processing mitochondrial genome graphs using various bioinformatics tools.
+  doc_url: "https://github.com/whelixw/vgOrient#readme"
+  dev_url: "https://github.com/whelixw/vgOrient"
+
+extra:
+  recipe-maintainers:
+    - whelixw
+


### PR DESCRIPTION
## Add Recipe for `vgorient` Package

**Description:**

This pull request adds a new recipe for the `vgorient` package to the Bioconda channel.

**About `vgorient`:**

- **Homepage:** [https://github.com/whelixw/mitographs](https://github.com/whelixw/mitographs)
- **Description:** `vgorient` is a collection of scripts for analyzing and processing mitochondrial genome graphs using various bioinformatics tools. The package includes the following executable scripts:
  - `jaccard_dit_wrapper.py`
  - `VG_diterative.py`
  - `kmer_jaccard.py`
  - `cut_and_rot.py`

**Key Features:**

- Provides tools for processing mitochondrial graphs.
- Utilizes external tools like `vg` for graph operations.
- Facilitates comparative analysis of mitochondrial genomes.

**Recipe Details:**

- **Version:** 0.1.0
- **License:** MIT
- **Source:** Downloaded from the GitHub release tarball corresponding to the `v0.1.0` tag.
- **Build:** Marked as `noarch: python` since it is a platform-independent pure Python package.
- **Dependencies:**
  - `python >=3.8,<3.12`
  - `vg`
  - `biopython >=1.83`
  - `networkx >=3.3`
  - `numpy >=1.26.4`

**Linting and Testing:**

- The recipe passes all Bioconda linting checks.
- Built and tested locally using `conda build`.
- Scripts have been verified to execute correctly within a Conda environment.

**Additional Notes:**

- The package name `vgorient` matches the recipe folder name, following Bioconda guidelines.
- The source uses a stable release tarball with a provided `sha256` checksum to ensure integrity.
- All scripts include shebang lines and are installed as executable commands.
- The `noarch: python` designation allows for broader compatibility across platforms.

---

**Checklist:**

- [x] Used a release tarball and included `sha256` checksum.
- [x] Recipe folder name and package name match.
- [x] Marked as `noarch: python` for a pure Python package.
- [x] All dependencies are specified in the `requirements` section.
- [x] Linted with `bioconda-utils lint` and passed all checks.
- [x] Tested the build locally and confirmed functionality.

**Request:**

Please review the recipe and provide any feedback or suggestions for improvement. Thank you for considering the inclusion of `vgorient` in the Bioconda channel.
----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
