### PR TITLE
add recipe for pymethylation_utils pypi package

### DIFF
--- a/recipes/pymethylation_utils/meta.yaml
+++ b/recipes/pymethylation_utils/meta.yaml
@@ -13,6 +13,8 @@ build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
+  run_exports:
+    - {{ pin_subpackage('pymethylation_utils', max_pin="x.x") }}
 
 requirements:
   host:
@@ -25,11 +27,12 @@ test:
   imports:
     - pymethylation_utils
   commands:
-    - pip check
+    - python -c "import pymethylation_utils; print(pymethylation_utils.__version__)"  # Verify the version
   requires:
     - pip
 
 about:
+  home: "https://github.com/SebastianDall/pymethylation_utils"
   summary: Python wrapper for the methylation_utils Rust binary
   license: MIT
   license_file: LICENSE

--- a/recipes/pymethylation_utils/meta.yaml
+++ b/recipes/pymethylation_utils/meta.yaml
@@ -1,0 +1,39 @@
+{% set name = "pymethylation_utils" %}
+{% set version = "0.4.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/pymethylation_utils-{{ version }}.tar.gz
+  sha256: 310e976c5abf7b555b1525a3e25ed89193af0a04fea0d02c93dc85c4a252f8b7
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+
+test:
+  imports:
+    - pymethylation_utils
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  summary: Python wrapper for the methylation_utils Rust binary
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - SebastianDall


### PR DESCRIPTION
A python wrapper for [methylation_utils](https://github.com/SebastianDall/methylation_utils), which processes a methylation pileup file created with [modkit](https://github.com/nanoporetech/modkit). It finds the contig methylation pattern of predefined motifs. This package is a dependency of a new release in [Nanomotif](https://github.com/MicrobialDarkMatter/nanomotif), which is able to find motifs in metagenomic samples. Nanomotif is also on bioconda.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
