### PR TITLE
Update ivar version to 1.4.4 and added osx-arm64 to additional platforms

### DIFF
--- a/recipes/ivar/build.sh
+++ b/recipes/ivar/build.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 
-export CPATH=${PREFIX}/include
+export M4="${BUILD_PREFIX}/bin/m4"
+export CPATH="${PREFIX}/include"
 
-./autogen.sh
-./configure --prefix=$PREFIX --with-hts=$PREFIX
-make -j${CPU_COUNT}
+autoreconf -if
+./configure --prefix="$PREFIX" --with-hts="$PREFIX" CXX="${CXX}"
+make -j"${CPU_COUNT}"
 # removing this for now as it triggers a build error from -Werror=maybe-uninitialized - pvanheus
 # make check
 make install

--- a/recipes/ivar/meta.yaml
+++ b/recipes/ivar/meta.yaml
@@ -16,7 +16,6 @@ build:
 
 requirements:
   build:
-    - {{ compiler("c") }}
     - {{ compiler("cxx") }}
     - make
     - automake

--- a/recipes/ivar/meta.yaml
+++ b/recipes/ivar/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "1.4.3" %}
-{% set sha256 = "b9b7b0301418ddec833ab2d5cc2f2995fabacdc4e45c5c14d53a130e5931ed24" %}
+{% set version = "1.4.4" %}
+{% set sha256 = "e5c3905ffefb910a22aee44dc9374bf597b1cad84821c5f3b9e780d73513c083" %}
 
 package:
   name: ivar
@@ -10,7 +10,7 @@ source:
   sha256: "{{ sha256 }}"
 
 build:
-  number: 1
+  number: 0
   run_exports:
     - {{ pin_subpackage('ivar', max_pin='x') }}
 
@@ -44,6 +44,9 @@ about:
 extra:
   additional-platforms:
     - linux-aarch64
+    - osx-arm64
+  watch:
+    - enable: yes
   identifiers:
     - biotools:ivar
     - usegalaxy-eu:ivar_variants

--- a/recipes/ivar/meta.yaml
+++ b/recipes/ivar/meta.yaml
@@ -16,8 +16,8 @@ build:
 
 requirements:
   build:
-    - '{{ compiler("c") }}'
-    - '{{ compiler("cxx") }}'
+    - {{ compiler("c") }}
+    - {{ compiler("cxx") }}
     - make
     - automake
     - autoconf
@@ -35,11 +35,13 @@ test:
     - ivar version
 
 about:
-  home: https://andersen-lab.github.io/ivar/html/
-  license: GPL-3.0
+  home: "https://github.com/andersen-lab/ivar"
+  license: "GPL-3.0-or-later"
+  license_family: GPL3
   license_file: LICENSE
-  summary: iVar is a computational package that contains functions broadly useful for viral amplicon-based sequencing.
-  dev_url: https://github.com/andersen-lab/ivar
+  summary: "iVar is a computational package that contains functions broadly useful for viral amplicon-based sequencing."
+  dev_url: "https://github.com/andersen-lab/ivar"
+  doc_url: "https://andersen-lab.github.io/ivar/html"
 
 extra:
   additional-platforms:
@@ -50,3 +52,11 @@ extra:
   identifiers:
     - biotools:ivar
     - usegalaxy-eu:ivar_variants
+    - usegalaxy-eu:ivar_filtervariants
+    - usegalaxy-eu:ivar_consensus
+    - usegalaxy-eu:ivar_removereads
+    - usegalaxy-eu:ivar_trim
+    - usegalaxy-eu:ivar_getmasked
+    - doi:10.1186/s13059-018-1618-7
+  recipe-maintainers:
+    - gkarthik


### PR DESCRIPTION
* Bumped iVar to v1.4.4.
* Added `osx-arm64` to additional platforms