### PR TITLE
Include latest psirc fixes

### DIFF
--- a/recipes/psirc/meta.yaml
+++ b/recipes/psirc/meta.yaml
@@ -6,11 +6,11 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/nictru/psirc/archive/0c4e49d7636c0e9120d9119e098bb515a17dc9b6.zip
-  sha256: 7acff956ceb8e24b43aa14ad35bbce8f2e646884d83aec45e9e6326d9a1a5a26
+  url: https://github.com/nictru/psirc/archive/9046acc666c971eea17b6da9112beb3bed8000dc.zip
+  sha256: feb67bf60b68c2207e46c81a7b2340c4beb0af7af1bbc44c7669f28aac0ecc50
 
 build:
-  number: 1
+  number: 2
   run_exports:
     - {{ pin_subpackage('psirc', max_pin="x") }}
 
@@ -25,6 +25,7 @@ requirements:
     - zlib
   run:
     - perl
+    - kallisto
 
 test:
   commands:


### PR DESCRIPTION
Only two fixes that make usage of this package easier:
- Add kallisto as a run dependency
- Change perl shebang from `/usr/bin/perl` to `/usr/bin/env perl`
