### PR TITLE
t-coffee: add versions of dependencies and revert the removal of arm64 support

### DIFF
--- a/recipes/t-coffee/build.sh
+++ b/recipes/t-coffee/build.sh
@@ -46,3 +46,12 @@ mkdir -p "${PREFIX}/bin"
 rm -fv ${PREFIX}/bin/*
 
 sed -e "s|CHANGEME|${SHARE_DIR}|" -e "s|__OS__|${OS}|" "$RECIPE_DIR/t_coffee.sh" > "${PREFIX}/bin/t_coffee"
+
+# Get test data 
+# mkdir -p $PREFIX/share/test/
+# wget https://raw.githubusercontent.com/nf-core/test-datasets/refs/heads/multiplesequencealign/testdata/setoxin-ref.fa -O $PREFIX/share/test/seatoxin-ref.fa
+# wget https://raw.githubusercontent.com/nf-core/test-datasets/multiplesequencealign/testdata/af2_structures/seatoxin-ref.tar.gz -O seatoxin-ref.tar.gz
+# tar -xvf $PREFIX/share/test/seatoxin-ref.tar.gz
+# mv $PREFIX/share/test/seatoxin-ref/* $PREFIX/share/test/
+# rm -r $PREFIX/share/test/seatoxin-ref
+# wget https://raw.githubusercontent.com/nf-core/test-datasets/refs/heads/multiplesequencealign/testdata/templates/seatoxin-ref_template.txt -O $PREFIX/share/test/seatoxin-ref_template.txt

--- a/recipes/t-coffee/build.sh
+++ b/recipes/t-coffee/build.sh
@@ -8,22 +8,37 @@
 # $PKG_BUILDNUM The build number of the package
 #
 set -eux -o pipefail
+# silence some LANG perl warning messages:
+export LANG=C.UTF-8
 
 SHARE_DIR="${PREFIX}/libexec/${PKG_NAME}-${PKG_VERSION}-${PKG_BUILDNUM}"
 OS=$(./install get_os)
 
+# -fsigned-char is needed for aarch64; register needs to be hidden for os-x's C++ compiler
+CFLAGS="${CFLAGS} -fsigned-char -Wno-write-strings -Dregister='' -O0"
+
+rm -fv bin/${OS}/*			# remove the download binaries - we rebuild
+
+cd t_coffee_source
+make -j ${CPU_COUNT} CFLAGS="${CFLAGS} -fsigned-char -Wno-write-strings -Dregister='' -O0" CC="${CXX}" LDFLAGS="${LDFLAGS}" FCC="${FC}" FFLAGS="${FFLAGS}" all
+cp t_coffee TMalign ../bin/${OS}/ # overwrite the distributed x86 linux binary 
+cd ..
+
 mkdir -p "${PREFIX}/bin"
 
-./install all -tcdir="${SHARE_DIR}" CC="$CXX" CFLAGS="$CFLAGS"
+# the t-coffee home only has plugins with x86_64 support; let's not 
+# download them. Instead use only bioconda's own installs.
+# the t_coffee application is the only one from the set required by Bio::Tools::Run::Alignment::TCoffee
+./install t_coffee -tcdir="${SHARE_DIR}" CC="${CXX}" CFLAGS="${CFLAGS}"
 
-# llvm-otool -l fails for these plugins on macosx
-if [ "$OS" = macosx ]
-then
-    for bad_plug in probconsRNA prank
-    do
-	rm -fv "${SHARE_DIR}/plugins/macosx/${bad_plug}"
-    done
-fi
+# # llvm-otool -l fails for these plugins on macosx
+# if [ "$OS" = macosx ]
+# then
+#     for bad_plug in probconsRNA prank
+#     do
+# 	rm -fv "${SHARE_DIR}/plugins/macosx/${bad_plug}"
+#     done
+# fi
 
 # The installer may try to update dependencies and install them to bin/,
 # which will cause conflicts with the dependencies as separately packaged.

--- a/recipes/t-coffee/build.sh
+++ b/recipes/t-coffee/build.sh
@@ -47,11 +47,3 @@ rm -fv ${PREFIX}/bin/*
 
 sed -e "s|CHANGEME|${SHARE_DIR}|" -e "s|__OS__|${OS}|" "$RECIPE_DIR/t_coffee.sh" > "${PREFIX}/bin/t_coffee"
 
-# Get test data 
-# mkdir -p $PREFIX/share/test/
-# wget https://raw.githubusercontent.com/nf-core/test-datasets/refs/heads/multiplesequencealign/testdata/setoxin-ref.fa -O $PREFIX/share/test/seatoxin-ref.fa
-# wget https://raw.githubusercontent.com/nf-core/test-datasets/multiplesequencealign/testdata/af2_structures/seatoxin-ref.tar.gz -O seatoxin-ref.tar.gz
-# tar -xvf $PREFIX/share/test/seatoxin-ref.tar.gz
-# mv $PREFIX/share/test/seatoxin-ref/* $PREFIX/share/test/
-# rm -r $PREFIX/share/test/seatoxin-ref
-# wget https://raw.githubusercontent.com/nf-core/test-datasets/refs/heads/multiplesequencealign/testdata/templates/seatoxin-ref_template.txt -O $PREFIX/share/test/seatoxin-ref_template.txt

--- a/recipes/t-coffee/coredump.patch
+++ b/recipes/t-coffee/coredump.patch
@@ -1,0 +1,24 @@
+diff -ur a/t_coffee_source/util_lib/util.c b/t_coffee_source/util_lib/util.c
+--- a/t_coffee_source/util_lib/util.c	2023-07-07 22:06:54.000000000 +0000
++++ b/t_coffee_source/util_lib/util.c	2025-01-16 00:27:11.959164302 +0000
+@@ -5628,7 +5628,7 @@
+ 
+ static int nproc;
+ 
+-int set_nproc(int np)
++void set_nproc(int np)
+ {
+ 
+   //set to 0 if to be reset by environement
+diff -ur a/t_coffee_source/util_lib/util.h b/t_coffee_source/util_lib/util.h
+--- a/t_coffee_source/util_lib/util.h	2023-07-07 22:06:54.000000000 +0000
++++ b/t_coffee_source/util_lib/util.h	2025-01-16 00:28:11.108005343 +0000
+@@ -586,7 +586,7 @@
+ methods: idem
+ mcoffee: idem
+ */
+-int set_nproc (int nproc);
++void set_nproc (int nproc);
+ int get_nproc ();
+ char *get_os();
+ char *get_lockdir_4_tcoffee ();

--- a/recipes/t-coffee/meta.yaml
+++ b/recipes/t-coffee/meta.yaml
@@ -25,12 +25,8 @@ requirements:
     - {{ compiler('cxx') }}
     - {{ compiler('fortran') }}
     - perl-xml-simple
-    - perl
-  host: 
-    - gcc
     - perl            ==5.32.1
   run:
-    - gcc
     - perl            ==5.32.1
     - clustalo        ==1.2.4
     - clustalw        ==2.1

--- a/recipes/t-coffee/meta.yaml
+++ b/recipes/t-coffee/meta.yaml
@@ -27,27 +27,30 @@ requirements:
     - perl-xml-simple
     - perl
     - wget
+  host: 
+    - gcc
+    - perl            ==5.32.1
   run:
-    - blast
-    - clustalo ==1.2.4
-    - clustalw ==2.1
-    - consan ==1.2 # [not osx]
-    - dialign-tx >=1.0.2
-    - famsa ==2.2.3
-    - kalign2 ==2.04
-    - mafft ==7.526
-    - muscle ==3.8.1551
-    - mustang >=3.2.3
-    - pasta ==1.9.2
-    - perl
-    - phylip ==3.697
-    - poa >=2.0 # [not osx]
-    - prank ==170427
-    - probcons ==1.12
-    - probconsrna ==1.10
-    - sap ==1.1.3
-    - tmalign ==20170708
-    - viennarna ==2.7.0
+    - gcc
+    - perl            ==5.32.1
+    - clustalo        ==1.2.4
+    - clustalw        ==2.1
+    - consan          ==1.2 # [not osx]
+    - dialign-tx      >=1.0.2
+    - famsa           ==2.2.3
+    - kalign2         ==2.04
+    - mafft           ==7.526
+    - muscle          ==3.8.1551
+    - mustang         >=3.2.3
+    - pasta           ==1.9.2
+    - phylip          ==3.697
+    - poa             >=2.0 # [not osx]
+    - prank           ==170427
+    - probcons        ==1.12
+    - probconsrna     ==1.10
+    - sap             ==1.1.3
+    - tmalign         ==20170708
+    - viennarna       ==2.7.0
     
 test:
   commands:
@@ -60,9 +63,6 @@ test:
     - HOME=/tmp t_coffee 2>&1 | grep "probcons is  Installed"  # [not osx]
     - HOME=/tmp t_coffee 2>&1 | grep "probconsRNA is  Installed"  # [not osx]
     - HOME=/tmp t_coffee 2>&1 | grep "sap is  Installed"  # [not osx]
-    #- HOME=/tmp t_coffee -seq $PREFIX/share/test/seatoxin-ref.fa -output fasta_aln -outfile $PREFIX/share/test/seatoxin-ref_default.aln
-    #- HOME=/tmp t_coffee -seq $PREFIX/share/test/seatoxin-ref.fa -method TMalign_pair -template_file $PREFIX/share/test/seatoxin-ref_template.txt -output fasta_aln -outfile $PREFIX/share/test/seatoxin-ref_tmalign.aln
-
 
 about:
   home: http://www.tcoffee.org/Projects/tcoffee/

--- a/recipes/t-coffee/meta.yaml
+++ b/recipes/t-coffee/meta.yaml
@@ -1,11 +1,11 @@
-{% set version = "13.46.0.919e8c6b" %}
+{% set version = "13.46.1.b8b01e06" %}
 {% set name = "t-coffee" %}
 package:
   name: {{ name }}
   version: {{ version }}
 
 build:
-  number: 3
+  number: 0
   run_exports:
     - {{ pin_subpackage('t-coffee', max_pin="x") }}
   skip: True    # [osx]
@@ -14,7 +14,7 @@ source:
   # The latest stable release is at http://www.tcoffee.org/Packages/Stable/Latest/ ,
   # but is then archived at http://www.tcoffee.org/Packages/Archives/
   url: https://s3.eu-central-1.amazonaws.com/tcoffee-packages/Archives/T-COFFEE_distribution_Version_{{ version }}.tar.gz
-  sha256: 31fd0ca0734974c93cb68bef6e394f463a4589c3315fd28cf2bd41b8a167db22
+  sha256: 54d2b00956af79a884fe7174522522c77e65796d5aa08974dad86e061e6d12d1
   patches:
     - expose-os-detection.patch
     - coredump.patch
@@ -26,28 +26,28 @@ requirements:
     - {{ compiler('fortran') }}
     - perl-xml-simple
     - perl
+    - wget
   run:
     - blast
-    - clustalo
-    - clustalw
-    - consan # [not osx]
-    - dca
+    - clustalo ==1.2.4
+    - clustalw ==2.1
+    - consan ==1.2 # [not osx]
     - dialign-tx >=1.0.2
-    - famsa
-    - kalign2
-    - mafft
-    - muscle
+    - famsa ==2.2.3
+    - kalign2 ==2.04
+    - mafft ==7.526
+    - muscle ==3.8.1551
     - mustang >=3.2.3
-    - pasta
+    - pasta ==1.9.2
     - perl
-    - phylip
+    - phylip ==3.697
     - poa >=2.0 # [not osx]
-    - prank
-    - probcons
-    - probconsrna
-    - sap
-    - tmalign
-    - viennarna
+    - prank ==170427
+    - probcons ==1.12
+    - probconsrna ==1.10
+    - sap ==1.1.3
+    - tmalign ==20170708
+    - viennarna ==2.7.0
     
 test:
   commands:
@@ -60,6 +60,9 @@ test:
     - HOME=/tmp t_coffee 2>&1 | grep "probcons is  Installed"  # [not osx]
     - HOME=/tmp t_coffee 2>&1 | grep "probconsRNA is  Installed"  # [not osx]
     - HOME=/tmp t_coffee 2>&1 | grep "sap is  Installed"  # [not osx]
+    #- HOME=/tmp t_coffee -seq $PREFIX/share/test/seatoxin-ref.fa -output fasta_aln -outfile $PREFIX/share/test/seatoxin-ref_default.aln
+    #- HOME=/tmp t_coffee -seq $PREFIX/share/test/seatoxin-ref.fa -method TMalign_pair -template_file $PREFIX/share/test/seatoxin-ref_template.txt -output fasta_aln -outfile $PREFIX/share/test/seatoxin-ref_tmalign.aln
+
 
 about:
   home: http://www.tcoffee.org/Projects/tcoffee/

--- a/recipes/t-coffee/meta.yaml
+++ b/recipes/t-coffee/meta.yaml
@@ -26,7 +26,6 @@ requirements:
     - {{ compiler('fortran') }}
     - perl-xml-simple
     - perl
-    - wget
   host: 
     - gcc
     - perl            ==5.32.1

--- a/recipes/t-coffee/meta.yaml
+++ b/recipes/t-coffee/meta.yaml
@@ -1,14 +1,14 @@
 {% set version = "13.46.0.919e8c6b" %}
-
+{% set name = "t-coffee" %}
 package:
-  name: t-coffee
+  name: {{ name }}
   version: {{ version }}
 
 build:
-  number: 4
+  number: 3
   run_exports:
     - {{ pin_subpackage('t-coffee', max_pin="x") }}
-  skip: True # [osx]
+  skip: True    # [osx]
 
 source:
   # The latest stable release is at http://www.tcoffee.org/Packages/Stable/Latest/ ,
@@ -17,55 +17,34 @@ source:
   sha256: 31fd0ca0734974c93cb68bef6e394f463a4589c3315fd28cf2bd41b8a167db22
   patches:
     - expose-os-detection.patch
-
+    - coredump.patch
 requirements:
   build:
     - make
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - {{ compiler('fortran') }}
     - perl-xml-simple
-    - blast
-    - clustalo
-    - clustalw
-    - consan # [not osx]
-    - dca
-    - dialign-tx 1.0.2
-    - famsa
-    - kalign2
-    - mafft
-    - muscle
-    - mustang 3.2.3
-    - pasta
     - perl
-    - phylip
-    - poa 2.0 # [not osx]
-    - prank
-    - probcons
-    - probconsrna
-    - ruby
-    - sap
-    - tmalign
-    - viennarna
   run:
     - blast
     - clustalo
     - clustalw
     - consan # [not osx]
     - dca
-    - dialign-tx 1.0.2
+    - dialign-tx >=1.0.2
     - famsa
     - kalign2
     - mafft
     - muscle
-    - mustang 3.2.3
+    - mustang >=3.2.3
     - pasta
     - perl
     - phylip
-    - poa 2.0 # [not osx]
+    - poa >=2.0 # [not osx]
     - prank
     - probcons
     - probconsrna
-    - ruby
     - sap
     - tmalign
     - viennarna
@@ -73,6 +52,8 @@ requirements:
 test:
   commands:
     - HOME=/tmp t_coffee -version
+    # what does the package think it has installed:
+    - HOME=/tmp t_coffee 
     # These messages don't end up getting compiled in correctly under OSX
     - HOME=/tmp t_coffee 2>&1 | grep "kalign is  Installed"  # [not osx]
     - HOME=/tmp t_coffee 2>&1 | grep "mafft is  Installed"  # [not osx]
@@ -87,5 +68,7 @@ about:
   summary: "A collection of tools for Multiple Alignments of DNA, RNA, Protein Sequence"
 
 extra:
+  additional-platforms:
+    - linux-aarch64
   identifiers:
     - doi:10.1006/jmbi.2000.4042

--- a/recipes/t-coffee/t_coffee.sh
+++ b/recipes/t-coffee/t_coffee.sh
@@ -8,5 +8,5 @@ else
 fi
 export MAX_N_PID_4_TCOFFEE
 export PLUGINS_4_TCOFFEE=CHANGEME/plugins/__OS__
-
+export TEMP='./tmp'
 exec "CHANGEME/bin/__OS__/t_coffee" "$@"


### PR DESCRIPTION
Reverts bioconda/bioconda-recipes#53845

This is a revert of a revert. 

We removed the changes introduced because it seeminlgy broke some downstream applications. 

We figured the issue was not the addition of the arm64 support but a change in some dependencies version (tmalign in concrete) which was then not compatible with t-coffee. 

Now all versions are explicitly provided. 

