### PR TITLE
Update r-psminer and rename to r-pathosurveilr

### DIFF
--- a/recipes/r-pathosurveilr/meta.yaml
+++ b/recipes/r-pathosurveilr/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version|replace("-", "_") }}
 
 source:
-  url: https://github.com/grunwaldlab/pPathoSurveilR/archive/v{{ version }}.tar.gz
+  url: https://github.com/grunwaldlab/PathoSurveilR/archive/v{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:

--- a/recipes/r-pathosurveilr/meta.yaml
+++ b/recipes/r-pathosurveilr/meta.yaml
@@ -1,12 +1,12 @@
-{% set version = '0.2.0' %}
-{% set sha256 = '225b2f7c10fe680df3fd95de73562859a957aa1330f3ff5b9f8a2f3ca4ca84b4' %}
+{% set version = '0.3.0' %}
+{% set sha256 = '9540e0f52c859d25dfaa4aa4a1f958a6def83fac4126055392ad2344f9e572c9' %}
 
 package:
-  name: r-psminer
+  name: r-pathosurveilr
   version: {{ version|replace("-", "_") }}
 
 source:
-  url: https://github.com/grunwaldlab/psminer/archive/v{{ version }}.tar.gz
+  url: https://github.com/grunwaldlab/pPathoSurveilR/archive/v{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:
@@ -17,7 +17,7 @@ build:
     - lib/R/lib/
     - lib/
   run_exports:
-    - {{ pin_subpackage('r-psminer', max_pin="x.x") }}
+    - {{ pin_subpackage('r-pathosurveilr', max_pin="x.x") }}
 
 requirements:
   host:
@@ -75,11 +75,10 @@ requirements:
 
 test:
   commands:
-    - $R -e "library('psminer')"
+    - $R -e "library('PathoSurveilR')"
 
 about:
-  home: https://github.com/grunwaldlab/psminer
+  home: https://github.com/grunwaldlab/PathoSurveilR
   license: MIT
   license_family: MIT
-  summary: |
-    Utilities for interacting with the pathogensurveillance pipeline.
+  summary: Utilities for interacting with the pathogensurveillance pipeline.


### PR DESCRIPTION
This needed to be renamed because there was already a package on CRAN called `psminer` that we did not know about.