### PR TITLE
Update grz-cli to 0.1.4

### DIFF
--- a/recipes/grz-cli/meta.yaml
+++ b/recipes/grz-cli/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/grz_cli-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/grz_cli-{{ version }}.tar.gz
   sha256: b79ae294576a0a8180bc9678392d5efc367b71b7f439d153d2dae5bd0009d96f
 
 build:

--- a/recipes/grz-cli/meta.yaml
+++ b/recipes/grz-cli/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "grz-cli" %}
-{% set version = "0.1.1" %}
+{% set version = "0.1.4" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/grz_cli-{{ version }}.tar.gz
-  sha256: 199dd5d96405065db6224d75e991dd385b28685bc7f581e75a8c09d913737fa7
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/grz_cli-{{ version }}.tar.gz
+  sha256: b79ae294576a0a8180bc9678392d5efc367b71b7f439d153d2dae5bd0009d96f
 
 build:
   entry_points:


### PR DESCRIPTION
Update grz-cli to 0.1.4 manually.
Also change source url path from pypi.org to pypi.io such that the autobumper can correctly pick up on changes.