### PR TITLE
Update gsearch v0.2.8

### DIFF
--- a/recipes/gsearch/build.sh
+++ b/recipes/gsearch/build.sh
@@ -31,11 +31,11 @@ fi
 # build statically linked binary with Rust
 export RUSTC_BOOTSTRAP=1
 ##RUST_BACKTRACE=1 cargo install --features "${FEATURES}" --verbose --path . --root $PREFIX
-export CARGO_TARGET_DIR="${PWD}/target"
+export CARGO_TARGET_DIR="${PWD}"
 cargo build --workspace --release --features "${FEATURES}" 
 cargo metadata --format-version 1 --no-deps \
   | tr '\n' ' ' \
   | sed 's/}[[:space:]]*,[[:space:]]*{/\n{/g' \
   | awk '/"kind"[[:space:]]*:[^]]*"bin"/{match($0,/"name"[[:space:]]*:[[:space:]]*"[^"]+"/); n=substr($0,RSTART,RLENGTH); sub(/.*:"/,"",n); sub(/"$/,"",n); print n}' \
-  | xargs -r -I{} install -m0755 "${CARGO_TARGET_DIR}/release/{}" "$PREFIX/bin/"
+  | xargs -r -I{} install -m0755 "${CARGO_TARGET_DIR}/target/release/{}" "$PREFIX/bin/"
 

--- a/recipes/gsearch/build.sh
+++ b/recipes/gsearch/build.sh
@@ -33,6 +33,8 @@ export RUSTC_BOOTSTRAP=1
 ##RUST_BACKTRACE=1 cargo install --features "${FEATURES}" --verbose --path . --root $PREFIX
 cargo build --workspace --release --features "${FEATURES}" 
 cargo metadata --format-version 1 --no-deps \
-  | jq -r '.packages[].targets[] | select(.kind[]=="bin") | .name' \
-  | xargs -I{} install -m 0755 "target/release/{}" "$PREFIX/bin/"
+  | tr '\n' ' ' \
+  | sed 's/}[[:space:]]*,[[:space:]]*{/\n{/g' \
+  | awk '/"kind"[[:space:]]*:[^]]*"bin"/{match($0,/"name"[[:space:]]*:[[:space:]]*"[^"]+"/); n=substr($0,RSTART,RLENGTH); sub(/.*:"/,"",n); sub(/"$/,"",n); print n}' \
+  | xargs -r -I{} install -m0755 "target/release/{}" "$PREFIX/bin/"
 

--- a/recipes/gsearch/build.sh
+++ b/recipes/gsearch/build.sh
@@ -30,4 +30,9 @@ fi
 
 # build statically linked binary with Rust
 export RUSTC_BOOTSTRAP=1
-RUST_BACKTRACE=1 cargo install --features "${FEATURES}" --verbose --path . --root $PREFIX
+##RUST_BACKTRACE=1 cargo install --features "${FEATURES}" --verbose --path . --root $PREFIX
+cargo build --workspace --release --features "${FEATURES}" 
+cargo metadata --format-version 1 --no-deps \
+  | jq -r '.packages[].targets[] | select(.kind[]=="bin") | .name' \
+  | xargs -I{} install -m 0755 "target/release/{}" "$PREFIX/bin/"
+

--- a/recipes/gsearch/build.sh
+++ b/recipes/gsearch/build.sh
@@ -31,10 +31,11 @@ fi
 # build statically linked binary with Rust
 export RUSTC_BOOTSTRAP=1
 ##RUST_BACKTRACE=1 cargo install --features "${FEATURES}" --verbose --path . --root $PREFIX
+export CARGO_TARGET_DIR="${PWD}/target"
 cargo build --workspace --release --features "${FEATURES}" 
 cargo metadata --format-version 1 --no-deps \
   | tr '\n' ' ' \
   | sed 's/}[[:space:]]*,[[:space:]]*{/\n{/g' \
   | awk '/"kind"[[:space:]]*:[^]]*"bin"/{match($0,/"name"[[:space:]]*:[[:space:]]*"[^"]+"/); n=substr($0,RSTART,RLENGTH); sub(/.*:"/,"",n); sub(/"$/,"",n); print n}' \
-  | xargs -r -I{} install -m0755 "target/release/{}" "$PREFIX/bin/"
+  | xargs -r -I{} install -m0755 "${CARGO_TARGET_DIR}/release/{}" "$PREFIX/bin/"
 

--- a/recipes/gsearch/build.sh
+++ b/recipes/gsearch/build.sh
@@ -30,12 +30,5 @@ fi
 
 # build statically linked binary with Rust
 export RUSTC_BOOTSTRAP=1
-##RUST_BACKTRACE=1 cargo install --features "${FEATURES}" --verbose --path . --root $PREFIX
-export CARGO_TARGET_DIR="${PWD}/target"
-cargo build --workspace --release --features "${FEATURES}" 
-cargo metadata --format-version 1 --no-deps \
-  | tr '\n' ' ' \
-  | sed 's/}[[:space:]]*,[[:space:]]*{/\n{/g' \
-  | awk '/"kind"[[:space:]]*:[^]]*"bin"/{match($0,/"name"[[:space:]]*:[[:space:]]*"[^"]+"/); n=substr($0,RSTART,RLENGTH); sub(/.*:"/,"",n); sub(/"$/,"",n); print n}' \
-  | xargs -r -I{} install -m0755 "${CARGO_TARGET_DIR}/release/{}" "$PREFIX/bin/"
-
+RUST_BACKTRACE=1 cargo install --features "${FEATURES}" --verbose --path . --root $PREFIX
+RUST_BACKTRACE=1 cargo install --verbose --path ./binaux --root $PREFIX --force

--- a/recipes/gsearch/build.sh
+++ b/recipes/gsearch/build.sh
@@ -31,11 +31,11 @@ fi
 # build statically linked binary with Rust
 export RUSTC_BOOTSTRAP=1
 ##RUST_BACKTRACE=1 cargo install --features "${FEATURES}" --verbose --path . --root $PREFIX
-export CARGO_TARGET_DIR="${PWD}"
+export CARGO_TARGET_DIR="${PWD}/target"
 cargo build --workspace --release --features "${FEATURES}" 
 cargo metadata --format-version 1 --no-deps \
   | tr '\n' ' ' \
   | sed 's/}[[:space:]]*,[[:space:]]*{/\n{/g' \
   | awk '/"kind"[[:space:]]*:[^]]*"bin"/{match($0,/"name"[[:space:]]*:[[:space:]]*"[^"]+"/); n=substr($0,RSTART,RLENGTH); sub(/.*:"/,"",n); sub(/"$/,"",n); print n}' \
-  | xargs -r -I{} install -m0755 "${CARGO_TARGET_DIR}/target/release/{}" "$PREFIX/bin/"
+  | xargs -r -I{} install -m0755 "${CARGO_TARGET_DIR}/release/{}" "$PREFIX/bin/"
 

--- a/recipes/gsearch/meta.yaml
+++ b/recipes/gsearch/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.2.7" %}
+{% set version = "0.2.8" %}
 
 package:
   name: gsearch
@@ -10,7 +10,7 @@ build:
       - {{ pin_subpackage('gsearch', max_pin="x.x") }}
 source:
   url: https://github.com/jianshu93/gsearch/archive/v{{ version }}.tar.gz
-  sha256: 9c4b6af8f05d735a03efdc9298c5ee247e7f2f47061c03f083a2f7fbfa3db87d
+  sha256: 86cf955161687d9588ecd4c806d795dfb191c8992d3eb9037fedba6d1ceb1a11
 
 requirements:
   build:


### PR DESCRIPTION
Update gsearch to v0.2.8

----

in this release, I added coreset instruction command to cluster large HNSW graphs. 

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
