### PR TITLE
easypqp: export matplotlib and xdc cache dir

### DIFF
--- a/recipes/easypqp/meta.yaml
+++ b/recipes/easypqp/meta.yaml
@@ -3,20 +3,20 @@
 {% set sha256 = "d3ebc1c7cbe61f081c5ab71e76e7130aa7fae955895ffe8f719363b29870a000" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/easypqp-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/easypqp-{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:
   number: 1
   noarch: python
   script: |
-    mkdir -p ${PREFIX}/tmp/matplotlib-cache ${PREFIX}/tmp/fontconfig-cache
     export MPLCONFIGDIR=${PREFIX}/tmp/matplotlib-cache
     export XDG_CACHE_HOME=${PREFIX}/tmp/fontconfig-cache
+    mkdir -p ${MPLCONFIGDIR} ${XDG_CACHE_HOME}
     {{ PYTHON }} -m pip install . --no-cache-dir --no-deps --no-build-isolation -vvv
   entry_points:
     - easypqp=easypqp.main:cli

--- a/recipes/easypqp/meta.yaml
+++ b/recipes/easypqp/meta.yaml
@@ -11,9 +11,13 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1  # Incremented for tracking the fix
   noarch: python
-  script: {{ PYTHON }} -m pip install . --no-cache-dir --no-deps --no-build-isolation -vvv
+  script: |
+    mkdir -p ${PREFIX}/tmp/matplotlib-cache ${PREFIX}/tmp/fontconfig-cache
+    export MPLCONFIGDIR=${PREFIX}/tmp/matplotlib-cache
+    export XDG_CACHE_HOME=${PREFIX}/tmp/fontconfig-cache
+    {{ PYTHON }} -m pip install . --no-cache-dir --no-deps --no-build-isolation -vvv
   entry_points:
     - easypqp=easypqp.main:cli
   run_exports:
@@ -21,11 +25,11 @@ build:
 
 requirements:
   host:
-    - python >=3.6
+    - python >=3.9
     - pip
     - setuptools
   run:
-    - python >=3.6
+    - python >= 3.9
     - numba
     - click
     - numpy

--- a/recipes/easypqp/meta.yaml
+++ b/recipes/easypqp/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1  # Incremented for tracking the fix
+  number: 1
   noarch: python
   script: |
     mkdir -p ${PREFIX}/tmp/matplotlib-cache ${PREFIX}/tmp/fontconfig-cache
@@ -29,7 +29,7 @@ requirements:
     - pip
     - setuptools
   run:
-    - python >= 3.9
+    - python >=3.9
     - numba
     - click
     - numpy


### PR DESCRIPTION
Attempt to fix the following error when running the quay.io container of this package

> Command error:
Unable to find image 'quay.io/biocontainers/easypqp:0.1.50--pyhdfd78af_0' locally
0.1.50--pyhdfd78af_0: Pulling from biocontainers/easypqp
36b7914fc8ba: Already exists
2cc3d3b08aaa: Already exists
bd9ddc54bea9: Already exists
1bb084e8d0f9: Pulling fs layer
1bb084e8d0f9: Verifying Checksum
1bb084e8d0f9: Download complete
1bb084e8d0f9: Pull complete
Digest: sha256:82ec6181308514b01ce4618fd410732de501d1620738007944a7c119b409bdfa
Status: Downloaded newer image for quay.io/biocontainers/easypqp:0.1.50--pyhdfd78af_0
Matplotlib created a temporary cache directory at /tmp/matplotlib-1ck8ubs9 because the default path (/.config/matplotlib) is not a writable directory; it is highly recommended to set the MPLCONFIGDIR environment variable to a writable directory, in particular to speed up the import of Matplotlib and to better support multiprocessing.
Fontconfig error: No writable cache directories
/usr/local/lib/python3.10/site-packages/numpy/core/fromnumeric.py:57: FutureWarning: 'DataFrame.swapaxes' is deprecated and will be removed in a future version. Please use 'DataFrame.transpose' instead.
return bound(*args, **kwds)
----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
