### PR TITLE
bioconductor-copynumber restore to enable aarch64 supporting package

### DIFF
--- a/recipes/bioconductor-biocgenerics/meta.yaml
+++ b/recipes/bioconductor-biocgenerics/meta.yaml
@@ -9,7 +9,7 @@ about:
   summary: S4 generic functions used in Bioconductor
 build:
   noarch: generic
-  number: 1
+  number: 3
   rpaths:
     - lib/R/lib/
     - lib/

--- a/recipes/bioconductor-biocgenerics/meta.yaml
+++ b/recipes/bioconductor-biocgenerics/meta.yaml
@@ -9,7 +9,7 @@ about:
   summary: S4 generic functions used in Bioconductor
 build:
   noarch: generic
-  number: 0
+  number: 1
   rpaths:
     - lib/R/lib/
     - lib/

--- a/recipes/bioconductor-copynumber/build.sh
+++ b/recipes/bioconductor-copynumber/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+mv DESCRIPTION DESCRIPTION.old
+grep -v '^Priority: ' DESCRIPTION.old > DESCRIPTION
+mkdir -p ~/.R
+echo -e "CC=$CC
+FC=$FC
+CXX=$CXX
+CXX98=$CXX
+CXX11=$CXX
+CXX14=$CXX" > ~/.R/Makevars
+$R CMD INSTALL --build .

--- a/recipes/bioconductor-copynumber/build.sh
+++ b/recipes/bioconductor-copynumber/build.sh
@@ -1,11 +1,4 @@
 #!/bin/bash
 mv DESCRIPTION DESCRIPTION.old
 grep -v '^Priority: ' DESCRIPTION.old > DESCRIPTION
-mkdir -p ~/.R
-echo -e "CC=$CC
-FC=$FC
-CXX=$CXX
-CXX98=$CXX
-CXX11=$CXX
-CXX14=$CXX" > ~/.R/Makevars
 $R CMD INSTALL --build .

--- a/recipes/bioconductor-copynumber/meta.yaml
+++ b/recipes/bioconductor-copynumber/meta.yaml
@@ -1,0 +1,49 @@
+{% set version = "1.38.0" %}
+{% set name = "copynumber" %}
+{% set bioc = "3.16" %}
+
+package:
+  name: 'bioconductor-{{ name|lower }}'
+  version: '{{ version }}'
+source:
+  url:
+    - 'https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/{{ name }}_{{ version }}.tar.gz'
+    - 'https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/Archive/{{ name }}/{{ name }}_{{ version }}.tar.gz'
+    - 'https://bioarchive.galaxyproject.org/{{ name }}_{{ version }}.tar.gz'
+    - 'https://depot.galaxyproject.org/software/bioconductor-{{ name }}/bioconductor-{{ name }}_{{ version }}_src_all.tar.gz'
+  md5: 1b7a578d6f0ae8a5c59c65e7d65ea0cb
+build:
+  number: 1
+  rpaths:
+    - lib/R/lib/
+    - lib/
+  noarch: generic
+requirements:
+  host:
+    - bioconductor-biocgenerics
+    - bioconductor-genomicranges
+    - bioconductor-iranges
+    - bioconductor-s4vectors
+    - r-base
+  run:
+    - bioconductor-biocgenerics
+    - bioconductor-genomicranges =1.58.0
+    - bioconductor-iranges
+    - bioconductor-s4vectors
+    - r-base
+test:
+  commands:
+    - '$R -e "library(''{{ name }}'')"'
+about:
+  home: 'https://bioconductor.org/packages/{{ bioc }}/bioc/html/{{ name }}.html'
+  license: Artistic-2.0
+  summary: 'Segmentation of single- and multi-track copy number data by penalized least squares regression.'
+  description: 'Penalized least squares regression is applied to fit piecewise constant curves to copy number data to locate genomic regions of constant copy number. Procedures are available for individual segmentation of each sample, joint segmentation of several samples and joint segmentation of the two data tracks from SNP-arrays. Several plotting functions are available for visualization of the data and the segmentation results.'
+extra:
+  identifiers:
+    - biotools:copynumber
+  parent_recipe:
+    name: bioconductor-copynumber
+    path: recipes/bioconductor-copynumber
+    version: 1.20.0
+

--- a/recipes/bioconductor-genomeinfodb/meta.yaml
+++ b/recipes/bioconductor-genomeinfodb/meta.yaml
@@ -10,7 +10,7 @@ about:
 
 build:
   noarch: generic
-  number: 1
+  number: 2
   rpaths:
     - lib/R/lib/
     - lib/

--- a/recipes/bioconductor-genomeinfodb/meta.yaml
+++ b/recipes/bioconductor-genomeinfodb/meta.yaml
@@ -10,7 +10,7 @@ about:
 
 build:
   noarch: generic
-  number: 0
+  number: 1
   rpaths:
     - lib/R/lib/
     - lib/

--- a/recipes/bioconductor-genomicranges/meta.yaml
+++ b/recipes/bioconductor-genomicranges/meta.yaml
@@ -9,7 +9,7 @@ about:
   summary: Representation and manipulation of genomic intervals
 
 build:
-  number: 0
+  number: 1
   rpaths:
     - lib/R/lib/
     - lib/

--- a/recipes/bioconductor-iranges/meta.yaml
+++ b/recipes/bioconductor-iranges/meta.yaml
@@ -9,7 +9,7 @@ about:
   summary: Foundation of integer range manipulation in Bioconductor
 
 build:
-  number: 1
+  number: 2
   rpaths:
     - lib/R/lib/
     - lib/

--- a/recipes/bioconductor-s4vectors/meta.yaml
+++ b/recipes/bioconductor-s4vectors/meta.yaml
@@ -9,7 +9,7 @@ about:
   summary: Foundation of vector-like and list-like containers in Bioconductor
 
 build:
-  number: 1
+  number: 2
   rpaths:
     - lib/R/lib/
     - lib/

--- a/recipes/bioconductor-ucsc.utils/meta.yaml
+++ b/recipes/bioconductor-ucsc.utils/meta.yaml
@@ -8,8 +8,7 @@ about:
   license: Artistic-2.0
   summary: Low-level utilities to retrieve data from the UCSC Genome Browser
 build:
-  noarch: generic
-  number: 0
+  number: 1
   rpaths:
     - lib/R/lib/
     - lib/

--- a/recipes/bioconductor-xvector/meta.yaml
+++ b/recipes/bioconductor-xvector/meta.yaml
@@ -9,7 +9,7 @@ about:
   summary: Foundation of external vector representation and manipulation in Bioconductor
 
 build:
-  number: 1
+  number: 2
   rpaths:
     - lib/R/lib/
     - lib/

--- a/recipes/bioconductor-zlibbioc/meta.yaml
+++ b/recipes/bioconductor-zlibbioc/meta.yaml
@@ -10,7 +10,7 @@ about:
   summary: An R packaged zlib-1.2.5
 
 build:
-  number: 1
+  number: 2
   rpaths:
     - lib/R/lib/
     - lib/


### PR DESCRIPTION
bioconductor-copynumber has been removed from bioconductor since 3.18 due to lack of maintainers, and subsequently removed from bioconda but is still used by some packages: hmftools-amber/cobalt (still used by some nf-core pipelines), r-eacon, and a couple of bioconductor packages.

The legacy builds enable x86 to continue to function, but that leaves no workable path for aarch64 as the legacy binaries cannot be made due to lack of support in legacy versions of some current tools.

This PR restores bioconductor-copynumber and lets it build against more recent bioconductor/r-base. If removed in a subsequent PR, at least the binaries will continue to exist for aarch64 and x86.

A number of  bioconductor packages needed a build bump (including some 'generic' noarch) - which are in this PR too. It's not clear to me why - but the build couldn't resolve a working version without these, and often got stuck on older r-base version availability.



Describe your pull request here

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
