### PR TITLE
Update excludonfinder to 0.1.4

### DIFF
--- a/recipes/excludonfinder/meta.yaml
+++ b/recipes/excludonfinder/meta.yaml
@@ -10,8 +10,10 @@ source:
   sha256: b25267178817b0e4534c89aa1f9763f9fe383b2abd2e089293476775056fc364
 
 build:
-  number: 0
+  number: 1  # Incrementado de 0 a 1
   noarch: generic
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x.x") }}  # Usando x.x porque empieza con 0
   script:
     - mkdir -p $PREFIX/bin
     - mkdir -p $PREFIX/share/${PKG_NAME}/scripts

--- a/recipes/excludonfinder/meta.yaml
+++ b/recipes/excludonfinder/meta.yaml
@@ -12,8 +12,6 @@ source:
 build:
   number: 0
   noarch: generic
-  run_exports:
-    - {{ pin_subpackage('excludonfinder', max_pin="x.x") }}
   script:
     - mkdir -p $PREFIX/bin
     - mkdir -p $PREFIX/share/${PKG_NAME}/scripts
@@ -36,11 +34,11 @@ requirements:
     - r-data.table >=1.14
     - r-biocmanager >=1.30.19
     - bioconductor-rtracklayer >=1.54.0
-    - parallel >=20211022
 
 test:
   commands:
-    - ExcludonFinder 2&1>/dev/null
+    - ExcludonFinder -h
+    - ExcludonFinder --help
 
 about:
   home: https://github.com/Alvarosmb/ExcludonFinder


### PR DESCRIPTION
- Update to version 0.1.4
- Fix script paths handling
- Add support for both -h and --help flags
- Remove run_exports section