### PR TITLE
Update r-dimsum to 1.4; Fix: Incorporate autobump version update and allow any patch version of fastqc 0.11

### DIFF
--- a/recipes/r-dimsum/meta.yaml
+++ b/recipes/r-dimsum/meta.yaml
@@ -24,7 +24,7 @@ requirements:
   host:
     - r-base ==4.0
     - pandoc >=1.17.2
-    - bioconda::fastqc =0.11
+    - bioconda::fastqc ==0.11.*
     - bioconda::cutadapt ==2.4
     - bioconda::vsearch >=2.17
     - bioconda::starcode >=1.3
@@ -47,7 +47,7 @@ requirements:
   run:
     - r-base ==4.0
     - pandoc >=1.17.2
-    - bioconda::fastqc ==0.11
+    - bioconda::fastqc ==0.11.*
     - bioconda::cutadapt ==2.4
     - bioconda::vsearch  >=2.17
     - bioconda::starcode >=1.3
@@ -71,30 +71,7 @@ requirements:
 test:
   commands:
     - DiMSum -h
-  requirements:
-    - r-base ==4.0
-    - pandoc >=1.17.2
-    - bioconda::fastqc ==0.11
-    - bioconda::cutadapt ==2.4
-    - bioconda::vsearch  >=2.17
-    - bioconda::starcode >=1.3
-    - bioconda::bioconductor-biostrings
-    - bioconda::bioconductor-iranges
-    - bioconda::bioconductor-shortread
-    - r-cairo
-    - r-cowplot
-    - r-data.table
-    - r-ggally
-    - r-ggplot2
-    - r-gridextra
-    - r-hexbin
-    - r-optparse
-    - r-plyr
-    - r-reshape2
-    - r-rmarkdown
-    - r-seqinr
-    - r-stringr
-    
+
 about:
   home: https://github.com/lehner-lab/DiMSum
   dev_url: "{{ github }}" 

--- a/recipes/r-dimsum/meta.yaml
+++ b/recipes/r-dimsum/meta.yaml
@@ -71,7 +71,30 @@ requirements:
 test:
   commands:
     - DiMSum -h
-
+  requirements:
+    - r-base ==4.0
+    - pandoc >=1.17.2
+    - bioconda::fastqc ==0.11
+    - bioconda::cutadapt ==2.4
+    - bioconda::vsearch  >=2.17
+    - bioconda::starcode >=1.3
+    - bioconda::bioconductor-biostrings
+    - bioconda::bioconductor-iranges
+    - bioconda::bioconductor-shortread
+    - r-cairo
+    - r-cowplot
+    - r-data.table
+    - r-ggally
+    - r-ggplot2
+    - r-gridextra
+    - r-hexbin
+    - r-optparse
+    - r-plyr
+    - r-reshape2
+    - r-rmarkdown
+    - r-seqinr
+    - r-stringr
+    
 about:
   home: https://github.com/lehner-lab/DiMSum
   dev_url: "{{ github }}" 

--- a/recipes/r-dimsum/meta.yaml
+++ b/recipes/r-dimsum/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = '1.3.2' %}
+{% set version = '1.4' %}
 {% set github = "https://github.com/lehner-lab/DiMSum" %}
 
 package:
@@ -7,7 +7,7 @@ package:
 
 source:
   url: "{{ github }}/archive/v{{ version }}.tar.gz"
-  sha256: dc6ce5f778ebcf2f3658be3d65805dda7cca7dec0c817f4fb4c334ece5ed0e5b 
+  sha256: 1f37a2f5d252884da5cbdfcf297d7cdcbdb09053eca133dc21c0018c2d884879 
 
 build:
   number: 0
@@ -24,13 +24,13 @@ requirements:
   host:
     - r-base ==4.0
     - pandoc >=1.17.2
-    - fastqc =0.11
-    - cutadapt ==2.4
-    - vsearch >=2.17
-    - starcode >=1.3
-    - bioconductor-biostrings
-    - bioconductor-iranges
-    - bioconductor-shortread
+    - bioconda::fastqc =0.11
+    - bioconda::cutadapt ==2.4
+    - bioconda::vsearch >=2.17
+    - bioconda::starcode >=1.3
+    - bioconda::bioconductor-biostrings
+    - bioconda::bioconductor-iranges
+    - bioconda::bioconductor-shortread
     - r-cairo
     - r-cowplot
     - r-data.table
@@ -47,13 +47,13 @@ requirements:
   run:
     - r-base ==4.0
     - pandoc >=1.17.2
-    - fastqc ==0.11
-    - cutadapt ==2.4
-    - vsearch  >=2.17
-    - starcode >=1.3
-    - bioconductor-biostrings
-    - bioconductor-iranges
-    - bioconductor-shortread
+    - bioconda::fastqc ==0.11
+    - bioconda::cutadapt ==2.4
+    - bioconda::vsearch  >=2.17
+    - bioconda::starcode >=1.3
+    - bioconda::bioconductor-biostrings
+    - bioconda::bioconductor-iranges
+    - bioconda::bioconductor-shortread
     - r-cairo
     - r-cowplot
     - r-data.table


### PR DESCRIPTION
This pull request addresses a build failure in autobump pull request #55493. The failure was due to not allowing any patch version of fastqc 0.11.