### PR TITLE
Update plink2 to 2.0.0-a.6.9

### DIFF
--- a/recipes/plink2/meta.yaml
+++ b/recipes/plink2/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: "2.0.0-a.6.9"
 
 build:
-  number: 1
+  number: 0
   run_exports:
       - {{ pin_subpackage('plink2', max_pin=None) }}
 

--- a/recipes/plink2/meta.yaml
+++ b/recipes/plink2/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: plink2
-  version: "2.0.0-a.6.9"
+  version: "2.0.0a.6.9" # original version contains a hyphen '2.0.0-a.6.9', removed here as it is not valid for conda
 
 build:
   number: 0

--- a/recipes/plink2/meta.yaml
+++ b/recipes/plink2/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: plink2
-  version: "2.00a5.12"
+  version: "2.0.0-a.6.9"
 
 build:
   number: 1
@@ -8,10 +8,10 @@ build:
       - {{ pin_subpackage('plink2', max_pin=None) }}
 
 source:
-  url: https://s3.amazonaws.com/plink2-assets/alpha5/plink2_linux_x86_64_20240625.zip # [linux]
-  sha256: 7bf73ad7bbd3256a83cd72ed068bee4175bd6052a7bf30a659dbdb696d9d1d9e     # [linux]
-  url: https://s3.amazonaws.com/plink2-assets/alpha5/plink2_mac_20240625.zip   # [osx]
-  sha256: 08e962c59d7f28b4ecc39d0279b859775cc5d2fbb892b7b350a982f4d7de437d     # [osx]
+  url: https://s3.amazonaws.com/plink2-assets/alpha6/plink2_linux_x86_64_20250129.zip # [linux]
+  sha256: 5477728b725f2aedd6fab33139dc884c215dd8dcb58583cadf373d3dc50ba8b7     # [linux]
+  url: https://s3.amazonaws.com/plink2-assets/alpha6/plink2_mac_20250129.zip   # [osx]
+  sha256: 971689937475a1189d7ff9cbf79e647c153df0e12b07c559a510a51cacbf2674     # [osx]
 
 requirements:
   build:
@@ -19,7 +19,7 @@ requirements:
 
 test:
   commands:
-    - plink2 --help | grep "PLINK v2.00a5.12"
+    - plink2 --help | grep "PLINK v2.0.0-a.6.9"
 
 about:
   home: https://www.cog-genomics.org/plink2


### PR DESCRIPTION
Update `plink2` to version 2.0.0-a.6.9 (29 Jan 2025), following what was done on #48787. 