### PR TITLE
perl-template-toolkit: Do not build for osx-arm64

### DIFF
--- a/recipes/perl-template-toolkit/meta.yaml
+++ b/recipes/perl-template-toolkit/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: d161c89dee9b213a7c55709ea782e2dd5923dbd1215b9576612889e6e74a2e06
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage(name, max_pin='x') }}
 
@@ -43,4 +43,3 @@ about:
 extra:
   additional-platforms:
     - linux-aarch64
-    - osx-arm64

--- a/scripts/check-for-additional-platforms.sh
+++ b/scripts/check-for-additional-platforms.sh
@@ -22,7 +22,7 @@ wget https://github.com/mikefarah/yq/releases/latest/download/yq_${yq_platform}_
 chmod +x ${HOME}/bin/yq
 
 # Find recipes changed from this merge
-files=`git diff --name-only --diff-filter AMR ${git_range} | grep -v 'template' | grep -E 'meta.yaml$' `
+files=`git diff --name-only --diff-filter AMR ${git_range} | grep -E 'meta.yaml$' `
 build=0
 
 for file in $files; do

--- a/scripts/check-for-additional-platforms.sh
+++ b/scripts/check-for-additional-platforms.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -x
+
 # Do not set -x, this script outputs a value with echo
 
 # Check to see if any changed recipes have specified the key


### PR DESCRIPTION
Several dependencies are missing:
```
Attempting to finalize metadata for perl-template-toolkit
2025-02-19T00:25:09.6612660Z Reloading output folder: ...working... done
2025-02-19T00:25:09.7988480Z Getting pinned dependencies: ...working... done
2025-02-19T00:25:16.3462490Z Reloading output folder: ...working... done
2025-02-19T00:25:16.4355420Z Getting pinned dependencies: ...working... failed
2025-02-19T00:25:16.4406050Z WARNING: failed to get package records, retrying.  exception was: Unsatisfiable dependencies for platform osx-arm64: {MatchSpec("perl-test-leaktrace"), MatchSpec("perl-xml-libxml"), MatchSpec("perl-image-info==1.38=pl5321hdfd78af_2")}
2025-02-19T00:25:16.4408180Z Encountered problems while solving:
2025-02-19T00:25:16.4408860Z   - nothing provides requested perl-test-leaktrace
2025-02-19T00:25:16.4457710Z   - nothing provides perl-xml-libxml needed by perl-image-info-1.38-pl5321hdfd78af_2
```

Fixes #53961

Describe your pull request here

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
