### PR TITLE
Update HATCHet to v2.1.1

### DIFF
--- a/recipes/hatchet/meta.yaml
+++ b/recipes/hatchet/meta.yaml
@@ -17,7 +17,7 @@ source:
     sha256: 1d58586f9a33ac7035f51f6a04707248218f70bddbec78cb83f11c986ac652cd  # [osx]
 
 build:
-  number: 2
+  number: 0
   skip: True  # [py < 37]
   entry_points:
     - hatchet = hatchet.__main__:main

--- a/recipes/hatchet/meta.yaml
+++ b/recipes/hatchet/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "hatchet" %}
-{% set version = "2.1.0" %}
+{% set version = "2.1.1" %}
 
 package:
   name: '{{ name|lower }}'
@@ -7,7 +7,7 @@ package:
 
 source:
   - url: https://github.com/raphael-group/{{ name }}/archive/v{{ version }}.tar.gz
-    sha256: 979dded4450134ff023f4a7ffbdb6d0d175ac7567e89ab4045c2e12706c3827d
+    sha256: c02d997eb266580af6f52990fe053d7cf7734403d9801250b1c6de554875f4bf
 
   - url: https://packages.gurobi.com/9.0/gurobi9.0.2_linux64.tar.gz  # [not osx]
     sha256: 6527581aef11c3e425c52993d108861ef53ec13971d9931861bf9c88d9d111f3  # [not osx]


### PR DESCRIPTION
We have made minor update to support recent updates on third-party dependencies. This PR updates the version number to v2.1.1 and hash checksum in YAML file. Thank you.
