### PR TITLE
Update ncbi-fcs-gx recipe v0.5.5

### DIFF
--- a/recipes/ncbi-fcs-gx/meta.yaml
+++ b/recipes/ncbi-fcs-gx/meta.yaml
@@ -27,7 +27,7 @@ build:
   number: 0
   skip: True  # [not linux or not x86_64]
   run_exports:
-    - {{ pin_compatible('nxbi-fcs-gx', max_pin="x.x") }}
+    - {{ pin_compatible('ncbi-fcs-gx', max_pin="x.x") }}
 
 test:
   commands:

--- a/recipes/ncbi-fcs-gx/meta.yaml
+++ b/recipes/ncbi-fcs-gx/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: ncbi-fcs-gx
-  version: 0.5.4
+  version: 0.5.5
 
 source:
-  url: https://github.com/ncbi/fcs-gx/archive/refs/tags/v0.5.4.zip
-  sha256: 4398f935f5f5053a9a47d46416e28e8e7df34942bc72f6b5ac266de8ee365cf0
+  url: https://github.com/ncbi/fcs-gx/archive/refs/tags/v0.5.5.zip
+  sha256: 58266b067f72f1997aba3ef34f10f4dfb914a21abdbb081da897505cc1fe4b8d
   patches:
     - no_static.patch
 
@@ -24,10 +24,10 @@ requirements:
     - grep >=3.4
 
 build:
-  number: 1
+  number: 0
   skip: True  # [not linux or not x86_64]
   run_exports:
-    - {{ pin_compatible('ncbi-fcs-gx', max_pin="x.x") }}
+    - {{ pin_compatible('nxbi-fcs-gx', max_pin="x.x") }}
 
 test:
   commands:


### PR DESCRIPTION
Update ncbi-fcs-gx recipe v0.5.5

- update meta.yaml
- keep no_static.patch