### PR TITLE
update build failure for bioconductor-lpsymphony

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -15,14 +15,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Git debugging
-        run: |
-          set -x
-          echo $GITHUB_BASE_REF
-          echo $GITHUB_REF
-          echo $GITHUB_SHA
-          git log --oneline -n 5
-
       - name: Fetch commits through the merge base
         uses: fulcrumgenomics/fetch-through-merge-base@v1
         with:
@@ -71,14 +63,6 @@ jobs:
     needs: lint
     steps:
       - uses: actions/checkout@v4
-
-      - name: Git debugging
-        run: |
-          set -x
-          echo $GITHUB_BASE_REF
-          echo $GITHUB_REF
-          echo $GITHUB_SHA
-          git log --oneline -n 5
 
       - name: Fetch commits through the merge base
         uses: fulcrumgenomics/fetch-through-merge-base@v1
@@ -168,14 +152,6 @@ jobs:
     needs: build-linux
     steps:
       - uses: actions/checkout@v4
-
-      - name: Git debugging
-        run: |
-          set -x
-          echo $GITHUB_BASE_REF
-          echo $GITHUB_REF
-          echo $GITHUB_SHA
-          git log --oneline -n 5
       
       - name: Fetch commits through the merge base
         uses: fulcrumgenomics/fetch-through-merge-base@v1

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -15,6 +15,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Git debugging
+        run: |
+          set -x
+          echo $GITHUB_BASE_REF
+          echo $GITHUB_REF
+          echo $GITHUB_SHA
+          git log --oneline -n 5
+
       - name: Fetch commits through the merge base
         uses: fulcrumgenomics/fetch-through-merge-base@v1
         with:
@@ -63,6 +71,14 @@ jobs:
     needs: lint
     steps:
       - uses: actions/checkout@v4
+
+      - name: Git debugging
+        run: |
+          set -x
+          echo $GITHUB_BASE_REF
+          echo $GITHUB_REF
+          echo $GITHUB_SHA
+          git log --oneline -n 5
 
       - name: Fetch commits through the merge base
         uses: fulcrumgenomics/fetch-through-merge-base@v1
@@ -152,6 +168,14 @@ jobs:
     needs: build-linux
     steps:
       - uses: actions/checkout@v4
+
+      - name: Git debugging
+        run: |
+          set -x
+          echo $GITHUB_BASE_REF
+          echo $GITHUB_REF
+          echo $GITHUB_SHA
+          git log --oneline -n 5
       
       - name: Fetch commits through the merge base
         uses: fulcrumgenomics/fetch-through-merge-base@v1

--- a/recipes/bioconductor-lpsymphony/build_failure.osx-64.yaml
+++ b/recipes/bioconductor-lpsymphony/build_failure.osx-64.yaml
@@ -1,106 +1,112 @@
-recipe_sha: a2b5507af7bf831c6d854cf116ff70fd6a6c9ba91db46664cea2f8ce35c77703  # The hash of the recipe's meta.yaml at which this recipe failed to build.
+recipe_sha: 683ba785b8a62e64a40241cc2def0d6a2779b6434520c98e9c86e1cf2f170234  # The hash of the recipe's meta.yaml at which this recipe failed to build.
 skiplist: true # Set to true to skiplist this recipe so that it will be ignored as long as its latest commit is the one given above.
 log: |2-
-      raise BuildScriptException(str(exc), caused_by=exc) from exc
-  conda_build.exceptions.BuildScriptException: Command '['/bin/bash', '-o', 'errexit', '/opt/mambaforge/envs/bioconda/conda-bld/bioconductor-lpsymphony_1734455465033/work/conda_build.sh']' returned non-zero exit status 1.
-  configure: running /bin/sh './configure' --prefix=$SRC_DIR/src/SYMPHONY  'CC=x86_64-apple-darwin13.4.0-clang' 'CXX=x86_64-apple-darwin13.4.0-clang' 'CFLAGS=-w -g -O2' 'CXXFLAGS=-w -g -O2' '--enable-static' '--disable-shared' '--with-pic' '--with-application=no' '--disable-dependency-tracking' '--disable-zlib' '--disable-bzlib' '--disable-openmp' '--disable-cplex-libcheck' '--disable-glpk-libcheck' '--disable-osl-libcheck' '--disable-soplex-libcheck' '--disable-xpress-libcheck' 'CPPFLAGS=-D_FORTIFY_SOURCE=2 -isystem $PREFIX/include -mmacosx-version-min=10.13 -D_FORTIFY_SOURCE=2 -isystem $PREFIX/include -mmacosx-version-min=10.13' 'CPP=x86_64-apple-darwin13.4.0-clang-cpp' 'F77=$PREFIX/bin/x86_64-apple-darwin13.4.0-gfortran' 'FFLAGS=-march=core2 -mtune=haswell -ftree-vectorize -fPIC -fstack-protector -O2 -pipe -isystem $PREFIX/include -fdebug-prefix-map=$SRC_DIR=/usr/local/src/conda/bioconductor-lpsymphony-1.34.0 -fdebug-prefix-map=$PREFIX=/usr/local/src/conda-prefix' 'LDFLAGS=-Wl,-headerpad_max_install_names -Wl,-dead_strip_dylibs -Wl,-rpath,$PREFIX/lib -L$PREFIX/lib -Wl,-headerpad_max_install_names -Wl,-dead_strip_dylibs -Wl,-rpath,$PREFIX/lib -L$PREFIX/lib' 'build_alias=x86_64-apple-darwin13.4.0' 'host_alias=x86_64-apple-darwin13.4.0' --cache-file=/dev/null --srcdir=.
-  checking build system type... x86_64-apple-darwin13.4.0
-  checking for svnversion... no
-  checking whether we want to compile in debug mode... no
-  checking for x86_64-apple-darwin13.4.0-clang... x86_64-apple-darwin13.4.0-clang
-  checking for C compiler default output file name... a.out
-  checking whether the C compiler works... yes
-  checking whether we are cross compiling... no
-  checking for suffix of executables...
-  checking for suffix of object files... o
-  checking whether we are using the GNU C compiler... yes
-  checking whether x86_64-apple-darwin13.4.0-clang accepts -g... yes
-  checking for x86_64-apple-darwin13.4.0-clang option to accept ANSI C... none needed
-  configure: C compiler options are: -w -g -O2   -DSYMPHONY_BUILD
-  checking for x86_64-apple-darwin13.4.0-clang... x86_64-apple-darwin13.4.0-clang
-  checking whether we are using the GNU C compiler... yes
-  checking whether x86_64-apple-darwin13.4.0-clang accepts -g... yes
-  checking whether C compiler x86_64-apple-darwin13.4.0-clang works... yes
-  configure: C compiler options are: -w -g -O2   -DSYMPHONY_BUILD
-  checking for egrep... grep -E
-  checking whether ln -s works... yes
-  checking for a BSD-compatible install... /usr/bin/install -c
-  checking whether build environment is sane... yes
-  checking for gawk... no
-  checking for mawk... no
-  checking for nawk... no
-  checking for awk... awk
-  checking whether make sets $(MAKE)... yes
-  checking for style of include used by make... GNU
-  checking dependency style of x86_64-apple-darwin13.4.0-clang... none
-  checking dependency style of x86_64-apple-darwin13.4.0-clang... none
-  checking whether to enable maintainer-specific portions of Makefiles... no
-  configure: Using libtool script in directory ..
-  checking if library version is set... 9:10:6
-  checking for x86_64-apple-darwin13.4.0-pkg-config... no
-  checking for pkg-config... pkg-config
-  checking pkg-config is at least version 0.16.0... yes
-  checking for COIN-OR package CoinDepend... yes: 2.10.6
-  checking for COIN-OR package Clp... yes: 1.16.6
-  checking for COIN-OR package DyLP... not given: Package 'osi-dylp' not found
-  checking for COIN-OR package Vol... not given: Package 'osi-vol' not found
-  checking for COIN-OR package Cgl... yes: 0.59.4
-  checking for COIN-OR package OsiTests... yes: 0.107.4
-  checking for COIN-OR package Sample... not given: Package 'coindatasample' not found
-  checking for COIN-OR package Netlib... not given: Package 'coindatanetlib' not found
-  checking for COIN-OR package Miplib3... not given: Package 'coindatamiplib3' not found
-  checking for COIN-OR package Cpx... not given: Package 'osi-cplex' not found
-  checking for COIN-OR package Glpk... not given: Package 'osi-glpk' not found
-  checking for COIN-OR package Msk... not given: Package 'osi-mosek' not found
-  checking for COIN-OR package Xpr... not given: Package 'osi-xpress' not found
-  checking for SYMPHONY default solver... Clp
-  checking whether to compile with gmpl... no
-  checking whether to compile application library... no
-  checking if user provides library for Pvm... no
-  checking whether this is a VPATH configuration... no
-  checking which command should be used to link input files... ln -s
-  configure: creating ./config.status
-  config.status: creating Makefile
-  config.status: creating src/Makefile
-  config.status: creating src/OsiSym/Makefile
-  config.status: creating test/Makefile
-  config.status: creating Examples/Makefile
-  config.status: creating Applications/Makefile.Applications
-  config.status: creating Applications/CNRP/Makefile
-  config.status: creating Applications/MATCH/Makefile
-  config.status: creating Applications/MCKP/Makefile
-  config.status: creating Applications/MPP/Makefile
-  config.status: creating Applications/SPP/Makefile
-  config.status: creating Applications/SPPCUTS/Makefile
-  config.status: creating Applications/USER/Makefile
-  config.status: creating Applications/VRP/Makefile
-  config.status: creating symphony.pc
-  config.status: creating symphony-app.pc
-  config.status: creating symphony-uninstalled.pc
-  config.status: creating osi-sym.pc
-  config.status: creating osi-sym-uninstalled.pc
-  config.status: creating include/config.h
-  config.status: creating include/config_sym.h
-  config.status: executing depfiles commands
-  configure: In case of trouble, first consult the troubleshooting page at https://projects.coin-or.org/BuildTools/wiki/user-troubleshooting
-  configure: Configuration of SYMPHONY successful
-  configure: In case of trouble, first consult the troubleshooting page at https://projects.coin-or.org/BuildTools/wiki/user-troubleshooting
-  configure: Main configuration of SYMPHONY successful
-  make[1]: Entering directory '$SRC_DIR/src/SYMPHONY'
-  Making all in CoinUtils
-  make[2]: Entering directory '$SRC_DIR/src/SYMPHONY/CoinUtils'
-  Making all in src
-  make[3]: Entering directory '$SRC_DIR/src/SYMPHONY/CoinUtils/src'
-  make  all-am
-  make[4]: Entering directory '$SRC_DIR/src/SYMPHONY/CoinUtils/src'
-  /bin/sh ../../libtool --tag=CXX --mode=compile x86_64-apple-darwin13.4.0-clang -DHAVE_CONFIG_H -I. -Iecho .   -D_FORTIFY_SOURCE=2 -isystem $PREFIX/include -mmacosx-version-min=10.13 -D_FORTIFY_SOURCE=2 -isystem $PREFIX/include -mmacosx-version-min=10.13  -w -g -O2   -DCOINUTILS_BUILD -c -o CoinAlloc.lo CoinAlloc.cpp
-   x86_64-apple-darwin13.4.0-clang -DHAVE_CONFIG_H -I. -I. -D_FORTIFY_SOURCE=2 -isystem $PREFIX/include -mmacosx-version-min=10.13 -D_FORTIFY_SOURCE=2 -isystem $PREFIX/include -mmacosx-version-min=10.13 -w -g -O2 -DCOINUTILS_BUILD -c CoinAlloc.cpp  -fno-common -DPIC -o CoinAlloc.o
-  /bin/sh ../../libtool --tag=CXX --mode=compile x86_64-apple-darwin13.4.0-clang -DHAVE_CONFIG_H -I. -Iecho .   -D_FORTIFY_SOURCE=2 -isystem $PREFIX/include -mmacosx-version-min=10.13 -D_FORTIFY_SOURCE=2 -isystem $PREFIX/include -mmacosx-version-min=10.13  -w -g -O2   -DCOINUTILS_BUILD -c -o CoinBuild.lo CoinBuild.cpp
-   x86_64-apple-darwin13.4.0-clang -DHAVE_CONFIG_H -I. -I. -D_FORTIFY_SOURCE=2 -isystem $PREFIX/include -mmacosx-version-min=10.13 -D_FORTIFY_SOURCE=2 -isystem $PREFIX/include -mmacosx-version-min=10.13 -w -g -O2 -DCOINUTILS_BUILD -c CoinBuild.cpp  -fno-common -DPIC -o CoinBuild.o
-  make[4]: Leaving directory '$SRC_DIR/src/SYMPHONY/CoinUtils/src'
-  make[3]: Leaving directory '$SRC_DIR/src/SYMPHONY/CoinUtils/src'
-  make[2]: Leaving directory '$SRC_DIR/src/SYMPHONY/CoinUtils'
-  make[1]: Leaving directory '$SRC_DIR/src/SYMPHONY'
+    using C++ compiler: 'clang version 18.1.8'
+    using SDK: ''
+    In file included from CoinBuild.cpp:18:
+    ./CoinHelperFunctions.hpp:44:11: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
+       44 | CoinCopyN(register const T* from, const int size, register T* to)
+          |           ^~~~~~~~
+    ./CoinHelperFunctions.hpp:44:51: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
+       44 | CoinCopyN(register const T* from, const int size, register T* to)
+          |                                                   ^~~~~~~~
+    ./CoinHelperFunctions.hpp:55:5: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
+       55 |     register int n = (size + 7) / 8;
+          |     ^~~~~~~~
+    ./CoinHelperFunctions.hpp:57:2: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
+       57 |         register const T* downfrom = from + size;
+          |         ^~~~~~~~
+    ./CoinHelperFunctions.hpp:58:2: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
+       58 |         register T* downto = to + size;
+          |         ^~~~~~~~
+    ./CoinHelperFunctions.hpp:102:10: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
+      102 | CoinCopy(register const T* first, register const T* last, register T* to)
+          |          ^~~~~~~~
+    ./CoinHelperFunctions.hpp:102:35: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
+      102 | CoinCopy(register const T* first, register const T* last, register T* to)
+          |                                   ^~~~~~~~
+    ./CoinHelperFunctions.hpp:102:59: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
+      102 | CoinCopy(register const T* first, register const T* last, register T* to)
+          |                                                           ^~~~~~~~
+    ./CoinHelperFunctions.hpp:117:19: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
+      117 | CoinDisjointCopyN(register const T* from, const int size, register T* to)
+          |                   ^~~~~~~~
+    ./CoinHelperFunctions.hpp:117:59: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
+      117 | CoinDisjointCopyN(register const T* from, const int size, register T* to)
+          |                                                           ^~~~~~~~
+    ./CoinHelperFunctions.hpp:138:10: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
+      138 |     for (register int n = size / 8; n > 0; --n, from += 8, to += 8) {
+          |          ^~~~~~~~
+    ./CoinHelperFunctions.hpp:170:18: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
+      170 | CoinDisjointCopy(register const T* first, register const T* last,
+          |                  ^~~~~~~~
+    ./CoinHelperFunctions.hpp:170:43: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
+      170 | CoinDisjointCopy(register const T* first, register const T* last,
+          |                                           ^~~~~~~~
+    ./CoinHelperFunctions.hpp:171:4: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
+      171 |                  register T* to)
+          |                  ^~~~~~~~
+    ./CoinHelperFunctions.hpp:259:13: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
+      259 | CoinMemcpyN(register const T* from, const int size, register T* to)
+          |             ^~~~~~~~
+    ./CoinHelperFunctions.hpp:259:53: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
+      259 | CoinMemcpyN(register const T* from, const int size, register T* to)
+          |                                                     ^~~~~~~~
+    ./CoinHelperFunctions.hpp:299:10: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
+      299 |     for (register int n = size / 8; n > 0; --n, from += 8, to += 8) {
+          |          ^~~~~~~~
+    ./CoinHelperFunctions.hpp:346:12: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
+      346 | CoinMemcpy(register const T* first, register const T* last,
+          |            ^~~~~~~~
+    ./CoinHelperFunctions.hpp:346:37: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
+      346 | CoinMemcpy(register const T* first, register const T* last,
+          |                                     ^~~~~~~~
+    fatal error: too many errors emitted, stopping now [-ferror-limit=]
+    20 errors generated.
+    make[4]: *** [Makefile:679: CoinBuild.lo] Error 1
+    make[3]: *** [Makefile:506: all] Error 2
+    make[2]: *** [Makefile:436: all-recursive] Error 1
+    make[1]: *** [Makefile:324: all-recursive] Error 1
+    make: *** [Makevars:14: SYMPHONY.ts] Error 2
+    ERROR: compilation failed for package 'lpsymphony'
+    * removing '/opt/mambaforge/envs/bioconda/conda-bld/bioconductor-lpsymphony_1740443170794/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_/lib/R/library/lpsymphony'
+    checking for a BSD-compatible install... /usr/bin/install -c
+    checking whether build environment is sane... yes
+    checking for gawk... no
+    checking for mawk... no
+    checking for nawk... no
+    checking for awk... awk
+    checking whether make sets $(MAKE)... yes
+    checking for style of include used by make... GNU
+    Traceback (most recent call last):
+      File "/opt/mambaforge/envs/bioconda/lib/python3.10/site-packages/conda_build/build.py", line 2558, in build
+    checking dependency style of x86_64-apple-darwin13.4.0-clang... none
+    checking dependency style of x86_64-apple-darwin13.4.0-clang++... none
+    checking whether to enable maintainer-specific portions of Makefiles... no
+    configure: Using libtool script in directory ..
+    checking if library version is set... 10:4:9
+    checking for x86_64-apple-darwin13.4.0-pkg-config... no
+        utils.check_call_env(
+    checking for pkg-config... pkg-config
+    checking pkg-config is at least version 0.16.0... yes
+      File "/opt/mambaforge/envs/bioconda/lib/python3.10/site-packages/conda_build/utils.py", line 404, in check_call_env
+    checking for COIN-OR package CoinUtils... yes: 2.10.6
+    checking for COIN-OR package Osi... yes: 0.107.4
+    checking for COIN-OR package Sample... not given: Package 'coindatasample' not found
+    checking for COIN-OR package OsiClp... yes: 1.16.6
+    checking for COIN-OR package OsiCpx... not given: Package 'osi-cplex' not found
+    checking for COIN-OR package OsiGlpk... not given: Package 'osi-glpk' not found
+    checking for COIN-OR package OsiMsk... not given: Package 'osi-mosek' not found
+    checking for COIN-OR package OsiXpr... not given: Package 'osi-xpress' not found
+    checking for COIN-OR package OsiVol... not given: Package 'osi-vol' not found
+    checking for COIN-OR package OsiDyLP... not given: Package 'osi-dylp' not found
+    checking cmath usability... yes
+    checking cmath presence... yes
+    checking for cmath... yes
+        return _func_defaulting_env_to_os_environ("call", *popenargs, **kwargs)
+      File "/opt/mambaforge/envs/bioconda/lib/python3.10/site-packages/conda_build/utils.py", line 380, in _func_defaulting_env_to_os_environ
+        raise subprocess.CalledProcessError(proc.returncode, _args)
+    subprocess.CalledProcessError: Command '['/bin/bash', '-o', 'errexit', '/opt/mambaforge/envs/bioconda/conda-bld/bioconductor-lpsymphony_1740443170794/work/conda_build.sh']' returned non-zero exit status 1.
 # Last 100 lines of the build log.
 category: |-
   compiler error


### PR DESCRIPTION
Updating the hash so this gets skipped in the osx-64 nightly build. I also pasted in the pertinent part of the log since there was not much useful information in what was automatically included.


(This PR was demonstrating some issues so I aded some logging to the workflow, but now it's working so that's been reverted.)
