### PR TITLE
Update: realign dependency of snakemake package to snakemake pyproject

### DIFF
--- a/recipes/snakemake/meta.yaml
+++ b/recipes/snakemake/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: 53d2ccef9f063e73975c1d8846ae1ed20595e323e81552013b282c25ffec6385
 
 build:
-  number: 0
+  number: 1
   noarch: generic
   run_exports:
     - {{ pin_subpackage("snakemake", max_pin="x") }}
@@ -51,10 +51,10 @@ about:
   doc_url: "https://snakemake.readthedocs.io/en/stable"
   summary: A popular workflow management system aiming at full in-silico reproducibility.
   description: |
-        Snakemake is a workflow management system that aims to reduce the complexity of creating 
-        workflows by providing a fast and comfortable execution environment, together with a clean 
-        and modern specification language in python style. Snakemake workflows are essentially Python 
-        scripts extended by declarative code to define rules. Rules describe how to create output 
+        Snakemake is a workflow management system that aims to reduce the complexity of creating
+        workflows by providing a fast and comfortable execution environment, together with a clean
+        and modern specification language in python style. Snakemake workflows are essentially Python
+        scripts extended by declarative code to define rules. Rules describe how to create output
         files from input files.
 
 extra:
@@ -84,7 +84,7 @@ outputs:
         - pip
         - setuptools
       run:
-        # Keep in sync with snakemake/setup.cfg 
+        # Keep in sync with snakemake/setup.cfg
         - python >=3.11,<3.13 # we restrict to <3.13 because Python can have breaking changes in minor version bumps
         - appdirs
         - immutables
@@ -98,16 +98,16 @@ outputs:
         - nbformat
         - packaging
         - psutil
-        - pulp >=2.3.1,<2.10
+        - pulp >=2.3.1,<3.0
         - pyyaml
         - requests >=2.8.1,<3.0
         - reretry
         - smart_open >=4.0,<8.0
         - snakemake-interface-executor-plugins >=9.3.2,<10.0.0
         - snakemake-interface-common >=1.17.0,<2.0
-        - snakemake-interface-storage-plugins >=3.2.3,<4.0
+        - snakemake-interface-storage-plugins >=3.2.3,<5.0
         - snakemake-interface-report-plugins >=1.1.0,<2.0.0
-        - snakemake-interface-logger-plugins
+        - snakemake-interface-logger-plugins >=1.1.0,<2.0.0
         - tabulate
         - throttler
         - wrapt
@@ -133,10 +133,10 @@ outputs:
       summary: A popular workflow management system aiming at full in-silico reproducibility.
       description: |
         Snakemake is a workflow management system that aims to reduce the complexity
-        of creating workflows by providing a fast and comfortable execution 
-        environment, together with a clean and modern specification language in 
-        python style. Snakemake workflows are essentially Python scripts extended 
-        by declarative code to define rules. Rules describe how to create output 
+        of creating workflows by providing a fast and comfortable execution
+        environment, together with a clean and modern specification language in
+        python style. Snakemake workflows are essentially Python scripts extended
+        by declarative code to define rules. Rules describe how to create output
         files from input files. This package provides the core snakemake functionality.
-        For features like reports and remote files, check out the snakemake package 
+        For features like reports and remote files, check out the snakemake package
         which provides all optional dependencies.

--- a/recipes/snakemake/meta.yaml
+++ b/recipes/snakemake/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: 53d2ccef9f063e73975c1d8846ae1ed20595e323e81552013b282c25ffec6385
 
 build:
-  number: 1
+  number: 2
   noarch: generic
   run_exports:
     - {{ pin_subpackage("snakemake", max_pin="x") }}
@@ -98,14 +98,14 @@ outputs:
         - nbformat
         - packaging
         - psutil
-        - pulp >=2.3.1,<3.0
+        - pulp >=2.3.1,<3.1
         - pyyaml
         - requests >=2.8.1,<3.0
         - reretry
         - smart_open >=4.0,<8.0
-        - snakemake-interface-executor-plugins >=9.3.2,<10.0.0
+        - snakemake-interface-executor-plugins >=9.3.2,<10.0
         - snakemake-interface-common >=1.17.0,<2.0
-        - snakemake-interface-storage-plugins >=3.2.3,<5.0
+        - snakemake-interface-storage-plugins >=4.1.0,<5.0
         - snakemake-interface-report-plugins >=1.1.0,<2.0.0
         - snakemake-interface-logger-plugins >=1.1.0,<2.0.0
         - tabulate

--- a/recipes/snakemake/meta.yaml
+++ b/recipes/snakemake/meta.yaml
@@ -84,7 +84,7 @@ outputs:
         - pip
         - setuptools
       run:
-        # Keep in sync with snakemake/setup.cfg
+        # Keep in sync with snakemake's pyproject.toml: https://github.com/snakemake/snakemake/blob/main/pyproject.toml
         - python >=3.11,<3.13 # we restrict to <3.13 because Python can have breaking changes in minor version bumps
         - appdirs
         - immutables


### PR DESCRIPTION
Previous dependency constraints prevented installation of snakemake-interface-storage-plugins to version 4

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
