### PR TITLE
`khmer` v3 does not work the same as v2 and is incompatible

### DIFF
--- a/recipes/primerforge/meta.yaml
+++ b/recipes/primerforge/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - python >=3.9,<3.12
     - biopython ==1.81
     - ispcr
-    - khmer >=2.1.1
+    - khmer >=2.1,<3
     - numpy
     - primer3-py >=2.0
     - pyahocorasick


### PR DESCRIPTION
primerForge does not work with `khmer` v3. I do not know what has changed between versions, but it does not generate the same results it used to. `khmer` v2.1 does work. I have restricted the build to reflect this.

@mencian the recipes for both primerForge v1.5.2 and primerForge v1.5.3 are broken because of this incompatibility. It passes the bioconda recipe checks, but the unit tests fail.