### PR TITLE
FIX Update meta.yaml to fix python3 location problem

### DIFF
--- a/recipes/screadcounts/meta.yaml
+++ b/recipes/screadcounts/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "screadcounts" %}
 {% set version = "1.4.1" %}
-{% set sha256 = "9036745a327539bfd0f0079048bdbf77e2a4061ea662da121a244be338311503" %}
+{% set sha256 = "ebc4d6d2fc136bea00f43767c0ce1f3e4d9d905868f3f1a69f7292cbd3b95243" %}
 
 package:
   name: {{ name }}

--- a/recipes/screadcounts/meta.yaml
+++ b/recipes/screadcounts/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   noarch: generic
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage('screadcounts', max_pin="x.x") }}
 


### PR DESCRIPTION
script to run screadcounts can't find the python3 binary when installed inside conda, ensure failure exit code when this happens so that we can debug the issue...