### PR TITLE
ci: optimize fetch-depth in github actions

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -19,13 +19,15 @@ jobs:
         id: github_base_ref
         run: |
           if [ -z "$GITHUB_BASE_REF" ] ; then
-              echo GITHUB_BASE_REF="master" >> $GITHUB_ENV     
+              export GITHUB_BASE_REF="master"
+              export GITHUB_BASE_REF="${GITHUB_BASE_REF}" >> $GITHUB_ENV     
           fi
+          echo github_base_ref="${GITHUB_BASE_REF}" >> $GITHUB_OUTPUT
   
       - name: Fetch commits through the merge base
         uses: BioData/fetch-through-merge-base@v0
         with:
-          base_ref: ${{ env.GITHUB_BASE_REF }}
+          base_ref: ${{ steps.github_base_ref.outputs.github_base_ref }}
           head_ref: ${{ github.sha }}
 
       - name: set path
@@ -73,13 +75,15 @@ jobs:
         id: github_base_ref
         run: |
           if [ -z "$GITHUB_BASE_REF" ] ; then
-              echo GITHUB_BASE_REF="master" >> $GITHUB_ENV     
+              export GITHUB_BASE_REF="master"
+              export GITHUB_BASE_REF="${GITHUB_BASE_REF}" >> $GITHUB_ENV     
           fi
+          echo github_base_ref="${GITHUB_BASE_REF}" >> $GITHUB_OUTPUT
   
       - name: Fetch commits through the merge base
         uses: BioData/fetch-through-merge-base@v0
         with:
-          base_ref: ${{ env.GITHUB_BASE_REF }}
+          base_ref: ${{ steps.github_base_ref.outputs.github_base_ref }}
           head_ref: ${{ github.sha }}
 
 

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -25,10 +25,10 @@ jobs:
           echo github_base_ref="${GITHUB_BASE_REF}" >> $GITHUB_OUTPUT
   
       - name: Fetch commits through the merge base
-        uses: BioData/fetch-through-merge-base@v0
+        uses: fulcrumgenomics/fetch-through-merge-base@v1
         with:
-          base_ref: ${{ steps.github_base_ref.outputs.github_base_ref }}
-          head_ref: ${{ github.sha }}
+          base-ref: ${{ steps.github_base_ref.outputs.github_base_ref }}
+          head-ref: ${{ github.sha }}
 
       - name: set path
         run: echo "/opt/mambaforge/bin" >> $GITHUB_PATH
@@ -81,10 +81,10 @@ jobs:
           echo github_base_ref="${GITHUB_BASE_REF}" >> $GITHUB_OUTPUT
   
       - name: Fetch commits through the merge base
-        uses: BioData/fetch-through-merge-base@v0
+        uses: fulcrumgenomics/fetch-through-merge-base@v1
         with:
-          base_ref: ${{ steps.github_base_ref.outputs.github_base_ref }}
-          head_ref: ${{ github.sha }}
+          base-ref: ${{ steps.github_base_ref.outputs.github_base_ref }}
+          head-ref: ${{ github.sha }}
 
 
       - name: set path
@@ -178,10 +178,10 @@ jobs:
           echo github_base_ref="${GITHUB_BASE_REF}" >> $GITHUB_OUTPUT
   
       - name: Fetch commits through the merge base
-        uses: BioData/fetch-through-merge-base@v0
+        uses: fulcrumgenomics/fetch-through-merge-base@v1
         with:
-          base_ref: ${{ steps.github_base_ref.outputs.github_base_ref }}
-          head_ref: ${{ github.sha }}
+          base-ref: ${{ steps.github_base_ref.outputs.github_base_ref }}
+          head-ref: ${{ github.sha }}
 
       - name: set path
         run: echo "/opt/mambaforge/bin" >> $GITHUB_PATH

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -14,8 +14,6 @@ jobs:
       max-parallel: 13
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: set path
         run: echo "/opt/mambaforge/bin" >> $GITHUB_PATH
@@ -61,8 +59,6 @@ jobs:
     needs: lint
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: set path
         run: echo "/opt/mambaforge/bin" >> $GITHUB_PATH
@@ -148,8 +144,6 @@ jobs:
     needs: build-linux
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: set path
         run: echo "/opt/mambaforge/bin" >> $GITHUB_PATH
@@ -220,8 +214,6 @@ jobs:
   #   needs: build-linux
   #   steps:
   #     - uses: actions/checkout@v4
-  #       with:
-  #         fetch-depth: 0
 
   #     # bail if there's no osx-arm64 recipes
   #     - name: Check for Additional Platforms

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -172,13 +172,15 @@ jobs:
         id: github_base_ref
         run: |
           if [ -z "$GITHUB_BASE_REF" ] ; then
-              echo GITHUB_BASE_REF="master" >> $GITHUB_ENV     
+              export GITHUB_BASE_REF="master"
+              export GITHUB_BASE_REF="${GITHUB_BASE_REF}" >> $GITHUB_ENV     
           fi
+          echo github_base_ref="${GITHUB_BASE_REF}" >> $GITHUB_OUTPUT
   
       - name: Fetch commits through the merge base
         uses: BioData/fetch-through-merge-base@v0
         with:
-          base_ref: ${{ env.GITHUB_BASE_REF }}
+          base_ref: ${{ steps.github_base_ref.outputs.github_base_ref }}
           head_ref: ${{ github.sha }}
 
       - name: set path

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -15,20 +15,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set GITHUB_BASE_REF if not already set
-        id: github_base_ref
-        run: |
-          if [ -z "$GITHUB_BASE_REF" ] ; then
-              export GITHUB_BASE_REF="master"
-              export GITHUB_BASE_REF="${GITHUB_BASE_REF}" >> $GITHUB_ENV     
-          fi
-          echo github_base_ref="${GITHUB_BASE_REF}" >> $GITHUB_OUTPUT
-  
       - name: Fetch commits through the merge base
         uses: fulcrumgenomics/fetch-through-merge-base@v1
         with:
           base-ref: ${{ steps.github_base_ref.outputs.github_base_ref }}
           head-ref: ${{ github.sha }}
+          fallback-base-ref: master
 
       - name: set path
         run: echo "/opt/mambaforge/bin" >> $GITHUB_PATH
@@ -71,20 +63,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set GITHUB_BASE_REF if not already set
-        id: github_base_ref
-        run: |
-          if [ -z "$GITHUB_BASE_REF" ] ; then
-              export GITHUB_BASE_REF="master"
-              export GITHUB_BASE_REF="${GITHUB_BASE_REF}" >> $GITHUB_ENV     
-          fi
-          echo github_base_ref="${GITHUB_BASE_REF}" >> $GITHUB_OUTPUT
-  
       - name: Fetch commits through the merge base
         uses: fulcrumgenomics/fetch-through-merge-base@v1
         with:
           base-ref: ${{ steps.github_base_ref.outputs.github_base_ref }}
           head-ref: ${{ github.sha }}
+          fallback-base-ref: master
 
 
       - name: set path
@@ -168,20 +152,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       
-      - name: Set GITHUB_BASE_REF if not already set
-        id: github_base_ref
-        run: |
-          if [ -z "$GITHUB_BASE_REF" ] ; then
-              export GITHUB_BASE_REF="master"
-              export GITHUB_BASE_REF="${GITHUB_BASE_REF}" >> $GITHUB_ENV     
-          fi
-          echo github_base_ref="${GITHUB_BASE_REF}" >> $GITHUB_OUTPUT
-  
       - name: Fetch commits through the merge base
         uses: fulcrumgenomics/fetch-through-merge-base@v1
         with:
           base-ref: ${{ steps.github_base_ref.outputs.github_base_ref }}
           head-ref: ${{ github.sha }}
+          fallback-base-ref: master
 
       - name: set path
         run: echo "/opt/mambaforge/bin" >> $GITHUB_PATH

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -15,6 +15,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set GITHUB_BASE_REF if not already set
+        id: github_base_ref
+        run: |
+          if [ -z "$GITHUB_BASE_REF" ] ; then
+              echo GITHUB_BASE_REF="master" >> $GITHUB_ENV     
+          fi
+  
+      - name: Fetch commits through the merge base
+        uses: BioData/fetch-through-merge-base@v0
+        with:
+          base_ref: ${{ env.GITHUB_BASE_REF }}
+          head_ref: ${{ github.sha }}
+
       - name: set path
         run: echo "/opt/mambaforge/bin" >> $GITHUB_PATH
 
@@ -43,10 +56,6 @@ jobs:
           conda config --show-sources
           python -c 'import bioconda_utils.utils as u ; import pathlib as p ; print(*(f"{f}:\n{p.Path(f).read_text()}" for f in u.load_conda_build_config().exclusive_config_files), sep="\n")'
           echo '============'
-          if [ -z "$GITHUB_BASE_REF" ] ; then
-              export GITHUB_BASE_REF="master"
-          fi
-          git fetch origin "$GITHUB_BASE_REF"
           bioconda-utils lint --loglevel debug --full-report --git-range origin/"$GITHUB_BASE_REF" HEAD
           conda clean -y --all
 
@@ -59,6 +68,20 @@ jobs:
     needs: lint
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set GITHUB_BASE_REF if not already set
+        id: github_base_ref
+        run: |
+          if [ -z "$GITHUB_BASE_REF" ] ; then
+              echo GITHUB_BASE_REF="master" >> $GITHUB_ENV     
+          fi
+  
+      - name: Fetch commits through the merge base
+        uses: BioData/fetch-through-merge-base@v0
+        with:
+          base_ref: ${{ env.GITHUB_BASE_REF }}
+          head_ref: ${{ github.sha }}
+
 
       - name: set path
         run: echo "/opt/mambaforge/bin" >> $GITHUB_PATH
@@ -91,10 +114,6 @@ jobs:
           eval "$(conda shell.bash hook)"
           conda activate bioconda
           source common.sh
-          if [ -z "$GITHUB_BASE_REF" ] ; then
-              export GITHUB_BASE_REF="master"
-          fi
-          git fetch origin "$GITHUB_BASE_REF"
 
           bioconda-utils build recipes config.yml \
             --docker --mulled-test \
@@ -144,6 +163,19 @@ jobs:
     needs: build-linux
     steps:
       - uses: actions/checkout@v4
+      
+      - name: Set GITHUB_BASE_REF if not already set
+        id: github_base_ref
+        run: |
+          if [ -z "$GITHUB_BASE_REF" ] ; then
+              echo GITHUB_BASE_REF="master" >> $GITHUB_ENV     
+          fi
+  
+      - name: Fetch commits through the merge base
+        uses: BioData/fetch-through-merge-base@v0
+        with:
+          base_ref: ${{ env.GITHUB_BASE_REF }}
+          head_ref: ${{ github.sha }}
 
       - name: set path
         run: echo "/opt/mambaforge/bin" >> $GITHUB_PATH
@@ -176,11 +208,6 @@ jobs:
           for n in linux-64 osx-64 noarch; do
               rm -f /opt/mambaforge/envs/bioconda/conda-bld/$n/*.tar.bz2
           done
-
-          if [ -z "$GITHUB_BASE_REF" ] ; then
-              export GITHUB_BASE_REF="master"
-          fi
-          git fetch origin "$GITHUB_BASE_REF"
 
           bioconda-utils build recipes config.yml \
             --git-range origin/"$GITHUB_BASE_REF" HEAD

--- a/.github/workflows/build-failures.yml
+++ b/.github/workflows/build-failures.yml
@@ -18,6 +18,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set GITHUB_BASE_REF if not already set
+        id: github_base_ref
+        run: |
+          if [ -z "$GITHUB_BASE_REF" ] ; then
+              echo GITHUB_BASE_REF="master" >> $GITHUB_ENV     
+          fi
+  
+      - name: Fetch commits through the merge base
+        uses: BioData/fetch-through-merge-base@v0
+        with:
+          base_ref: ${{ env.GITHUB_BASE_REF }}
+          head_ref: ${{ github.sha }}
+
       - name: set path
         run: echo "/opt/mambaforge/bin" >> $GITHUB_PATH
 
@@ -58,10 +71,6 @@ jobs:
             echo "Automatically updated (nightly) list of build failures that currently block builds from the listed recipes. Please help with fixing them!" >> $md
             bioconda-utils list-build-failures recipes --output-format markdown --link-prefix https://github.com/bioconda/bioconda-recipes/blob/master >> $md
           else
-            if [ -z "$GITHUB_BASE_REF" ] ; then
-                export GITHUB_BASE_REF="master"
-            fi
-            git fetch origin "$GITHUB_BASE_REF"
             md="build-failures/build-failures-${branch}.md"
             echo "# Build failures on \`${branch}\`" > $md
             echo "Automatically updated list of build failures that currently block builds from the listed recipes on the \`${branch}\` branch." >> $md

--- a/.github/workflows/build-failures.yml
+++ b/.github/workflows/build-failures.yml
@@ -17,8 +17,6 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: set path
         run: echo "/opt/mambaforge/bin" >> $GITHUB_PATH

--- a/.github/workflows/build-failures.yml
+++ b/.github/workflows/build-failures.yml
@@ -18,20 +18,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set GITHUB_BASE_REF if not already set
-        id: github_base_ref
-        run: |
-          if [ -z "$GITHUB_BASE_REF" ] ; then
-              export GITHUB_BASE_REF="master"
-              export GITHUB_BASE_REF="${GITHUB_BASE_REF}" >> $GITHUB_ENV     
-          fi
-          echo github_base_ref="${GITHUB_BASE_REF}" >> $GITHUB_OUTPUT
-  
       - name: Fetch commits through the merge base
         uses: fulcrumgenomics/fetch-through-merge-base@v1
         with:
           base-ref: ${{ steps.github_base_ref.outputs.github_base_ref }}
           head-ref: ${{ github.sha }}
+          fallback-base-ref: master
 
       - name: set path
         run: echo "/opt/mambaforge/bin" >> $GITHUB_PATH

--- a/.github/workflows/build-failures.yml
+++ b/.github/workflows/build-failures.yml
@@ -28,10 +28,10 @@ jobs:
           echo github_base_ref="${GITHUB_BASE_REF}" >> $GITHUB_OUTPUT
   
       - name: Fetch commits through the merge base
-        uses: BioData/fetch-through-merge-base@v0
+        uses: fulcrumgenomics/fetch-through-merge-base@v1
         with:
-          base_ref: ${{ steps.github_base_ref.outputs.github_base_ref }}
-          head_ref: ${{ github.sha }}
+          base-ref: ${{ steps.github_base_ref.outputs.github_base_ref }}
+          head-ref: ${{ github.sha }}
 
       - name: set path
         run: echo "/opt/mambaforge/bin" >> $GITHUB_PATH

--- a/.github/workflows/build-failures.yml
+++ b/.github/workflows/build-failures.yml
@@ -22,13 +22,15 @@ jobs:
         id: github_base_ref
         run: |
           if [ -z "$GITHUB_BASE_REF" ] ; then
-              echo GITHUB_BASE_REF="master" >> $GITHUB_ENV     
+              export GITHUB_BASE_REF="master"
+              export GITHUB_BASE_REF="${GITHUB_BASE_REF}" >> $GITHUB_ENV     
           fi
+          echo github_base_ref="${GITHUB_BASE_REF}" >> $GITHUB_OUTPUT
   
       - name: Fetch commits through the merge base
         uses: BioData/fetch-through-merge-base@v0
         with:
-          base_ref: ${{ env.GITHUB_BASE_REF }}
+          base_ref: ${{ steps.github_base_ref.outputs.github_base_ref }}
           head_ref: ${{ github.sha }}
 
       - name: set path

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -12,9 +12,10 @@ jobs:
       fail-fast: false
       max-parallel: 13
     steps:
+      # Fetch the last two commits for the --git-range argument to bioconda-utils
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 2 
 
       - name: set path
         run: echo "/opt/mambaforge/bin" >> $GITHUB_PATH
@@ -59,9 +60,10 @@ jobs:
       fail-fast: false
       max-parallel: 4
     steps:
+      # Fetch the last two commits for the --git-range argument to bioconda-utils
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 2
 
       - name: set path
         run: echo "/opt/mambaforge/bin" >> $GITHUB_PATH
@@ -111,9 +113,10 @@ jobs:
   #     fail-fast: false
   #     max-parallel: 4
   #   steps:
+  #     # Fetch the last two commits for the --git-range argument to bioconda-utils
   #     - uses: actions/checkout@v4
   #       with:
-  #         fetch-depth: 0
+  #         fetch-depth: 2
 
   #     # bail if there's no osx-arm64 recipes
   #     - name: Check for Additional Platforms

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,8 +12,6 @@ jobs:
       max-parallel: 4
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: set path
         run: echo "/opt/mambaforge/bin" >> $GITHUB_PATH


### PR DESCRIPTION
Attempts to speed up GHA via shallower checkouts: https://github.com/bioconda/bioconda-recipes/issues/53383.  Reduces checkout time from minutes to tens of seconds

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
