### PR TITLE
Update nextstrain-cli: add urllib3 >=2.0.0 dep for Python >=3.10

### DIFF
--- a/recipes/nextstrain-cli/meta.yaml
+++ b/recipes/nextstrain-cli/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: de69203a8f1d3b140cbbad640df745e00827c23018f16171887a1d8fd538ce27
 
 build:
-  number: 0
+  number: 1
   noarch: python
   entry_points:
     - nextstrain = nextstrain.cli.__main__:main
@@ -44,6 +44,7 @@ requirements:
     - fsspec !=2023.9.1
     - boto3
     - s3fs >=2021.04.0,!=2023.9.1
+    - urllib3 >=2.0.0 # [py>=310]
 
 test:
   requires:


### PR DESCRIPTION
Follows Python packaging change in nextstrain-cli 9.0.0.


### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
