### PR TITLE
Update PretextGraph to 0.0.8

### DIFF
--- a/recipes/pretextgraph/meta.yaml
+++ b/recipes/pretextgraph/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "PretextGraph" %}
-{% set version = "0.0.7" %}
-{% set sha256 = "4c99c46105cf4de3f22ab3065b0e5445cdf3caed8f66aafaf08249c365455d37" %}
+{% set version = "0.0.8" %}
+{% set sha256 = "ea541f35750bacc5d8cdcae2d02242128da9a0466530062274d877c24f6b6ff5" %}
 
 package:
   name: "{{ name|lower }}"
   version: "{{ version }}"
 
 source:
-  url: https://github.com/sanger-tol/PretextGraph/releases/download/{{ version }}/{{ name|lower }}-{{ version }}.tar.gz
+  url: https://github.com/sanger-tol/PretextGraph/releases/download/{{ version }}/{{ name|lower }}-{{ version }}.tar.xz
   sha256: {{ sha256 }}
 
 build:


### PR DESCRIPTION
- fixed the gradually dropping to 0 problem
- added noise_filter for `coverage` and `repeat_density`
- update the extension types
