### PR TITLE
try to restore group_humann2_uniref_abundances_to_go recipe

### DIFF
--- a/build-fail-blacklist
+++ b/build-fail-blacklist
@@ -216,7 +216,6 @@ recipes/bolt-lmm
 recipes/unitig-counter
 recipes/spydrpick
 recipes/bctools
-recipes/group_humann2_uniref_abundances_to_go
 recipes/isonclust2
 recipes/sibelia
 recipes/var-agg

--- a/recipes/group_humann2_uniref_abundances_to_go/meta.yaml
+++ b/recipes/group_humann2_uniref_abundances_to_go/meta.yaml
@@ -7,7 +7,7 @@ source:
   url: https://github.com/ASaiM/group_humann2_uniref_abundances_to_GO/archive/v1.3.0.zip
 
 build:
-  number: 1
+  number: 2
   noarch: generic
 
 requirements:

--- a/recipes/group_humann2_uniref_abundances_to_go/meta.yaml
+++ b/recipes/group_humann2_uniref_abundances_to_go/meta.yaml
@@ -20,7 +20,7 @@ requirements:
   run:
     - python <3
     - humann2
-    - goatools =0.6.4
+    - goatools =0.6.10
     - wget
 
 test:

--- a/recipes/group_humann2_uniref_abundances_to_go/meta.yaml
+++ b/recipes/group_humann2_uniref_abundances_to_go/meta.yaml
@@ -16,7 +16,7 @@ requirements:
   run:
     - python <3
     - humann2
-    - goatools
+    # - goatools
     - wget
 
 test:

--- a/recipes/group_humann2_uniref_abundances_to_go/meta.yaml
+++ b/recipes/group_humann2_uniref_abundances_to_go/meta.yaml
@@ -5,12 +5,15 @@ package:
 source:
   md5: a78d947cfff8e76297840dd6ce8bfe7f
   url: https://github.com/ASaiM/group_humann2_uniref_abundances_to_GO/archive/v1.3.0.zip
+  patches:
+    - url.patch
 
 build:
   number: 2
   noarch: generic
   run_exports:
     - {{ pin_subpackage("group_humann2_uniref_abundances_to_go", max_pin="x.x") }}
+
 
 requirements:
   run:

--- a/recipes/group_humann2_uniref_abundances_to_go/meta.yaml
+++ b/recipes/group_humann2_uniref_abundances_to_go/meta.yaml
@@ -20,7 +20,7 @@ requirements:
   run:
     - python <3
     - humann2
-    - goatools
+    - goatools =0.6.4
     - wget
 
 test:

--- a/recipes/group_humann2_uniref_abundances_to_go/meta.yaml
+++ b/recipes/group_humann2_uniref_abundances_to_go/meta.yaml
@@ -6,6 +6,7 @@ source:
   md5: a78d947cfff8e76297840dd6ce8bfe7f
   url: https://github.com/ASaiM/group_humann2_uniref_abundances_to_GO/archive/v1.3.0.zip
   patches:
+    # xref https://github.com/ASaiM/group_humann2_uniref_abundances_to_GO/issues/12#issuecomment-2613954247
     - url.patch
 
 build:
@@ -19,7 +20,7 @@ requirements:
   run:
     - python <3
     - humann2
-    # - goatools
+    - goatools
     - wget
 
 test:

--- a/recipes/group_humann2_uniref_abundances_to_go/meta.yaml
+++ b/recipes/group_humann2_uniref_abundances_to_go/meta.yaml
@@ -9,6 +9,8 @@ source:
 build:
   number: 2
   noarch: generic
+  run_exports:
+    - {{ pin_subpackage("group_humann2_uniref_abundances_to_go", max_pin="x.x") }}
 
 requirements:
   run:

--- a/recipes/group_humann2_uniref_abundances_to_go/url.patch
+++ b/recipes/group_humann2_uniref_abundances_to_go/url.patch
@@ -1,0 +1,14 @@
+diff -ruN group_humann2_uniref_abundances_to_GO-1.3.0/src/group_humann2_uniref_abundances_to_GO_download_datasets.sh group_humann2_uniref_abundances_to_GO-1.3.0_org/src/group_humann2_uniref_abundances_to_GO_download_datasets.sh
+--- group_humann2_uniref_abundances_to_GO-1.3.0/src/group_humann2_uniref_abundances_to_GO_download_datasets.sh	2025-01-25 13:38:40.590388314 +0100
++++ group_humann2_uniref_abundances_to_GO-1.3.0_org/src/group_humann2_uniref_abundances_to_GO_download_datasets.sh	2019-05-02 14:29:33.000000000 +0200
+@@ -17,7 +17,7 @@
+ 
+ if [ ! -f $humann2_uniref_go ]; then
+     echo "Download humann2 correspondance between Uniref50 and GO"
+-    wget https://github.com/biobakery/humann/raw/1bb2639903be9a748c2e2e6f5287a48c3a524cc9/humann/data/misc/map_infogo1000_uniref50.txt.gz
++    wget https://bitbucket.org/biobakery/humann2/raw/d1ac153083d48a5384e3b3d3597b9e36b1a4606e/humann2/data/misc/map_infogo1000_uniref50.txt.gz
+     gunzip map_infogo1000_uniref50.txt.gz
+     mv "map_infogo1000_uniref50.txt" $humann2_uniref_go
+-fi
++fi
+\ No newline at end of file


### PR DESCRIPTION
currently fails for me with

```
[Jan 25 12:41:44] SERR
[Jan 25 12:41:44] SERR LibMambaUnsatisfiableError: Encountered problems while solving:
[Jan 25 12:41:44] SERR - package humann2-2.8.1-py27_0 requires python >=2.7,<2.8.0a0, but none of the providers can be installed
[Jan 25 12:41:44] SERR
[Jan 25 12:41:44] SERR Could not solve for environment specs
[Jan 25 12:41:44] SERR The following package could not be installed
[Jan 25 12:41:44] SERR └─ group_humann2_uniref_abundances_to_go 1.3.0**  is not installable because it requires
[Jan 25 12:41:44] SERR ├─ goatools with the potential options
[Jan 25 12:41:44] SERR │  ├─ goatools 1.2.3 would require
[Jan 25 12:41:44] SERR │  │  └─ python_abi 3.10.* *_cp310, which can be installed;
[Jan 25 12:41:44] SERR │  ├─ goatools 1.2.3 would require
[Jan 25 12:41:44] SERR │  │  └─ python_abi 3.7.* *_cp37m, which can be installed;
[Jan 25 12:41:44] SERR │  ├─ goatools 1.2.3 would require
[Jan 25 12:41:44] SERR │  │  └─ python_abi 3.8.* *_cp38, which can be installed;
[Jan 25 12:41:44] SERR │  ├─ goatools 1.2.3 would require
[Jan 25 12:41:44] SERR │  │  └─ python_abi 3.9.* *_cp39, which can be installed;
[Jan 25 12:41:44] SERR │  ├─ goatools [1.3.1|1.3.11|...|1.4.9] would require
[Jan 25 12:41:44] SERR │  │  └─ python >=3.7  with the potential options
[Jan 25 12:41:44] SERR │  │     ├─ python [3.10.0|3.10.1|...|3.9.9], which can be installed;
[Jan 25 12:41:44] SERR │  │     ├─ python [3.10.0|3.10.1|...|3.9.9] would require
[Jan 25 12:41:44] SERR │  │     │  └─ openssl >=1.1.1l,<1.1.2a , which can be installed;
[Jan 25 12:41:44] SERR │  │     ├─ python [3.10.4|3.8.13|3.9.12] would require
[Jan 25 12:41:44] SERR │  │     │  └─ openssl >=1.1.1n,<1.1.2a , which can be installed;
[Jan 25 12:41:44] SERR │  │     ├─ python [3.10.5|3.9.13] would require
[Jan 25 12:41:44] SERR │  │     │  └─ openssl >=1.1.1o,<1.1.2a , which can be installed;
[Jan 25 12:41:44] SERR │  │     ├─ python [3.10.6|3.11.0] would require
[Jan 25 12:41:44] SERR │  │     │  └─ openssl >=1.1.1q,<1.1.2a , which can be installed;
[Jan 25 12:41:44] SERR │  │     ├─ python [3.7.0|3.7.1|...|3.8.8], which can be installed;
[Jan 25 12:41:44] SERR │  │     ├─ python [3.10.15|3.11.10|...|3.8.20] would require
[Jan 25 12:41:44] SERR │  │     │  └─ openssl >=3.3.2,<4.0a0 , which can be installed;
[Jan 25 12:41:44] SERR │  │     ├─ python [3.10.16|3.11.11|3.12.8|3.13.0|3.13.1] would require
[Jan 25 12:41:44] SERR │  │     │  └─ openssl >=3.4.0,<4.0a0 , which can be installed;
[Jan 25 12:41:44] SERR │  │     ├─ python [3.10.7|3.10.8|...|3.9.15] would require
[Jan 25 12:41:44] SERR │  │     │  └─ openssl >=1.1.1s,<1.1.2a , which can be installed;
[Jan 25 12:41:44] SERR │  │     └─ python [3.12.0rc3|3.13.0rc1|3.13.0rc2|3.13.0rc3] would require
[Jan 25 12:41:44] SERR │  │        └─ _python_rc, which does not exist (perhaps a missing channel);
[Jan 25 12:41:44] SERR │  ├─ goatools 1.4.12 would require
[Jan 25 12:41:44] SERR │  │  └─ python >=3.9  with the potential options
[Jan 25 12:41:44] SERR │  │     ├─ python [3.10.0|3.10.1|...|3.9.9], which can be installed;
[Jan 25 12:41:44] SERR │  │     ├─ python [3.10.0|3.10.1|...|3.9.9], which can be installed (as previously explained);
[Jan 25 12:41:44] SERR │  │     ├─ python [3.10.4|3.8.13|3.9.12], which can be installed (as previously explained);
[Jan 25 12:41:44] SERR │  │     ├─ python [3.10.5|3.9.13], which can be installed (as previously explained);
[Jan 25 12:41:44] SERR │  │     ├─ python [3.10.6|3.11.0], which can be installed (as previously explained);
[Jan 25 12:41:44] SERR │  │     ├─ python [3.10.15|3.11.10|...|3.8.20], which can be installed (as previously explained);
[Jan 25 12:41:44] SERR │  │     ├─ python [3.10.16|3.11.11|3.12.8|3.13.0|3.13.1], which can be installed (as previously explained);
[Jan 25 12:41:44] SERR │  │     ├─ python [3.10.7|3.10.8|...|3.9.15], which can be installed (as previously explained);
[Jan 25 12:41:44] SERR │  │     └─ python [3.12.0rc3|3.13.0rc1|3.13.0rc2|3.13.0rc3], which cannot be installed (as previously explained);
[Jan 25 12:41:44] SERR │  ├─ goatools [0.5.9|0.6.10|...|1.2.3] conflicts with any installable versions previously reported;
[Jan 25 12:41:44] SERR │  └─ goatools 0.7.11 would require
[Jan 25 12:41:44] SERR │     └─ pywget, which does not exist (perhaps a missing channel);
[Jan 25 12:41:44] SERR ├─ humann2, which requires
[Jan 25 12:41:44] SERR │  └─ python [2.7* |>=2.7,<2.8.0a0 ] but there are no viable options
[Jan 25 12:41:44] SERR │     ├─ python [2.7.12|2.7.13|2.7.14|2.7.15] would require
[Jan 25 12:41:44] SERR │     │  ├─ openssl 1.0.* , which conflicts with any installable versions previously reported;
[Jan 25 12:41:44] SERR │     │  └─ python_abi * *_cp27mu, which conflicts with any installable versions previously reported;
[Jan 25 12:41:44] SERR │     ├─ python 2.7.15 would require
[Jan 25 12:41:44] SERR │     │  └─ python_abi * *_cp27mu, which conflicts with any installable versions previously reported;
[Jan 25 12:41:44] SERR │     ├─ python 2.7.15 would require
[Jan 25 12:41:44] SERR │     │  └─ python_abi 2.7.* *_cp27mu, which conflicts with any installable versions previously reported;
[Jan 25 12:41:44] SERR │     └─ python 2.7.15 would require
[Jan 25 12:41:44] SERR │        ├─ openssl >=1.0.2o,<1.0.3a , which conflicts with any installable versions previously reported;
[Jan 25 12:41:44] SERR │        └─ python_abi * *_cp27mu, which conflicts with any installable versions previously reported;
[Jan 25 12:41:44] SERR └─ python <3  but there are no viable options
[Jan 25 12:41:44] SERR ├─ python [2.7.12|2.7.13|2.7.14|2.7.15], which cannot be installed (as previously explained);
[Jan 25 12:41:44] SERR ├─ python 2.7.15, which cannot be installed (as previously explained);
[Jan 25 12:41:44] SERR ├─ python 2.7.15, which cannot be installed (as previously explained);
[Jan 25 12:41:44] SERR ├─ python 2.7.15, which cannot be installed (as previously explained);
[Jan 25 12:41:44] SERR └─ python [1.0.1|1.2|...|2.6.9] conflicts with any installable versions previously reported.
```

Describe your pull request here

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
