### PR TITLE
Add grz-pydantic-models recipe

### DIFF
--- a/recipes/grz-pydantic-models/meta.yaml
+++ b/recipes/grz-pydantic-models/meta.yaml
@@ -1,0 +1,42 @@
+{% set name = "grz-pydantic-models" %}
+{% set version = "1.2.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/grz_pydantic_models-{{ version }}.tar.gz
+  sha256: 86db230d14dbbc17a0956a4efecbe755548865de409dbc54bf23507eac203172
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python >=3.12
+    - hatchling
+    - pip
+  run:
+    - python >=3.12
+    - pydantic >=2.9.2,<3
+
+test:
+  imports:
+    - grz_pydantic_models
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  summary: Pydantic models for the GRZ metadata schema
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - tedil
+    - twrightsman

--- a/recipes/grz-pydantic-models/meta.yaml
+++ b/recipes/grz-pydantic-models/meta.yaml
@@ -13,6 +13,8 @@ build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x.x") }}
 
 requirements:
   host:
@@ -32,6 +34,7 @@ test:
     - pip
 
 about:
+  home: https://github.com/BfArM-MVH/grz-pydantic-models
   summary: Pydantic models for the GRZ metadata schema
   license: MIT
   license_file: LICENSE


### PR DESCRIPTION
This PR adds `grz-pydantic-models`, a dependency of `grz-cli`.