### PR TITLE
SISTR v1.1.3 build #2 release to fix I 1,4,[5],12:i:- serovar mistyped for I 1,4,[5],12:b:-

### DIFF
--- a/recipes/sistr_cmd/meta.yaml
+++ b/recipes/sistr_cmd/meta.yaml
@@ -7,11 +7,11 @@ package:
 
 source:
   url: https://github.com/phac-nml/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 2fe83a75ec63edcd3fe3f9703e1d1367da3ac554fbf9c19f64c45d20f0332af0
+  sha256: f5618c136f87859790d0c2612f14bed6b52dd4c60c974a05ab469528d7478ec6
   
 
 build:
-  number: 1
+  number: 2
   noarch: python
   run_exports:
     - {{ pin_subpackage(name, max_pin="x") }}


### PR DESCRIPTION
This build #2 fixes a very minor typo in the serovar  `I 1,4,[5],12:b:-` where letter `b` was mistyped as `i`. This affects the QC message output by the tool (`Perform d-tartrate test (dT) as both dT+ and dT- I 1,4,[5],12:b:- subtypes exist.`) alerting users about the need to perform d-tartrate test that is also done for Paratyphi B and Paratyphi B variant Java

As per `CHANGELOG.md`:
- Paratyphi B, Paratyphi B var. Java and I 1,4,[5],12:b:- will get information message in the qc_messages about the d-tartrate testing

@rpetit3  Please take a quick look at this re-release as we are about to release this version publicly to the Canadian provincial labs