### PR TITLE
Update snippy 4.6 recipe to not use vt from 2015

### DIFF
--- a/recipes/snippy/meta.yaml
+++ b/recipes/snippy/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: '{{ sha256 }}'
 
 build:
-  number: 5
+  number: 6
   noarch: generic
   run_exports:
     - {{ pin_subpackage(name, max_pin="x") }}
@@ -30,7 +30,7 @@ requirements:
     - vcflib >=1.0.0_rc3,<=1.0.2 # crashes with v1.0.3 and later
     - tabixpp 1.1.0 # vcflib requires libtabixpp.so.0, no longer available as of 1.1.2
     - snpeff >=4.3,<=5.0 # crashes with v5.1
-    - vt >=0.5772
+    - vt >=0.5772,<2015 # vt versions used years numbers at one point, 0.5772 was released in Aug 24, 2016
     - snp-sites >=2.4
     - any2fasta >=0.4
     - samclip >=0.4


### PR DESCRIPTION
* vt used year numbers for versioning (2015.11.10) before changing to version 0.5. These are still available in the linux-64 subdir. And 2015 is greater than 0.5 so the newer versions never get used. The latest 2015.11.10 build has a bug that causes zero variants to be detected. Excluding 2015 from the version range will mean that the newer 0.5221 versions of vt get used.
-----

There is a version of vt in the bioconda linux-64 subdir that causes snippy to fail to detect variants, this is reported in https://github.com/tseemann/snippy/issues/410. The workaround on the linked issue rolls back the version of vt to a previous version by pinning the channel with a tag.
```conda install --name snippy-env -c bioconda/label/cf201901 vt==2015.11.10```

There are however later releases of vt, but the version numbers are semantically before 2015.11.10. This PR excludes the problematic version from the version range, ensuring that the intended 0.5772 and later versions are used. 

## conda search of vt in linux-64 subdir

$ conda search --subdir linux-64 -c conda-forge -c bioconda -c defaults vt
Loading channels: done
```
# Name                       Version           Build  Channel
vt                           0.57721     h064f3d2_11  bioconda
vt                           0.57721     h0dc1af0_10  bioconda
vt                           0.57721      h0dc1af0_9  bioconda
vt                           0.57721      h17a1952_6  bioconda
vt                           0.57721     h2419454_12  bioconda
vt                           0.57721      h41af197_4  bioconda
vt                           0.57721      h5eb663c_7  bioconda
vt                           0.57721      h5eb663c_8  bioconda
vt                           0.57721      hdf88d34_2  bioconda
vt                           0.57721      heae7c10_3  bioconda
vt                           0.57721      hf1e2573_5  bioconda
vt                           0.57721      hf74b74d_0  bioconda
vt                           0.57721      hf74b74d_1  bioconda
vt                        2015.11.10               0  bioconda
vt                        2015.11.10               1  bioconda
vt                        2015.11.10               2  bioconda
vt                        2015.11.10      h5ef6573_4  bioconda
vt                        2015.11.10      he941832_3  bioconda
```
----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
