### PR TITLE
ci: update check names in mergify

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -5,7 +5,8 @@ pull_request_rules:
       - "label=autobump"
       - created-at<3 days ago # note the operator direction: 3 days ago yield a timestamp pointing to 3 days ago, and we want to be smaller
       - "check-success=Linux Tests"
-      - "check-success=OSX Tests"
+      - "check-success=OSX-64 Tests"
+      - "check-success=build and test (ARM)"
       #- "check-success=bioconda.bioconda-recipes"
       - "#commits=1" # by enforcing only a single commit, we ensure that the PR is not hijacked by others to introduce additional changes
     actions:


### PR DESCRIPTION
Mergify hasn't been merging successful autobumps because the "OSX Tests" check name changed to "OSX-64 Tests". Also, we should not merge if the ARM builds failed.