### PR TITLE
SISTR v1.1.3 build #1 due to pytables < 3.10.2 req

### DIFF
--- a/recipes/sistr_cmd/meta.yaml
+++ b/recipes/sistr_cmd/meta.yaml
@@ -7,11 +7,11 @@ package:
 
 source:
   url: https://github.com/phac-nml/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 702879e6fd3c819f5f3eae0e8be3e740a19c8e0dc0fe6d00cebb1dda284636bb
+  sha256: 2fe83a75ec63edcd3fe3f9703e1d1367da3ac554fbf9c19f64c45d20f0332af0
   
 
 build:
-  number: 0
+  number: 1
   noarch: python
   run_exports:
     - {{ pin_subpackage(name, max_pin="x") }}
@@ -33,7 +33,7 @@ requirements:
     - python >=3.4
     - {{ pin_compatible('numpy', max_pin="x") }}
     - pandas >=0.22,<3
-    - pytables >=3.3.0
+    - pytables >=3.3.0,<3.10.2
     - {{ pin_compatible('scipy', max_pin="x.x") }}
     - {{ pin_compatible('pycurl') }}
     - blast >=2.9.0


### PR DESCRIPTION
The pytables > 3.10.2 could cause installation issues on older systems running Ubuntu 22.04 that do not have `blosc2` library available required now for pytables 3.10.2 https://github.com/PyTables/PyTables/releases

In addition improved recipe by using pip3 installer instead of `python setup.py install` as per guidelines

Error on Ubuntu 22.04
```
zip_safe flag not set; analyzing archive contents...
sistr.__pycache__.sistr_cmd.cpython-310: module references __file__
error: Couldn't find a setup script in /tmp/easy_install-lpl7j_y_/blosc2-3.2.0.tar.gz
Error: Process completed with exit code 1.
```

Updated database version 3 url  due to small error identified in the database as stated here https://zenodo.org/records/15078586.
