### PR TITLE
bump maker

### DIFF
--- a/build-fail-blacklist
+++ b/build-fail-blacklist
@@ -729,9 +729,6 @@ recipes/hiline
 recipes/eqtlbma
 recipes/barriers
 
-# Requires rmblast update
-recipes/maker
-
 # Takes hours to solve the environment
 recipes/rop
 

--- a/recipes/maker/meta.yaml
+++ b/recipes/maker/meta.yaml
@@ -1,4 +1,4 @@
-{% set blast_version = "2.12.0" %}
+{% set blast_version = "2.14.1" %}
 
 package:
   name: maker

--- a/recipes/maker/meta.yaml
+++ b/recipes/maker/meta.yaml
@@ -13,6 +13,8 @@ source:
 
 build:
   number: 4
+  run_exports:
+    - {{ pin_subpackage("maker", max_pin="x") }}
 
 requirements:
   build:

--- a/recipes/maker/meta.yaml
+++ b/recipes/maker/meta.yaml
@@ -12,7 +12,7 @@ source:
     - "mpi_init.patch"
 
 build:
-  number: 3
+  number: 4
 
 requirements:
   build:


### PR DESCRIPTION
hoping to solve (with strict channel priority)

```
Could not solve for environment specs
The following package could not be installed
└─ maker 3.01.03**  is not installable because it requires
   ├─ perl >=5.26.2,<5.26.3.0a0 , which can be installed;
   └─ perl-bit-vector but there are no viable options
      ├─ perl-bit-vector 7.4 would require
      │  └─ perl >=5.32.1,<5.33.0a0 *_perl5, which conflicts with any installable versions previously reported;
      └─ perl-bit-vector 7.4 conflicts with any installable versions previously reported.
```

or the following wo channel priority

```
Could not solve for environment specs
The following package could not be installed
└─ maker 3.01.03**  is not installable because it requires
   ├─ perl >=5.26.2,<5.26.3.0a0 , which can be installed;
   └─ perl-bioperl-core >=1.007002 , which requires
      └─ perl-array-compare but there are no viable options
         ├─ perl-array-compare [2.11|3.0.1] would require
         │  └─ perl-type-tiny but there are no viable options
         │     ├─ perl-type-tiny 1.016007 would require
         │     │  └─ perl-exporter-tiny >=1.000000  but there are no viable options
         │     │     ├─ perl-exporter-tiny 1.002002 would require
         │     │     │  └─ perl >=5.32.1,<6.0a0 *_perl5, which conflicts with any installable versions previously reported;
         │     │     └─ perl-exporter-tiny [1.000000|1.002001|1.002002] conflicts with any installable versions previously reported;
         │     └─ perl-type-tiny [1.000005|1.002002|...|1.016006] conflicts with any installable versions previously reported;
         └─ perl-array-compare 3.0.1 would require
            └─ perl-types-standard, which requires
               └─ perl-exporter-tiny but there are no viable options
                  ├─ perl-exporter-tiny 1.002002, which cannot be installed (as previously explained);
                  ├─ perl-exporter-tiny [1.000000|1.002001|1.002002] conflicts with any installable versions previously reported;
                  └─ perl-exporter-tiny 0.042 conflicts with any installable versions previously reported.
```

Describe your pull request here

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
