### PR TITLE
fermi-lite: Add aarch64 target and switch upstream source

### DIFF
--- a/recipes/fermi-lite/build.sh
+++ b/recipes/fermi-lite/build.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+git submodule init && git submodule update
 make CC="${CC}" CFLAGS="-fcommon ${CFLAGS} ${LDFLAGS}" CPPFLAGS="${CPPFLAGS}"
 mkdir -p "${PREFIX}/"{bin,include}
 cp fml-asm ${PREFIX}/bin

--- a/recipes/fermi-lite/meta.yaml
+++ b/recipes/fermi-lite/meta.yaml
@@ -6,11 +6,11 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/lh3/fermi-lite/archive/v{{ version }}.tar.gz
+  url: https://github.com/mr-c/fermi-lite/archive/v{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:
-  number: 8
+  number: 9
   run_exports:
     - {{ pin_subpackage('fermi-lite', max_pin='x.x') }}
 
@@ -26,6 +26,10 @@ requirements:
 test:
   commands:
     - fml-asm 2>&1 | grep -qF fml-asm
+
+extra:
+  additional-platforms:
+    - linux-aarch64
 
 about:
   home: https://github.com/lh3/fermi-lite


### PR DESCRIPTION
See https://github.com/lh3/fermi-lite/pull/14#issuecomment-2686900178

Context for this PR is ESVEE requiring appropriate aarch64 support on the native bindings. This is a sub-effort of https://github.com/nf-core/oncoanalyser/pull/134:

```
Command output:
  04:38:19.722 [INFO ] Esvee version 1.0
  04:38:19.804 [INFO ] writing to output directory(assemble/)
  04:38:19.809 [INFO ] fragment length bounds(min=473 max=527)
  04:38:19.817 [INFO ] loaded 10 junctions, types(split=6 discordant=4 indel=0 hotspot=4) from file: prep/subject_a.tumor.esvee.prep.junction.tsv
  04:38:19.866 [ERROR] process run error: java.lang.IllegalStateException: We have pre-built fermi-lite binaries only for x86_64 and amd64.  Your os.arch is aarch64.Set property LIBBWA_PATH to point to a native library for your architecture.

Command error:
  04:38:19.722 [INFO ] Esvee version 1.0
  04:38:19.804 [INFO ] writing to output directory(assemble/)
  04:38:19.809 [INFO ] fragment length bounds(min=473 max=527)
  04:38:19.817 [INFO ] loaded 10 junctions, types(split=6 discordant=4 indel=0 hotspot=4) from file: prep/subject_a.tumor.esvee.prep.junction.tsv
  04:38:19.866 [ERROR] process run error: java.lang.IllegalStateException: We have pre-built fermi-lite binaries only for x86_64 and amd64.  Your os.arch is aarch64.Set property LIBBWA_PATH to point to a native library for your architecture.
  java.lang.IllegalStateException: We have pre-built fermi-lite binaries only for x86_64 and amd64.  Your os.arch is aarch64.Set property LIBBWA_PATH to point to a native library for your architecture.
        at org.broadinstitute.hellbender.utils.bwa.BwaMemIndex.loadNativeLibrary(BwaMemIndex.java:447)
        at org.broadinstitute.hellbender.utils.bwa.BwaMemIndex.<init>(BwaMemIndex.java:330)
        at com.hartwig.hmftools.esvee.assembly.alignment.AlignmentChecker.<init>(AlignmentChecker.java:43)
        at com.hartwig.hmftools.esvee.assembly.JunctionGroupAssembler.<init>(JunctionGroupAssembler.java:64)
        at com.hartwig.hmftools.esvee.assembly.JunctionGroupAssembler.createThreadTasks(JunctionGroupAssembler.java:89)
        at com.hartwig.hmftools.esvee.assembly.AssemblyApplication.runPrimaryAssembly(AssemblyApplication.java:270)
        at com.hartwig.hmftools.esvee.assembly.AssemblyApplication.run(AssemblyApplication.java:125)
        at com.hartwig.hmftools.esvee.assembly.AssemblyApplication.main(AssemblyApplication.java:504)
```