### PR TITLE
Update mgnify pipelines toolkit to version 1.0.1

### DIFF
--- a/recipes/mgnify-pipelines-toolkit/meta.yaml
+++ b/recipes/mgnify-pipelines-toolkit/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/mgnify_pipelines_toolkit-{{ version }}.tar.gz
-  sha256: 072ad821da2a4297073e9cf2dfff5013d9e88a3275f48a90e7fd40a02aeff437
+  sha256: d456c8d143143aa5332dab48611766b8aacc1f7dc9de80e88b0ff334bbe08c96
 
 build:
   entry_points:

--- a/recipes/mgnify-pipelines-toolkit/meta.yaml
+++ b/recipes/mgnify-pipelines-toolkit/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "mgnify-pipelines-toolkit" %}
-{% set version = "1.0.0" %}
+{% set version = "1.0.1" %}
 
 package:
   name: {{ name|lower }}
@@ -29,7 +29,7 @@ build:
     - mapseq_to_asv_table = mgnify_pipelines_toolkit.analysis.amplicon.mapseq_to_asv_table:main
     - primer_val_classification = mgnify_pipelines_toolkit.analysis.amplicon.primer_val_classification:main
     - add_rhea_chebi_annotation = mgnify_pipelines_toolkit.analysis.assembly.add_rhea_chebi_annotation:main
-    - cgc_merge = mgnify_pipelines_toolkit.analysis.assembly.cgc_merge:combine_main
+    - combined_gene_caller_merge = mgnify_pipelines_toolkit.analysis.assembly.combined_gene_caller_merge:main
     - generate_gaf = mgnify_pipelines_toolkit.analysis.assembly.generate_gaf:main
     - summarise_goslims = mgnify_pipelines_toolkit.analysis.assembly.summarise_goslims:main
     - fasta_to_delimited = mgnify_pipelines_toolkit.utils.fasta_to_delimited:main
@@ -55,6 +55,7 @@ requirements:
     - pandera
     - requests
     - pyfastx >=2.2.0
+    - intervaltree ==3.1.0
 
 test:
   imports:
@@ -72,6 +73,7 @@ test:
     - remove_ambiguous_reads --help
     - rev_comp_se_primers --help
     - standard_primer_matching --help
+    - combined_gene_caller_merge --help
 
 about:
   home: https://github.com/EBI-Metagenomics/mgnify-pipelines-toolkit
@@ -87,3 +89,4 @@ about:
 extra:
   recipe-maintainers:
     - chrisAta
+    - mberacochea


### PR DESCRIPTION
This PR upgrades the mgnify pipelines toolkit to version 1.0.1 (a bugfix release)
