### PR TITLE
Fixed #52603 vcflib fastahack dependency

### DIFF
--- a/recipes/vcflib/meta.yaml
+++ b/recipes/vcflib/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "vcflib" %}
-{% set version = "1.0.12" %}
+{% set version = "1.0.13" %}
 {% set sha256 = "cb1e78d675f06ae3b22ffed7e1dea317e4c7f826e51e5b5dabd80240efbe1019" %}
 
 package:
@@ -15,7 +15,7 @@ source:
     - tabix.patch
 
 build:
-  number: 1
+  number: 2
   run_exports:
     - {{ pin_subpackage('vcflib', max_pin="x") }}
 
@@ -42,6 +42,7 @@ requirements:
     - zlib
     - bzip2
     - xz
+    - fastahack
   run:
     - python >=3
     - perl
@@ -51,7 +52,7 @@ requirements:
     - tabixpp
     - wfa2-lib
     - wget
-
+    - fastahack
 test:
   requires:
     - wget

--- a/recipes/vcflib/meta.yaml
+++ b/recipes/vcflib/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "vcflib" %}
-{% set version = "1.0.13" %}
+{% set version = "1.0.12" %}
 {% set sha256 = "cb1e78d675f06ae3b22ffed7e1dea317e4c7f826e51e5b5dabd80240efbe1019" %}
 
 package:


### PR DESCRIPTION
Fixed vcflib not having dependency on fastahack causing `vcfvarstats --help` not to work.
