### PR TITLE
Update hmftools-esvee recipe: Bump sambamba version and openjdk version range(s)

### DIFF
--- a/recipes/hmftools-esvee/meta.yaml
+++ b/recipes/hmftools-esvee/meta.yaml
@@ -12,14 +12,14 @@ source:
 
 build:
   noarch: generic
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage("hmftools-esvee", max_pin="x.x") }}
 
 requirements:
   run:
-    - openjdk >=8,<=21
-    - sambamba ==0.6.8
+    - openjdk >=8,<=23
+    - sambamba ==1.0.1
 
 test:
   commands:


### PR DESCRIPTION
Tested successfully with AWS Corretto Java SDK 23 on an ARM64 instance.

No need for:

```yaml
extra:
  additional-platforms:
    - linux-aarch64
```

Since this is a `noarch` target (Java).