### PR TITLE
Add mm2plus recipe to Bioconda

### DIFF
--- a/recipes/mm2plus/LICENSE.txt
+++ b/recipes/mm2plus/LICENSE.txt
@@ -1,0 +1,47 @@
+This software constitutes a joint work and the contributions of individual
+authors are subject to different licenses.  Contributions and licenses are
+listed in the applicable source files, with specific details on each
+individual contribution captured in the revision control system.
+
+--
+For all code, except as indicated otherwise:
+
+PUBLIC DOMAIN NOTICE
+
+This software is freely available to the public for use
+without a copyright notice. Restrictions cannot be placed on its present or
+future use.
+
+--
+For code used from minimap2:
+
+URL: https://lh3.github.io/minimap2
+
+The MIT License
+
+Copyright (c) 2018-     Dana-Farber Cancer Institute
+              2017-2018 Broad Institute, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+--
+For code used from mm2-fast:
+Copyright (C) 2021 Intel Corporation

--- a/recipes/mm2plus/build.sh
+++ b/recipes/mm2plus/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+mkdir -p $PREFIX/bin
+cp mm2plus* $PREFIX/bin

--- a/recipes/mm2plus/conda_build_config.yaml
+++ b/recipes/mm2plus/conda_build_config.yaml
@@ -1,0 +1,5 @@
+# current version does not build with newer compilers
+cxx_compiler_version:
+  - 11  # [linux]
+c_compiler_version:
+  - 11  # [linux]

--- a/recipes/mm2plus/meta.yaml
+++ b/recipes/mm2plus/meta.yaml
@@ -1,0 +1,38 @@
+{% set version = "1.0" %}
+
+package:
+  name: mm2plus
+  version: {{ version }}
+
+source:
+  url: "https://github.com/at-cg/mm2-plus/releases/download/v{{ version }}/mm2-plus-{{ version }}_x64-linux.tar.bz2"
+  sha256: "e5b4fc2e12a475bdb46bfdbdfc563d2bae02a908f8e6f4a2c55d759e84d240de"
+
+build:
+  number: 1
+
+requirements:
+  build:
+    - make
+    - {{ compiler('cxx') }}
+  host:
+    - zlib
+
+test:
+  commands:
+    - mm2plus --version
+    - mm2plus.sse4.1 --version
+    - mm2plus.sse4.2 --version
+    - mm2plus.avx --version
+    - mm2plus.avx2 --version
+    - mm2plus.avx512 --version
+
+about:
+  home: https://github.com/at-cg/mm2-plus
+  license: MIT
+  license_file: LICENSE.txt
+  summary: Fast long-read mapper and whole-genome aligner (accelerated version of minimap2)
+
+extra:
+  identifiers:
+    - doi:10.1101/2024.11.25.625328


### PR DESCRIPTION
# Add recipe for mm2plus (v1.0)

This PR adds the `mm2plus` recipe to Bioconda. The package provides optimized binaries for the `minimap2` long-read mapper and whole-genome aligner, supporting various CPU instruction sets.

## Key Details:
- **Package name:** `mm2plus`
- **Version:** 1.0
- **Source:** [mm2plus GitHub releases](https://github.com/at-cg/mm2-plus/releases)
- **Supported platform:** Linux (x86_64)
- **Recipe components:** `meta.yaml`.

## Testing:
- **Test Commands:**
  The recipe verifies the installation by running the following commands:
  - `mm2plus --version`
  - `mm2plus.sse4.1 --version`
  - `mm2plus.sse4.2 --version`
  - `mm2plus.avx --version`
  - `mm2plus.avx2 --version`
  - `mm2plus.avx512 --version`
- The recipe has been tested locally using `conda-build` and `bioconda-utils`.
- Successfully installs all supported binaries and validates them.

## Checklist:
- [x] `meta.yaml` is properly formatted and follows Bioconda guidelines.
- [x] Build script utilizes `{{ compiler('cxx') }}` for cross-platform compatibility.
- [x] Dependencies (`zlib`, `make`) are explicitly included.
- [x] The `test` section ensures all binaries are tested post-installation.
- [x] The recipe adheres to Bioconda contribution guidelines.

## Additional Notes:
- The binaries are downloaded directly from the official [GitHub releases page](https://github.com/at-cg/mm2-plus/releases).
- The `about` section includes a DOI for reference: `doi:10.1101/2024.11.25.625328`.

Thank you for reviewing this PR! Please let me know if any changes or improvements are required.