### PR TITLE
(Don't merge)test bifrost arm on circleci 

### DIFF
--- a/recipes/bifrost/meta.yaml
+++ b/recipes/bifrost/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: e1b2491328b0cc1a32e433a8a9780f05547fa4b8d674b58abdda9ac8809f5341
 
 build:
-  number: 1
+  number: 3
   # v1.3.0 breaks Bifrost Index File (.bfi) compatibility with previous Bifrost versions
   run_exports:
     - {{ pin_subpackage('bifrost', max_pin="x.x") }}


### PR DESCRIPTION
bifrost is failing on osx-arm64 on github actions. I want to see if it still works on CircleCI like the last PR or if something in the pinnings update broke it.