### PR TITLE
Add recipe for mutalyzer_hgvs_parser

### DIFF
--- a/mutalyzer_hgvs_parser/meta.yaml
+++ b/mutalyzer_hgvs_parser/meta.yaml
@@ -1,0 +1,41 @@
+{% set name = "mutalyzer_hgvs_parser" %}
+{% set version = "0.3.7" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  sha256: 5d3ca837f99372bf27af035aaed281804df6ced79c1d87b6ae4f82be1d18943c
+
+build:
+  number: 0
+  noarch: python
+  script: "{{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation"
+
+requirements:
+  host:
+    - pip
+    - python
+  run:
+    - python
+    - lark >=1.0.0
+
+about:
+  home: The package home page
+  license: MIT
+  license_family: MIT
+  summary: "Mutalyzer HGVS variant description parser"
+  doc_url: https://mutalyzer-hgvs-parser.readthedocs.io
+  dev_url: https://github.com/mutalyzer/hgvs-parser
+
+extra:
+  recipe-maintainers:
+    - Redmar-van-den-Berg
+
+
+test:
+  commands:
+    - mutalyzer_hgvs_parser --help
+    - mutalyzer_hgvs_parser -c "NG_012337.1:c.20del"

--- a/recipes/mutalyzer_hgvs_parser/meta.yaml
+++ b/recipes/mutalyzer_hgvs_parser/meta.yaml
@@ -14,7 +14,7 @@ build:
   noarch: python
   script: "{{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation"
   run_exports:
-    - {{ pin_subpackage("mutalyzer_hgvs_parser", max_pin="x") }}
+    - {{ pin_subpackage("mutalyzer_hgvs_parser", max_pin="x.x") }}
 
 requirements:
   host:

--- a/recipes/mutalyzer_hgvs_parser/meta.yaml
+++ b/recipes/mutalyzer_hgvs_parser/meta.yaml
@@ -13,6 +13,8 @@ build:
   number: 0
   noarch: python
   script: "{{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation"
+  run_exports:
+    - {{ pin_subpackage("mutalyzer_hgvs_parser", max_pin="x") }}
 
 requirements:
   host:


### PR DESCRIPTION
New recipe for mutalyzer_hgvs_parser, a python library and command line tool to parse HGVS descriptions (a nomenclature to describe genetic variants).

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).
### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
