### PR TITLE
ngscheckmate - migrate to python3 and enable linux-aarch64 and osx-arm64 

### DIFF
--- a/recipes/ngscheckmate/build.sh
+++ b/recipes/ngscheckmate/build.sh
@@ -30,7 +30,7 @@ python $PREFIX/NGSCheckMate/vaf_ncm.py "\$@"
 EOF
 
 cd $PREFIX/NGSCheckMate/ngscheckmate_fastq-source
-make COMPILER=${CC} CFLAGS="${CFLAGS} -c" 
+make COMPILER=${CC} CFLAGS="${CFLAGS} -c" DFLAGS="${LDFLAGS}"
 cd $PREFIX
 ln -s $PREFIX/NGSCheckMate/ngscheckmate_fastq-source/ngscheckmate_fastq $PREFIX/bin/
 cat << EOF > $PREFIX/bin/makesnvpattern.pl

--- a/recipes/ngscheckmate/build.sh
+++ b/recipes/ngscheckmate/build.sh
@@ -30,6 +30,9 @@ python $PREFIX/NGSCheckMate/vaf_ncm.py "\$@"
 EOF
 
 ln -s $PREFIX/NGSCheckMate/ngscheckmate_fastq $PREFIX/bin/ngscheckmate_fastq
+cd $PREFIX/NFSCheckMate/ngscheckmate_fastq-source
+make
+cd $PREFIX
 
 cat << EOF > $PREFIX/bin/makesnvpattern.pl
 #!/usr/bin/env bash

--- a/recipes/ngscheckmate/build.sh
+++ b/recipes/ngscheckmate/build.sh
@@ -30,7 +30,7 @@ python $PREFIX/NGSCheckMate/vaf_ncm.py "\$@"
 EOF
 
 cd $PREFIX/NGSCheckMate/ngscheckmate_fastq-source
-make COMPILER=${CC} CFLAGS="${CFLAGS}"
+make COMPILER=${CC} CFLAGS="${CFLAGS} -c" 
 cd $PREFIX
 ln -s $PREFIX/NGSCheckMate/ngscheckmate_fastq-source/ngscheckmate_fastq $PREFIX/bin/
 cat << EOF > $PREFIX/bin/makesnvpattern.pl

--- a/recipes/ngscheckmate/build.sh
+++ b/recipes/ngscheckmate/build.sh
@@ -30,11 +30,9 @@ python $PREFIX/NGSCheckMate/vaf_ncm.py "\$@"
 EOF
 
 cd $PREFIX/NGSCheckMate/ngscheckmate_fastq-source
-bin/ngscheckmate_fastq
 make
 cd $PREFIX
-ln -s $PREFIX/NGSCheckMate/ngscheckmate_fastq-source/ngscheckmate_fastq $PREFIX/
-
+ln -s $PREFIX/NGSCheckMate/ngscheckmate_fastq-source/ngscheckmate_fastq $PREFIX/bin/
 cat << EOF > $PREFIX/bin/makesnvpattern.pl
 #!/usr/bin/env bash
 

--- a/recipes/ngscheckmate/build.sh
+++ b/recipes/ngscheckmate/build.sh
@@ -30,7 +30,7 @@ python $PREFIX/NGSCheckMate/vaf_ncm.py "\$@"
 EOF
 
 cd $PREFIX/NGSCheckMate/ngscheckmate_fastq-source
-make
+make COMPILER=${CC} CFLAGS="${CFLAGS}"
 cd $PREFIX
 ln -s $PREFIX/NGSCheckMate/ngscheckmate_fastq-source/ngscheckmate_fastq $PREFIX/bin/
 cat << EOF > $PREFIX/bin/makesnvpattern.pl

--- a/recipes/ngscheckmate/build.sh
+++ b/recipes/ngscheckmate/build.sh
@@ -32,7 +32,7 @@ EOF
 cd $PREFIX/NGSCheckMate/ngscheckmate_fastq-source
 make COMPILER=${CC} CFLAGS="${CFLAGS} -c" DFLAGS="${LDFLAGS}"
 cd $PREFIX
-ln -s $PREFIX/NGSCheckMate/ngscheckmate_fastq-source/ngscheckmate_fastq $PREFIX/bin/
+ln -sf $PREFIX/NGSCheckMate/ngscheckmate_fastq-source/ngscheckmate_fastq $PREFIX/bin/
 cat << EOF > $PREFIX/bin/makesnvpattern.pl
 #!/usr/bin/env bash
 

--- a/recipes/ngscheckmate/build.sh
+++ b/recipes/ngscheckmate/build.sh
@@ -29,10 +29,11 @@ export NCM_HOME=$PREFIX/NGSCheckMate
 python $PREFIX/NGSCheckMate/vaf_ncm.py "\$@"
 EOF
 
-ln -s $PREFIX/NGSCheckMate/ngscheckmate_fastq $PREFIX/bin/ngscheckmate_fastq
 cd $PREFIX/NGSCheckMate/ngscheckmate_fastq-source
+bin/ngscheckmate_fastq
 make
 cd $PREFIX
+ln -s $PREFIX/NGSCheckMate/ngscheckmate_fastq-source/ngscheckmate_fastq $PREFIX/
 
 cat << EOF > $PREFIX/bin/makesnvpattern.pl
 #!/usr/bin/env bash

--- a/recipes/ngscheckmate/build.sh
+++ b/recipes/ngscheckmate/build.sh
@@ -30,7 +30,7 @@ python $PREFIX/NGSCheckMate/vaf_ncm.py "\$@"
 EOF
 
 ln -s $PREFIX/NGSCheckMate/ngscheckmate_fastq $PREFIX/bin/ngscheckmate_fastq
-cd $PREFIX/NFSCheckMate/ngscheckmate_fastq-source
+cd $PREFIX/NGSCheckMate/ngscheckmate_fastq-source
 make
 cd $PREFIX
 

--- a/recipes/ngscheckmate/meta.yaml
+++ b/recipes/ngscheckmate/meta.yaml
@@ -1,8 +1,9 @@
 {% set name = "ngscheckmate" %}
+{% set version = "1.0.1" %}
 
 package:
   name: {{ name }}
-  version: 1.0.1
+  version: {{ version }}
 
 source:
   url: https://github.com/parklab/NGSCheckMate/archive/ef7a38c51dadbd4ef5b6b6db60775f239926f0a8.zip
@@ -13,22 +14,18 @@ source:
 build:
   number: 3
   run_exports:
-    - {{ pin_subpackage(name, max_pin='x.x') }}
+    - {{ pin_subpackage(name, max_pin='x') }}
 
 requirements:
   build:
     - {{ compiler('c') }}
     - make
-
   host:
     - python >=2.7
-    - r-base >=4
-    - perl
     - samtools
     - bcftools
     - bowtie
     - zlib
-
   run:
     - python >=2.7
     - r-base >=4
@@ -44,14 +41,20 @@ test:
     - vaf_ncm.py -h
     - ngscheckmate_fastq
     - makesnvpattern.pl
+    
+about:
+  home: "https://github.com/parklab/NGSCheckMate"
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: "Software package for identifying next generation sequencing (NGS) data files from the same individual."
+  description: "This version is built from a pull request which fixes a handful of known bugs."
+  dev_url: "https://github.com/parklab/NGSCheckMate"
+  doc_url: "https://github.com/parklab/NGSCheckMate/blob/master/Documentation.pdf"
 
 extra:
   additional-platforms:
     - linux-aarch64
     - osx-arm64
-    
-about:
-  home: https://github.com/parklab/NGSCheckMate
-  license: MIT
-  summary: Software package for identifying next generation sequencing (NGS) data files from the same individual.
-  description: This version is built from a pull request which fixes a handful of known bugs.
+  identifiers:
+    - biotools:ngscheckmate

--- a/recipes/ngscheckmate/meta.yaml
+++ b/recipes/ngscheckmate/meta.yaml
@@ -46,7 +46,6 @@ about:
   home: "https://github.com/parklab/NGSCheckMate"
   license: MIT
   license_family: MIT
-  license_file: LICENSE
   summary: "Software package for identifying next generation sequencing (NGS) data files from the same individual."
   description: "This version is built from a pull request which fixes a handful of known bugs."
   dev_url: "https://github.com/parklab/NGSCheckMate"

--- a/recipes/ngscheckmate/meta.yaml
+++ b/recipes/ngscheckmate/meta.yaml
@@ -8,7 +8,7 @@ source:
   url: https://github.com/parklab/NGSCheckMate/archive/ef7a38c51dadbd4ef5b6b6db60775f239926f0a8.zip
   md5: 42d4578e02a81e4e55857f126ae719af
   patches:
-    - py3.patch # from https://github.com/parklab/NGSCheckMate/compare/master...dslarm:NGSCheckMate:master.patch
+    - py3.patch  # from https://github.com/parklab/NGSCheckMate/compare/master...dslarm:NGSCheckMate:master.patch
 
 build:
   number: 3

--- a/recipes/ngscheckmate/meta.yaml
+++ b/recipes/ngscheckmate/meta.yaml
@@ -27,6 +27,7 @@ requirements:
     - samtools
     - bcftools
     - bowtie
+    - zlib
 
   run:
     - python >=2.7
@@ -35,6 +36,7 @@ requirements:
     - samtools
     - bcftools
     - bowtie
+
 test:
   commands:
     - ncm.py -h

--- a/recipes/ngscheckmate/meta.yaml
+++ b/recipes/ngscheckmate/meta.yaml
@@ -8,7 +8,7 @@ source:
   url: https://github.com/parklab/NGSCheckMate/archive/ef7a38c51dadbd4ef5b6b6db60775f239926f0a8.zip
   md5: 42d4578e02a81e4e55857f126ae719af
   patches:
-    - py3.patch
+    - py3.patch # from https://github.com/parklab/NGSCheckMate/compare/master...dslarm:NGSCheckMate:master.patch
 
 build:
   number: 3
@@ -16,6 +16,10 @@ build:
     - {{ pin_subpackage(name, max_pin='x.x') }}
 
 requirements:
+  build:
+    - {{ compiler('c') }}
+    - make
+
   host:
     - python >=2.7
     - r-base >=4
@@ -23,6 +27,7 @@ requirements:
     - samtools
     - bcftools
     - bowtie
+
   run:
     - python >=2.7
     - r-base >=4

--- a/recipes/ngscheckmate/meta.yaml
+++ b/recipes/ngscheckmate/meta.yaml
@@ -21,13 +21,13 @@ requirements:
     - {{ compiler('c') }}
     - make
   host:
-    - python >=2.7
+    - python
     - samtools
     - bcftools
     - bowtie
     - zlib
   run:
-    - python >=2.7
+    - python
     - r-base >=4
     - perl
     - samtools

--- a/recipes/ngscheckmate/meta.yaml
+++ b/recipes/ngscheckmate/meta.yaml
@@ -7,6 +7,8 @@ package:
 source:
   url: https://github.com/parklab/NGSCheckMate/archive/ef7a38c51dadbd4ef5b6b6db60775f239926f0a8.zip
   md5: 42d4578e02a81e4e55857f126ae719af
+  patches:
+    - py3.patch
 
 build:
   number: 2
@@ -16,14 +18,14 @@ build:
 
 requirements:
   host:
-    - python =2.7
+    - python >=2.7
     - r-base >=4
     - perl
     - samtools
     - bcftools
     - bowtie
   run:
-    - python =2.7
+    - python >=2.7
     - r-base >=4
     - perl
     - samtools

--- a/recipes/ngscheckmate/meta.yaml
+++ b/recipes/ngscheckmate/meta.yaml
@@ -21,13 +21,13 @@ requirements:
     - {{ compiler('c') }}
     - make
   host:
-    - python
+    - python >=2.7
     - samtools
     - bcftools
     - bowtie
     - zlib
   run:
-    - python
+    - python >=2.7
     - r-base >=4
     - perl
     - samtools

--- a/recipes/ngscheckmate/meta.yaml
+++ b/recipes/ngscheckmate/meta.yaml
@@ -11,8 +11,7 @@ source:
     - py3.patch
 
 build:
-  number: 2
-  noarch: generic
+  number: 3
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x') }}
 
@@ -39,6 +38,11 @@ test:
     - ngscheckmate_fastq
     - makesnvpattern.pl
 
+extra:
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64
+    
 about:
   home: https://github.com/parklab/NGSCheckMate
   license: MIT

--- a/recipes/ngscheckmate/py3.patch
+++ b/recipes/ngscheckmate/py3.patch
@@ -431,6 +431,71 @@ index 528565f..37cad01 100644
      run_R_scripts()
 -#	remove_internal_files()
 +#       remove_internal_files()
+diff --git a/ngscheckmate_fastq-source/ngscheckmate.h b/ngscheckmate_fastq-source/ngscheckmate.h
+index 4d8d0c6..0259cb7 100644
+--- a/ngscheckmate_fastq-source/ngscheckmate.h
++++ b/ngscheckmate_fastq-source/ngscheckmate.h
+@@ -4,6 +4,7 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
++#include <unistd.h>
+ #include <pthread.h>
+ #include <limits.h>
+ #include "stringhash2.h"
+@@ -26,15 +27,15 @@ typedef struct read_fastq_args_struct
+ 
+ 
+ 
+-int nthread;
+-pthread_t *pth;
+-int *working_thread;
++extern int nthread;
++extern pthread_t *pth;
++extern int *working_thread;
+ 
+-int max_index;
+-int read_length;
+-long nReads;
+-char nodeptherror;
+-char* index_array;
++extern int max_index;
++extern int read_length;
++extern long nReads;
++extern char nodeptherror;
++extern char* index_array;
+ 
+ hash* read_patternfile_construct_hash(char*);
+ void store_each_pattern (char*, char, int, hash*);
+diff --git a/ngscheckmate_fastq-source/ngscheckmate_fastq b/ngscheckmate_fastq-source/ngscheckmate_fastq
+index d99202f..258365f 100755
+Binary files a/ngscheckmate_fastq-source/ngscheckmate_fastq and b/ngscheckmate_fastq-source/ngscheckmate_fastq differ
+diff --git a/ngscheckmate_fastq-source/ngscheckmate_main.c b/ngscheckmate_fastq-source/ngscheckmate_main.c
+index ef92f05..ce9079e 100644
+--- a/ngscheckmate_fastq-source/ngscheckmate_main.c
++++ b/ngscheckmate_fastq-source/ngscheckmate_main.c
+@@ -1,6 +1,18 @@
+ #include "ngscheckmate.h"
+ #include <getopt.h>
+ 
++extern void printusage(char* program);
++
++int nthread = 0;
++pthread_t *pth = NULL;
++int *working_thread = NULL;
++
++int max_index = 0;
++int read_length = 0;
++long nReads = 0L;
++char nodeptherror = '\0';
++char* index_array = NULL;
++
+ int main(int argc, char* argv[])
+ {
+ 
+diff --git a/ngscheckmate_fastq-source/patternconvert.h.gch b/ngscheckmate_fastq-source/patternconvert.h.gch
+index 2303d61..78cac10 100644
+Binary files a/ngscheckmate_fastq-source/patternconvert.h.gch and b/ngscheckmate_fastq-source/patternconvert.h.gch differ
 diff --git a/vaf_ncm.py b/vaf_ncm.py
 index 61a9168..900c0d4 100644
 --- a/vaf_ncm.py

--- a/recipes/ngscheckmate/py3.patch
+++ b/recipes/ngscheckmate/py3.patch
@@ -1,0 +1,484 @@
+diff --git a/ncm.py b/ncm.py
+index 2f52021..6372770 100644
+--- a/ncm.py
++++ b/ncm.py
+@@ -65,7 +65,7 @@ def pearson_def(x, y):
+ def createDataSetFromDir(base_dir, bedFile):
+     for root, dirs, files in os.walk(base_dir):
+         for file in files:
+-    	    if not file.endswith(".vcf"):
++            if not file.endswith(".vcf"):
+                 continue
+ 
+             link = root + '/' +  file
+@@ -608,7 +608,7 @@ def clustering(K):
+             sum = sum + max_value
+             Pos_count =  Pos_count + 1
+             outPOS=str(label[target]) +  "\tmatched to\t" + str(label[max_indice])+ "\tscore=\t" + str(max_value)
+-            print outPOS
++            print(outPOS)
+             #POS_F.write(outPOS + "\n")
+             orderCount = orderCount + 1
+ 
+@@ -683,8 +683,8 @@ def classify(T):
+                 NEG_F.write(outNEG + "\n")
+ 
+ 
+-    print sum/Pos_count
+-    print othersum/Neg_count
++    print(sum/Pos_count)
++    print(othersum/Neg_count)
+ 
+     POS_F.close()
+     NEG_F.close()
+@@ -915,8 +915,8 @@ def classifying():
+         output_matrix = dict()
+         
+         if out_tag!="stdout":
+-        	out_f = open(outdir + "/" + out_tag + "_all.txt","w")
+-        	out_matched = open(outdir + "/" + out_tag + "_matched.txt","w")
++                out_f = open(outdir + "/" + out_tag + "_all.txt","w")
++                out_matched = open(outdir + "/" + out_tag + "_matched.txt","w")
+ 
+         for i in range(0, len(keyList)):
+             output_matrix[keyList[i]] = dict()
+@@ -939,7 +939,7 @@ def classifying():
+                 p1V,p1S, p0V, p0S = trainNV(array(trainMatrix),array(trainCategory))
+                 result = classifyNV(samples[i],p0V,p0S, p1V, p1S)
+                 if result[1] == 1:
+-                    print str(temp[i][0]) + '\tsample is matched to\t',str(temp[i][1]),'\t', samples[i]
++                    print(str(temp[i][0]) + '\tsample is matched to\t',str(temp[i][1]),'\t', samples[i])
+                 predStrength.append(result[0])
+         else :
+             for i in range(0,len(samples)):
+@@ -955,13 +955,13 @@ def classifying():
+                     output_matrix[temp[i][0].strip()][temp[i][1].strip()] = samples[i]
+                     output_matrix[temp[i][1].strip()][temp[i][0].strip()] = samples[i]
+                     if out_tag=="stdout":
+-                        print str(temp[i][0]) + '\tmatched\t',str(temp[i][1]),'\t', round(samples[i],4),'\t',round(depth,2)
++                        print(str(temp[i][0]) + '\tmatched\t',str(temp[i][1]),'\t', round(samples[i],4),'\t',round(depth,2))
+                     else :
+                         out_f.write(str(temp[i][0]) + '\tmatched\t' + str(temp[i][1])  + '\t'+  str(round(samples[i],4)) + '\t' + str(round(depth,2)) + '\n')
+                         out_matched.write(str(temp[i][0]) + '\tmatched\t' + str(temp[i][1])  + '\t'+  str(round(samples[i],4)) + '\t' + str(round(depth,2)) + '\n')
+                 else:
+                     if out_tag=="stdout":
+-                        print str(temp[i][0]) + '\tunmatched\t',str(temp[i][1]),'\t', round(samples[i],4),'\t',round(depth,2)
++                        print(str(temp[i][0]) + '\tunmatched\t',str(temp[i][1]),'\t', round(samples[i],4),'\t',round(depth,2))
+                     else :
+                         out_f.write(str(temp[i][0]) + '\tunmatched\t' + str(temp[i][1])  + '\t'+  str(round(samples[i],4)) + '\t' + str(round(depth,2)) + '\n')
+                 predStrength.append(result[0])
+@@ -990,8 +990,8 @@ def classifying():
+             
+         output_matrix_f.close()         
+         if out_tag!="stdout":
+-        	out_f.close()
+-        	out_matched.close()   
++                out_f.close()
++                out_matched.close()   
+ 
+ 
+ 
+@@ -1070,7 +1070,7 @@ def classifying_test():
+                 p1V,p1S, p0V, p0S = trainNV(array(trainMatrix),array(trainCategory))
+                 result = classifyNV(samples[i],p0V,p0S, p1V, p1S)
+                 if result[1] == 1:
+-                    print str(temp[i][0]) + '\tsample is matched to\t',str(temp[i][1]),'\t', samples[i]
++                    print(str(temp[i][0]) + '\tsample is matched to\t',str(temp[i][1]),'\t', samples[i])
+                 predStrength.append(result[0])
+         else :
+             for i in range(0,len(samples)):
+@@ -1081,13 +1081,13 @@ def classifying_test():
+                     output_matrix[temp[i][0].strip()][temp[i][1].strip()] = samples[i]
+                     output_matrix[temp[i][1].strip()][temp[i][0].strip()] = samples[i]
+                     if out_tag=="stdout":
+-                        print str(temp[i][0]) + '\tmatched\t',str(temp[i][1]),'\t', round(samples[i],4),'\t',round(depth,2)
++                        print(str(temp[i][0]) + '\tmatched\t',str(temp[i][1]),'\t', round(samples[i],4),'\t',round(depth,2))
+                     else :
+                         out_f.write(str(temp[i][0]) + '\tmatched\t' + str(temp[i][1])  + '\t'+  str(round(samples[i],4)) + '\t' + str(round(depth,2)) + '\n')
+                         out_matched.write(str(temp[i][0]) + '\tmatched\t' + str(temp[i][1])  + '\t'+  str(round(samples[i],4)) + '\t' + str(round(depth,2)) + '\n')
+                 else:
+                     if out_tag=="stdout":
+-                        print str(temp[i][0]) + '\tunmatched\t',str(temp[i][1]),'\t', round(samples[i],4),'\t',round(depth,2)
++                        print(str(temp[i][0]) + '\tunmatched\t',str(temp[i][1]),'\t', round(samples[i],4),'\t',round(depth,2))
+                     else :
+                         out_f.write(str(temp[i][0]) + '\tunmatched\t' + str(temp[i][1])  + '\t'+  str(round(samples[i],4)) + '\t' + str(round(depth,2)) + '\n')
+                 predStrength.append(result[0])
+@@ -1179,12 +1179,12 @@ def run_mpileup():
+     if "NCM_HOME" in os.environ.keys():
+         INSTALL_DIR=os.environ['NCM_HOME'] + "/"
+     else:
+-        print "WARNNING : NCM_HOME is not defined yet. Therefore, program will try to search ncm.conf file from the current directory"
++        print("WARNNING : NCM_HOME is not defined yet. Therefore, program will try to search ncm.conf file from the current directory")
+         INSTALL_DIR=""
+     with open(INSTALL_DIR + "ncm.conf",'r') as F:
+         for line in F.readlines():
+             temp = line.split('=')
+-	    if temp[0].startswith("SAMTOOLS"):
++            if temp[0].startswith("SAMTOOLS"):
+                 SAMTOOLS = temp[1].strip()
+             elif temp[0].startswith("BCFTOOLS"):
+                 BCFTOOLS = temp[1].strip()
+@@ -1203,7 +1203,7 @@ def run_mpileup():
+                 if version_tag.find("Version") != -1:
+                     version_list = version_tag.split(" ")
+                     version = version_list[1]
+-    print version
++    print(version)
+ 
+     for sample in bam_list:
+         filename = sample.split("/")
+@@ -1212,7 +1212,7 @@ def run_mpileup():
+             command = SAMTOOLS + " mpileup -I -uf " + REF + " -l " + bedFile + " " + sample + " | "  + BCFTOOLS + " view -cg - > " + outdir + "/" + tag  + ".vcf"
+         else:
+             command = SAMTOOLS + " mpileup -uf " + REF + " -l " + bedFile + " " + sample + " | "  + BCFTOOLS + " call -c > " + outdir + "/" + tag  + ".vcf"
+-        print command
++        print(command)
+         call(command,shell=True)
+  #       proc = subprocess.Popen(command, shell=True, stderr=subprocess.PIPE, stdout=subprocess.PIPE)
+ #        return_code = proc.wait()
+@@ -1443,7 +1443,7 @@ if __name__ == '__main__':
+             get_bam_list()
+         run_mpileup()
+         base_dir = outdir
+-        print "Generate Data Set from " + base_dir + "\nusing this bed file : " + bedFile
++        print("Generate Data Set from " + base_dir + "\nusing this bed file : " + bedFile)
+         if args.testsamplename != None:
+             testsamplename = args.testsamplename
+             createDataSetFromDir_TEST(base_dir,bedFile,"1")
+@@ -1454,7 +1454,7 @@ if __name__ == '__main__':
+             classifying()
+     elif args.VCF_type != False :
+         if args.datadir != None :
+-            print "Generate Data Set from " + base_dir + "\nusing this bed file : " + bedFile
++            print("Generate Data Set from " + base_dir + "\nusing this bed file : " + bedFile)
+             if args.testsamplename != None:
+                 testsamplename = args.testsamplename
+                 createDataSetFromDir_TEST(base_dir,bedFile,"1")
+@@ -1464,7 +1464,7 @@ if __name__ == '__main__':
+                 createDataSetFromDir(base_dir,bedFile)
+                 classifying()
+         elif args.datalist != None :
+-            print "Generate Data Set from " + base_list + "\nusing this bed file : " + bedFile
++            print("Generate Data Set from " + base_list + "\nusing this bed file : " + bedFile)
+             if args.testsamplename != None:
+                 testsamplename = args.testsamplename
+                 createDataSetFromList_TEST(base_list,bedFile,"1")
+@@ -1487,4 +1487,4 @@ if __name__ == '__main__':
+     pdf_tag = out_tag
+     generate_R_scripts()
+     run_R_scripts()
+-#	remove_internal_files()
++#       remove_internal_files()
+diff --git a/ncm_fastq.py b/ncm_fastq.py
+index daa5910..f4cf7a4 100644
+--- a/ncm_fastq.py
++++ b/ncm_fastq.py
+@@ -298,7 +298,7 @@ def plotROC(predStrengths, classLabels):
+     plt.title('ROC curves')
+     ax.axis([0,1,0,1])
+     plt.show()
+-    print "the Area Under the Curve is: ",ySum*xStep
++    print("the Area Under the Curve is: ",ySum*xStep)
+ 
+ 
+ def run_fastq_version():
+@@ -306,7 +306,7 @@ def run_fastq_version():
+     if "NCM_HOME" in os.environ.keys():
+         INSTALL_DIR=os.environ['NCM_HOME'] + "/"
+     else :
+-        print "WARNNING : NCM_HOME is not defined yet. Therefore, program will try to search ngscheckmate_fastq file from the current directory"
++        print("WARNNING : NCM_HOME is not defined yet. Therefore, program will try to search ngscheckmate_fastq file from the current directory")
+         INSTALL_DIR="./"
+ 
+     command = INSTALL_DIR + "ngscheckmate_fastq "
+@@ -326,9 +326,9 @@ def run_fastq_version():
+     if PE == 1:
+             command =  command  + "-1 "  + fastq1 + " -2 " + fastq2 +" " + bed_file +" > " + outdir + "/" + temp_out + ".ncm"
+     if PE == 0:
+-	        command = command + "-1 " + fastq1  +" " + bed_file +" > " + outdir + "/" + temp_out + ".ncm"
++                command = command + "-1 " + fastq1  +" " + bed_file +" > " + outdir + "/" + temp_out + ".ncm"
+ 
+-    print command
++    print(command)
+ 
+     proc = subprocess.Popen(command, shell=True, stderr=subprocess.PIPE, stdout=subprocess.PIPE)
+     return_code = proc.wait()
+@@ -420,7 +420,7 @@ def classifying():
+                 p1V,p1S, p0V, p0S = trainNV(array(trainMatrix),array(trainCategory))
+                 result = classifyNV(samples[i],p0V,p0S, p1V, p1S)
+                 if result[1] == 1:
+-                    print str(temp[i][0]) + '\tsample is matched to\t',str(temp[i][1]),'\t', samples[i]
++                    print(str(temp[i][0]) + '\tsample is matched to\t',str(temp[i][1]),'\t', samples[i])
+                 predStrength.append(result[0])
+     #            AUCs.append(calAUC(mat(predStrength),classLabel))
+     #            plotROC(mat(predStrength),classLabel)
+@@ -439,13 +439,13 @@ def classifying():
+                     output_matrix[temp[i][0].strip()][temp[i][1].strip()] = samples[i]
+                     output_matrix[temp[i][1].strip()][temp[i][0].strip()] = samples[i]
+                     if out_tag=="stdout":
+-                        print str(temp[i][0][:-4]) + '\tmatched\t',str(temp[i][1][:-4]),'\t', round(samples[i],4),'\t',round(depth,2)
++                        print(str(temp[i][0][:-4]) + '\tmatched\t',str(temp[i][1][:-4]),'\t', round(samples[i],4),'\t',round(depth,2))
+                     else :
+                         out_f.write(str(temp[i][0][:-4]) + '\tmatched\t' + str(temp[i][1][:-4])  + '\t'+  str(round(samples[i],4)) + '\t' + str(round(depth,2)) + '\n')
+                         out_matched.write(str(temp[i][0][:-4]) + '\tmatched\t' + str(temp[i][1][:-4])  + '\t'+  str(round(samples[i],4)) + '\t' + str(round(depth,2)) + '\n')               
+                 else:
+                     if out_tag=="stdout":
+-                        print str(temp[i][0][:-4]) + '\tunmatched\t',str(temp[i][1][:-4]),'\t', round(samples[i],4),'\t',round(depth,2)
++                        print(str(temp[i][0][:-4]) + '\tunmatched\t',str(temp[i][1][:-4]),'\t', round(samples[i],4),'\t',round(depth,2))
+                     else :
+                         out_f.write(str(temp[i][0][:-4]) + '\tunmatched\t' + str(temp[i][1][:-4])  + '\t'+  str(round(samples[i],4)) + '\t' + str(round(depth,2)) + '\n')
+                 #print sum_file[temp[i][0]],sum_file[temp[i][1].strip()]
+@@ -546,7 +546,7 @@ def classifying_test():
+             p1V,p1S, p0V, p0S = trainNV(array(trainMatrix),array(trainCategory))
+             result = classifyNV(samples[i],p0V,p0S, p1V, p1S)
+             if result[1] == 1:
+-                print str(temp[i][0]) + '\tsample is matched to\t',str(temp[i][1]),'\t', samples[i]
++                print(str(temp[i][0]) + '\tsample is matched to\t',str(temp[i][1]),'\t', samples[i])
+             predStrength.append(result[0])
+ #            AUCs.append(calAUC(mat(predStrength),classLabel))
+ #            plotROC(mat(predStrength),classLabel)
+@@ -560,13 +560,13 @@ def classifying_test():
+                 output_matrix[temp[i][0].strip()][temp[i][1].strip()] = samples[i]
+                 output_matrix[temp[i][1].strip()][temp[i][0].strip()] = samples[i]
+                 if out_tag=="stdout":
+-                    print str(temp[i][0][:-4]) + '\tmatched\t',str(temp[i][1][:-4]),'\t', round(samples[i],4),'\t',round(depth,2)
++                    print(str(temp[i][0][:-4]) + '\tmatched\t',str(temp[i][1][:-4]),'\t', round(samples[i],4),'\t',round(depth,2))
+                 else :
+                     out_f.write(str(temp[i][0][:-4]) + '\tmatched\t' + str(temp[i][1][:-4])  + '\t'+  str(round(samples[i],4)) + '\t' + str(round(depth,2)) + '\n')
+                     out_matched.write(str(temp[i][0][:-4]) + '\tmatched\t' + str(temp[i][1][:-4])  + '\t'+  str(round(samples[i],4)) + '\t' + str(round(depth,2)) + '\n')               
+             else:
+                 if out_tag=="stdout":
+-                    print str(temp[i][0][:-4]) + '\tunmatched\t',str(temp[i][1][:-4]),'\t', round(samples[i],4),'\t',round(depth,2)
++                    print(str(temp[i][0][:-4]) + '\tunmatched\t',str(temp[i][1][:-4]),'\t', round(samples[i],4),'\t',round(depth,2))
+                 else :
+                     out_f.write(str(temp[i][0][:-4]) + '\tunmatched\t' + str(temp[i][1][:-4])  + '\t'+  str(round(samples[i],4)) + '\t' + str(round(depth,2)) + '\n')
+             #print sum_file[temp[i][0]],sum_file[temp[i][1].strip()]
+@@ -881,9 +881,9 @@ if __name__ == '__main__':
+                         temp_out = temp[1]
+                         run_fastq_version()
+                 else:
+-                        print "Input File Error: Each line should be contain one or two fastq files name with tab delimited"
+-                        print line.strip()
+-                        print "upper format is invalid"
++                        print("Input File Error: Each line should be contain one or two fastq files name with tab delimited")
++                        print(line.strip())
++                        print("upper format is invalid")
+ 
+     # set directories
+     base_dir = outdir
+@@ -920,12 +920,12 @@ if __name__ == '__main__':
+ 
+     if args.testsamplename != None:
+         testsamplename = args.testsamplename
+-        print "Generate Data Set from " + outdir + "\nusing this bed file : " + bedFile
++        print("Generate Data Set from " + outdir + "\nusing this bed file : " + bedFile)
+         createDataSetFromDir_test(outdir,bedFile,"1")
+         createDataSetFromDir_test(outdir,bedFile,"2")
+         classifying_test()
+     else:
+-        print "Generate Data Set from " + outdir + "\nusing this bed file : " + bedFile
++        print("Generate Data Set from " + outdir + "\nusing this bed file : " + bedFile)
+         createDataSetFromDir(outdir,bedFile)
+         classifying()
+ 
+diff --git a/ncm_test.py b/ncm_test.py
+index 528565f..37cad01 100644
+--- a/ncm_test.py
++++ b/ncm_test.py
+@@ -60,7 +60,7 @@ def pearson_def(x, y):
+ def createDataSetFromDir(base_dir, bedFile):
+     for root, dirs, files in os.walk(base_dir):
+         for file in files:
+-    	    if not file.endswith(".vcf"):
++            if not file.endswith(".vcf"):
+                 continue
+ 
+             link = root + '/' +  file
+@@ -357,7 +357,7 @@ def clustering(K):
+             sum = sum + max_value
+             Pos_count =  Pos_count + 1
+             outPOS=str(label[target]) +  "\tmatched to\t" + str(label[max_indice])+ "\tscore=\t" + str(max_value)
+-            print outPOS
++            print(outPOS)
+             #POS_F.write(outPOS + "\n")
+             orderCount = orderCount + 1
+ 
+@@ -432,8 +432,8 @@ def classify(T):
+                 NEG_F.write(outNEG + "\n")
+ 
+ 
+-    print sum/Pos_count
+-    print othersum/Neg_count
++    print(sum/Pos_count)
++    print(othersum/Neg_count)
+ 
+     POS_F.close()
+     NEG_F.close()
+@@ -664,7 +664,7 @@ def classifying():
+         output_matrix = dict()
+         
+         if out_tag!="stdout":
+-        	out_f = open(outdir + "/" + out_tag + "_all.txt","w")
++                out_f = open(outdir + "/" + out_tag + "_all.txt","w")
+ 
+         for i in range(0, len(samples)):
+             output_matrix[temp[i][0]] = dict()
+@@ -687,7 +687,7 @@ def classifying():
+                 p1V,p1S, p0V, p0S = trainNV(array(trainMatrix),array(trainCategory))
+                 result = classifyNV(samples[i],p0V,p0S, p1V, p1S)
+                 if result[1] == 1:
+-                    print str(temp[i][0]) + '\tsample is matched to\t',str(temp[i][1]),'\t', samples[i]
++                    print(str(temp[i][0]) + '\tsample is matched to\t',str(temp[i][1]),'\t', samples[i])
+                 predStrength.append(result[0])
+     #            AUCs.append(calAUC(mat(predStrength),classLabel))
+     #            plotROC(mat(predStrength),classLabel)
+@@ -700,12 +700,12 @@ def classifying():
+                 if result[1] ==1:
+                     output_matrix[temp[i][0].strip()][temp[i][1].strip()] = samples[i]
+                     if out_tag=="stdout":
+-                        print str(temp[i][0][:-4]) + '\tmatched\t',str(temp[i][1][:-4]),'\t', round(samples[i],4),'\t',round(depth,2)
++                        print(str(temp[i][0][:-4]) + '\tmatched\t',str(temp[i][1][:-4]),'\t', round(samples[i],4),'\t',round(depth,2))
+                     else :
+                         out_f.write(str(temp[i][0][:-4]) + '\tmatched\t' + str(temp[i][1][:-4])  + '\t'+  str(round(samples[i],4)) + '\t' + str(round(depth,2)) + '\n')
+                 else:
+                     if out_tag=="stdout":
+-                        print str(temp[i][0][:-4]) + '\tunmatched\t',str(temp[i][1][:-4]),'\t', round(samples[i],4),'\t',round(depth,2)
++                        print( str(temp[i][0][:-4]) + '\tunmatched\t',str(temp[i][1][:-4]),'\t', round(samples[i],4),'\t',round(depth,2))
+                     else :
+                         out_f.write(str(temp[i][0][:-4]) + '\tunmatched\t' + str(temp[i][1][:-4])  + '\t'+  str(round(samples[i],4)) + '\t' + str(round(depth,2)) + '\n')
+                 #print sum_file[temp[i][0]],sum_file[temp[i][1].strip()]
+@@ -727,7 +727,7 @@ def classifying():
+             
+         output_matrix_f.close()         
+         if out_tag!="stdout":
+-        	out_f.close()   
++                out_f.close()   
+ 
+ 
+ 
+@@ -805,7 +805,7 @@ def classifying_test():
+                 p1V,p1S, p0V, p0S = trainNV(array(trainMatrix),array(trainCategory))
+                 result = classifyNV(samples[i],p0V,p0S, p1V, p1S)
+                 if result[1] == 1:
+-                    print str(temp[i][0]) + '\tsample is matched to\t',str(temp[i][1]),'\t', samples[i]
++                    print(str(temp[i][0]) + '\tsample is matched to\t',str(temp[i][1]),'\t', samples[i])
+                 predStrength.append(result[0])
+     #            AUCs.append(calAUC(mat(predStrength),classLabel))
+     #            plotROC(mat(predStrength),classLabel)
+@@ -817,10 +817,10 @@ def classifying_test():
+                 result = classifyNV(samples[i],p0V,p0S, p1V, p1S)
+                 if result[1] ==1:
+                     output_matrix[temp[i][0].strip()][temp[i][1].strip()] = samples[i]
+-            	    if out_tag=="stdout":
+-                        print str(temp[i][0][:-6]) + '\tmatched\t',str(temp[i][1][:-6]),'\t', round(samples[i],4),'\t',round(depth,2)
+-            	    else :
+-                	    out_f.write(str(temp[i][0][:-6]) + '\tmatched\t' + str(temp[i][1][:-6])  + '\t'+  str(round(samples[i],4)) + '\t' + str(round(depth,2)) + '\n')
++                    if out_tag=="stdout":
++                        print(str(temp[i][0][:-6]) + '\tmatched\t',str(temp[i][1][:-6]),'\t', round(samples[i],4),'\t',round(depth,2))
++                    else :
++                            out_f.write(str(temp[i][0][:-6]) + '\tmatched\t' + str(temp[i][1][:-6])  + '\t'+  str(round(samples[i],4)) + '\t' + str(round(depth,2)) + '\n')
+                 #print sum_file[temp[i][0]],sum_file[temp[i][1].strip()]
+                 predStrength.append(result[0])
+     #            AUCs.append(calAUC(mat(predStrength),classLabel))
+@@ -894,7 +894,7 @@ def run_mpileup():
+     with open("./ncm.conf",'r') as F:
+         for line in F.readlines():
+             temp = line.split('\"')
+-	    if temp[0].startswith("SAMTOOLS"):
++            if temp[0].startswith("SAMTOOLS"):
+                 SAMTOOLS = temp[1].strip()
+             elif temp[0].startswith("BCFTOOLS"):
+                 BCFTOOLS = temp[1].strip()
+@@ -907,7 +907,7 @@ def run_mpileup():
+         tag = filename[-1][0:filename[-1].rindex(".")]
+         command = SAMTOOLS + " mpileup -I -uf " + REF + " -l " + bedFile + " " + sample + " | "  + BCFTOOLS + " view -cg - > " + outdir + "/" + tag  + ".vcf"
+ 
+-        print command
++        print(command)
+         call(command,shell=True)
+  #       proc = subprocess.Popen(command, shell=True, stderr=subprocess.PIPE, stdout=subprocess.PIPE)
+ #        return_code = proc.wait()
+@@ -1126,7 +1126,7 @@ if __name__ == '__main__':
+             get_bam_list()
+         run_mpileup()
+         base_dir = outdir
+-        print "Generate Data Set from " + base_dir + "\nusing this bed file : " + bedFile
++        print("Generate Data Set from " + base_dir + "\nusing this bed file : " + bedFile)
+         if args.testsamplename != None:
+             testsamplename = args.testsamplename
+             createDataSetFromDir_TEST(base_dir,bedFile,"1")
+@@ -1137,7 +1137,7 @@ if __name__ == '__main__':
+             classifying()
+     elif args.VCF_type != False :
+         if args.datadir != None :
+-            print "Generate Data Set from " + base_dir + "\nusing this bed file : " + bedFile
++            print("Generate Data Set from " + base_dir + "\nusing this bed file : " + bedFile)
+             if args.testsamplename != None:
+                 testsamplename = args.testsamplename
+                 createDataSetFromDir_TEST(base_dir,bedFile,"1")
+@@ -1147,7 +1147,7 @@ if __name__ == '__main__':
+                 createDataSetFromDir(base_dir,bedFile)
+                 classifying()
+         elif args.datalist != None :
+-            print "Generate Data Set from " + base_list + "\nusing this bed file : " + bedFile
++            print("Generate Data Set from " + base_list + "\nusing this bed file : " + bedFile)
+             if args.testsamplename != None:
+                 testsamplename = args.testsamplename
+                 createDataSetFromList_TEST(base_list,bedFile,"1")
+@@ -1170,4 +1170,4 @@ if __name__ == '__main__':
+     pdf_tag = out_tag
+     generate_R_scripts()
+     run_R_scripts()
+-#	remove_internal_files()
++#       remove_internal_files()
+diff --git a/vaf_ncm.py b/vaf_ncm.py
+index 61a9168..900c0d4 100644
+--- a/vaf_ncm.py
++++ b/vaf_ncm.py
+@@ -233,7 +233,7 @@ def plotROC(predStrengths, classLabels):
+     plt.title('ROC curves')
+     ax.axis([0,1,0,1])
+     plt.show()
+-    print "the Area Under the Curve is: ",ySum*xStep
++    print ("the Area Under the Curve is: ",ySum*xStep)
+ 
+ 
+ 
+@@ -323,7 +323,7 @@ def classifying():
+                 p1V,p1S, p0V, p0S = trainNV(array(trainMatrix),array(trainCategory))
+                 result = classifyNV(samples[i],p0V,p0S, p1V, p1S)
+                 if result[1] == 1:
+-                    print str(temp[i][0]) + '\tsample is matched to\t',str(temp[i][1]),'\t', samples[i]
++                    print (str(temp[i][0]) + '\tsample is matched to\t',str(temp[i][1]),'\t', samples[i])
+                 predStrength.append(result[0])
+     #            AUCs.append(calAUC(mat(predStrength),classLabel))
+     #            plotROC(mat(predStrength),classLabel)
+@@ -341,12 +341,12 @@ def classifying():
+                 if result[1] ==1:
+                     output_matrix[temp[i][0].strip()][temp[i][1].strip()] = samples[i]
+                     if out_tag=="stdout":
+-                        print str(temp[i][0][:-4]) + '\tmatched\t',str(temp[i][1][:-4]),'\t', round(samples[i],4),'\t',round(depth,2)
++                        print (str(temp[i][0][:-4]) + '\tmatched\t',str(temp[i][1][:-4]),'\t', round(samples[i],4),'\t',round(depth,2))
+                     else :
+                         out_f.write(str(temp[i][0][:-4]) + '\tmatched\t' + str(temp[i][1][:-4])  + '\t'+  str(round(samples[i],4)) + '\t' + str(round(depth,2)) + '\n')
+                 else:
+                     if out_tag=="stdout":
+-                        print str(temp[i][0][:-4]) + '\tunmatched\t',str(temp[i][1][:-4]),'\t', round(samples[i],4),'\t',round(depth,2)
++                        print (str(temp[i][0][:-4]) + '\tunmatched\t',str(temp[i][1][:-4]),'\t', round(samples[i],4),'\t',round(depth,2))
+                     else :
+                         out_f.write(str(temp[i][0][:-4]) + '\tunmatched\t' + str(temp[i][1][:-4])  + '\t'+  str(round(samples[i],4)) + '\t' + str(round(depth,2)) + '\n')
+                 #print sum_file[temp[i][0]],sum_file[temp[i][1].strip()]
+@@ -565,10 +565,10 @@ if __name__ == '__main__':
+ 
+         Options
+           -N PREFIX     Output file prefix (default : "output")
+-          -f 		Use strict VAF correlation cutoffs. Recommended when your data may include   
+- 		        related individuals (parents-child, siblings)
++          -f            Use strict VAF correlation cutoffs. Recommended when your data may include   
++                        related individuals (parents-child, siblings)
+           -nz           Use the mean of non-zero depths across the SNPs as a reference depth
+- 		        (default: Use the mean depth across all the SNPs)
++                        (default: Use the mean depth across all the SNPs)
+             """
+ 
+     parser = argparse.ArgumentParser(description=help, formatter_class=RawTextHelpFormatter)


### PR DESCRIPTION
* change python2 to python3 - largely tabulation and print syntax
* the ngscheckmate_fastq binary is now built by the build script; the source has been updated to be more modern C, and the installation no longer uses the linux-x86_64-only binary that was in this package.
* this package no longer marked as architecture generic.