### PR TITLE
Change osx-arm to osx-arm64 in additional targets

### DIFF
--- a/recipes/alevin-fry/meta.yaml
+++ b/recipes/alevin-fry/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage("alevin-fry", max_pin="x.x") }}
     
@@ -39,4 +39,4 @@ about:
 extra:
   additional-platforms:
     - linux-aarch64
-    - osx-arm
+    - osx-arm64


### PR DESCRIPTION
This PR changes 'osx-arm' to 'osx-arm64' in additional targets so as to build for the proper OSX arm target.
