### PR TITLE
Bump up abnumber to 0.4.2

### DIFF
--- a/recipes/abnumber/meta.yaml
+++ b/recipes/abnumber/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.4.1" %} # Remember to update sha256 below
+{% set version = "0.4.2" %} # Remember to update sha256 below
 
 package:
   name: abnumber
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/prihoda/abnumber/archive/v{{ version }}.tar.gz
-  sha256: '240c7ccc1f85607ffdd0109f19761ab0488a059ae15e3ccd6066ef36c192a047'
+  sha256: 'b816fee3db6c018f6963a5e4ce2d23b2889251fb42b7b93d42e81805cd418bc5'
 
 build:
   noarch: python

--- a/recipes/abnumber/meta.yaml
+++ b/recipes/abnumber/meta.yaml
@@ -19,6 +19,7 @@ requirements:
   host:
     - python >=3.6
     - pip
+    - setuptools
   run:
     - python >=3.6
     - biopython


### PR DESCRIPTION
Bump up abnumber to 0.4.2 https://github.com/prihoda/AbNumber/releases/tag/v0.4.2