### PR TITLE
mob_suite v3.1.9 build #1 fixing the sqlite error linked to double and single quote use by ete3 library

### DIFF
--- a/recipes/mob_suite/meta.yaml
+++ b/recipes/mob_suite/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}  
 
 build:
-  number: 0
+  number: 1
   noarch: python
   run_exports:
     - {{ pin_subpackage(name, max_pin="x") }}
@@ -37,8 +37,9 @@ requirements:
     - scipy >=1.1.0
     - ete3 >=3.1.3
     - six
-    - blast >=2.9.0
+    - blast >=2.9.0,<2.16.0
     - mash >=2.0
+    - libsqlite <3.49 #version 3.49 causes ete3 sqlite should this be a string literal in single-quotes error
 
 test:
   imports:


### PR DESCRIPTION
The ete3 library uses sqlite to query taxonomy database. Recent `libsqlite v3.49.0` library causes error when forming and sql query. This build fixes the upper bound of the `blast` to version < 2.16 and `libsqlite <3.49` to avoid the following error.

```
Traceback (most recent call last):
  File "/galaxy/database/dependencies/_conda/envs/__mob_suite@3.1.9/lib/python3.11/site-packages/mob_suite/utils.py", line 167, in getTaxonConvergence
    ranks = ncbi.get_rank(lineage)
            ^^^^^^^^^^^^^^^^^^^^^^
  File "/galaxy/database/dependencies/_conda/envs/__mob_suite@3.1.9/lib/python3.11/site-packages/ete3/ncbi_taxonomy/ncbiquery.py", line 201, in get_rank
    result = self.db.execute(cmd)
             ^^^^^^^^^^^^^^^^^^^^
sqlite3.OperationalError: no such column: "211968" - should this be a string literal in single-quotes?

```
