### PR TITLE
Update Nextflow

### DIFF
--- a/recipes/nextflow/build.sh
+++ b/recipes/nextflow/build.sh
@@ -1,6 +1,5 @@
 mkdir -p $PREFIX/bin
 sed "s|^NXF_DIST=.*|NXF_DIST=$PREFIX/share/$PKG_NAME/dist|" nextflow > $PREFIX/bin/nextflow
-sed -i.bak "s|^CAPSULE_CACHE_DIR=.*|CAPSULE_CACHE_DIR=\${CAPSULE_CACHE_DIR:=$PREFIX/share/$PKG_NAME/capsule}|" $PREFIX/bin/nextflow
 rm -f *.bak
 
 chmod 755 $PREFIX/bin/nextflow

--- a/recipes/nextflow/meta.yaml
+++ b/recipes/nextflow/meta.yaml
@@ -16,14 +16,15 @@ source:
   sha256: {{ sha256 }}
 
 requirements:
+  # Next major version release (25.04.x) will require at least Java 17
   host:
-    - conda-forge::openjdk >=17,<=23
-    - conda-forge::coreutils
-    - conda-forge::curl
+    - openjdk >=11,<=23
+    - coreutils
+    - curl
   run:
-    - conda-forge::openjdk >=17,<=23
-    - conda-forge::coreutils
-    - conda-forge::curl
+    - openjdk >=11,<=23
+    - coreutils
+    - curl
 
 test:
   commands:

--- a/recipes/nextflow/meta.yaml
+++ b/recipes/nextflow/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 0
+  number: 1
   noarch: generic
   run_exports:
     - {{ pin_subpackage('nextflow', max_pin="x.x") }}

--- a/recipes/nextflow/meta.yaml
+++ b/recipes/nextflow/meta.yaml
@@ -17,11 +17,11 @@ source:
 
 requirements:
   host:
-    - conda-forge::openjdk >=11,<=21
+    - conda-forge::openjdk >=17,<=23
     - conda-forge::coreutils
     - conda-forge::curl
   run:
-    - conda-forge::openjdk >=11,<=21
+    - conda-forge::openjdk >=17,<=23
     - conda-forge::coreutils
     - conda-forge::curl
 
@@ -37,4 +37,6 @@ about:
 extra:
   recipe-maintainers:
     - pditommaso
+    - bentsherman
+    - ewels
     - mjsteinbaugh


### PR DESCRIPTION
- Remove handling for capsule files in build.sh (Nextflow no longer uses capsules)
- Updated range of supported Java versions
- Added @bentsherman and @ewels as recipe maintainers

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
