### PR TITLE
ci: fix base ref in GHA workflow

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -21,6 +21,7 @@ jobs:
           base-ref: ${{ env.GITHUB_BASE_REF }}
           head-ref: ${{ github.sha }}
           fallback-base-ref: master
+          fallback-fetch-all: true
 
       - name: set path
         run: echo "/opt/mambaforge/bin" >> $GITHUB_PATH
@@ -69,7 +70,7 @@ jobs:
           base-ref: ${{ env.GITHUB_BASE_REF }}
           head-ref: ${{ github.sha }}
           fallback-base-ref: master
-
+          fallback-fetch-all: true
 
       - name: set path
         run: echo "/opt/mambaforge/bin" >> $GITHUB_PATH
@@ -154,10 +155,12 @@ jobs:
       
       - name: Fetch commits through the merge base
         uses: fulcrumgenomics/fetch-through-merge-base@v1
+        continue-on-error: true
         with:
           base-ref: ${{ env.GITHUB_BASE_REF }}
           head-ref: ${{ github.sha }}
           fallback-base-ref: master
+          fallback-fetch-all: true
 
       - name: set path
         run: echo "/opt/mambaforge/bin" >> $GITHUB_PATH

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Fetch commits through the merge base
         uses: fulcrumgenomics/fetch-through-merge-base@v1
         with:
-          base-ref: ${{ steps.github_base_ref.outputs.github_base_ref }}
+          base-ref: ${{ env.GITHUB_BASE_REF }}
           head-ref: ${{ github.sha }}
           fallback-base-ref: master
 
@@ -66,7 +66,7 @@ jobs:
       - name: Fetch commits through the merge base
         uses: fulcrumgenomics/fetch-through-merge-base@v1
         with:
-          base-ref: ${{ steps.github_base_ref.outputs.github_base_ref }}
+          base-ref: ${{ env.GITHUB_BASE_REF }}
           head-ref: ${{ github.sha }}
           fallback-base-ref: master
 
@@ -155,7 +155,7 @@ jobs:
       - name: Fetch commits through the merge base
         uses: fulcrumgenomics/fetch-through-merge-base@v1
         with:
-          base-ref: ${{ steps.github_base_ref.outputs.github_base_ref }}
+          base-ref: ${{ env.GITHUB_BASE_REF }}
           head-ref: ${{ github.sha }}
           fallback-base-ref: master
 

--- a/.github/workflows/build-failures.yml
+++ b/.github/workflows/build-failures.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Fetch commits through the merge base
         uses: fulcrumgenomics/fetch-through-merge-base@v1
         with:
-          base-ref: ${{ steps.github_base_ref.outputs.github_base_ref }}
+          base-ref: master
           head-ref: ${{ github.sha }}
           fallback-base-ref: master
 

--- a/.github/workflows/build-failures.yml
+++ b/.github/workflows/build-failures.yml
@@ -24,6 +24,7 @@ jobs:
           base-ref: master
           head-ref: ${{ github.sha }}
           fallback-base-ref: master
+          fallback-fetch-all: true
 
       - name: set path
         run: echo "/opt/mambaforge/bin" >> $GITHUB_PATH


### PR DESCRIPTION
- [x] Fixes the base reference to be used in GHA.
- [x] if we can't fetch a common reference, fallback to fetching all commits

CC: @martin-g 

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
