### PR TITLE
Add rocm-core package for ROCm support in Bioconda

### DIFF
--- a/recipes/rocm-core/LICENSE
+++ b/recipes/rocm-core/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 - 2024 Advanced Micro Devices, Inc. All rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/recipes/rocm-core/build.sh
+++ b/recipes/rocm-core/build.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -ex
+
+mkdir -p build
+
+cd build
+
+cmake -DCMAKE_INSTALL_PREFIX="$PREFIX" \
+      -DROCM_VERSION="$PKG_VERSION" \
+      -DBUILD_DOCS=OFF \
+      ..
+
+make -j$(nproc)
+
+make install

--- a/recipes/rocm-core/meta.yaml
+++ b/recipes/rocm-core/meta.yaml
@@ -20,6 +20,7 @@ requirements:
   build:
     - cmake
     - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
     - make
 test:
   commands:

--- a/recipes/rocm-core/meta.yaml
+++ b/recipes/rocm-core/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "6.1.0" %}
+{% set version = "6.3.2" %}
 {% set build = 0 %}
 
 package:
@@ -14,7 +14,7 @@ build:
 
 source:
   url: https://github.com/ROCm/rocm-core/archive/refs/tags/rocm-{{ version }}.tar.gz
-  sha256: 9dfe542d1647c42993b06f594c316dad63ba6d6fb2a7398bd72c5768fd1d7b5b
+  sha256: 3243f661e5e995341e81127a6096ac80169b8481826ebadc02e24020f1ff985d
 
 requirements:
   build:

--- a/recipes/rocm-core/meta.yaml
+++ b/recipes/rocm-core/meta.yaml
@@ -1,0 +1,36 @@
+{% set version = "6.0.2" %}
+{% set build = 0 %}
+
+package:
+  name: rocm-core
+  version: {{ version }}
+
+build:
+  number: {{ build }}
+  string: h{{ PKG_HASH }}_{{ build }}
+  skip: true  # [win or osx]
+  run_exports:
+    - {{ pin_compatible('rocm-core', max_pin='x.x.x') }}
+
+source:
+  url: https://github.com/ROCm/rocm-core/archive/refs/tags/rocm-{{ version }}.tar.gz
+  sha256: 04f01dca2862f0bf781de8afb74aabefc3c9b1d9f01bc8cadb2eb3d7395119cc
+
+requirements:
+  build:
+    - cmake
+    - {{ compiler('c') }}
+    - make
+test:
+  commands:
+    - test -f "$PREFIX/lib/librocm-core.so"
+
+about:
+  home: https://github.com/ROCm/rocm-core
+  license: MIT
+  license_file: LICENSE
+  summary: ROCM-CORE is a package which can be used to get ROCm release version, get ROCm install path information etc.
+
+extra:
+  recipe-maintainers:
+    - j34ni

--- a/recipes/rocm-core/meta.yaml
+++ b/recipes/rocm-core/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "6.0.2" %}
+{% set version = "6.1.0" %}
 {% set build = 0 %}
 
 package:
@@ -14,7 +14,7 @@ build:
 
 source:
   url: https://github.com/ROCm/rocm-core/archive/refs/tags/rocm-{{ version }}.tar.gz
-  sha256: 04f01dca2862f0bf781de8afb74aabefc3c9b1d9f01bc8cadb2eb3d7395119cc
+  sha256: 9dfe542d1647c42993b06f594c316dad63ba6d6fb2a7398bd72c5768fd1d7b5b
 
 requirements:
   build:


### PR DESCRIPTION
This PR adds the `rocm-core` package to Bioconda, providing the foundational runtime and versioning components for AMD's ROCm (Radeon Open Compute) platform. This enables GPU-accelerated computing with AMD GPUs in Bioconda environments. The package is built from the official ROCm source and includes minimal dependencies required for runtime compatibility.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
