### PR TITLE
Update r-ukbrapr - remove deprecated dependencies

### DIFF
--- a/recipes/r-ukbrapr/meta.yaml
+++ b/recipes/r-ukbrapr/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   script: R CMD INSTALL --build .
-  number: 0
+  number: 1
   noarch: generic
   run_exports:
     - {{ pin_subpackage('r-ukbrapr', max_pin="x.x.x") }}

--- a/recipes/r-ukbrapr/meta.yaml
+++ b/recipes/r-ukbrapr/meta.yaml
@@ -27,9 +27,6 @@ requirements:
     - r-purrr >=1.0.0
     - r-lubridate >=1.9.0
     - r-rlang >=1.0.0
-    - r-reticulate >=1.34.0
-    - r-arrow >=13.0.0
-    - r-sparklyr >=1.8.4
     - r-cli >=3.6.1
     - r-prettyunits >=1.0.0
     - r-lifecycle >=1.0.0
@@ -42,9 +39,6 @@ requirements:
     - r-purrr >=1.0.0
     - r-lubridate >=1.9.0
     - r-rlang >=1.0.0
-    - r-reticulate >=1.34.0
-    - r-arrow >=13.0.0
-    - r-sparklyr >=1.8.4
     - r-cli >=3.6.1
     - r-prettyunits >=1.0.0
     - r-lifecycle >=1.0.0


### PR DESCRIPTION
v0.3.0 removed some deprecated dependencies. Updating recipe to reflect this. 