### PR TITLE
Revert "Update snakemake-interface-storage-plugins to 3.6.0"

### DIFF
--- a/recipes/snakemake-interface-storage-plugins/meta.yaml
+++ b/recipes/snakemake-interface-storage-plugins/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "snakemake-interface-storage-plugins" %}
-{% set version = "3.6.0" %}
+{% set version = "3.5.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/snakemake_interface_storage_plugins-{{ version }}.tar.gz
-  sha256: ab60d29bd3faa942713c4cc4ed028ed08afee785ec2ee1c356e94d6ecce59e3b
+  sha256: 88ee1dde95f9d5abb03113c52fb8cfa78ee502cce9ec788c161b3c09076fc075
 
 build:
   noarch: python


### PR DESCRIPTION
Reverts bioconda/bioconda-recipes#54666
The release should be a major version bump instead. Hence retracting this.