### PR TITLE
Update cctyper - new build to automatically install database

### DIFF
--- a/recipes/cctyper/activate.sh
+++ b/recipes/cctyper/activate.sh
@@ -1,0 +1,1 @@
+export CCTYPER_DB="${CONDA_PREFIX}/cct_data/"

--- a/recipes/cctyper/build.sh
+++ b/recipes/cctyper/build.sh
@@ -1,18 +1,7 @@
-## Install CCTyper code
+echo "Installing the package"
 ${PYTHON} -m pip install . -vv --no-deps --no-build-isolation
-## Setup the database
-## Download and unpack the data from the released CCTyper code
-wget https://github.com/Russel88/CRISPRCasTyper/archive/refs/tags/v1.8.0.tar.gz
-tar -xvf v1.8.0.tar.gz
-## Create a folder in the conda directory to host these files ("cct_data")
-mkdir -p "${PREFIX}/cct_data"
-## Copy the relevant files, as well as the Profiles folder after uncompressing
-cp CRISPRCasTyper-1.8.0/data/*.* ${PREFIX}/cct_data/
-tar -xvf CRISPRCasTyper-1.8.0/data/Profiles.tar.gz
-mv Profiles/ ${PREFIX}/cct_data/
-## Set up the env variable (not sure it's needed, but probably not harmful)
-export CCTYPER_DB="${PREFIX}/cct_data/"
-## Set up the files needed to update this env variable (CCTYPER_DB) at each activation / deactivation
+echo "Making sure the env variable pointing to this database will be correctly set up when loading this conda environment"
+## Set up the files needed to update the env variable (CCTYPER_DB) at each activation / deactivation
 for CHANGE in "activate" "deactivate"
 do
     mkdir -p "${PREFIX}/etc/conda/${CHANGE}.d"

--- a/recipes/cctyper/build.sh
+++ b/recipes/cctyper/build.sh
@@ -1,0 +1,20 @@
+## Install CCTyper code
+${PYTHON} -m pip install . -vv --no-deps --no-build-isolation
+## Setup the database
+## Download and unpack the data from the released CCTyper code
+wget https://github.com/Russel88/CRISPRCasTyper/archive/refs/tags/v1.8.0.tar.gz
+tar -xvf v1.8.0.tar.gz
+## Create a folder in the conda directory to host these files ("cct_data")
+mkdir -p "${PREFIX}/cct_data"
+## Copy the relevant files, as well as the Profiles folder after uncompressing
+cp CRISPRCasTyper-1.8.0/data/*.* ${PREFIX}/cct_data/
+tar -xvf CRISPRCasTyper-1.8.0/data/Profiles.tar.gz
+mv Profiles/ ${PREFIX}/cct_data/
+## Set up the env variable (not sure it's needed, but probably not harmful)
+export CCTYPER_DB="${PREFIX}/cct_data/"
+## Set up the files needed to update this env variable (CCTYPER_DB) at each activation / deactivation
+for CHANGE in "activate" "deactivate"
+do
+    mkdir -p "${PREFIX}/etc/conda/${CHANGE}.d"
+    cp "${RECIPE_DIR}/${CHANGE}.sh" "${PREFIX}/etc/conda/${CHANGE}.d/${PKG_NAME}_${CHANGE}.sh"
+done

--- a/recipes/cctyper/deactivate.sh
+++ b/recipes/cctyper/deactivate.sh
@@ -1,0 +1,1 @@
+unset CCTYPER_DB

--- a/recipes/cctyper/meta.yaml
+++ b/recipes/cctyper/meta.yaml
@@ -19,25 +19,23 @@ requirements:
   host:
     - python >=3.8,<3.9.0a0
     - pip
-    - wget
     - setuptools
 
   run:
-    - python >=3.8,<3.9.0a0
-    - python_abi 3.8.* *_cp38
+    - python >=3.8
     - biopython >=1.78,<=1.79
-    - blast 2.5.*
+    - blast >=2.5,<3
     - cairosvg
     - grep
-    - hmmer 3.*
+    - hmmer >=3.0,<4
     - imageio
-    - minced 0.4.2.*
+    - minced >=0.4.2,<0.5
     - multiprocess >=0.70.14,<=0.70.15
     - numpy >=1.16,<=1.24.3
     - pandas >=1.3,<=2.0.3
     - prodigal >=2.0,<=2.6.2
-    - libxgboost 1.7.1.*
-    - py-xgboost >=1.4,<=1.7.1
+    - libxgboost >=1.7,<2
+    - py-xgboost >=1.4,<2
     - scikit-learn >=1.1.3,<=1.3.0
     - scipy >=1,<=1.10.1
     - sed

--- a/recipes/cctyper/meta.yaml
+++ b/recipes/cctyper/meta.yaml
@@ -11,8 +11,7 @@ source:
 
 build:
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage(name, max_pin="x.x") }}
 

--- a/recipes/cctyper/meta.yaml
+++ b/recipes/cctyper/meta.yaml
@@ -19,6 +19,7 @@ requirements:
   host:
     - python >=3.8,<3.9.0a0
     - pip
+    - wget
     - setuptools
 
   run:

--- a/recipes/cctyper/post-link.sh
+++ b/recipes/cctyper/post-link.sh
@@ -1,0 +1,14 @@
+echo "Setting up CCTyper database"
+## Setup the database
+## Download and unpack the data from the released CCTyper code
+curl -O -L https://github.com/Russel88/CRISPRCasTyper/archive/refs/tags/v1.8.0.tar.gz
+tar -xvf v1.8.0.tar.gz
+## Create a folder in the conda directory to host these files ("cct_data")
+mkdir -p "${PREFIX}/cct_data"
+## Copy the relevant files, as well as the Profiles folder after uncompressing
+cp CRISPRCasTyper-1.8.0/data/*.* ${PREFIX}/cct_data/
+tar -xvf CRISPRCasTyper-1.8.0/data/Profiles.tar.gz
+mv Profiles/ ${PREFIX}/cct_data/
+## Set up the env variable (not sure it's needed, but probably not harmful)
+export CCTYPER_DB="${PREFIX}/cct_data/"
+echo "CCTyper database is now available in ${CCTYPER_DB}"

--- a/recipes/cctyper/pre-unlink.sh
+++ b/recipes/cctyper/pre-unlink.sh
@@ -1,0 +1,5 @@
+echo "Removing CCT database"
+CCT_DB_DIR=${PREFIX}/cct_data
+if [[ -d $CCT_DB_DIR ]]; then
+    rm -r $CCT_DB_DIR
+fi

--- a/recipes/cctyper/pre-unlink.sh
+++ b/recipes/cctyper/pre-unlink.sh
@@ -3,3 +3,8 @@ CCT_DB_DIR=${PREFIX}/cct_data
 if [[ -d $CCT_DB_DIR ]]; then
     rm -r $CCT_DB_DIR
 fi
+echo "Also removing the files that were setting up the relevant env variable"
+for CHANGE in "activate" "deactivate"
+do
+    rm "${PREFIX}/etc/conda/${CHANGE}.d/${PKG_NAME}_${CHANGE}.sh"
+done


### PR DESCRIPTION
This is an update of the cctyper recipe. The tool is still exactly the same (so no version number change) but the build number was increased as the recipe was changed.
The recipe was changed to now automatically install the CCTyper database upon build, rather than having the user need to install the database separately.

