### PR TITLE
Fix mgnify toolkit v1 - missing dep and renamed script

### DIFF
--- a/recipes/mgnify-pipelines-toolkit/meta.yaml
+++ b/recipes/mgnify-pipelines-toolkit/meta.yaml
@@ -29,14 +29,14 @@ build:
     - mapseq_to_asv_table = mgnify_pipelines_toolkit.analysis.amplicon.mapseq_to_asv_table:main
     - primer_val_classification = mgnify_pipelines_toolkit.analysis.amplicon.primer_val_classification:main
     - add_rhea_chebi_annotation = mgnify_pipelines_toolkit.analysis.assembly.add_rhea_chebi_annotation:main
-    - cgc_merge = mgnify_pipelines_toolkit.analysis.assembly.cgc_merge:combine_main
+    - combined_gene_caller_merge = mgnify_pipelines_toolkit.analysis.assembly.combined_gene_caller_merge:combine_main
     - generate_gaf = mgnify_pipelines_toolkit.analysis.assembly.generate_gaf:main
     - summarise_goslims = mgnify_pipelines_toolkit.analysis.assembly.summarise_goslims:main
     - fasta_to_delimited = mgnify_pipelines_toolkit.utils.fasta_to_delimited:main
     - get_mpt_version = mgnify_pipelines_toolkit.utils.get_mpt_version:main
   noarch: python
   script: {{ PYTHON }} -m pip install . -vvv --no-deps --no-build-isolation --no-cache-dir
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage('mgnify-pipelines-toolkit', max_pin="x.x") }}
 
@@ -55,6 +55,7 @@ requirements:
     - pandera
     - requests
     - pyfastx >=2.2.0
+    - intervaltree ==3.1.0
 
 test:
   imports:
@@ -72,6 +73,7 @@ test:
     - remove_ambiguous_reads --help
     - rev_comp_se_primers --help
     - standard_primer_matching --help
+    - combined_gene_caller_merge --help
 
 about:
   home: https://github.com/EBI-Metagenomics/mgnify-pipelines-toolkit
@@ -87,3 +89,4 @@ about:
 extra:
   recipe-maintainers:
     - chrisAta
+    - mberacochea


### PR DESCRIPTION
This PR fixes 2 issues with https://github.com/EBI-Metagenomics/mgnify-pipelines-toolkit release v1.0. The bioconda package is missing a dependency https://github.com/EBI-Metagenomics/mgnify-pipelines-toolkit/blob/main/pyproject.toml#L27C6-L27C25 and one script that was renamed https://github.com/EBI-Metagenomics/mgnify-pipelines-toolkit/blob/main/pyproject.toml#L68.

