### PR TITLE
Update excludonfinder to 0.1.4

### DIFF
--- a/recipes/excludonfinder/meta.yaml
+++ b/recipes/excludonfinder/meta.yaml
@@ -1,16 +1,17 @@
 {% set name = "excludonfinder" %}
-{% set version = "0.1.1" %}
+{% set version = "0.1.4" %}
+
 package:
   name: {{ name }}
   version: {{ version }}
+
 source:
   url: https://github.com/Alvarosmb/ExcludonFinder/archive/v{{ version }}.tar.gz
-  sha256: cc0a4a3c23d99c473563113e693f00511e1f9fc5a77dec2826ee956b32c323e1
+  sha256: b25267178817b0e4534c89aa1f9763f9fe383b2abd2e089293476775056fc364
+
 build:
-  number: 2
+  number: 0
   noarch: generic
-  run_exports:
-    - {{ pin_subpackage('excludonfinder', max_pin="x.x") }}
   script:
     - mkdir -p $PREFIX/bin
     - mkdir -p $PREFIX/share/${PKG_NAME}/scripts
@@ -19,6 +20,7 @@ build:
     - cp -rf scripts/main.sh $PREFIX/share/${PKG_NAME}/scripts/
     - chmod +x $PREFIX/bin/ExcludonFinder
     - chmod +x $PREFIX/share/${PKG_NAME}/scripts/*.{sh,R}
+
 requirements:
   run:
     - r-base >=4.1
@@ -32,10 +34,12 @@ requirements:
     - r-data.table >=1.14
     - r-biocmanager >=1.30.19
     - bioconductor-rtracklayer >=1.54.0
-    - parallel >=20211022
+
 test:
   commands:
+    - ExcludonFinder -h
     - ExcludonFinder --help
+
 about:
   home: https://github.com/Alvarosmb/ExcludonFinder
   license: MIT

--- a/recipes/excludonfinder/meta.yaml
+++ b/recipes/excludonfinder/meta.yaml
@@ -1,0 +1,44 @@
+{% set name = "excludonfinder" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/Alvarosmb/ExcludonFinder/archive/v{{ version }}.tar.gz
+  sha256: # Will add this later
+
+build:
+  number: 0
+  noarch: generic
+  run_exports:
+    - {{ pin_subpackage('excludonfinder', max_pin="x.x") }}
+  script:
+    - mkdir -p $PREFIX/bin
+    - cp scripts/ExcludonFinder $PREFIX/bin/
+    - chmod +x $PREFIX/bin/ExcludonFinder
+
+requirements:
+  run:
+    - r-base >=4.1
+    - bwa-mem2 >=2.2.1
+    - minimap2 >=2.24
+    - samtools >=1.15
+    - subread >=2.0.1
+    - r-dplyr >=1.0.7
+    - r-foreach >=1.5.2
+    - r-doparallel >=1.0.17
+    - r-data.table >=1.14
+    - r-biocmanager >=1.30.19
+    - bioconductor-rtracklayer >=1.54.0
+    - parallel >=20211022
+
+test:
+  commands:
+    - ExcludonFinder --help
+
+about:
+  home: https://github.com/Alvarosmb/ExcludonFinder
+  license: MIT
+  summary: A tool for identifying and analyzing excludons in genomic data using RNA-seq data

--- a/recipes/excludonfinder/meta.yaml
+++ b/recipes/excludonfinder/meta.yaml
@@ -1,24 +1,24 @@
 {% set name = "excludonfinder" %}
-{% set version = "0.1.0" %}
-
+{% set version = "0.1.1" %}
 package:
   name: {{ name }}
   version: {{ version }}
-
 source:
   url: https://github.com/Alvarosmb/ExcludonFinder/archive/v{{ version }}.tar.gz
-  sha256: # Will add this later
-
+  sha256: cc0a4a3c23d99c473563113e693f00511e1f9fc5a77dec2826ee956b32c323e1
 build:
-  number: 0
+  number: 2
   noarch: generic
   run_exports:
     - {{ pin_subpackage('excludonfinder', max_pin="x.x") }}
   script:
     - mkdir -p $PREFIX/bin
-    - cp scripts/ExcludonFinder $PREFIX/bin/
+    - mkdir -p $PREFIX/share/${PKG_NAME}/scripts
+    - cp -rf scripts/ExcludonFinder $PREFIX/bin/
+    - cp -rf scripts/TUs_annotation.R $PREFIX/share/${PKG_NAME}/scripts/
+    - cp -rf scripts/main.sh $PREFIX/share/${PKG_NAME}/scripts/
     - chmod +x $PREFIX/bin/ExcludonFinder
-
+    - chmod +x $PREFIX/share/${PKG_NAME}/scripts/*.{sh,R}
 requirements:
   run:
     - r-base >=4.1
@@ -33,12 +33,13 @@ requirements:
     - r-biocmanager >=1.30.19
     - bioconductor-rtracklayer >=1.54.0
     - parallel >=20211022
-
 test:
   commands:
     - ExcludonFinder --help
-
 about:
   home: https://github.com/Alvarosmb/ExcludonFinder
   license: MIT
-  summary: A tool for identifying and analyzing excludons in genomic data using RNA-seq data
+  license_family: MIT
+  license_file: LICENSE
+  summary: "A tool for identifying and analyzing excludons in genomic data using RNA-seq data."
+  dev_url: https://github.com/Alvarosmb/ExcludonFinder


### PR DESCRIPTION
- Update to version 0.1.4
- Fix script paths handling
- Add support for both -h and --help flags
- Remove run_exports section