### PR TITLE
Add Star 2.7.3a

### DIFF
--- a/recipes/star/2.7.3a/build.sh
+++ b/recipes/star/2.7.3a/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+export INCLUDES="-I${PREFIX}/include"
+export LIBPATH="-L${PREFIX}/lib"
+export CXXFLAGS="${CXXFLAGS} -std=c++17 -O3 -I${PREFIX}/include -fopenmp"
+export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib"
+
+if [[ "$(uname)" == "Darwin" ]]; then
+    echo "Installing STAR for OSX."
+    mkdir -p $PREFIX/bin
+    install -v -m 0755 bin/MacOSX_x86_64/STAR $PREFIX/bin
+    install -v -m 0755 bin/MacOSX_x86_64/STARlong $PREFIX/bin
+else 
+    echo "Building STAR for Linux"
+    mkdir -p $PREFIX/bin
+    cd source
+    make -pj"$(nproc)" CXX="${CXX}" CXXFLAGS="${CXXFLAGS}" STAR STARlong
+    install -v -m 0755 STAR $PREFIX/bin
+    install -v -m 0755 STARlong $PREFIX/bin
+fi

--- a/recipes/star/2.7.3a/meta.yaml
+++ b/recipes/star/2.7.3a/meta.yaml
@@ -1,0 +1,51 @@
+{% set name = "star" %}
+{% set version = "2.7.3a" %}
+{% set sha256 = "de204175351dc5f5ecc40cf458f224617654bdb8e00df55f0bb03a5727bf26f9" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/alexdobin/STAR/archive/{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+  patches:
+    - patches/0004-comptimeplace.patch
+
+build:
+  number: 1
+  run_exports:
+    - {{ pin_subpackage('star', max_pin="x") }}
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - make
+    - vim
+  host:
+    - zlib
+
+test:
+  commands:
+    - STAR --version
+    - STARlong --version
+
+about:
+  home: "https://github.com/alexdobin/STAR"
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  license_file: LICENSE
+  summary: "An RNA-seq read aligner."
+  dev_url: "https://github.com/alexdobin/STAR"
+  doc_url: "https://github.com/alexdobin/STAR/blob/{{ version }}/doc/STARmanual.pdf"
+
+extra:
+  additional-platforms:
+    - linux-aarch64
+  identifiers:
+    - biotools:star
+    - usegalaxy-eu:rna_starsolo
+    - usegalaxy-eu:rna_star
+  recipe-maintainers:
+    - mjsteinbaugh

--- a/recipes/star/2.7.3a/patches/0004-comptimeplace.patch
+++ b/recipes/star/2.7.3a/patches/0004-comptimeplace.patch
@@ -1,0 +1,20 @@
+--- source/Makefile.orig	2025-02-11 22:18:02.275802305 +0000
++++ source/Makefile	2025-02-12 02:01:11.323775139 +0000
+@@ -18,7 +18,7 @@
+ LDFLAGS_Mac_static :=-pthread -lz -static-libgcc htslib/libhts.a
+ LDFLAGS_gdb := $(LDFLAGS_shared)
+ 
+-COMPTIMEPLACE := -D'COMPILATION_TIME_PLACE="$(shell echo `date` $(HOSTNAME):`pwd`)"'
++COMPTIMEPLACE := -D'COMPILATION_TIME_PLACE="$(shell echo `date` $(HOSTNAME):$(PWD))"'
+ 
+ CXXFLAGS_common := -pipe -std=c++11 -Wall -Wextra -fopenmp $(COMPTIMEPLACE)
+ CXXFLAGS_main := -O3 $(CXXFLAGS_common)
+@@ -66,7 +66,7 @@
+ 
+ 
+ %.o : %.cpp
+-	$(CXX) -c $(CPPFLAGS) $(CXXFLAGS) $<
++	$(CXX) -c $(CPPFLAGS) $(CXXFLAGS_common) $<
+ 
+ %.o : %.c
+ 	$(CXX) -c $(CPPFLAGS) $(CFLAGS) $<


### PR DESCRIPTION
Adds support for this specific STAR version since it's needed for an ongoing effort to port `oncoanalyser` pipeline to `linux-aarch64`.

This specific version is needed since latest versions generate runtime issues, as reported by Hartwig.

/cc @scwatts 