### PR TITLE
Update libcarna to 3.4.0

### DIFF
--- a/recipes/libcarna/build.sh
+++ b/recipes/libcarna/build.sh
@@ -2,10 +2,15 @@
 
 set -xe
 
-export CMAKE_ARGS="-DCMAKE_INSTALL_PREFIX=${PREFIX} -DCMAKE_INSTALL_LIBDIR=${PREFIX}"
+export CMAKE_ARGS="-DCMAKE_INSTALL_PREFIX=${PREFIX} -DCMAKE_INSTALL_LIBDIR=${PREFIX} -DINSTALL_LICENSE_DIR=share/LibCarna"
 export CMAKE_ARGS="${CMAKE_ARGS} -DINSTALL_CMAKE_DIR=${PREFIX}/share/cmake/Modules"
 
-INSTALL=off BUILD=only_release ./linux_build-egl.bash
+# Build
+LIBCARNA_NO_INSTALL=1 BUILD=only_release ./linux_build-egl.bash
 
+# Fix FindLibCarna.cmake
+sed -i "s|${PREFIX}|\\\$ENV{CONDA_PREFIX}|g" build/make_release/misc/FindLibCarna.cmake
+
+# Install
 cd "build/make_release"
 make install

--- a/recipes/libcarna/meta.yaml
+++ b/recipes/libcarna/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "libcarna" %}
-{% set version = "3.3.3" %}
-{% set repo_url = "https://github.com/kostrykin/Carna" %}
-{% set docs_url = "https://kostrykin.github.io/Carna/html" %}
+{% set version = "3.4.0" %}
+{% set repo_url = "https://github.com/kostrykin/LibCarna" %}
+{% set docs_url = "https://kostrykin.github.io/LibCarna/html" %}
 
 package:
   name: {{ name }}
@@ -9,7 +9,7 @@ package:
 
 source:
   url: "{{ repo_url }}/archive/refs/tags/{{ version }}.zip"
-  sha256: 0ec99c1188c6ec81747e97a018a88eacad39a39c83c3b79fb669cd89cb9c7637
+  sha256: 0041aa13e822d95332bd3026fa5914c612621111611e5b9b538119bc99b1d46e
 
 build:
   number: 0
@@ -45,7 +45,7 @@ test:
 
 about:
   home: "{{ repo_url }}"
-  license: 'BSD-3-Clause'
+  license: 'MIT'
   summary: 'Real-time 3D visualization of biomedical data and beyond'
   dev_url: "{{ repo_url }}"
   doc_url: "{{ docs_url }}"

--- a/recipes/libcarna/meta.yaml
+++ b/recipes/libcarna/meta.yaml
@@ -31,6 +31,8 @@ requirements:
     - libegl-devel  # [linux]
     - libglu        # [linux]
   run:
+    - libglu  # [linux]
+    - _openmp_mutex
 
 test:
   files:

--- a/recipes/libcarna/run_test.sh
+++ b/recipes/libcarna/run_test.sh
@@ -3,8 +3,6 @@ set -xe
 mkdir -p test/build
 cd test/build
 
-#export CONDA_PREFIX=$PREFIX
-
 cmake -DCMAKE_MODULE_PATH="${CONDA_PREFIX}/share/cmake/Modules" ..
 make
 

--- a/recipes/libcarna/run_test.sh
+++ b/recipes/libcarna/run_test.sh
@@ -3,6 +3,8 @@ set -xe
 mkdir -p test/build
 cd test/build
 
+#export CONDA_PREFIX=$PREFIX
+
 cmake -DCMAKE_MODULE_PATH="${CONDA_PREFIX}/share/cmake/Modules" ..
 make
 

--- a/recipes/libcarna/test/CMakeLists.txt
+++ b/recipes/libcarna/test/CMakeLists.txt
@@ -1,15 +1,23 @@
 cmake_minimum_required( VERSION 3.5 )
-
 project( libcarna-test )
-
 include( FindPackageHandleStandardArgs )
 
+# Find dependency required to build the test
 find_package( Eigen3 REQUIRED )
 include_directories( ${EIGEN3_INCLUDE_DIR} )
 
-find_package( Carna ${REQUIRED_VERSION_CARNA} REQUIRED COMPONENTS release )
-include_directories( ${CARNA_INCLUDE_DIR} )
-set( CARNA_VERSION ${FOUND_VERSION} )
+# Verify that the Find*.cmake file is properly installed
+find_package( LibCarna ${REQUIRED_VERSION_LIBCARNA} REQUIRED COMPONENTS release )
+include_directories( ${LibCarna_INCLUDE_DIR} )
+set( LIBCARNA_VERSION ${FOUND_VERSION} )
 
+# Verify that headers are found and libraries can be linked
 add_executable( test test.cpp )
-target_link_libraries( test -lGLU ${Carna_LIBRARIES} )
+target_link_libraries( test -lGLU ${LibCarna_LIBRARIES} )
+
+# Verify that all LICENSE files are shipped
+foreach( LICENSE_NAME Carna LibCarna Eigen GLEW )
+    if( NOT EXISTS "${LibCarna_LICENSE_DIR}/LICENSE-${LICENSE_NAME}" )
+        message( FATAL_ERROR "LICENSE file missing: ${LICENSE_NAME}" )
+    endif()
+endforeach()

--- a/recipes/libcarna/test/test.cpp
+++ b/recipes/libcarna/test/test.cpp
@@ -1,9 +1,9 @@
-#include <Carna/base/Node.h>
+#include <LibCarna/base/Node.hpp>
 
 int main()
 {
     /* Call code that is implemented in the shared library,
      * to test the linking of the library.
      */
-    Carna::base::Node root;
+    LibCarna::base::Node root;
 }


### PR DESCRIPTION
Update libcarna to 3.4.0, plus:
- Fix issue with Find*.cmake file
- Add missing LICENSE files
- Fix missing dependency warning

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
