### PR TITLE
Use `runs-on: ubuntu-22.04` instead of `ubuntu-latest`

### DIFF
--- a/.github/workflows/Bulk.yml
+++ b/.github/workflows/Bulk.yml
@@ -7,7 +7,7 @@ jobs:
   build-linux:
     name: Bulk Linux Builds
     if: "contains(github.event.head_commit.message, '[ci run]')"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       max-parallel: 6

--- a/.github/workflows/CommentResponder.yml
+++ b/.github/workflows/CommentResponder.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   comment:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: bioconda-bot comment
     if: >-
       (
@@ -31,7 +31,7 @@ jobs:
       run: bioconda-bot comment
 
   repost:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: bioconda-bot repost
     if: >-
       (
@@ -53,7 +53,7 @@ jobs:
       run: bioconda-bot comment
 
   merge:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: bioconda-bot merge
     if: >-
       (
@@ -78,7 +78,7 @@ jobs:
           for merging the PR.
 
   update:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: bioconda-bot update
     if: >-
       (

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -8,7 +8,7 @@ concurrency:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: true
       max-parallel: 13
@@ -54,7 +54,7 @@ jobs:
 
   build-linux:
     name: Linux Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: true
       max-parallel: 13

--- a/.github/workflows/build-failures.yml
+++ b/.github/workflows/build-failures.yml
@@ -14,7 +14,7 @@ jobs:
   update-build-failure-page:
     name: Update build failure page
     if: ${{ github.repository == 'bioconda/bioconda-recipes' && !contains(github.event.head_commit.message, '[ci skip]') }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -7,7 +7,7 @@ jobs:
   build-linux:
     name: Linux Upload
     if: github.repository == 'bioconda/bioconda-recipes'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       max-parallel: 13


### PR DESCRIPTION
ubuntu-latest soon will be re-linked to ubuntu-24.04 and this may lead to problems because it provides less pre-installed software

The upgrade to 24.04 should be done intentionally with another PR.

See
https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#ubuntu-latest-upcoming-breaking-changes and https://github.com/actions/runner-images/issues/10636

Describe your pull request here

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
