### PR TITLE
Update bioconductor-scater 1.34.1

### DIFF
--- a/recipes/bioconductor-scater/meta.yaml
+++ b/recipes/bioconductor-scater/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.34.0" %}
+{% set version = "1.34.1" %}
 {% set name = "scater" %}
 {% set bioc = "3.20" %}
 
@@ -23,7 +23,7 @@ extra:
   parent_recipe:
     name: bioconductor-scater
     path: recipes/bioconductor-scater
-    version: 1.8.4
+    version: 1.34.1
 
 package:
   name: bioconductor-{{ name|lower }}
@@ -87,7 +87,7 @@ requirements:
     - r-viridis
 
 source:
-  md5: a9ee792d78c5f066f05a90247cd1aa6a
+  md5: a05deaff576e3e02ed28a512d7c07dea
   url:
     - https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/{{ name }}_{{ version }}.tar.gz
     - https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/Archive/{{ name }}/{{ name }}_{{ version }}.tar.gz


### PR DESCRIPTION
I'm hoping that building the latest bioconductor-scater 1.34.1 will help resolve the conda solver issues I am observing in my PR to fix the bioconductor-singlecelltk build.

xref: https://github.com/bioconda/bioconda-recipes/pull/54729