### PR TITLE
Add recipe: snakemake-executor-plugin-cannon

### DIFF
--- a/recipes/grampa/build.sh
+++ b/recipes/grampa/build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -xe
+
+mkdir -p ${PREFIX}/bin
+mkdir -p ${SP_DIR}
+
+cp -f grampa.py ${PREFIX}/bin
+chmod 0755 ${PREFIX}/bin/grampa.py
+cp -f ${PREFIX}/bin/grampa.py ${PREFIX}/bin/grampa
+chmod 0755 ${PREFIX}/bin/grampa
+mkdir -p ${SP_DIR}
+cp -Rf grampa_lib ${SP_DIR}/grampa_lib

--- a/recipes/grampa/meta.yaml
+++ b/recipes/grampa/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "GRAMPA" %}
-{% set version = "1.4.3" %}
+{% set version = "1.4.4" %}
 
 package:
   name: "{{ name|lower }}"
@@ -7,20 +7,13 @@ package:
 
 source:
   url: "https://github.com/gwct/grampa/archive/refs/tags/v{{ version }}.tar.gz"
-  sha256: 93fbf70cf1f0f6681d18a55c1aa08b14c022e3e8ef2fd9941ce2a2cd7804fa70
+  sha256: 81325b44291227f9cd4e93da98909f103a0c99123e08f39adf795a334465b578
 
 build:
-  number: 1
+  number: 0
   noarch: python
   run_exports:
     - {{ pin_subpackage('grampa', max_pin="x") }}  
-  script:
-    - cp -f grampa.py ${PREFIX}/bin
-    - chmod 0755 ${PREFIX}/bin/grampa.py
-    - cp -f ${PREFIX}/bin/grampa.py ${PREFIX}/bin/grampa
-    - chmod 0755 ${PREFIX}/bin/grampa
-    - mkdir -p ${SP_DIR}
-    - cp -Rf grampa_lib ${SP_DIR}/grampa_lib
 
 requirements:
   host:

--- a/recipes/grampa/run_test.sh
+++ b/recipes/grampa/run_test.sh
@@ -19,7 +19,7 @@ unzip bioconda-test-data.zip
 echo " ** TEST DATA DOWNLOAD OK."
 
 echo " ** BEGIN GRAMPA TEST."
-if ! grampa --tests; then
+if ! grampa --tests bioconda; then
   echo " ** ERROR: GRAMPA tests failed." >&2
   exit 1
 fi

--- a/recipes/snakemake-executor-plugin-cannon/meta.yaml
+++ b/recipes/snakemake-executor-plugin-cannon/meta.yaml
@@ -1,0 +1,46 @@
+{% set name = "snakemake-executor-plugin-cannon" %}
+{% set version = "1.2.1a0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/snakemake_executor_plugin_cannon-{{ version }}.tar.gz
+  sha256: e5aef2e9f81b68606468d47d42e34c86dc28d7ca9b739c940dd97ad5a4731608
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vvv --no-deps --no-build-isolation --no-cache-dir
+  number: 0
+  run_exports:
+    - {{ pin_subpackage(name, max_pin='x') }}
+
+requirements:
+  host:
+    - python >=3.11,<4.0
+    - poetry-core
+    - pip
+  run:
+    - python >=3.11.0,<4.0.0
+    - snakemake-interface-common >=1.13.0,<2.0.0
+    - snakemake-interface-executor-plugins >=9.1.1,<10.0.0
+    - snakemake-executor-plugin-slurm-jobstep >=0.3.0,<0.4.0
+    - throttler >=1.2.2,<2.0.0
+
+test:
+  imports:
+    - snakemake_executor_plugin_cannon
+
+about:
+  home: https://github.com/harvardinformatics/snakemake-executor-plugin-cannon
+  summary: "A Snakemake executor plugin for submitting jobs to the Cannon cluster at Harvard University."
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  dev_url: https://github.com/harvardinformatics/snakemake-executor-plugin-cannon
+
+extra:
+  recipe-maintainers:
+    - gwct
+    - nsohail19


### PR DESCRIPTION
This adds a recipe for the snakemake-executor-plugin-cannon, which is a fork of the snakemake-exector-plugin-slurm specifically for the Cannon cluster at Harvard University.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
