### PR TITLE
Update SemiBin to 2.2.0

### DIFF
--- a/recipes/semibin/meta.yaml
+++ b/recipes/semibin/meta.yaml
@@ -1,19 +1,18 @@
 {% set name = "SemiBin" %}
-{% set version = "2.1.0" %}
+{% set version = "2.2.0" %}
 
 package:
   name: "{{ name|lower }}"
   version: "{{ version }}"
 
 source:
-  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
-  sha256: 5345982bbc38e283043867d361ca8db727fec34a4c40b3a70e01914154d39bd5
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name|lower }}-{{ version }}.tar.gz"
+  sha256: aef60a99f75be5d45226a1fd6aabe5526d78d6dbca0f578c45b0c5bc198d9513
 
 build:
   noarch: python
   number: 0
   entry_points:
-    - SemiBin=SemiBin.main:main_no_version
     - SemiBin1=SemiBin.main:main1
     - SemiBin2=SemiBin.main:main2
   script: {{ PYTHON }} -m pip install --no-deps --no-build-isolation . -vvv
@@ -24,6 +23,7 @@ requirements:
   host:
     - pip
     - python >=3.7
+    - setuptools
   run:
     - numpy
     - pandas
@@ -35,7 +35,6 @@ requirements:
     - coloredlogs
     - pytorch
     - tqdm
-    - mmseqs2 13.45111
     - bedtools
     - hmmer
     - numexpr
@@ -46,13 +45,14 @@ test:
   imports:
     - SemiBin
   commands:
-    - SemiBin --help
+    - SemiBin2 --help
+    - SemiBin2 check_install
 
 about:
   home: "https://github.com/BigDataBiology/SemiBin"
   license: MIT
   license_family: MIT
-  summary: "Metagenomic binning with semi-supervised siamese neural networks"
+  summary: "Metagenomic binning with siamese neural networks"
   doc_url: https://semibin.readthedocs.io/en/latest/
 
 extra:


### PR DESCRIPTION
Update SemiBin to version 2.2.0

In addition to updating version & hash, MMSeqs2 is no longer required and the `SemiBin` entry_point is no longer installed (only `SemiBin1` or `SemiBin2`)

----


<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
