### PR TITLE
Muscle - add legacy version - required by pasta

### DIFF
--- a/recipes/muscle/3.8.1551/build.sh
+++ b/recipes/muscle/3.8.1551/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+make GPP=$CXX
+
+binaries="\
+muscle \
+"
+
+mkdir -p $PREFIX/bin
+for i in $binaries; do cp $SRC_DIR/$i $PREFIX/bin && chmod +x $PREFIX/bin/$i; done

--- a/recipes/muscle/3.8.1551/build.sh
+++ b/recipes/muscle/3.8.1551/build.sh
@@ -2,9 +2,4 @@
 
 make GPP=$CXX -j"${CPU_COUNT}"
 
-binaries="\
-muscle \
-"
-
-mkdir -p $PREFIX/bin
-for i in $binaries; do cp $SRC_DIR/$i $PREFIX/bin && chmod +x $PREFIX/bin/$i; done
+install -m 0755 muscle ${PREFIX}/bin/ 

--- a/recipes/muscle/3.8.1551/build.sh
+++ b/recipes/muscle/3.8.1551/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-make GPP=$CXX
+make GPP=$CXX -j"${CPU_COUNT}"
 
 binaries="\
 muscle \

--- a/recipes/muscle/3.8.1551/build.sh
+++ b/recipes/muscle/3.8.1551/build.sh
@@ -2,4 +2,5 @@
 
 make GPP=$CXX -j"${CPU_COUNT}"
 
+mkdir -p ${PREFIX}/bin/ 
 install -m 0755 muscle ${PREFIX}/bin/ 

--- a/recipes/muscle/3.8.1551/meta.yaml
+++ b/recipes/muscle/3.8.1551/meta.yaml
@@ -6,8 +6,8 @@ package:
   version: {{ version }}
 
 source:
-  md5: 1b7c9661f275a82d3cf708f923736bf8
   url: http://www.drive5.com/muscle/muscle_src_3.8.1551.tar.gz
+  sha256: c70c552231cd3289f1bad51c9bd174804c18bb3adcf47f501afec7a68f9c482e
   patches:
     - osx-makefile.patch
 

--- a/recipes/muscle/3.8.1551/meta.yaml
+++ b/recipes/muscle/3.8.1551/meta.yaml
@@ -1,0 +1,35 @@
+{% set name = "muscle" %}
+{% set version = "3.8.1551" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  md5: 1b7c9661f275a82d3cf708f923736bf8
+  url: http://www.drive5.com/muscle/muscle_src_3.8.1551.tar.gz
+  patches:
+    - osx-makefile.patch
+
+build:
+  number: 6
+
+requirements:
+  build:
+    - make
+    - {{ compiler('cxx') }}
+  run:
+
+test:
+  commands:
+    - muscle -version
+about:
+  home: 'http://www.drive5.com/muscle/'
+  license: "http://www.drive5.com/muscle/manual/license.html"
+  summary: "MUSCLE: multiple sequence alignment with high accuracy and high throughput"
+
+extra:
+  additional-platforms:
+    - linux-aarch64
+  identifiers:
+    - biotools:muscle

--- a/recipes/muscle/3.8.1551/meta.yaml
+++ b/recipes/muscle/3.8.1551/meta.yaml
@@ -12,7 +12,9 @@ source:
     - osx-makefile.patch
 
 build:
-  number: 6
+  number: 7
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x") }}
 
 requirements:
   build:

--- a/recipes/muscle/3.8.1551/meta.yaml
+++ b/recipes/muscle/3.8.1551/meta.yaml
@@ -2,7 +2,7 @@
 {% set version = "3.8.1551" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:

--- a/recipes/muscle/3.8.1551/osx-makefile.patch
+++ b/recipes/muscle/3.8.1551/osx-makefile.patch
@@ -1,0 +1,14 @@
+--- Makefile    2016-11-02 13:08:37.215317736 +0100
++++ Makefile    2016-11-02 13:09:33.532509393 +0100
+@@ -10,8 +10,8 @@
+ # this is fixed by deleting "-static" from the LDLIBS line.
+
+ CFLAGS = -O3 -funroll-loops -Winline -DNDEBUG=1
+-LDLIBS = -lm -static
+-# LDLIBS = -lm
++#LDLIBS = -lm -static
++ LDLIBS = -lm
+
+ OBJ = .o
+ EXE =
+


### PR DESCRIPTION
Pasta has a hard requirement for muscle < 4 due to a change of command arguments in muscle 5.  

Muscle 4 was removed from bioconda in 2022 and replaced by muscle 5.  Pasta can't build for linux-aarch64 until this is resolved.
This PR re-enabled the last working version of the 3.8 series by adding a subdirectory with this revision in as per other packages that do this kind of legacy support (first time I've added one, I hope this is the right idea)
This PR also adds linux-aarch64
