### PR TITLE
Create meta.yaml for drug2cell

### DIFF
--- a/recipes/drug2cell/meta.yaml
+++ b/recipes/drug2cell/meta.yaml
@@ -1,0 +1,36 @@
+{% set name = "drug2cell" %}
+{% set version = "main" %}
+{% set sha256 = "a6353f989f92f05b36972d42795f7f071245d351bf05027dc7e3e4a074ea5bb8" %}
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+source:
+  url: https://github.com/teichlab/drug2cell/archive/main.tar.gz
+  sha256: {{ sha256 }}
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+    - anndata
+    - pandas
+    - numpy
+    - statsmodels
+    - scipy  
+    - blitzgsea
+    
+#test:
+  #commands:
+    #- drug2cell --version
+about:
+  home: https://github.com/teichlab/drug2cell/
+  license: MIT
+  license_file: LICENSE
+  summary: "This is a collection of utility functions for gene group activity evaluation in scanpy"
+


### PR DESCRIPTION
I am attempting to create a conda recipe for drug2cell tool, the package is successful expect for the test section that I commented out in the meta.yaml file.

## Package Plan ##

environment location: 
/opt/anaconda3/envs/drug2cell/opt/anaconda3/conda-bld/osx-arm64/drug2cell-main-py312_0.tar.bz2
    
