### PR TITLE
try reverting star build.sh

### DIFF
--- a/recipes/star/build.sh
+++ b/recipes/star/build.sh
@@ -1,15 +1,8 @@
 #!/bin/bash
-
-export INCLUDES="-I${PREFIX}/include"
-export LIBPATH="-L${PREFIX}/lib"
-export CXXFLAGS="${CXXFLAGS} -std=c++17 -O3 -I${PREFIX}/include"
-export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib"
-
-if [[ "$(uname)" == "Darwin" ]]; then
+if [ "$(uname)" == "Darwin" ]; then
     echo "Installing STAR for OSX."
     mkdir -p $PREFIX/bin
-    install -v -m 0755 bin/MacOSX_x86_64/STAR $PREFIX/bin
-    install -v -m 0755 bin/MacOSX_x86_64/STARlong $PREFIX/bin
+    cp bin/MacOSX_x86_64/* $PREFIX/bin
 else 
     echo "Building STAR for Linux"
     mkdir -p $PREFIX/bin
@@ -17,24 +10,24 @@ else
 
     AMD64_SIMD_LEVELS=("avx2" "avx" "sse4.1" "ssse3" "sse3")
 
-    if [[ "$(arch)" == "x86_64" ]]; then
+    if [ "$(arch)" == "x86_64" ]; then
         for SIMD in ${AMD64_SIMD_LEVELS[@]}; do
-            make -j"$(nproc)" CXX="${CXX}" CXXFLAGSextra="-m$SIMD" CXXFLAGS="${CXXFLAGS}" STAR STARlong
-            cp -rf STAR $PREFIX/bin/STAR-$SIMD
-            cp -rf STARlong $PREFIX/bin/STARlong-$SIMD
-	    chmod 0755 $PREFIX/bin/STAR-$SIMD
-	    chmod 0755 $PREFIX/bin/STARlong-$SIMD
+            make -j "$(nproc)" CXXFLAGSextra="-m$SIMD" STAR STARlong
+            cp STAR $PREFIX/bin/STAR-$SIMD
+            cp STARlong $PREFIX/bin/STARlong-$SIMD
             make clean
         done
-        make -j"${CPU_COUNT}" STAR STARlong
-        mv STAR $PREFIX/bin/STAR-plain
-        mv STARlong $PREFIX/bin/STARlong-plain
-        cp -rf ../simd-dispatch.sh $PREFIX/bin/STAR
-        cp -rf ../simd-dispatch.sh $PREFIX/bin/STARlong
-	chmod 0755 $PREFIX/bin/STAR-plain $PREFIX/bin/STARlong-plain
+        make STAR STARlong
+        cp STAR $PREFIX/bin/STAR-plain
+        cp STARlong $PREFIX/bin/STARlong-plain
+        cp ../simd-dispatch.sh $PREFIX/bin/STAR
+        cp ../simd-dispatch.sh $PREFIX/bin/STARlong
     else
-        make -pj"$(nproc)" CXX="${CXX}" CXXFLAGS="${CXXFLAGS}" STAR STARlong
-        install -v -m 0755 STAR $PREFIX/bin
-        install -v -m 0755 STARlong $PREFIX/bin
+        make -pj "$(nproc)" STAR STARlong
+        cp STAR $PREFIX/bin/STAR
+        cp STARlong $PREFIX/bin/STARlong
     fi
 fi
+
+chmod +x $PREFIX/bin/STAR
+chmod +x $PREFIX/bin/STARlong

--- a/recipes/star/meta.yaml
+++ b/recipes/star/meta.yaml
@@ -16,7 +16,7 @@ source:
     - patches/0003-create-simd-dispatch.patch
 
 build:
-  number: 4
+  number: 5
   run_exports:
     - {{ pin_subpackage('star', max_pin="x") }}
 


### PR DESCRIPTION
Testing for https://github.com/bioconda/bioconda-recipes/issues/53018, try reverting the build.sh, so that the only change from https://github.com/bioconda/bioconda-recipes/pull/52349 (which seems to have caused the issue) is the fix to the patch so that the fallback script is correctly referenced.


----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
