### PR TITLE
Update get_fasta_info

### DIFF
--- a/recipes/get_fasta_info/build.sh
+++ b/recipes/get_fasta_info/build.sh
@@ -2,6 +2,6 @@
 export CFLAGS="-I$PREFIX/include"
 export LDFLAGS="-L$PREFIX/lib"
 export CPATH=${PREFIX}/include
-autoreconf -i --verbose
+./autogen.sh
 ./configure --prefix=$PREFIX
 make install

--- a/recipes/get_fasta_info/meta.yaml
+++ b/recipes/get_fasta_info/meta.yaml
@@ -16,17 +16,14 @@ build:
 
 requirements:
   build:
-    - {{ compiler('c') }}
     - make
+    - {{ compiler('c') }}
     - autoconf
     - automake
-    - libgcc
   host:
-    - libgcc
     - libzlib
     - zlib
   run:
-    - libgcc
     - libzlib
 
 test:

--- a/recipes/get_fasta_info/meta.yaml
+++ b/recipes/get_fasta_info/meta.yaml
@@ -1,27 +1,33 @@
-{% set version = "2.4" %}
-{% set sha256 = "ebe27e3481597cac86468fdf0917a605c4672183ab65a9dc7a34d309b33d0457" %}
+{% set version = "2.5.0" %}
+{% set sha256 = "6f401933da823766223a1b1af4bbfa1fd420f008d58ac3f88ab178004d968715" %}
 
 package:
   name: get_fasta_info
   version: '{{ version }}'
 
 source:
-  url: https://github.com/nylander/get_fasta_info/archive/refs/tags/v.{{ version }}.tar.gz
+  url: https://github.com/nylander/get_fasta_info/archive/refs/tags/v{{ version }}.tar.gz
   sha256: '{{ sha256 }}'
 
 build:
-  number: 3
+  number: 0
+  run_exports:
+    - {{ pin_subpackage('get_fasta_info', max_pin="x") }}
 
 requirements:
   build:
-    - make
     - {{ compiler('c') }}
+    - make
     - autoconf
     - automake
+    - libgcc
   host:
+    - libgcc
+    - libzlib
     - zlib
   run:
-    - zlib
+    - libgcc
+    - libzlib
 
 test:
   commands:


### PR DESCRIPTION
Update get_fasta_info to v2.5.0
- Refactored code
- Added new options for setting missing data symbols
- Restructured file hierarchy for building using Automake+Autoconf or CMake