### PR TITLE
ngscheckmate: bump the build - attempt to get aarch64 installing

### DIFF
--- a/recipes/ngscheckmate/meta.yaml
+++ b/recipes/ngscheckmate/meta.yaml
@@ -9,7 +9,7 @@ source:
   md5: 42d4578e02a81e4e55857f126ae719af
 
 build:
-  number: 1
+  number: 2
   noarch: generic
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x') }}


### PR DESCRIPTION
ngscheckmate is a noarch-generic package - and yet on linux-aarch64, a freshly installed conda environment and in rocky9 linux:
```
Could not solve for environment specs
The following packages are incompatible
├─ ngscheckmate is installable with the potential options
│  ├─ ngscheckmate 1.0.0 would require
│  │  └─ python 2.7.18.* , which does not exist (perhaps a missing channel);
│  ├─ ngscheckmate 1.0.0 would require
│  │  └─ bcftools 1.3.1.* , which does not exist (perhaps a missing channel);
│  └─ ngscheckmate 1.0.1 would require
│     └─ python [2.* |2.7.* ] with the potential options
│        ├─ python 2.7.15, which can be installed;
│        └─ python 2.7.15 would require
│           └─ openssl >=1.0.2p,<1.0.3a , which does not exist (perhaps a missing channel);
└─ pin-1 is not installable because it requires
   └─ python 3.12.* , which conflicts with any installable versions previously reported.
```

Nothing in the recipe is pinning it to bcftools 1.3.1 - which likely predates linux-aarch64 addition (now at 1.21...).  So am wondering if this just means trigger a new build to store the updated dependencies.