### PR TITLE
recipe for older pplacer 1.1.alpha17 version

### DIFF
--- a/recipes/pplacer/1.1.alpha17/build.sh
+++ b/recipes/pplacer/1.1.alpha17/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+mkdir -p $PREFIX/bin
+
+cd $SRC_DIR
+cp guppy pplacer rppr $PREFIX/bin
+chmod +x $PREFIX/bin/{guppy,pplacer,rppr}

--- a/recipes/pplacer/1.1.alpha17/build.sh
+++ b/recipes/pplacer/1.1.alpha17/build.sh
@@ -6,6 +6,15 @@ cd $SRC_DIR
 mv guppy pplacer rppr $PREFIX/bin
 chmod +x $PREFIX/bin/{guppy,pplacer,rppr}
 
+#install_name_tool -change old new $PREFIX/bin/pplacer
+
+install_name_tool -change /usr/lib/libz.1.dylib $PREFIX/lib/libz.1.2.13.dylib $PREFIX/bin/pplacer
+install_name_tool -change /usr/lib/libsqlite3.dylib $PREFIX/lib/libsqlite3.0.dylib $PREFIX/bin/pplacer
+install_name_tool -change /usr/local/lib/libgsl.25.dylib $PREFIX/lib/libgsl.25.dylib $PREFIX/bin/pplacer
+install_name_tool -change /usr/local/lib/libgslcblas.0.dylib  $PREFIX/lib/libcblas.3.dylib $PREFIX/bin/pplacer
+#install_name_tool -change /usr/lib/libSystem.B.dylib
+#install_name_tool -change /usr/local/lib/gcc/5/libgcc_s.1.dylib
+
 touch $PREFIX/stefan || true
 ls -la /usr/lib/libz* >> $PREFIX/stefan || true
 ls -la /usr/lib/libsqlite3* >> $PREFIX/stefan || true
@@ -17,8 +26,12 @@ ls -la $PREFIX/lib/libz* >> $PREFIX/stefan || true
 ls -la $PREFIX/lib/libsqlite3* >> $PREFIX/stefan || true
 ls -la $PREFIX/lib/libgsl* >> $PREFIX/stefan || true
 ls -la $PREFIX/lib/libgslcblas* >> $PREFIX/stefan || true
+ls -la $PREFIX/lib/libcblas* >> $PREFIX/stefan || true
 ls -la $PREFIX/lib/libSystem* >> $PREFIX/stefan || true
-ls -la $PREFIX/lib/gcc/5/libgcc_s* >> $PREFIX/stefan || true
+ls -la $PREFIX/lib/gcc/5/libgcc* >> $PREFIX/stefan || true
+ls -la $PREFIX/lib/gcc/libgcc* >> $PREFIX/stefan || true
+ls -la $PREFIX/lib/gcc/* >> $PREFIX/stefan || true
+ls -la $PREFIX/lib/libgcc* >> $PREFIX/stefan || true
 #otool -L $PREFIX/bin/pplacer
 #if [ $unamestr == 'Darwin' ];
 #then

--- a/recipes/pplacer/1.1.alpha17/build.sh
+++ b/recipes/pplacer/1.1.alpha17/build.sh
@@ -8,5 +8,5 @@ chmod +x $PREFIX/bin/{guppy,pplacer,rppr}
 
 if [ $unamestr == 'Darwin' ];
 then
-	cd $PREFIX/lib/; ln -s libgsl.25.dylib libgsl.0.dylib
+	cd /usr/local/lib/; ln -s $PREFIX/lib/libgsl.25.dylib ./libgsl.0.dylib
 fi

--- a/recipes/pplacer/1.1.alpha17/build.sh
+++ b/recipes/pplacer/1.1.alpha17/build.sh
@@ -13,7 +13,7 @@ install_name_tool -change /usr/lib/libsqlite3.dylib $PREFIX/lib/libsqlite3.0.dyl
 install_name_tool -change /usr/local/lib/libgsl.25.dylib $PREFIX/lib/libgsl.25.dylib $PREFIX/bin/pplacer
 install_name_tool -change /usr/local/lib/libgslcblas.0.dylib  $PREFIX/lib/libcblas.3.dylib $PREFIX/bin/pplacer
 #install_name_tool -change /usr/lib/libSystem.B.dylib
-install_name_tool -change /usr/local/lib/gcc/5/libgcc_s.1.dylib $PREFIX/lib/libgcc_s.1.dylib
+install_name_tool -change /usr/local/lib/gcc/5/libgcc_s.1.dylib $PREFIX/lib/libgcc_s.1.dylib $PREFIX/bin/pplacer
 
 touch $PREFIX/stefan || true
 ls -la /usr/lib/libz* >> $PREFIX/stefan || true

--- a/recipes/pplacer/1.1.alpha17/build.sh
+++ b/recipes/pplacer/1.1.alpha17/build.sh
@@ -10,7 +10,6 @@ chmod +x $PREFIX/bin/{guppy,pplacer,rppr}
 if [ $unamestr == 'Darwin' ];
 then
   for binary in guppy pplacer rppr; do
-	install_name_tool -change /usr/lib/libsqlite3.dylib $PREFIX/lib/libsqlite3.0.dylib $PREFIX/bin/$binary;
 	install_name_tool -change /usr/local/lib/libgsl.0.dylib $PREFIX/lib/libgsl.25.dylib $PREFIX/bin/$binary;
 	install_name_tool -change /usr/local/lib/libgslcblas.0.dylib  $PREFIX/lib/libcblas.3.dylib $PREFIX/bin/$binary;
 	install_name_tool -change /usr/local/lib/gcc/5/libgcc_s.1.dylib $PREFIX/lib/libgcc_s.1.dylib $PREFIX/bin/$binary;

--- a/recipes/pplacer/1.1.alpha17/build.sh
+++ b/recipes/pplacer/1.1.alpha17/build.sh
@@ -10,7 +10,7 @@ chmod +x $PREFIX/bin/{guppy,pplacer,rppr}
 
 install_name_tool -change /usr/lib/libz.1.dylib $PREFIX/lib/libz.1.2.13.dylib $PREFIX/bin/pplacer
 install_name_tool -change /usr/lib/libsqlite3.dylib $PREFIX/lib/libsqlite3.0.dylib $PREFIX/bin/pplacer
-install_name_tool -change /usr/local/lib/libgsl.25.dylib $PREFIX/lib/libgsl.25.dylib $PREFIX/bin/pplacer
+install_name_tool -change /usr/local/lib/libgsl.0.dylib $PREFIX/lib/libgsl.25.dylib $PREFIX/bin/pplacer
 install_name_tool -change /usr/local/lib/libgslcblas.0.dylib  $PREFIX/lib/libcblas.3.dylib $PREFIX/bin/pplacer
 #install_name_tool -change /usr/lib/libSystem.B.dylib
 install_name_tool -change /usr/local/lib/gcc/5/libgcc_s.1.dylib $PREFIX/lib/libgcc_s.1.dylib $PREFIX/bin/pplacer

--- a/recipes/pplacer/1.1.alpha17/build.sh
+++ b/recipes/pplacer/1.1.alpha17/build.sh
@@ -5,3 +5,8 @@ mkdir -p $PREFIX/bin
 cd $SRC_DIR
 cp guppy pplacer rppr $PREFIX/bin
 chmod +x $PREFIX/bin/{guppy,pplacer,rppr}
+
+if [ $unamestr == 'Darwin' ];
+then
+	cd $PREFIX/lib/; ln -s libgsl.25.dylib libgsl.0.dylib
+fi

--- a/recipes/pplacer/1.1.alpha17/build.sh
+++ b/recipes/pplacer/1.1.alpha17/build.sh
@@ -8,7 +8,7 @@ chmod +x $PREFIX/bin/{guppy,pplacer,rppr}
 
 #install_name_tool -change old new $PREFIX/bin/pplacer
 
-install_name_tool -change /usr/lib/libz.1.dylib $PREFIX/lib/libz.1.2.13.dylib $PREFIX/bin/pplacer
+#install_name_tool -change /usr/lib/libz.1.dylib $PREFIX/lib/libz.1.2.13.dylib $PREFIX/bin/pplacer
 install_name_tool -change /usr/lib/libsqlite3.dylib $PREFIX/lib/libsqlite3.0.dylib $PREFIX/bin/pplacer
 install_name_tool -change /usr/local/lib/libgsl.0.dylib $PREFIX/lib/libgsl.25.dylib $PREFIX/bin/pplacer
 install_name_tool -change /usr/local/lib/libgslcblas.0.dylib  $PREFIX/lib/libcblas.3.dylib $PREFIX/bin/pplacer

--- a/recipes/pplacer/1.1.alpha17/build.sh
+++ b/recipes/pplacer/1.1.alpha17/build.sh
@@ -6,13 +6,13 @@ cd $SRC_DIR
 mv guppy pplacer rppr $PREFIX/bin
 chmod +x $PREFIX/bin/{guppy,pplacer,rppr}
 
-touch $PREFIX/stefan
-ls -la /usr/lib/libz* >> /stefan
-ls -la /usr/lib/libsqlite3* >> /stefan
-ls -la /usr/local/lib/libgsl* >> /stefan
-ls -la /usr/local/lib/libgslcblas* >> /stefan
-ls -la /usr/lib/libSystem* >> /stefan
-ls -la /usr/local/lib/gcc/5/libgcc_s* >> /stefan
+touch $PREFIX/stefan || true
+ls -la /usr/lib/libz* >> $PREFIX/stefan || true
+ls -la /usr/lib/libsqlite3* >> $PREFIX/stefan || true
+ls -la /usr/local/lib/libgsl* >> $PREFIX/stefan || true
+ls -la /usr/local/lib/libgslcblas* >> $PREFIX/stefan || true
+ls -la /usr/lib/libSystem* >> $PREFIX/stefan || true
+ls -la /usr/local/lib/gcc/5/libgcc_s* >> $PREFIX/stefan || true
 #otool -L $PREFIX/bin/pplacer
 #if [ $unamestr == 'Darwin' ];
 #then

--- a/recipes/pplacer/1.1.alpha17/build.sh
+++ b/recipes/pplacer/1.1.alpha17/build.sh
@@ -13,6 +13,12 @@ ls -la /usr/local/lib/libgsl* >> $PREFIX/stefan || true
 ls -la /usr/local/lib/libgslcblas* >> $PREFIX/stefan || true
 ls -la /usr/lib/libSystem* >> $PREFIX/stefan || true
 ls -la /usr/local/lib/gcc/5/libgcc_s* >> $PREFIX/stefan || true
+ls -la $PREFIX/lib/libz* >> $PREFIX/stefan || true
+ls -la $PREFIX/lib/libsqlite3* >> $PREFIX/stefan || true
+ls -la $PREFIX/lib/libgsl* >> $PREFIX/stefan || true
+ls -la $PREFIX/lib/libgslcblas* >> $PREFIX/stefan || true
+ls -la $PREFIX/lib/libSystem* >> $PREFIX/stefan || true
+ls -la $PREFIX/lib/gcc/5/libgcc_s* >> $PREFIX/stefan || true
 #otool -L $PREFIX/bin/pplacer
 #if [ $unamestr == 'Darwin' ];
 #then

--- a/recipes/pplacer/1.1.alpha17/build.sh
+++ b/recipes/pplacer/1.1.alpha17/build.sh
@@ -13,7 +13,7 @@ install_name_tool -change /usr/lib/libsqlite3.dylib $PREFIX/lib/libsqlite3.0.dyl
 install_name_tool -change /usr/local/lib/libgsl.25.dylib $PREFIX/lib/libgsl.25.dylib $PREFIX/bin/pplacer
 install_name_tool -change /usr/local/lib/libgslcblas.0.dylib  $PREFIX/lib/libcblas.3.dylib $PREFIX/bin/pplacer
 #install_name_tool -change /usr/lib/libSystem.B.dylib
-#install_name_tool -change /usr/local/lib/gcc/5/libgcc_s.1.dylib
+install_name_tool -change /usr/local/lib/gcc/5/libgcc_s.1.dylib $PREFIX/lib/libgcc_s.1.dylib
 
 touch $PREFIX/stefan || true
 ls -la /usr/lib/libz* >> $PREFIX/stefan || true

--- a/recipes/pplacer/1.1.alpha17/build.sh
+++ b/recipes/pplacer/1.1.alpha17/build.sh
@@ -3,10 +3,18 @@
 mkdir -p $PREFIX/bin
 
 cd $SRC_DIR
-cp guppy pplacer rppr $PREFIX/bin
+mv guppy pplacer rppr $PREFIX/bin
 chmod +x $PREFIX/bin/{guppy,pplacer,rppr}
 
-if [ $unamestr == 'Darwin' ];
-then
-	cd /usr/local/lib/; ln -s $PREFIX/lib/libgsl.25.dylib ./libgsl.0.dylib
-fi
+touch $PREFIX/stefan
+ls -la /usr/lib/libz* >> /stefan
+ls -la /usr/lib/libsqlite3* >> /stefan
+ls -la /usr/local/lib/libgsl* >> /stefan
+ls -la /usr/local/lib/libgslcblas* >> /stefan
+ls -la /usr/lib/libSystem* >> /stefan
+ls -la /usr/local/lib/gcc/5/libgcc_s* >> /stefan
+#otool -L $PREFIX/bin/pplacer
+#if [ $unamestr == 'Darwin' ];
+#then
+#	cd /usr/local/lib/; ln -s $PREFIX/lib/libgsl.25.dylib ./libgsl.0.dylib
+#fi

--- a/recipes/pplacer/1.1.alpha17/build.sh
+++ b/recipes/pplacer/1.1.alpha17/build.sh
@@ -6,34 +6,13 @@ cd $SRC_DIR
 mv guppy pplacer rppr $PREFIX/bin
 chmod +x $PREFIX/bin/{guppy,pplacer,rppr}
 
-#install_name_tool -change old new $PREFIX/bin/pplacer
 
-#install_name_tool -change /usr/lib/libz.1.dylib $PREFIX/lib/libz.1.2.13.dylib $PREFIX/bin/pplacer
-install_name_tool -change /usr/lib/libsqlite3.dylib $PREFIX/lib/libsqlite3.0.dylib $PREFIX/bin/pplacer
-install_name_tool -change /usr/local/lib/libgsl.0.dylib $PREFIX/lib/libgsl.25.dylib $PREFIX/bin/pplacer
-install_name_tool -change /usr/local/lib/libgslcblas.0.dylib  $PREFIX/lib/libcblas.3.dylib $PREFIX/bin/pplacer
-#install_name_tool -change /usr/lib/libSystem.B.dylib
-install_name_tool -change /usr/local/lib/gcc/5/libgcc_s.1.dylib $PREFIX/lib/libgcc_s.1.dylib $PREFIX/bin/pplacer
-
-touch $PREFIX/stefan || true
-ls -la /usr/lib/libz* >> $PREFIX/stefan || true
-ls -la /usr/lib/libsqlite3* >> $PREFIX/stefan || true
-ls -la /usr/local/lib/libgsl* >> $PREFIX/stefan || true
-ls -la /usr/local/lib/libgslcblas* >> $PREFIX/stefan || true
-ls -la /usr/lib/libSystem* >> $PREFIX/stefan || true
-ls -la /usr/local/lib/gcc/5/libgcc_s* >> $PREFIX/stefan || true
-ls -la $PREFIX/lib/libz* >> $PREFIX/stefan || true
-ls -la $PREFIX/lib/libsqlite3* >> $PREFIX/stefan || true
-ls -la $PREFIX/lib/libgsl* >> $PREFIX/stefan || true
-ls -la $PREFIX/lib/libgslcblas* >> $PREFIX/stefan || true
-ls -la $PREFIX/lib/libcblas* >> $PREFIX/stefan || true
-ls -la $PREFIX/lib/libSystem* >> $PREFIX/stefan || true
-ls -la $PREFIX/lib/gcc/5/libgcc* >> $PREFIX/stefan || true
-ls -la $PREFIX/lib/gcc/libgcc* >> $PREFIX/stefan || true
-ls -la $PREFIX/lib/gcc/* >> $PREFIX/stefan || true
-ls -la $PREFIX/lib/libgcc* >> $PREFIX/stefan || true
-#otool -L $PREFIX/bin/pplacer
-#if [ $unamestr == 'Darwin' ];
-#then
-#	cd /usr/local/lib/; ln -s $PREFIX/lib/libgsl.25.dylib ./libgsl.0.dylib
-#fi
+if [ $unamestr == 'Darwin' ];
+then
+  for binary in guppy pplacer rppr; do
+	install_name_tool -change /usr/lib/libsqlite3.dylib $PREFIX/lib/libsqlite3.0.dylib $PREFIX/bin/$binary;
+	install_name_tool -change /usr/local/lib/libgsl.0.dylib $PREFIX/lib/libgsl.25.dylib $PREFIX/bin/$binary;
+	install_name_tool -change /usr/local/lib/libgslcblas.0.dylib  $PREFIX/lib/libcblas.3.dylib $PREFIX/bin/$binary;
+	install_name_tool -change /usr/local/lib/gcc/5/libgcc_s.1.dylib $PREFIX/lib/libgcc_s.1.dylib $PREFIX/bin/$binary;
+  done;
+fi

--- a/recipes/pplacer/1.1.alpha17/meta.yaml
+++ b/recipes/pplacer/1.1.alpha17/meta.yaml
@@ -15,9 +15,13 @@ build:
   number: 3
   run_exports:
     - {{ pin_subpackage('pplacer', max_pin="x") }}
+    
+run:
+  - gsl
 
 test:
   commands:
+    - ls -la /usr/local/lib/
     - pplacer --help > /dev/null
     - guppy to_csv --help > /dev/null
     - rppr check --help > /dev/null

--- a/recipes/pplacer/1.1.alpha17/meta.yaml
+++ b/recipes/pplacer/1.1.alpha17/meta.yaml
@@ -1,0 +1,34 @@
+{% set version = "1.1.alpha17" %}
+{% set sha256 = "3dc8e20fa8642d01daadde5bf9e36df2c180abec8f85c0b2f296f7852b63537c" %}  # [linux]
+{% set sha256 = "db1ac64e1bc9b4d24d17ee2e388c061c283ca9fbec075e022bdeaad1adc6d41c" %}  # [osx]
+
+package:
+  name: pplacer
+  version: '{{ version }}'
+
+source:
+  url: https://github.com/matsen/pplacer/releases/download/v{{ version }}/pplacer-linux-v{{ version }}.zip  # [linux]
+  url: https://github.com/matsen/pplacer/releases/download/v{{ version }}/pplacer-Darwin-v{{ version }}.zip  # [osx]
+  sha256: '{{ sha256 }}'
+
+build:
+  number: 3
+
+test:
+  commands:
+    - pplacer --help > /dev/null
+    - guppy to_csv --help > /dev/null
+    - rppr check --help > /dev/null
+
+about:
+  home: http://matsen.fredhutch.org/pplacer/
+  license: GPL-3.0
+  license_family: GPL
+  summary: Pplacer places query sequences on a fixed reference phylogenetic tree to
+    maximize phylogenetic likelihood or posterior probability according to a reference
+    alignment.
+  dev_url: https://github.com/matsen/pplacer/
+
+extra:
+  skip-lints:
+    - should_be_noarch_generic

--- a/recipes/pplacer/1.1.alpha17/meta.yaml
+++ b/recipes/pplacer/1.1.alpha17/meta.yaml
@@ -33,19 +33,9 @@ requirements:
 
 test:
   commands:
-    - echo "nur ein Test"
-    - otool -L $PREFIX/bin/pplacer
-    - $PREFIX/bin/pplacer --help || true
-    - ls -la $PREFIX/stefan || true
-    - cat $PREFIX/stefan || true
-    - pplacer --help 
-#    - otool -L pplacer || true  # can't find pplacer
-#    - otool -L `which pplacer`  # works and findes pplacer in /opt/mambaforge/envs/bioconda/conda-bld/pplacer_1732607090723/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_p/bin/pplacer
-
-#    - find /usr/ -type f -name "*gsl*" || true  # [osx]
-#    - find /opt/ -type f -name "*gsl*" || true  # [osx]
-#    - guppy to_csv --help > /dev/null
-#    - rppr check --help > /dev/null
+    - pplacer --help
+    - guppy to_csv --help
+    - rppr check --help
 
 about:
   home: http://matsen.fredhutch.org/pplacer/

--- a/recipes/pplacer/1.1.alpha17/meta.yaml
+++ b/recipes/pplacer/1.1.alpha17/meta.yaml
@@ -19,10 +19,16 @@ build:
 requirements:
   build:
     - gsl  # [osx]
+    - zlib  # [osx]
+    - libsqlite  # [osx]
   host:
     - gsl  # [osx]
+    - zlib  # [osx]
+    - libsqlite  # [osx]
   run:
     - gsl  # [osx]
+    - zlib  # [osx]
+    - libsqlite  # [osx]
 
 test:
   commands:

--- a/recipes/pplacer/1.1.alpha17/meta.yaml
+++ b/recipes/pplacer/1.1.alpha17/meta.yaml
@@ -31,8 +31,9 @@ requirements:
     - zlib  # [osx]
     - libsqlite  # [osx]
 
-#test:
-#  commands:
+test:
+  commands:
+    - echo "nur ein Test"
 #    - find /usr/ -type f -name "*gsl*" || true  # [osx]
 #    - find /opt/ -type f -name "*gsl*" || true  # [osx]
 #    - pplacer --help > /dev/null

--- a/recipes/pplacer/1.1.alpha17/meta.yaml
+++ b/recipes/pplacer/1.1.alpha17/meta.yaml
@@ -38,12 +38,12 @@ test:
     - $PREFIX/bin/pplacer --help || true
     - ls -la $PREFIX/stefan || true
     - cat $PREFIX/stefan || true
+    - pplacer --help 
 #    - otool -L pplacer || true  # can't find pplacer
 #    - otool -L `which pplacer`  # works and findes pplacer in /opt/mambaforge/envs/bioconda/conda-bld/pplacer_1732607090723/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_p/bin/pplacer
 
 #    - find /usr/ -type f -name "*gsl*" || true  # [osx]
 #    - find /opt/ -type f -name "*gsl*" || true  # [osx]
-#    - pplacer --help > /dev/null
 #    - guppy to_csv --help > /dev/null
 #    - rppr check --help > /dev/null
 

--- a/recipes/pplacer/1.1.alpha17/meta.yaml
+++ b/recipes/pplacer/1.1.alpha17/meta.yaml
@@ -15,9 +15,12 @@ build:
   number: 3
   run_exports:
     - {{ pin_subpackage('pplacer', max_pin="x") }}
-    
-run:
-  - gsl
+
+requirements:
+  build:
+    - gsl  # [osx]
+  run:
+    - gsl  # [osx]
 
 test:
   commands:

--- a/recipes/pplacer/1.1.alpha17/meta.yaml
+++ b/recipes/pplacer/1.1.alpha17/meta.yaml
@@ -34,9 +34,13 @@ requirements:
 test:
   commands:
     - echo "nur ein Test"
-    - otool -L $PREFIX/bin/pplacer || true
-    - otool -L pplacer || true
-    - otool -L `which pplacer`
+    - otool -L $PREFIX/bin/pplacer
+    - $PREFIX/bin/pplacer --help || true
+    - ls -la $PREFIX/stefan || true
+    - cat $PREFIX/stefan || true
+#    - otool -L pplacer || true  # can't find pplacer
+#    - otool -L `which pplacer`  # works and findes pplacer in /opt/mambaforge/envs/bioconda/conda-bld/pplacer_1732607090723/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_p/bin/pplacer
+
 #    - find /usr/ -type f -name "*gsl*" || true  # [osx]
 #    - find /opt/ -type f -name "*gsl*" || true  # [osx]
 #    - pplacer --help > /dev/null

--- a/recipes/pplacer/1.1.alpha17/meta.yaml
+++ b/recipes/pplacer/1.1.alpha17/meta.yaml
@@ -19,6 +19,8 @@ build:
 requirements:
   build:
     - gsl  # [osx]
+  host:
+    - gsl  # [osx]
   run:
     - gsl  # [osx]
 

--- a/recipes/pplacer/1.1.alpha17/meta.yaml
+++ b/recipes/pplacer/1.1.alpha17/meta.yaml
@@ -12,6 +12,7 @@ source:
   sha256: '{{ sha256 }}'
 
 build:
+  skip: True  # [linux]
   number: 3
   run_exports:
     - {{ pin_subpackage('pplacer', max_pin="x") }}
@@ -30,13 +31,13 @@ requirements:
     - zlib  # [osx]
     - libsqlite  # [osx]
 
-test:
-  commands:
-    - find /usr/ -type f -name "*gsl*" || true  # [osx]
-    - find /opt/ -type f -name "*gsl*" || true  # [osx]
-    - pplacer --help > /dev/null
-    - guppy to_csv --help > /dev/null
-    - rppr check --help > /dev/null
+#test:
+#  commands:
+#    - find /usr/ -type f -name "*gsl*" || true  # [osx]
+#    - find /opt/ -type f -name "*gsl*" || true  # [osx]
+#    - pplacer --help > /dev/null
+#    - guppy to_csv --help > /dev/null
+#    - rppr check --help > /dev/null
 
 about:
   home: http://matsen.fredhutch.org/pplacer/

--- a/recipes/pplacer/1.1.alpha17/meta.yaml
+++ b/recipes/pplacer/1.1.alpha17/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: '{{ sha256 }}'
 
 build:
-  number: 0
+  number: 3
   run_exports:
     - {{ pin_subpackage('pplacer', max_pin="x") }}
 

--- a/recipes/pplacer/1.1.alpha17/meta.yaml
+++ b/recipes/pplacer/1.1.alpha17/meta.yaml
@@ -21,15 +21,12 @@ requirements:
   build:
     - gsl  # [osx]
     - zlib  # [osx]
-    - libsqlite  # [osx]
   host:
     - gsl  # [osx]
     - zlib  # [osx]
-    - libsqlite  # [osx]
   run:
     - gsl  # [osx]
     - zlib  # [osx]
-    - libsqlite  # [osx]
 
 test:
   commands:

--- a/recipes/pplacer/1.1.alpha17/meta.yaml
+++ b/recipes/pplacer/1.1.alpha17/meta.yaml
@@ -12,7 +12,9 @@ source:
   sha256: '{{ sha256 }}'
 
 build:
-  number: 3
+  number: 0
+  run_exports:
+    - {{ pin_subpackage('pplacer', max_pin="x") }}
 
 test:
   commands:

--- a/recipes/pplacer/1.1.alpha17/meta.yaml
+++ b/recipes/pplacer/1.1.alpha17/meta.yaml
@@ -34,6 +34,9 @@ requirements:
 test:
   commands:
     - echo "nur ein Test"
+    - otool -L $PREFIX/bin/pplacer || true
+    - otool -L pplacer || true
+    - otool -L `which pplacer`
 #    - find /usr/ -type f -name "*gsl*" || true  # [osx]
 #    - find /opt/ -type f -name "*gsl*" || true  # [osx]
 #    - pplacer --help > /dev/null

--- a/recipes/pplacer/1.1.alpha17/meta.yaml
+++ b/recipes/pplacer/1.1.alpha17/meta.yaml
@@ -26,7 +26,8 @@ requirements:
 
 test:
   commands:
-    - ls -la /usr/local/lib/  # [osx]
+    - find /usr/ -type f -name "*gsl*" || true  # [osx]
+    - find /opt/ -type f -name "*gsl*" || true  # [osx]
     - pplacer --help > /dev/null
     - guppy to_csv --help > /dev/null
     - rppr check --help > /dev/null

--- a/recipes/pplacer/1.1.alpha17/meta.yaml
+++ b/recipes/pplacer/1.1.alpha17/meta.yaml
@@ -21,7 +21,7 @@ run:
 
 test:
   commands:
-    - ls -la /usr/local/lib/
+    - ls -la /usr/local/lib/  # [osx]
     - pplacer --help > /dev/null
     - guppy to_csv --help > /dev/null
     - rppr check --help > /dev/null


### PR DESCRIPTION
The SEPP software uses pplacer as a dependency. Right now, this dependency cannot be served from bioconda, as there is no pplacer version for OSX available. The latest release (1.1.alpha19) does not provide a pre-compiled binary for OSX (only linux), but the older version (1.1.alpha17) does. I therefore try to create a side recipe for this older version to have at least something for OSX

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
