### PR TITLE
Trinity: add linux-aarch64 support

### DIFF
--- a/recipes/trinity/cflags-remove-m64.patch
+++ b/recipes/trinity/cflags-remove-m64.patch
@@ -20,25 +20,25 @@
  
  set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O2  -DNDEBUG ")
  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g -O0")
---- trinity-plugins/ParaFly/src/Makefile.orig	2025-02-24 18:48:19.761141657 +0000
-+++ trinity-plugins/ParaFly/src/Makefile	2025-02-24 18:48:52.950792914 +0000
-@@ -64,7 +64,7 @@
- DISTFILES = $(DIST_COMMON) $(DIST_SOURCES) $(TEXINFOS) $(EXTRA_DIST)
- ACLOCAL = ${SHELL} /home/bhaas/GITHUB/trinityrnaseq/trinity-plugins/ParaFly/missing --run aclocal-1.11
- AMTAR = ${SHELL} /home/bhaas/GITHUB/trinityrnaseq/trinity-plugins/ParaFly/missing --run tar
--AM_CXXFLAGS = -pedantic -Wall -Wextra -Wno-long-long -Wno-deprecated -m64
-+AM_CXXFLAGS = -pedantic -Wall -Wextra -Wno-long-long -Wno-deprecated
- AUTOCONF = ${SHELL} /home/bhaas/GITHUB/trinityrnaseq/trinity-plugins/ParaFly/missing --run autoconf
- AUTOHEADER = ${SHELL} /home/bhaas/GITHUB/trinityrnaseq/trinity-plugins/ParaFly/missing --run autoheader
- AUTOMAKE = ${SHELL} /home/bhaas/GITHUB/trinityrnaseq/trinity-plugins/ParaFly/missing --run automake-1.11
---- trinity-plugins/ParaFly/Makefile.orig	2025-02-24 18:48:10.851235192 +0000
-+++ trinity-plugins/ParaFly/Makefile	2025-02-24 18:48:42.500902744 +0000
-@@ -100,7 +100,7 @@
- distcleancheck_listfiles = find . -type f -print
- ACLOCAL = ${SHELL} /home/bhaas/GITHUB/trinityrnaseq/trinity-plugins/ParaFly/missing --run aclocal-1.11
- AMTAR = ${SHELL} /home/bhaas/GITHUB/trinityrnaseq/trinity-plugins/ParaFly/missing --run tar
--AM_CXXFLAGS = -pedantic -Wall -Wextra -Wno-long-long -Wno-deprecated -m64
-+AM_CXXFLAGS = -pedantic -Wall -Wextra -Wno-long-long -Wno-deprecated
- AUTOCONF = ${SHELL} /home/bhaas/GITHUB/trinityrnaseq/trinity-plugins/ParaFly/missing --run autoconf
- AUTOHEADER = ${SHELL} /home/bhaas/GITHUB/trinityrnaseq/trinity-plugins/ParaFly/missing --run autoheader
- AUTOMAKE = ${SHELL} /home/bhaas/GITHUB/trinityrnaseq/trinity-plugins/ParaFly/missing --run automake-1.11
+--- trinity-plugins/ParaFly/configure.ac.orig	2025-02-24 18:59:31.364093231 +0000
++++ trinity-plugins/ParaFly/configure.ac	2025-02-24 18:59:49.403903916 +0000
+@@ -3,7 +3,7 @@
+ AC_LANG([C++])
+ AC_PROG_CXX
+ AC_OPENMP
+-AC_SUBST([AM_CXXFLAGS], [-m64 $OPENMP_CXXFLAGS])
++AC_SUBST([AM_CXXFLAGS], [$OPENMP_CXXFLAGS])
+ case $CXX in
+   g++*) AC_SUBST([AM_CXXFLAGS],["-pedantic -Wall -Wextra -Wno-long-long -Wno-deprecated $AM_CXXFLAGS"]);;
+   sunCC*) AC_SUBST([AM_CXXFLAGS], ["-library=stlport4 -xopenmp -xvpara -fast $AM_CXXFLAGS"]) ;;
+--- trinity-plugins/ParaFly/configure.orig	2025-02-24 18:58:55.394470680 +0000
++++ trinity-plugins/ParaFly/configure	2025-02-24 18:59:15.054264317 +0000
+@@ -3112,7 +3112,7 @@
+   fi
+ 
+ 
+-AM_CXXFLAGS=-m64 $OPENMP_CXXFLAGS
++AM_CXXFLAGS=$OPENMP_CXXFLAGS
+ 
+ case $CXX in
+   g++*) AM_CXXFLAGS="-pedantic -Wall -Wextra -Wno-long-long -Wno-deprecated $AM_CXXFLAGS"

--- a/recipes/trinity/cflags-remove-m64.patch
+++ b/recipes/trinity/cflags-remove-m64.patch
@@ -9,3 +9,36 @@
  
  set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O2 -DNDEBUG ")
  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g -O0")
+--- Chrysalis/CMakeLists.txt.orig	2025-02-24 18:47:03.241952176 +0000
++++ Chrysalis/CMakeLists.txt	2025-02-24 18:47:12.251857513 +0000
+@@ -13,7 +13,7 @@
+     set(CMAKE_BUILD_TYPE "${default_build_type}")
+ endif()
+ 
+-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pipe -W -Wall -Wpedantic -fopenmp -pthread -m64")
++set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pipe -W -Wall -Wpedantic -fopenmp -pthread")
+ 
+ set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O2  -DNDEBUG ")
+ set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g -O0")
+--- trinity-plugins/ParaFly/src/Makefile.orig	2025-02-24 18:48:19.761141657 +0000
++++ trinity-plugins/ParaFly/src/Makefile	2025-02-24 18:48:52.950792914 +0000
+@@ -64,7 +64,7 @@
+ DISTFILES = $(DIST_COMMON) $(DIST_SOURCES) $(TEXINFOS) $(EXTRA_DIST)
+ ACLOCAL = ${SHELL} /home/bhaas/GITHUB/trinityrnaseq/trinity-plugins/ParaFly/missing --run aclocal-1.11
+ AMTAR = ${SHELL} /home/bhaas/GITHUB/trinityrnaseq/trinity-plugins/ParaFly/missing --run tar
+-AM_CXXFLAGS = -pedantic -Wall -Wextra -Wno-long-long -Wno-deprecated -m64
++AM_CXXFLAGS = -pedantic -Wall -Wextra -Wno-long-long -Wno-deprecated
+ AUTOCONF = ${SHELL} /home/bhaas/GITHUB/trinityrnaseq/trinity-plugins/ParaFly/missing --run autoconf
+ AUTOHEADER = ${SHELL} /home/bhaas/GITHUB/trinityrnaseq/trinity-plugins/ParaFly/missing --run autoheader
+ AUTOMAKE = ${SHELL} /home/bhaas/GITHUB/trinityrnaseq/trinity-plugins/ParaFly/missing --run automake-1.11
+--- trinity-plugins/ParaFly/Makefile.orig	2025-02-24 18:48:10.851235192 +0000
++++ trinity-plugins/ParaFly/Makefile	2025-02-24 18:48:42.500902744 +0000
+@@ -100,7 +100,7 @@
+ distcleancheck_listfiles = find . -type f -print
+ ACLOCAL = ${SHELL} /home/bhaas/GITHUB/trinityrnaseq/trinity-plugins/ParaFly/missing --run aclocal-1.11
+ AMTAR = ${SHELL} /home/bhaas/GITHUB/trinityrnaseq/trinity-plugins/ParaFly/missing --run tar
+-AM_CXXFLAGS = -pedantic -Wall -Wextra -Wno-long-long -Wno-deprecated -m64
++AM_CXXFLAGS = -pedantic -Wall -Wextra -Wno-long-long -Wno-deprecated
+ AUTOCONF = ${SHELL} /home/bhaas/GITHUB/trinityrnaseq/trinity-plugins/ParaFly/missing --run autoconf
+ AUTOHEADER = ${SHELL} /home/bhaas/GITHUB/trinityrnaseq/trinity-plugins/ParaFly/missing --run autoheader
+ AUTOMAKE = ${SHELL} /home/bhaas/GITHUB/trinityrnaseq/trinity-plugins/ParaFly/missing --run automake-1.11

--- a/recipes/trinity/cflags-remove-m64.patch
+++ b/recipes/trinity/cflags-remove-m64.patch
@@ -1,0 +1,11 @@
+--- Inchworm/CMakeLists.txt.orig	2025-02-24 18:37:08.778178215 +0000
++++ Inchworm/CMakeLists.txt	2025-02-24 18:37:16.638095965 +0000
+@@ -13,7 +13,7 @@
+     set(CMAKE_BUILD_TYPE "${default_build_type}")
+ endif()
+ 
+-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pipe -W -Wall -Wpedantic -fopenmp -m64")
++set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pipe -W -Wall -Wpedantic -fopenmp")
+ 
+ set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O2 -DNDEBUG ")
+ set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g -O0")

--- a/recipes/trinity/meta.yaml
+++ b/recipes/trinity/meta.yaml
@@ -11,6 +11,7 @@ source:
   sha256: {{ sha256 }}
   patches:
     - makefile.patch
+    - cflags-remove-m64.patch 
 
 build:
   number: 3

--- a/recipes/trinity/meta.yaml
+++ b/recipes/trinity/meta.yaml
@@ -13,7 +13,7 @@ source:
     - makefile.patch
 
 build:
-  number: 2
+  number: 3
   run_exports:
     - {{ pin_subpackage('trinity', max_pin="x") }}
 
@@ -81,6 +81,9 @@ about:
   dev_url: "https://github.com/trinityrnaseq/trinityrnaseq"
 
 extra:
+  additional-platforms:
+    - linux-aarch64
+
   identifiers:
     - biotools:trinity
     - usegalaxy-eu:trinity


### PR DESCRIPTION
- also removes -m64 flag from x86 configs, this has been default for many many years.