### PR TITLE
ci: adding caching of bioconda-utils install in PR workflow

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -33,6 +33,23 @@ jobs:
       - name: Set up bioconda-utils
         run: bash install-and-set-up-conda.sh
 
+      - name: Restore cache
+        id: cache
+        uses: actions/cache@v4
+        with:
+          path: /opt/mambaforge
+          key: ${{ runner.os }}--master--${{ hashFiles('install-and-set-up-conda.sh', 'common.sh', 'configure-conda.sh') }}
+
+      - name: Set up bioconda-utils
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: bash install-and-set-up-conda.sh
+
+      # This script can be used to reconfigure conda to use the right channel setup.
+      # This has to be done after the cache is restored, because
+      # the channel setup is not cached as it resides in the home directory.
+      # We could use a system-wide (and therefore cached) channel setup,
+      # but mamba does not support that at the time of implementation
+      # (it ignores settings made with --system).
       - name: Configure conda
         run: bash configure-conda.sh
 

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -30,9 +30,6 @@ jobs:
         run: |
           wget https://raw.githubusercontent.com/bioconda/bioconda-common/master/{install-and-set-up-conda,configure-conda,common}.sh
 
-      - name: Set up bioconda-utils
-        run: bash install-and-set-up-conda.sh
-
       - name: Restore cache
         id: cache
         uses: actions/cache@v4

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -196,6 +196,15 @@ jobs:
         run: |
           wget https://raw.githubusercontent.com/bioconda/bioconda-common/master/{install-and-set-up-conda,configure-conda,common}.sh
 
+      # This is required so actions/cache below will restore properly
+      # See: https://github.com/actions/cache/issues/629#issuecomment-1189184648
+      - name: Make gtar SUDO
+        run: |
+          echo -e "#!/bin/sh\nexec sudo /usr/local/bin/gtar.orig "$@"\n" > gtar;
+          sudo mv -v /usr/local/bin/gtar /usr/local/bin/gtar.orig;
+          sudo cp -v gtar /usr/local/bin/gtar;
+          sudo chmod +x /usr/local/bin/gtar;
+
       - name: Restore cache
         id: cache
         uses: actions/cache@v4

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -93,10 +93,23 @@ jobs:
         run: |
           wget https://raw.githubusercontent.com/bioconda/bioconda-common/master/{install-and-set-up-conda,configure-conda,common}.sh
 
+      - name: Restore cache
+        id: cache
+        uses: actions/cache@v4
+        with:
+          path: /opt/mambaforge
+          key: ${{ runner.os }}--master--${{ hashFiles('install-and-set-up-conda.sh', 'common.sh', 'configure-conda.sh') }}
+
       - name: Set up bioconda-utils
+        if: steps.cache.outputs.cache-hit != 'true'
         run: bash install-and-set-up-conda.sh
 
       # This script can be used to reconfigure conda to use the right channel setup.
+      # This has to be done after the cache is restored, because
+      # the channel setup is not cached as it resides in the home directory.
+      # We could use a system-wide (and therefore cached) channel setup,
+      # but mamba does not support that at the time of implementation
+      # (it ignores settings made with --system).
       - name: Configure conda
         run: bash configure-conda.sh
 
@@ -183,10 +196,23 @@ jobs:
         run: |
           wget https://raw.githubusercontent.com/bioconda/bioconda-common/master/{install-and-set-up-conda,configure-conda,common}.sh
 
+      - name: Restore cache
+        id: cache
+        uses: actions/cache@v4
+        with:
+          path: /opt/mambaforge
+          key: ${{ runner.os }}--master--${{ hashFiles('install-and-set-up-conda.sh', 'common.sh', 'configure-conda.sh') }}
+
       - name: Set up bioconda-utils
+        if: steps.cache.outputs.cache-hit != 'true'
         run: bash install-and-set-up-conda.sh
 
       # This script can be used to reconfigure conda to use the right channel setup.
+      # This has to be done after the cache is restored, because
+      # the channel setup is not cached as it resides in the home directory.
+      # We could use a system-wide (and therefore cached) channel setup,
+      # but mamba does not support that at the time of implementation
+      # (it ignores settings made with --system).
       - name: Configure conda
         run: bash configure-conda.sh
 

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -200,7 +200,8 @@ jobs:
       # See: https://github.com/actions/cache/issues/629#issuecomment-1189184648
       - name: Make gtar SUDO
         run: |
-          echo -e "#!/bin/sh\nexec sudo /usr/local/bin/gtar.orig "$@"\n" > gtar;
+          echo -e '#!/bin/sh\nexec sudo /usr/local/bin/gtar.orig "$@"\n' > gtar;
+          cat gtar;
           sudo mv -v /usr/local/bin/gtar /usr/local/bin/gtar.orig;
           sudo cp -v gtar /usr/local/bin/gtar;
           sudo chmod +x /usr/local/bin/gtar;


### PR DESCRIPTION
This takes the snipped of code from [`build-failures`](https://github.com/nh13/bioconda-recipes/blob/795299ebe05d970ca70711db525ff10ebca427c9/.github/workflows/build-failures.yml#L36-L52) and adds it to the [PR GHA workflow](https://github.com/nh13/bioconda-recipes/blob/795299ebe05d970ca70711db525ff10ebca427c9/.github/workflows/PR.yml).

This reduces the bioconda-utils setup time from ~1-2 minutes to 10-15 seconds (on linux) 😄  .

To test this workflow, I've re-run the checks a second time to show that the cache works.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
