### PR TITLE
update plink1.907.7

### DIFF
--- a/recipes/plink/meta.yaml
+++ b/recipes/plink/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "plink" %}
-{% set version = "1.9.0b.7.7" %}
+{% set version = "1.90b7.7" %}
 
 package:
   name: {{ name }}


### PR DESCRIPTION
Previous #54035  still doesn't show the updated version,  as the version number resolves as lower than current available package. Fixed that as per the suggestion in above PR. 

