### PR TITLE
add Wrapt timeout decorator

### DIFF
--- a/recipes/wrapt_timeout_decorator/meta.yaml
+++ b/recipes/wrapt_timeout_decorator/meta.yaml
@@ -1,0 +1,53 @@
+{% set name = "wrapt_timeout_decorator" %}
+{% set version = "1.5.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/wrapt_timeout_decorator-{{ version }}.tar.gz
+  sha256: 00f15646db89c629aa1b1566f4c1cf00ae6da0beece2905039f1cd7a60506a67
+
+build:
+  skip: true  # [py<38]
+  entry_points:
+    - wrapt_timeout_decorator = wrapt_timeout_decorator.wrapt_timeout_decorator_cli:cli_main
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+  run_exports:
+    - {{ pin_subpackage("wrapt_timeout_decorator", max_pin="x.x.x") }}
+
+requirements:
+  host:
+    - python >=3.8.0
+    - setuptools
+    - setuptools-scm
+    - pip
+  run:
+    - python >=3.8.0
+    - cli-exit-tools
+    - dill  # [not win]
+    - dill >0.3.0,!=0.3.5,!=0.3.5.1  # [win]
+    - lib-detect-testenv
+    - multiprocess
+    - psutil
+    - wrapt
+
+test:
+  imports:
+    - wrapt_timeout_decorator
+  commands:
+    - pip check
+    - wrapt_timeout_decorator --help
+  requires:
+    - pip
+
+about:
+  summary: The better timout decorator
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - nilchia

--- a/recipes/wrapt_timeout_decorator/meta.yaml
+++ b/recipes/wrapt_timeout_decorator/meta.yaml
@@ -10,9 +10,9 @@ source:
   sha256: 00f15646db89c629aa1b1566f4c1cf00ae6da0beece2905039f1cd7a60506a67
 
 build:
-  skip: true  # [py<38]
   entry_points:
     - wrapt_timeout_decorator = wrapt_timeout_decorator.wrapt_timeout_decorator_cli:cli_main
+  noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
   run_exports:
@@ -44,6 +44,7 @@ test:
     - pip
 
 about:
+  home: https://github.com/bitranox/wrapt_timeout_decorator
   summary: The better timout decorator
   license: MIT
   license_file: LICENSE


### PR DESCRIPTION
adds wrap-timeout-decorator dependency for VPT (#53647)

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
