### PR TITLE
Add cctyper from russel88 channel to bioconda

### DIFF
--- a/recipes/cctyper/LICENSE.txt
+++ b/recipes/cctyper/LICENSE.txt
@@ -1,0 +1,19 @@
+Copyright (c) 2020 Jakob Russel
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/recipes/cctyper/meta.yaml
+++ b/recipes/cctyper/meta.yaml
@@ -1,0 +1,65 @@
+{% set name = "cctyper" %}
+{% set version = "1.8.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/cctyper-{{ version }}.tar.gz
+  sha256: 73a4bc661c35e88000d3141d571901cc617d9a4b5517667fcf3bc3e6afc3bffa
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x.x") }}
+
+requirements:
+  host:
+    - python >=3.8,<3.9.0a0
+    - pip
+    - setuptools
+
+  run:
+    - python >=3.8,<3.9.0a0
+    - python_abi 3.8.* *_cp38
+    - biopython >=1.78,<=1.79
+    - blast 2.5.*
+    - cairosvg
+    - grep
+    - hmmer 3.*
+    - imageio
+    - minced 0.4.2.*
+    - multiprocess >=0.70.14,<=0.70.15
+    - numpy >=1.16,<=1.24.3
+    - pandas >=1.3,<=2.0.3
+    - prodigal >=2.0,<=2.6.2
+    - libxgboost 1.7.1.*
+    - py-xgboost >=1.4,<=1.7.1
+    - scikit-learn >=1.1.3,<=1.3.0
+    - scipy >=1,<=1.10.1
+    - sed
+    - tqdm >=4.64.1,<=4.66.5
+    - drawsvg >=1.8.0
+
+test:
+  imports:
+    - cctyper
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/Russel88/CRISPRCasTyper
+  dev_url: https://github.com/Russel88/CRISPRCasTyper
+  summary: 'CRISPRCasTyper: Automatic detection and subtyping of CRISPR-Cas operons'
+  license: MIT
+  license_file: LICENSE.txt
+
+
+extra:
+  identifiers:
+    - doi:10.1089/crispr.2020.0059


### PR DESCRIPTION
This PR tries to add CRISPRCas Typer ("cctyper") to bioconda. This is a published tool very useful to identify and type CRISPR arrays in microbial/viral genomes (https://www.liebertpub.com/doi/abs/10.1089/crispr.2020.0059). It is currently available on pypi and on another conda channel (https://anaconda.org/russel88/cctyper), but it is relevant for bioconda as well (also selfishly, it would enable us to push another tool to bioconda that depends on cctyper).