### PR TITLE
Update mm2plus v1.0 to mm2plus v1.1

### DIFF
--- a/recipes/mm2plus/meta.yaml
+++ b/recipes/mm2plus/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.0" %}
+{% set version = "1.1" %}
 
 package:
   name: mm2plus
@@ -6,7 +6,7 @@ package:
 
 source:
   url: "https://github.com/at-cg/mm2-plus/releases/download/v{{ version }}/mm2-plus-{{ version }}_x64-linux.tar.bz2"
-  sha256: "e5b4fc2e12a475bdb46bfdbdfc563d2bae02a908f8e6f4a2c55d759e84d240de"
+  sha256: "9a2cd922fe10fe67539606e231d228068219291c74d1ce6519186807872752dc"
 
 build:
   number: 0


### PR DESCRIPTION
### Update mm2plus to v1.1

This PR updates the `mm2plus` package from version 1.0 to 1.1.

#### Changes:
- Updated the source URL to the latest release (v1.1).
- Updated SHA256 checksum for verification.

#### Testing:
- [x] Built and tested locally with `bioconda-utils`.
- [x] Verified that the new version runs correctly.

#### Relevant links:
- [Release notes v1.1](https://github.com/at-cg/mm2-plus/releases/tag/v1.1)
- [Source repository](https://github.com/at-cg/mm2-plus)

Please review and merge.
