### PR TITLE
Add setuptools and core utils to dependencies of kgwasflow

### DIFF
--- a/recipes/kgwasflow/meta.yaml
+++ b/recipes/kgwasflow/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv"
   entry_points:
     - kgwasflow = workflow.kgwasflow:main
@@ -22,6 +22,7 @@ requirements:
   host:
     - python >=3.10.10
     - pip
+    - setuptools
   run:
     - python >=3.10.10
     - mamba
@@ -29,6 +30,7 @@ requirements:
     - pandas =1.5.3
     - snakemake-minimal =7.25.0
     - click
+    - coreutils
 
 test:
   commands:


### PR DESCRIPTION
When using the bio container of kgwasflow we noticed that there was an incorrect version of ln. Therefore, I added coreutils to the dependencies of kgwasflow. While updating the recipe we found out that setuptools was missing, as well. 
@akcorut Do you see any big issues with this?