### PR TITLE
Update: Preserve existing PERL5LIB path on run

### DIFF
--- a/recipes/pfam_scan/build.sh
+++ b/recipes/pfam_scan/build.sh
@@ -9,6 +9,6 @@ cp -r * $outdir
 # Short wrapper script which sets PERL5LIB while running
 cat > $PREFIX/bin/pfam_scan.pl <<EOF
 #!/bin/bash
-PERL5LIB=$outdir exec $outdir/pfam_scan.pl "\$@"
+PERL5LIB=$outdir:\${PERL5LIB} exec $outdir/pfam_scan.pl "\$@"
 EOF
 chmod +x $PREFIX/bin/pfam_scan.pl

--- a/recipes/pfam_scan/build.sh
+++ b/recipes/pfam_scan/build.sh
@@ -9,6 +9,6 @@ cp -r * $outdir
 # Short wrapper script which sets PERL5LIB while running
 cat > $PREFIX/bin/pfam_scan.pl <<EOF
 #!/bin/bash
-PERL5LIB=$outdir:\${PERL5LIB} exec $outdir/pfam_scan.pl "\$@"
+PERL5LIB=$outdir:$PREFIX/lib/perl5/site_perl:\${PERL5LIB} exec $outdir/pfam_scan.pl "\$@"
 EOF
 chmod +x $PREFIX/bin/pfam_scan.pl

--- a/recipes/pfam_scan/meta.yaml
+++ b/recipes/pfam_scan/meta.yaml
@@ -10,7 +10,7 @@ build:
   noarch: generic
   number: 5
   run_exports:
-    - {{ pin_subpackage("myrecipe", max_pin="x") }}
+    - {{ pin_subpackage("pfam_scan", max_pin="x") }}
 
 requirements:
   run:

--- a/recipes/pfam_scan/meta.yaml
+++ b/recipes/pfam_scan/meta.yaml
@@ -8,7 +8,9 @@ source:
 
 build:
   noarch: generic
-  number: 4
+  number: 5
+  run_exports:
+    - {{ pin_subpackage("myrecipe", max_pin="x") }}
 
 requirements:
   run:


### PR DESCRIPTION
Wrapper script for `pfam_scan.pl` currently overwrites `PERL5LIB` path. On OSX this causes error locating the IPC run.pm dependency.

This PR appends the existing `PERL5LIB` path at time of execution to fix this issue. No effect on other platforms.

