### PR TITLE
fix ensembl-vep missing dependency "perl-list-moreutils"

### DIFF
--- a/recipes/ensembl-vep/build.sh
+++ b/recipes/ensembl-vep/build.sh
@@ -6,9 +6,6 @@ version=${PKG_VERSION%%.*}
 mkdir -p $target
 mkdir -p $PREFIX/bin
 
-
-# Use insecure CURL
-sed -i.bak 's/curl -s --location/curl -k -s --location/' INSTALL.pl
 # Use vep_convert_cache.pl from vep_install.pl
 sed -i.bak 's@/convert_cache.pl@/vep_convert_cache@' INSTALL.pl
 # Find plugins in install directory
@@ -38,14 +35,14 @@ vep_install -a a --NO_HTSLIB --NO_TEST --NO_BIOPERL --NO_UPDATE
 rm -rf t/
 
 # Install plugins
-curl -L -ks -o VEP_plugins.tar.gz https://github.com/Ensembl/VEP_plugins/archive/release/$version.tar.gz
+curl -L -s -o VEP_plugins.tar.gz https://github.com/Ensembl/VEP_plugins/archive/release/$version.tar.gz
 tar -xzvpf VEP_plugins.tar.gz
 mv VEP_plugins*/*.pm .
 mv VEP_plugins*/config .
 rm -rf VEP_plugins*
 
 # Install loftee
-curl -L -ks -o loftee.tar.gz https://github.com/konradjk/loftee/archive/v1.0.3.tar.gz
+curl -L -s -o loftee.tar.gz https://github.com/konradjk/loftee/archive/v1.0.3.tar.gz
 tar -xzvpf loftee.tar.gz
 mv loftee-*/*.pl .
 mv loftee-*/*.pm .

--- a/recipes/ensembl-vep/meta.yaml
+++ b/recipes/ensembl-vep/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: ee68013eb035e17129e8f69977f525ebdd8321e73b3164a7bda6e103e2d10beb
 
 build:
-  number: 1
+  number: 2
   noarch: generic
   run_exports:
     - {{ pin_subpackage('ensembl-vep', max_pin="x") }}
@@ -27,6 +27,7 @@ requirements:
     - perl
     - perl-bioperl >=1.7.2
     - perl-bio-db-hts >=2.11
+    - perl-list-moreutils
     - perl-dbi
     - perl-dbd-mysql
     - perl-io-compress


### PR DESCRIPTION
this adds the missing dependency perl-list-moreutils 

it also removes the insecure curl requests.

note: with my strict conda channel priority perl>=5.27.0 had to be specified for this to build

context:

since bioconda::ensembl-vep>=112.0 the vep command errors out because of missing List/MoreUtils.pm 

see https://github.com/bioconda/bioconda-recipes/issues/54304#issue-2895018904