### PR TITLE
fix: jvarkit java path

### DIFF
--- a/recipes/jvarkit/jvarkit.sh
+++ b/recipes/jvarkit/jvarkit.sh
@@ -23,9 +23,13 @@ done
 DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
 JAR_DIR="$DIR"
-ENV_PREFIX="$(dirname "$(dirname "${DIR}")")"
+
 # Use Java installed with conda to ensure correct version
-java="$ENV_PREFIX/bin/java"
+if [[ -n "${JAVA_HOME}" ]]; then
+    java=${JAVA_HOME}/bin/java   # point to the installed Java
+else
+    java=/opt/anaconda1anaconda2anaconda3/bin/java   # default old-style where anaconda installed Java
+fi
 
 ### NOTE: always force the conda-installed java version
 # # if JAVA_HOME is set (non-empty), use it. Otherwise keep "java"

--- a/recipes/jvarkit/meta.yaml
+++ b/recipes/jvarkit/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   noarch: generic
-  number: 1
+  number: 2
   run_exports:
     - {{ pin_subpackage(name, max_pin=None) }}
     # it's date based (yyyy.mm.dd) there's no real semantic pinning, and breaking changes happen (e.g.: tools / libraries being removed)


### PR DESCRIPTION
Bug: broken java path with latest build.

```
mamba create -n jvarkit jvarkit
mamba activate jvarkit
jvarkit -h
```

```
/path/to/envs/jvarkit/bin/jvarkit: line 80: /path/to/envs/jvarkit/bin/java: No such file or directory
```

Update to discover the correct java path.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
