### PR TITLE
Update pytximport

### DIFF
--- a/recipes/pytximport/meta.yaml
+++ b/recipes/pytximport/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pytximport" %}
-{% set version = "0.10.0" %}
+{% set version = "0.10.1" %}
 
 package:
   name: {{ name|lower }}

--- a/recipes/pytximport/meta.yaml
+++ b/recipes/pytximport/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - python >=3.9
     - anndata >=0.8.0
     - click >=8.1.7
-    - dask >=2024.7.0
+    - click_default_group >=1.2.0
     - flox >=0.9.8
     - h5py >=3.11.0
     - numpy >=1.23.0
@@ -43,10 +43,10 @@ test:
     - pytximport --help
 
 about:
-  home: https://pytximport.readthedocs.io/en/latest/start.html
+  home: https://pytximport.readthedocs.io/en/stable/start.html
   dev_url: https://github.com/complextissue/pytximport
   doc_url: https://pytximport.readthedocs.io
-  summary: pytximport - gene count estimation from alignment-free quantification
+  summary: pytximport - gene count estimation from transcript-level quantification
   description: |
     pytximport is a Python port of tximport that allows users to import transcript counts from tools such as kallisto and Salmon, correct them for differential isoform usage, and summarize them at the gene level.
   license: GPL-3.0-only

--- a/recipes/pytximport/meta.yaml
+++ b/recipes/pytximport/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - python >=3.9
     - anndata >=0.8.0
     - click >=8.1.7
-    - click_default_group >=1.2.0
+    - conda-forge::click-default-group >=1.2.0
     - flox >=0.9.8
     - h5py >=3.11.0
     - numpy >=1.23.0


### PR DESCRIPTION
- Remove unnecessary dask dependency
- Add click_default_group dependency required for an upcoming update
- Clarify in the title that pytximport is not just for alignment-free but all transcript-level quantification data
- Link to the stable docs