### PR TITLE
reduce: Update build script to add `-DHET_DICTIONARY` and `-DHET_DICTOLD` flags

### DIFF
--- a/recipes/reduce/build.sh
+++ b/recipes/reduce/build.sh
@@ -11,5 +11,7 @@ fi
 
 cmake -S . -B build -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
   -DCMAKE_BUILD_TYPE=Release \
+  -DHET_DICTIONARY="${PREFIX}/reduce_wwPDB_het_dict.txt" \
+  -DHET_DICTOLD="${PREFIX}/reduce_get_dict.txt" \
   "${CONFIG_ARGS}"
 cmake --build build/ --target install -j "${CPU_COUNT}"

--- a/recipes/reduce/build.sh
+++ b/recipes/reduce/build.sh
@@ -9,6 +9,7 @@ else
   export CONFIG_ARGS=""
 fi
 
+# Refer to https://github.com/rlabduke/reduce/issues/60 for `-DHET_DICTIONARY` and `-DHET_DICTOLD` flags
 cmake -S . -B build -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
   -DCMAKE_BUILD_TYPE=Release \
   -DHET_DICTIONARY="${PREFIX}/reduce_wwPDB_het_dict.txt" \

--- a/recipes/reduce/meta.yaml
+++ b/recipes/reduce/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: f2f993e3f86ded38135d6433e0a7c2ed10fbe5da37f232c04d7316702582ed06
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage(name, max_pin="x") }}
 


### PR DESCRIPTION
This pull request includes updates to the build process and versioning for the `reduce` package. The most important changes include adding new flags(see https://github.com/rlabduke/reduce/issues/60) to the `cmake` command and updating the build number in the `meta.yaml` file.

Build process improvements:

* [`recipes/reduce/build.sh`](diffhunk://#diff-6bfbe2d3f68c7be97776494ff778f01b08607a3041f4d272ea1a99130ea7b11fR12-R16): Added `-DHET_DICTIONARY` and `-DHET_DICTOLD` flags to the `cmake` command to specify paths for dictionary files.

Versioning update:

* [`recipes/reduce/meta.yaml`](diffhunk://#diff-37430d7a465b92aa3eeb2b877b8f0a0114a69da464c4f46f0581677dceff8daaL13-R13): Incremented the build number from 0 to 1.