### PR TITLE
Update to AMRFinderPlus 4.0.15

### DIFF
--- a/recipes/ncbi-amrfinderplus/build.sh
+++ b/recipes/ncbi-amrfinderplus/build.sh
@@ -25,11 +25,3 @@ make CXX="$CXX $LDFLAGS" CPPFLAGS="$CXXFLAGS -I${PREFIX}/include" PREFIX="$PREFI
 
 make install INSTALL_DIR="$PREFIX/bin"
 
-### Temporary bug fix for issue with Makefile. These lines have been added to the makefile
-# for future releases, so remove after version 4.0.3
-if [ ! -e "$PREFIX/bin/stx/stxtyper" ]
-then
-    mkdir "$PREFIX/bin/stx"
-    ln -s ../stxtyper "$PREFIX/bin/stx/stxtyper"
-fi
-# end bug fix

--- a/recipes/ncbi-amrfinderplus/meta.yaml
+++ b/recipes/ncbi-amrfinderplus/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "4.0.3" %}
-{% set sha256 = "e3007c074ac77e410914691b38d7eaaaaf2cda6c" %}
+{% set version = "4.0.15" %}
+{% set sha256 = "7d068c3e53bbce53ffd5a00276bc32dc0baf7f5d3593ce3c7b92a428d623a055" %}
 
 package:
   name: ncbi-amrfinderplus

--- a/recipes/ncbi-amrfinderplus/meta.yaml
+++ b/recipes/ncbi-amrfinderplus/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 0
   run_exports:
     - {{ pin_subpackage('ncbi-amrfinderplus', max_pin="x") }}
 


### PR DESCRIPTION
This is just a minor update to the NCBI AMRFinderPlus software latest version. For some reason autobump didn't pick it up.