### PR TITLE
ECTYPER v2.0.0 build #2 addressing the bioconda 1.85 incompatibility

### DIFF
--- a/recipes/ectyper/meta.yaml
+++ b/recipes/ectyper/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
     url: https://github.com/phac-nml/ecoli_serotyping/archive/{{ version }}.tar.gz
-    sha256: 55c75a7eb856fafc24b8e3b226a394c3a2adbb5d96cd005ac9482884ce900265 
+    sha256: e39acd981e94f6106ffd7feb7db17c6846e652004c3b75c1f5c35d170e55cd59 
 
 build:
     number: 2

--- a/recipes/ectyper/meta.yaml
+++ b/recipes/ectyper/meta.yaml
@@ -7,10 +7,10 @@ package:
 
 source:
     url: https://github.com/phac-nml/ecoli_serotyping/archive/{{ version }}.tar.gz
-    sha256: bb363f61ca69d2118e855199d7f9046185bb054509cd0762083b4beec2b8c00e  
+    sha256: 998b81e06aafc576fdea6972c7c7b53133db54470350c13c3309cdd201fd4d21  
 
 build:
-    number: 1
+    number: 2
     noarch: python
     run_exports:
         - {{ pin_subpackage(name, max_pin="x") }}
@@ -29,7 +29,7 @@ requirements:
         - bowtie2 >=2.3.*
         - mash >=2.0.*
         - bcftools >=1.8.*
-        - biopython >=1.70.*
+        - biopython >=1.70.*,<1.85
         - blast >=2.7.1.*
         - seqtk >=1.2.*
         - requests >=2.*.*

--- a/recipes/ectyper/meta.yaml
+++ b/recipes/ectyper/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
     url: https://github.com/phac-nml/ecoli_serotyping/archive/{{ version }}.tar.gz
-    sha256: 998b81e06aafc576fdea6972c7c7b53133db54470350c13c3309cdd201fd4d21  
+    sha256: 55c75a7eb856fafc24b8e3b226a394c3a2adbb5d96cd005ac9482884ce900265 
 
 build:
     number: 2
@@ -29,7 +29,7 @@ requirements:
         - bowtie2 >=2.3.*
         - mash >=2.0.*
         - bcftools >=1.8.*
-        - biopython >=1.70.*,<1.85
+        - biopython >=1.70.*,<=1.85
         - blast >=2.7.1.*
         - seqtk >=1.2.*
         - requests >=2.*.*


### PR DESCRIPTION
This is build #2 where bioconda v1.85 recent update resulted in errors reading FASTA files. This incompatibility was addressed in this build thanks to making source code compatible with both previous and recent biopython versions. 


This addresses issue #99 at https://github.com/phac-nml/ecoli_serotyping/issues/99