### PR TITLE
maxbin2: start enabling linux-aarch64

### DIFF
--- a/recipes/maxbin2/meta.yaml
+++ b/recipes/maxbin2/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - bowtie2
     - hmmer
     - idba
-    - perl =5.26
+    - perl
     - perl-libwww-perl
     - r-base
     - r-gplots

--- a/recipes/maxbin2/meta.yaml
+++ b/recipes/maxbin2/meta.yaml
@@ -5,6 +5,9 @@
 build:
   number: 6
   skip: true  # [osx]
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x") }}
+
 
 package:
   name: {{ name }}
@@ -25,7 +28,7 @@ requirements:
     - hmmer
     - idba
     - perl=5.26
-    - perl-lwp-simple
+    - perl-libwww-perl
     - r-base
     - r-gplots
     - tar
@@ -39,6 +42,8 @@ about:
   summary: "MaxBin is software for binning assembled metagenomic sequences based on an Expectation-Maximization algorithm."
 
 extra:
+  additional-platforms:
+    - linux-aarch64
   recipe-maintainers:
     - colinbrislawn
     - keuv-grvl

--- a/recipes/maxbin2/meta.yaml
+++ b/recipes/maxbin2/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - bowtie2
     - hmmer
     - idba
-    - perl=5.26
+    - perl =5.26
     - perl-libwww-perl
     - r-base
     - r-gplots

--- a/recipes/maxbin2/meta.yaml
+++ b/recipes/maxbin2/meta.yaml
@@ -3,7 +3,7 @@
 {% set sha256 = "cb6429e857280c2b75823c8cd55058ed169c93bc707a46bde0c4383f2bffe09e" %}
 
 build:
-  number: 6
+  number: 7
   skip: true  # [osx]
   run_exports:
     - {{ pin_subpackage(name, max_pin="x") }}


### PR DESCRIPTION
- Replace perl-lwp-simple with perl-libwww-perl.
- perl-lwp-simple is blacklisted and only installs perl-libwww-perl these days, so let's cut out and go direct to perl-libwww-perl.
- perl-libwww-perl itself is in conda-forge - but required missing perl-mime-base64 for linux-aarch64 (https://github.com/conda-forge/perl-mime-base64-feedstock/pull/2).  Once that's merged and built, this PR should be retested.