### PR TITLE
Update meta.yaml for htstream 1.4.0 release

### DIFF
--- a/recipes/htstream/build.sh
+++ b/recipes/htstream/build.sh
@@ -6,7 +6,6 @@ mkdir build && cd build
 
 cmake \
   -DCMAKE_BUILD_TYPE=RELEASE \
-  -DCMAKE_CXX_FLAGS='-Wno-vla' \
   -DCMAKE_INSTALL_PREFIX=${PREFIX} \
   -DCMAKE_LIBRARY_PATH=${PREFIX}/lib \
   -DCMAKE_INCLUDE_PATH=${PREFIX}/include ..

--- a/recipes/htstream/build.sh
+++ b/recipes/htstream/build.sh
@@ -6,7 +6,7 @@ mkdir build && cd build
 
 cmake \
   -DCMAKE_BUILD_TYPE=RELEASE \
-  -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9 \
+  -DCMAKE_CXX_FLAGS='-Wno-vla' \
   -DCMAKE_INSTALL_PREFIX=${PREFIX} \
   -DCMAKE_LIBRARY_PATH=${PREFIX}/lib \
   -DCMAKE_INCLUDE_PATH=${PREFIX}/include ..

--- a/recipes/htstream/meta.yaml
+++ b/recipes/htstream/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "1.3.3" %}
-{% set sha256 = "1cccafd926615877a8b48cdd8efc118ad90289b378d86fd9c3c8368011419f4c" %}
+{% set version = "1.4.0" %}
+{% set sha256 = "cc681b39d31e14dfe3d9d075666697cf292cf8286d6b56c582e167a5138edbec" %}
 
 package:
   name: htstream

--- a/recipes/htstream/meta.yaml
+++ b/recipes/htstream/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 6
+  number: 0
 
 requirements:
   build:
@@ -30,6 +30,9 @@ requirements:
     - zlib
     - bzip2
     - xz
+
+  run_exports:
+    - boost
 
 test:
   commands:

--- a/recipes/htstream/meta.yaml
+++ b/recipes/htstream/meta.yaml
@@ -17,20 +17,17 @@ requirements:
     - make
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-
   host:
     - cmake
     - boost
     - zlib
     - bzip2
     - xz
-
   run:
     - boost
     - zlib
     - bzip2
     - xz
-
   run_exports:
     - boost
 

--- a/recipes/htstream/meta.yaml
+++ b/recipes/htstream/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "1.4.0" %}
-{% set sha256 = "cc681b39d31e14dfe3d9d075666697cf292cf8286d6b56c582e167a5138edbec" %}
+{% set version = "1.4.1" %}
+{% set sha256 = "1231a6ff5cd5c4ba434d834452e37a5da88f78f8ede05ee02dc063ac52ae024a" %}
 
 package:
   name: htstream

--- a/recipes/htstream/meta.yaml
+++ b/recipes/htstream/meta.yaml
@@ -11,6 +11,7 @@ source:
 
 build:
   number: 0
+  run_exports: '{{ pin_subpackage("htstream", max_pin="x.x") }}'
 
 requirements:
   build:
@@ -28,8 +29,6 @@ requirements:
     - zlib
     - bzip2
     - xz
-  run_exports:
-    - boost
 
 test:
   commands:


### PR DESCRIPTION
Update to version 1.4.0, should fix build for mac.