### PR TITLE
add cli-exit-tools

### DIFF
--- a/recipes/cli-exit-tools/meta.yaml
+++ b/recipes/cli-exit-tools/meta.yaml
@@ -1,0 +1,49 @@
+{% set name = "cli-exit-tools" %}
+{% set version = "1.2.7" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/cli_exit_tools-{{ version }}.tar.gz
+  sha256: e752427a4aa9db1f18370c8dc11ebef6e245cc5891ec2fa79e7169be583c2423
+
+build:
+  entry_points:
+    - cli_exit_tools = cli_exit_tools.cli_exit_tools_cli:cli_main
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+  run_exports:
+    - {{ pin_subpackage("cli-exit-tools", max_pin="x.x.x") }}
+
+requirements:
+  host:
+    - python >=3.8.0
+    - setuptools
+    - setuptools-scm
+    - pip
+  run:
+    - python >=3.8.0
+    - click
+    - lib-detect-testenv
+
+test:
+  imports:
+    - cli_exit_tools
+  commands:
+    - pip check
+    - cli_exit_tools --help
+  requires:
+    - pip
+
+about:
+  home: https://github.com/bitranox/cli_exit_tools
+  summary: functions to exit an cli application properly
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - nilchia


### PR DESCRIPTION
adds cli-exist-tools dependency for wrapt_timeout_decorator (#53650) required for VPT (#53647)

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
