### PR TITLE
updated ectyper_v2.0.0 build #3 recipe to fix minor bugs in serotyping

### DIFF
--- a/recipes/ectyper/meta.yaml
+++ b/recipes/ectyper/meta.yaml
@@ -7,10 +7,10 @@ package:
 
 source:
     url: https://github.com/phac-nml/ecoli_serotyping/archive/{{ version }}.tar.gz
-    sha256: e39acd981e94f6106ffd7feb7db17c6846e652004c3b75c1f5c35d170e55cd59 
+    sha256: ab4df95bdc8fa81689b9da2d1451ba0389d5fa07ac5bc60e070f0ab3af04d05e 
 
 build:
-    number: 2
+    number: 3
     noarch: python
     run_exports:
         - {{ pin_subpackage(name, max_pin="x") }}
@@ -24,14 +24,14 @@ requirements:
     run:
         - python >=3.5
         - pytest >=3.5
-        - pandas >=0.23.1.*
-        - samtools >=1.8.*
-        - bowtie2 >=2.3.*
-        - mash >=2.0.*
+        - pandas >=0.23.1.*,<3
+        - samtools >=1.8.*,<2
+        - bowtie2 >=2.3.*,<3
+        - mash >=2.0.*,<3
         - bcftools >=1.8.*
         - biopython >=1.70.*,<=1.85
         - blast >=2.7.1.*
-        - seqtk >=1.2.*
+        - seqtk >=1.2.*,<2
         - requests >=2.*.*
 test:
     import:
@@ -43,6 +43,6 @@ test:
 about:
     license: Apache 2
     summary: ECtyper is a python program for serotyping E. coli genomes
-    author: Chad Laing, Kyrylo Bessonov, Camille La Rose, Sam Sung
+    author: Kyrylo Bessonov, Chad Laing, Camille La Rose, Sam Sung
     home: https://github.com/phac-nml/ecoli_serotyping
 


### PR DESCRIPTION
Users identified small issues including
- higher number of mixed O-antigen calls
- [issue 101](https://github.com/phac-nml/ecoli_serotyping/issues/101) with the inconsistent number of output columns depending on `--pathotype` parameter specified or not