### PR TITLE
add lib-detect-testenv

### DIFF
--- a/recipes/lib-detect-testenv/meta.yaml
+++ b/recipes/lib-detect-testenv/meta.yaml
@@ -1,0 +1,44 @@
+{% set name = "lib-detect-testenv" %}
+{% set version = "2.0.8" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/lib_detect_testenv-{{ version }}.tar.gz
+  sha256: 96527b3114727e70e80f671c204a225ae6aaaf117983f8fa4f56e542b2368d43
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+  run_exports:
+    - {{ pin_subpackage("lib-detect-testenv", max_pin="x.x.x") }}
+
+requirements:
+  host:
+    - python >=3.8.0
+    - setuptools
+    - setuptools-scm
+    - pip
+  run:
+    - python >=3.8.0
+
+test:
+  imports:
+    - lib_detect_testenv
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/bitranox/lib_detect_testenv
+  summary: detects if pytest or doctest or pyrunner on pycharm is running
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - nilchia


### PR DESCRIPTION
adds lib-detect-testenv dependency for cli-exit-tools (#53651) and wrapt_timeout_decorator (#53650) required for VPT (#53647)

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
