### PR TITLE
update Tidyp for linux-aarch64,add usage of '-fPIC' flag

### DIFF
--- a/recipes/tidyp/build.sh
+++ b/recipes/tidyp/build.sh
@@ -4,11 +4,16 @@ set -xe
 
 mkdir -p ${HOME}/bin
 export PATH="${HOME}/bin:$PATH"
-ln -s ${CC} ${HOME}/bin/gcc
+
+ln -fs ${CC} ${HOME}/bin/gcc
 
 pushd build/gmake
+sed -i.bak '85s/^CFLAGS=/CFLAGS=-fPIC/' Makefile
 make
 popd
 
 mkdir -p ${PREFIX}/bin
+
 cp ./bin/tidyp ${PREFIX}/bin
+cp -r ./include ${PREFIX}/
+cp -r ./lib ${PREFIX}/

--- a/recipes/tidyp/meta.yaml
+++ b/recipes/tidyp/meta.yaml
@@ -7,7 +7,7 @@ source:
   sha256: 5f0965041119bed0ed70a7f0be39e8f0162141eea14d77f472b49f8b3303ab0b
 
 build:
-  number: 7
+  number: 8
   run_exports:
     - {{ pin_subpackage('tidyp', max_pin="x") }}
 


### PR DESCRIPTION
Test passed!
![tidyp](https://github.com/user-attachments/assets/1eb1a8e0-db69-42ae-b556-07fa77613b75)
