### PR TITLE
Update stare-abc yaml to include run_export

### DIFF
--- a/recipes/stare-abc/meta.yaml
+++ b/recipes/stare-abc/meta.yaml
@@ -6,6 +6,8 @@ package:
 
 build:
   number: 0
+  run_exports:
+    - {{ pin_subpackage('stare-abc', max_pin="x") }}
 
 source:
   url: https://github.com/SchulzLab/STARE/archive/refs/tags/v{{ version }}.tar.gz


### PR DESCRIPTION
Describe your pull request here

Last version release failed due to missing run_export in the yaml file, this PR intends to fix that.


### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
