### PR TITLE
Add PyTorch 2.x (CPU-only) dependency for immuneML

### DIFF
--- a/recipes/immuneml/meta.yaml
+++ b/recipes/immuneml/meta.yaml
@@ -52,7 +52,7 @@ requirements:
     - olga >=1.2.4
     - tensorflow >=2.12.0
     - keras >=2.12.0
-    - pytorch 2.5.1
+    - pytorch=2.*=cpu_*
 
 test:
   imports:

--- a/recipes/immuneml/meta.yaml
+++ b/recipes/immuneml/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 788591fe4d792ede77d5916489d36aab366ceae7ae411fa699b6aea486e9713f
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<39 or py>311 or target_platform == "osx-64"]#
   run_exports:
     - {{ pin_subpackage('immuneml', max_pin="x") }}

--- a/recipes/immuneml/meta.yaml
+++ b/recipes/immuneml/meta.yaml
@@ -52,7 +52,7 @@ requirements:
     - olga >=1.2.4
     - tensorflow >=2.12.0
     - keras >=2.12.0
-    - pytorch=2.*=cpu_*
+    - pytorch >=2.* cpu_*
 
 test:
   imports:

--- a/recipes/immuneml/meta.yaml
+++ b/recipes/immuneml/meta.yaml
@@ -52,6 +52,7 @@ requirements:
     - olga >=1.2.4
     - tensorflow >=2.12.0
     - keras >=2.12.0
+    - pytorch 2.5.1
 
 test:
   imports:


### PR DESCRIPTION
This PR updates the `immuneML` recipe to include `pytorch=2.*=cpu_*` as a dependency, ensuring compatibility for systems without GPU support. 


