### PR TITLE
Add linux-aarch64 to perl-extutils-cppguess and perl-set-intervaltree

### DIFF
--- a/recipes/perl-extutils-cppguess/meta.yaml
+++ b/recipes/perl-extutils-cppguess/meta.yaml
@@ -11,7 +11,8 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 2
+  run_exports: '{{ pin_subpackage(name,  max_pin="x.x") }}'
 
 requirements:
   build:
@@ -33,6 +34,12 @@ requirements:
 test:
   imports:
     - ExtUtils::CppGuess
+
+extra:
+  additional-platforms:
+    - linux-aarch64
+#   requires: perl-data-dumper feedstock to be enabled in conda
+#    - osx-arm64
 
 about:
   home: http://metacpan.org/pod/ExtUtils::CppGuess

--- a/recipes/perl-set-intervaltree/meta.yaml
+++ b/recipes/perl-set-intervaltree/meta.yaml
@@ -1,12 +1,12 @@
 {% set version = "0.12" %}
-{% set name = "Set-IntervalTree" %}
+{% set name = "perl-set-intervaltree" %}
 
 package:
-  name: perl-{{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://cpan.metacpan.org/authors/id/S/SL/SLOYD/{{ name }}-{{ version }}.tar.gz
+  url: https://cpan.metacpan.org/authors/id/S/SL/SLOYD/Set-IntervalTree-{{ version }}.tar.gz
   sha256: 6fd4000e4022968e2ce5b83c07b189219ef1925ecb72977b52a6f7d76adbc349
 
 build:

--- a/recipes/perl-set-intervaltree/meta.yaml
+++ b/recipes/perl-set-intervaltree/meta.yaml
@@ -10,7 +10,8 @@ source:
   sha256: 6fd4000e4022968e2ce5b83c07b189219ef1925ecb72977b52a6f7d76adbc349
 
 build:
-  number: 3
+  number: 4
+  run_exports: '{{ pin_subpackage(name,  max_pin="x.x") }}'
 
 requirements:
   build:
@@ -26,6 +27,12 @@ requirements:
 test:
   imports:
     - Set::IntervalTree
+
+extra:
+  additional-platforms:
+    - linux-aarch64
+#   requires: perl-data-dumper feedstock to be enabled in conda, perl-extutils-cppguess in bioconda
+#    - osx-arm64
 
 about:
   home: https://metacpan.org/pod/Set::IntervalTree


### PR DESCRIPTION
Adds linux-aarch64 to perl-extutils-cppguess and perl-set-intervaltree, and documents requirement for adding osx-arm64
