### PR TITLE
[feature] free space before build commands

### DIFF
--- a/.github/workflows/Bulk.yml
+++ b/.github/workflows/Bulk.yml
@@ -15,6 +15,27 @@ jobs:
         runner: [0, 1, 2, 3, 4, 5]
         # runner: [0]
     steps:
+      - name: Free space
+        # HACK fixes 'No space left on device'
+        # see:
+        # - https://github.com/orgs/community/discussions/25678#discussioncomment-5242449
+        # - https://github.com/galaxyproteomics/tools-galaxyp/blob/master/.github/workflows/pr.yaml#L293
+        # NOTE we don't use those, bioconda-utils run everything inside conda environment, anyway
+        run: |
+          sudo rm -rf \
+            /opt/hostedtoolcache \
+            /opt/google/chrome \
+            /opt/microsoft/msedge \
+            /opt/microsoft/powershell \
+            /opt/pipx \
+            /usr/local/julia* \
+            /usr/local/lib/android \
+            /usr/local/lib/node_modules \
+            /usr/local/share/chromium \
+            /usr/local/share/powershell \
+            /usr/share/dotnet \
+            /usr/share/swift
+
       - uses: actions/checkout@v4
         with:
           # checkout as BiocondaBot in order to have the permission to push fail logs

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -62,6 +62,27 @@ jobs:
       max-parallel: 13
     needs: lint
     steps:
+      - name: Free space
+        # HACK fixes 'No space left on device'
+        # see:
+        # - https://github.com/orgs/community/discussions/25678#discussioncomment-5242449
+        # - https://github.com/galaxyproteomics/tools-galaxyp/blob/master/.github/workflows/pr.yaml#L293
+        # NOTE we don't use those, bioconda-utils run everything inside conda environment, anyway
+        run: |
+          sudo rm -rf \
+            /opt/hostedtoolcache \
+            /opt/google/chrome \
+            /opt/microsoft/msedge \
+            /opt/microsoft/powershell \
+            /opt/pipx \
+            /usr/local/julia* \
+            /usr/local/lib/android \
+            /usr/local/lib/node_modules \
+            /usr/local/share/chromium \
+            /usr/local/share/powershell \
+            /usr/share/dotnet \
+            /usr/share/swift
+
       - uses: actions/checkout@v4
 
       - name: Fetch commits through the merge base

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -12,6 +12,27 @@ jobs:
       fail-fast: false
       max-parallel: 13
     steps:
+      - name: Free space
+        # HACK fixes 'No space left on device'
+        # see:
+        # - https://github.com/orgs/community/discussions/25678#discussioncomment-5242449
+        # - https://github.com/galaxyproteomics/tools-galaxyp/blob/master/.github/workflows/pr.yaml#L293
+        # NOTE we don't use those, bioconda-utils run everything inside conda environment, anyway
+        run: |
+          sudo rm -rf \
+            /opt/hostedtoolcache \
+            /opt/google/chrome \
+            /opt/microsoft/msedge \
+            /opt/microsoft/powershell \
+            /opt/pipx \
+            /usr/local/julia* \
+            /usr/local/lib/android \
+            /usr/local/lib/node_modules \
+            /usr/local/share/chromium \
+            /usr/local/share/powershell \
+            /usr/share/dotnet \
+            /usr/share/swift
+
       # Fetch the last two commits for the --git-range argument to bioconda-utils
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,6 +11,27 @@ jobs:
       fail-fast: false
       max-parallel: 4
     steps:
+      - name: Free space
+        # HACK fixes 'No space left on device'
+        # see:
+        # - https://github.com/orgs/community/discussions/25678#discussioncomment-5242449
+        # - https://github.com/galaxyproteomics/tools-galaxyp/blob/master/.github/workflows/pr.yaml#L293
+        # NOTE we don't use those, bioconda-utils run everything inside conda environment, anyway
+        run: |
+          sudo rm -rf \
+            /opt/hostedtoolcache \
+            /opt/google/chrome \
+            /opt/microsoft/msedge \
+            /opt/microsoft/powershell \
+            /opt/pipx \
+            /usr/local/julia* \
+            /usr/local/lib/android \
+            /usr/local/lib/node_modules \
+            /usr/local/share/chromium \
+            /usr/local/share/powershell \
+            /usr/share/dotnet \
+            /usr/share/swift
+
       - uses: actions/checkout@v4
 
       - name: set path


### PR DESCRIPTION
As discussed with @bgruening:
in workflows that run `bioconda-utils build` and `bioconda-utils handle-merged-pr -f build`, delete all github-provided SDKs to free space (bioconda-utils relies on conda environments anyway)

This is based on how [Galaxy](https://github.com/galaxyproteomics/tools-galaxyp/blob/master/.github/workflows/pr.yaml#L293) and [V-pipe](https://github.com/cbg-ethz/V-pipe/blob/master/.github/workflows/deploy-docker.yaml#L26) do it.


----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
