### PR TITLE
Update to relax the hmmer build version supported to allow newer version

### DIFF
--- a/recipes/itsxpress/meta.yaml
+++ b/recipes/itsxpress/meta.yaml
@@ -14,7 +14,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   entry_points:
     - itsxpress=itsxpress.main:main
   script: {{ PYTHON }} -m pip install --no-deps --no-build-isolation --no-cache-dir . -vvv
@@ -29,7 +29,7 @@ requirements:
   run:
     - python >=3.8
     - biopython >=1.79
-    - hmmer =3.1b2
+    - hmmer >=3.1b2
     - vsearch =2.22.1
     - pyzstd
 


### PR DESCRIPTION
This bumps the build version after setting the hmmer dependency to be >= '3.1bxx' because for QIIME2 installs hmmer v3.4 is dependency on newer tools and there is a conflict having old version of hmmer 3.1 dependency.

https://forum.qiime2.org/t/itsxpress-2-0-in-qiime2023-2-with-emp-data/26976/5
https://forum.qiime2.org/t/need-help-plugin-error-from-itsxpress/32046/8

@arivers I think can indicate if this would be a problem but this allows itsxpress and  q2-fragment-insertion to co-exist in same conda env if hmmer3.4 is allowed to be used.

