### PR TITLE
Add osx build to alignoth

### DIFF
--- a/recipes/alignoth/build.sh
+++ b/recipes/alignoth/build.sh
@@ -3,8 +3,9 @@
 export CFLAGS="${CFLAGS} -O3 -fno-rtti"
 export CPPFLAGS="${CPPFLAGS} -I${PREFIX}/include"
 export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib"
-
 export BINDGEN_EXTRA_CLANG_ARGS="${CFLAGS} ${CPPFLAGS} ${LDFLAGS}"
+
+cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
 
 RUST_BACKTRACE=1
 cargo install --no-track --locked --verbose --root "${PREFIX}" --path .

--- a/recipes/alignoth/build.sh
+++ b/recipes/alignoth/build.sh
@@ -1,11 +1,10 @@
 #!/bin/bash -e
 
-# TODO: Remove the following export when pinning is updated and we use
-#       {{ compiler('rust') }} in the recipe.
-export \
-    CARGO_NET_GIT_FETCH_WITH_CLI=true \
-    CARGO_HOME="${BUILD_PREFIX}/.cargo"
+export CFLAGS="${CFLAGS} -O3 -fno-rtti"
+export CPPFLAGS="${CPPFLAGS} -I${PREFIX}/include"
+export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib"
 
 export BINDGEN_EXTRA_CLANG_ARGS="${CFLAGS} ${CPPFLAGS} ${LDFLAGS}"
 
-cargo install --no-track --verbose --root "${PREFIX}" --path .
+RUST_BACKTRACE=1
+cargo install --no-track --locked --verbose --root "${PREFIX}" --path .

--- a/recipes/alignoth/meta.yaml
+++ b/recipes/alignoth/meta.yaml
@@ -1,23 +1,25 @@
+{% set name = "alignoth" %}
 {% set version = "0.13.0" %}
 
 package:
-  name: alignoth
+  name: {{ name }}
   version: {{ version }}
-
-build:
-  number: 2
-  run_exports:
-    - {{ pin_subpackage('alignoth', max_pin="x") }}
 
 source:
   url: https://github.com/alignoth/alignoth/archive/v{{ version }}.tar.gz
   sha256: a955e762d3593ac572424dbe775f1c554bb5ab10f391fb643c7d613cca416cc4
+
+build:
+  number: 2
+  run_exports:
+    - {{ pin_subpackage('alignoth', max_pin="x.x") }}
 
 requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler("cxx") }}
     - {{ compiler('rust') }}
+    - cargo-bundle-licenses
     - clangdev
     - pkg-config
     - make
@@ -27,19 +29,23 @@ requirements:
     - libcurl
     - openssl
 
-
 test:
   commands:
     - alignoth --help
 
 about:
-  home: https://alignoth.github.io
+  home: "https://alignoth.github.io"
   license: MIT
-  summary: A tool for creating alignment plots from bam files
+  license_family: MIT
+  license_file: LICENSE
+  summary: "A tool for creating alignment plots from bam files."
+  dev_url: "https://github.com/alignoth/alignoth"
+  doc_url: "https://github.com/alignoth/alignoth/blob/v{{ version }}/README.md"
 
 extra:
   recipe-maintainers:
     - fxwiegand
     - johanneskoester
-  additional-platforms:  #add aarch64
+  additional-platforms:
     - linux-aarch64
+    - osx-arm64

--- a/recipes/alignoth/meta.yaml
+++ b/recipes/alignoth/meta.yaml
@@ -5,10 +5,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 1
-  # TODO fails to build on osx with
-  # Undefined symbols for architecture x86_64: "_SSLCopyALPNProtocols", referenced from: _sectransp_connect_step2 in libcurl_sys-1f07db570920ba9f.rlib(sectransp.o)
-  skip: true  #[osx]
+  number: 2
   run_exports:
     - {{ pin_subpackage('alignoth', max_pin="x") }}
 

--- a/recipes/alignoth/meta.yaml
+++ b/recipes/alignoth/meta.yaml
@@ -17,7 +17,7 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler("cxx") }}
-    - rust >=1.30
+    - {{ compiler('rust') }}
     - clangdev
     - pkg-config
     - make


### PR DESCRIPTION
This pull request updates the build configuration for the `alignoth` package in its `meta.yaml` file. The most significant change is the increment of the build number and the removal of the build skip directive for macOS.