### PR TITLE
ECTyper v2.0.0 build #1 now with fixed automatic database init

### DIFF
--- a/recipes/ectyper/meta.yaml
+++ b/recipes/ectyper/meta.yaml
@@ -10,7 +10,7 @@ source:
     sha256: bb363f61ca69d2118e855199d7f9046185bb054509cd0762083b4beec2b8c00e  
 
 build:
-    number: 0
+    number: 1
     noarch: python
     run_exports:
         - {{ pin_subpackage(name, max_pin="x") }}

--- a/recipes/ectyper/post-link.sh
+++ b/recipes/ectyper/post-link.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 echo "Downloading and initializing species identification data (NCBI RefSeq MASH sketch and  assembly metadata) ..."
-python3 -c "from ectyper.speciesIdentification import get_refseq_mash_and_assembly_summary; get_refseq_mash_and_assembly_summary()"
+ectyper_init
 echo "Initialization completed"


### PR DESCRIPTION
Initial build 0 for ectyper v2.0.0 had obsolete database `post-link.sh` script that requires update with integrated utility `ectyper_init`. This will ensure that resulting recipe will be complete and images will be complete with all databases initialized. This is a very small but important script 