### PR TITLE
Add AmpliconTyper

### DIFF
--- a/recipes/amplicontyper/meta.yaml
+++ b/recipes/amplicontyper/meta.yaml
@@ -1,0 +1,57 @@
+{% set name = "AmpliconTyper" %}
+{% set version = "0.1.27" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/AntonS-bio/AmpliconTyper/archive/{{ version }}.tar.gz
+  sha256: e25b71eca63e62c56baffa0a447872aa48b1327ece16e6463ed3527d5389928a
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  run_exports:
+      - {{ pin_subpackage('amplicontyper', max_pin="x.x") }}  
+  number: 0
+
+requirements:
+  build:
+    - setuptools
+  host:
+    - pip
+    - python >=3.10
+    - setuptools
+  run:
+    - setuptools
+    - python >=3.10
+    - pandas >=2.0.0
+    - scikit-learn >=1.3.*
+    - pysam >=0.22.0
+    - numpy >=1.20.*
+    - tqdm >=4.66.*
+    - biopython >=1.78
+    - minimap2
+    - requests
+    - samtools
+
+test:
+  commands:
+    - train -h
+  requires:
+    - pip
+
+about:
+  license: GPL-3.0-only
+  license_file: LICENSE
+  home: https://github.com/AntonS-bio/AmpliconTyper
+  summary: 'Tool for training model and classifying reads from environmental ONT amplicon sequencing.'
+  description: |
+    Tool for training model and classifying reads from environmental ONT amplicon sequencing. 
+  doc_source_url: https://github.com/AntonS-bio/AmpliconTyper/blob/main/README.md
+
+
+extra:
+  recipe-maintainers:
+    - AntonS-bio


### PR DESCRIPTION
This package allows to genotype and detect AMR mutation in ONT sequenced amplicons.

Current use cases are Salmonella Typhi and Salmonella Paratyphi.

