### PR TITLE
Update FROGS to v5.0.1

### DIFF
--- a/recipes/frogs/meta.yaml
+++ b/recipes/frogs/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "frogs" %}
-{% set version = "5.0.0" %}
+{% set version = "5.0.1" %}
 {% set phyloseq_extended_version = "0.99" %}
 
 package:
@@ -15,7 +15,7 @@ build:
 
 source:
   - url: https://github.com/geraldinepascal/FROGS/archive/v{{ version }}.tar.gz 
-    md5: 3bfae780dbe766fb5b249d5a8438261d
+    md5: 64319c67c40c6c0aa5e4eac44847b209
   - url: https://github.com/mahendra-mariadassou/phyloseq-extended/archive/v{{ phyloseq_extended_version }}.tar.gz
     md5: 1ec072751503eebb791e876a60433120
     folder: lib/external-lib
@@ -63,7 +63,7 @@ about:
   home: https://github.com/geraldinepascal/FROGS
   license: 'GNU GPL v3'
   summary: 'FROGS is a workflow designed to metabarcoding sequence analysis'
-  description: 'FROGS produces an ASVs count matrix from high depth sequencing amplicon data. This is the official release 5.0.0 of FROGS.
+  description: 'FROGS produces an ASVs count matrix from high depth sequencing amplicon data. This is the official release 5.0.1 of FROGS.
   To fully install FROGS dependencies, please refer to the frogs-conda-requirements.txt and frogsfunc-conda-requirements.txt available at https://github.com/geraldinepascal/FROGS'
 
 extra:


### PR DESCRIPTION
Bugs fixed

- Issue: unable to use denoising.py with swarm and --denoising option with --distance > 1
- splitbc.pl: fix R2 truncation
- denoising.py: Allow vsearch to deal with AVITI reads (higher max quality value allowed)
