### PR TITLE
Remove openssh requirement

### DIFF
--- a/recipes/r-spacexr/meta.yaml
+++ b/recipes/r-spacexr/meta.yaml
@@ -7,7 +7,7 @@ source:
   sha256: 7d980ecea377a0e2131a87c3ff2b66f512ac69ecc96c2e2b8c1dd4d4f02403f8
 
 build:
-  number: 1
+  number: 2
   noarch: generic  # Specify that the package is noarch
   run_exports: '{{ pin_compatible("r-spacexr", max_pin="x.x") }}'
   rpaths:
@@ -66,7 +66,6 @@ requirements:
     - r-scales
     - r-lifecycle
     - r-evaluate
-    - openssh
 test:
   commands:
     - $R -e "library(spacexr)"


### PR DESCRIPTION
Adding the openssh requirement here still could not overcome the error in the Galaxy tool which is related to ssh. Removing the dependency here and adding the requirement in the tool should hopefully fix it.