### PR TITLE
Update ncbi-amrfinderplus to version 4.0.19

### DIFF
--- a/recipes/ncbi-amrfinderplus/meta.yaml
+++ b/recipes/ncbi-amrfinderplus/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "4.0.15" %}
-{% set sha256 = "7d068c3e53bbce53ffd5a00276bc32dc0baf7f5d3593ce3c7b92a428d623a055" %}
+{% set version = "4.0.19" %}
+{% set sha256 = "0aff68415dbd348549bf5e627a87cf56403ceee2e1b89522ea005ab8b56e89e5" %}
 
 package:
   name: ncbi-amrfinderplus


### PR DESCRIPTION
Manually update ncbi-amrfinderplus for AMRFinderPlus 4.0.19. For some reason autobump doesn't seem to be picking up new releases. 