### PR TITLE
Add sr2silo package

### DIFF
--- a/recipes/sr2silo/meta.yaml
+++ b/recipes/sr2silo/meta.yaml
@@ -16,6 +16,9 @@ build:
   script: {{ PYTHON }} -m pip install . -vv
   entry_points:
     - sr2silo = sr2silo.main:app
+  build:
+  run_exports:
+    - {{ pin_subpackage('sr2silo', max_pin="x.x.x") }}
 
 requirements:
   host:

--- a/recipes/sr2silo/meta.yaml
+++ b/recipes/sr2silo/meta.yaml
@@ -1,0 +1,57 @@
+{% set name = "sr2silo" %}
+{% set version = "0.0.4" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  path: ..
+  url: https://github.com/cbg-ethz/sr2silo/archive/v{{ version }}.tar.gz
+  sha256: 57e7198287ba0535f066a984e729ad3c156854c3fd430873b1f9183e5affac7a
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+  entry_points:
+    - sr2silo = sr2silo.main:app
+
+requirements:
+  host:
+    - python >=3.10
+    - pip
+    - poetry-core
+  run:
+    - python >=3.10
+    - pyyaml >=6.0.2
+    - boto3 >=1.35.72
+    - psutil >=6.1.1
+    - tqdm >=4.67.1
+    - click >=8.1.8
+    - pydantic >=2.10.6
+    - zstandard >=0.23.0
+    - typer >=0.15.1
+    - biopython >=1.83
+    - pysam >=0.23.0
+    - requests >=2.25.0
+    - moto >=5.0.22
+
+test:
+  imports:
+    - sr2silo
+  commands:
+    - sr2silo --help
+
+about:
+  home: https://github.com/cbg-ethz/sr2silo
+  summary: "Short-read to SILO format converter"
+  description: |
+    sr2silo is a tool for converting short read data to SILO format,
+    designed for bioinformatics applications.
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - koehng

--- a/recipes/sr2silo/meta.yaml
+++ b/recipes/sr2silo/meta.yaml
@@ -6,14 +6,13 @@ package:
   version: {{ version }}
 
 source:
-  path: ..
   url: https://github.com/cbg-ethz/sr2silo/archive/v{{ version }}.tar.gz
   sha256: 57e7198287ba0535f066a984e729ad3c156854c3fd430873b1f9183e5affac7a
 
 build:
   number: 0
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --no-cache-dir -vvv
   entry_points:
     - sr2silo = sr2silo.main:app
   build:
@@ -48,11 +47,14 @@ test:
 
 about:
   home: https://github.com/cbg-ethz/sr2silo
-  summary: "Short-read to SILO format converter"
+  dev_url: https://github.com/cbg-ethz/sr2silo
+  doc_url: "https://github.com/cbg-ethz/sr2silo/blob/v{{ version }}/README.md"
+  summary: "Short-read to SILO format converter."
   description: |
     sr2silo is a tool for converting short read data to SILO format,
     designed for bioinformatics applications.
   license: MIT
+  license_family: MIT
   license_file: LICENSE
 
 extra:


### PR DESCRIPTION
This PR adds sr2silo, a tool for converting short-read genomic alignments data (SAM/BAM/CRAM) to custom cleartext JSON format required for the upload to the [SILO](https://github.com/GenSpectrum/LAPIS-SILO) Database as part of the [GenSpectrum](https://genspectrum.org/) and the [Loculus project](https://loculus.org/).

This package is still in early development. However, we would like to start an early release for better integration.

sr2silo is a Python tool developed at ETH Zurich's D-BSSE [Computational Biology Group](https://bsse.ethz.ch/cbg) in collaboration with the [Computational Evolution Group](https://bsse.ethz.ch/cevo)

While this project is currently specific to our in-house application, we intend to generalize its functionality soon.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).
