### PR TITLE
ECTYPER v2.0.0 Updated build to #4 due to BioPython issue AttributeError: 'FastaWrit…

### DIFF
--- a/recipes/ectyper/meta.yaml
+++ b/recipes/ectyper/meta.yaml
@@ -7,10 +7,10 @@ package:
 
 source:
     url: https://github.com/phac-nml/ecoli_serotyping/archive/{{ version }}.tar.gz
-    sha256: ab4df95bdc8fa81689b9da2d1451ba0389d5fa07ac5bc60e070f0ab3af04d05e 
+    sha256: 3d5ec502880e8f842f3a4b7513dd94706f7176cb37cf71baac5403c5c83058ff
 
 build:
-    number: 3
+    number: 4
     noarch: python
     run_exports:
         - {{ pin_subpackage(name, max_pin="x") }}


### PR DESCRIPTION
Updated code to fix recent bug linked to lower level FastaIO functions (`FastaWriter()`) generating the below error. Updated code to use upper level FASTA write functions ([SeqIO.write()](https://github.com/phac-nml/ecoli_serotyping/blob/b4077d753da81172d180acd3c5bad1ba1b234624/ectyper/predictionFunctions.py#L59)) that fixed the issue and is recommended as per issue https://github.com/fhcrc/seqmagick/issues/93. 

In addition this build #4 prevents error on empty shiga toxin dataframe highlighted by the https://github.com/phac-nml/ecoli_serotyping/issues/104 by moving new column assignment after dataframe check at https://github.com/phac-nml/ecoli_serotyping/blob/b4077d753da81172d180acd3c5bad1ba1b234624/ectyper/predictionFunctions.py#L80

```
summary_files/eqa_cdc_panels/ESP23-9201-PNC-M04603-230421/ectyper/tmp_66prbIXmH/combined_ident_serotype.fasta ...
Traceback (most recent call last):
  File "/home/CSCScience.ca/kbessono/.conda/envs/ectyper@2.0.0/bin/ectyper", line 10, in <module>
    sys.exit(run_program())
  File "/home/CSCScience.ca/kbessono/.conda/envs/ectyper@2.0.0/lib/python3.9/site-packages/ectyper/ectyper.py", line 136, in run_program
    genomeFunctions.create_combined_alleles_and_markers_file(
  File "/home/CSCScience.ca/kbessono/.conda/envs/ectyper@2.0.0/lib/python3.9/site-packages/ectyper/genomeFunctions.py", line 417, in create_combined_alleles_and_markers_file
    path2patho_db  = predictionFunctions.json2fasta(definitions.PATHOTYPE_ALLELE_JSON, temp_dir)
  File "/home/CSCScience.ca/kbessono/.conda/envs/ectyper@2.0.0/lib/python3.9/site-packages/ectyper/predictionFunctions.py", line 58, in json2fasta
    fasta_out.write_file(sequences)
  File "/home/CSCScience.ca/kbessono/.local/lib/python3.9/site-packages/Bio/SeqIO/Interfaces.py", line 235, in write_file
    count = self.write_records(records, maxcount)
  File "/home/CSCScience.ca/kbessono/.local/lib/python3.9/site-packages/Bio/SeqIO/Interfaces.py", line 209, in write_records
    self.write_record(record)
  File "/home/CSCScience.ca/kbessono/.local/lib/python3.9/site-packages/Bio/SeqIO/FastaIO.py", line 305, in write_record
    assert self._header_written 
AttributeError: 'FastaWriter' object has no attribute '_header_written' 
```

@rpetit3 We are about to release the ECTyper v2.0.0 as part of the PulseNet Canada routine lab testing and had passed all validation sets. This build allows to get virulence genes information and pathotype for E.coli and non-E.coli samples with species `--verify` parameter turned ON (previously only for E.coli such results were visible under this QC check parameter). This adds convenience and makes a QC more relaxed. A user will get a warning message in `Warnings` field of the report stating that pathotype results are relevant to E.coli species (e.g. EHEC, STEC, etc.). Virulence gene profiles covering Shiga toxin, enterohemolysin and other key virulence genes are also provided for non-E.coli samples under `--verify` and `--pathotype` parameters that adds convenience (otherwise for Shigella one needed to run ECTyper twice with `--verify` and without `--verify`)