### PR TITLE
Update Pyscenic: pin dask to know working version

### DIFF
--- a/recipes/pyscenic/meta.yaml
+++ b/recipes/pyscenic/meta.yaml
@@ -13,7 +13,7 @@ source:
     - dill_patch.patch
 
 build:
-  number: 0
+  number: 1
   noarch: python
   entry_points:
     - pyscenic = pyscenic.cli.pyscenic:main
@@ -39,7 +39,7 @@ requirements:
     - cloudpickle
     - cytoolz
     - dill
-    - dask-core >=2023.4.1
+    - dask-core ==2022.11.1
     - distributed >=2023.4.1,<2023.5.0
     - frozendict
     - fsspec
@@ -48,7 +48,7 @@ requirements:
     - networkx
     - numba >=0.51.2
     - numexpr
-    - pandas >=1.3.5
+    - pandas ==1.5.1
     - pyyaml
     - requests
     - scikit-learn


### PR DESCRIPTION
This PR pins the versions of dask, pandas and numpy to match what is found on the pyscenic docker container released by the Aerts lab (where I have tested most functionality to work, and it is probably widely used). A pip list inside that container gives:

```
Package                 Version
----------------------- -----------------------
aiohttp                 3.8.3
aiosignal               1.3.1
arboreto                0.1.6
async-timeout           4.0.2
attrs                   22.1.0
bokeh                   2.4.3
boltons                 21.0.0
certifi                 2022.9.24
charset-normalizer      2.1.1
click                   8.1.3
cloudpickle             2.2.0
ctxcore                 0.2.0
cytoolz                 0.12.0
dask                    2022.11.1
dill                    0.3.6
distributed             2022.11.1
frozendict              2.3.4
frozenlist              1.3.3
fsspec                  2022.11.0
h5py                    3.7.0
HeapDict                1.0.1
idna                    3.4
interlap                0.2.7
Jinja2                  3.1.2
joblib                  1.2.0
llvmlite                0.39.1
locket                  1.0.0
loompy                  3.0.7
MarkupSafe              2.1.1
msgpack                 1.0.4
multidict               6.0.2
multiprocessing-on-dill 3.5.0a4
networkx                2.8.8
numba                   0.56.4
numexpr                 2.8.4
numpy                   1.23.5
numpy-groupies          0.9.20
packaging               21.3
pandas                  1.5.1
partd                   1.3.0
Pillow                  9.3.0
pip                     22.2.1
psutil                  5.9.4
pyarrow                 10.0.0
pynndescent             0.5.8
pyparsing               3.0.9
pyscenic                0.12.1+0.gce41b61.dirty
python-dateutil         2.8.2
pytz                    2022.6
PyYAML                  6.0
requests                2.28.1
scikit-learn            1.1.3
scipy                   1.9.3
setuptools              63.2.0
six                     1.16.0
sortedcontainers        2.4.0
tblib                   1.7.0
threadpoolctl           3.1.0
toolz                   0.12.0
tornado                 6.1
tqdm                    4.64.1
typing_extensions       4.4.0
umap-learn              0.5.3
urllib3                 1.26.12
yarl                    1.8.1
zict                    2.2.0
```

This should fix #51874 .

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
