### PR TITLE
Change version libsqlite for omamer recipe

### DIFF
--- a/recipes/omamer/meta.yaml
+++ b/recipes/omamer/meta.yaml
@@ -20,9 +20,10 @@ build:
 
 requirements:
   host:
-    - python =3.8
+    - python >=3.8
     - pip
     - setuptools
+    - libsqlite =3.40.0
   run:
     - python >=3.8
     - alive-progress

--- a/recipes/omamer/meta.yaml
+++ b/recipes/omamer/meta.yaml
@@ -14,13 +14,13 @@ build:
     - omamer = omamer.main:main
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation --no-cache-dir
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage(name, max_pin="x") }}
 
 requirements:
   host:
-    - python >=3.8
+    - python =3.8
     - pip
     - setuptools
   run:
@@ -28,6 +28,7 @@ requirements:
     - alive-progress
     - biopython
     - ete3
+    - libsqlite =3.40.0 # Workaround (https://github.com/etetoolkit/ete/pull/770)
     - numba
     - numpy <2
     - pandas >2.0.0

--- a/recipes/omamer/meta.yaml
+++ b/recipes/omamer/meta.yaml
@@ -23,13 +23,13 @@ requirements:
     - python >=3.8
     - pip
     - setuptools
-    - libsqlite =3.40.0
+    - libsqlite <=3.40.0
   run:
     - python >=3.8
     - alive-progress
     - biopython
     - ete3
-    - libsqlite =3.40.0 # Workaround (https://github.com/etetoolkit/ete/pull/770)
+    - libsqlite <=3.40.0 # Workaround (https://github.com/etetoolkit/ete/pull/770)
     - numba
     - numpy <2
     - pandas >2.0.0


### PR DESCRIPTION
Hello, I'm opening this PR to adapt the libsqlite version. 

I found this error on this PR (https://github.com/galaxyproject/iwc/pull/767):
`Traceback (most recent call last):
  File "/usr/local/bin/omark", line 52, in <module>
    omark.launcher(arg)
  File "/usr/local/lib/python3.9/site-packages/omark/omark.py", line 269, in launcher
    get_omamer_qscore(omamerfile, dbpath, outdir, taxid, original_FASTA_file = original_fasta, isoform_file=isoform_file, taxonomic_rank=taxonomic_rank)
  File "/usr/local/lib/python3.9/site-packages/omark/omark.py", line 116, in get_omamer_qscore
    closest_corr = spd.get_sampled_taxa(likely_clade, 5 , tax_tab, sp_tab, tax_buff, taxonomic_rank)
  File "/usr/local/lib/python3.9/site-packages/omark/species_determination.py", line 403, in get_sampled_taxa
    ranks = ncbi.get_rank(lineage_ncbi)
  File "/usr/local/lib/python3.9/site-packages/ete3/ncbi_taxonomy/ncbiquery.py", line 201, in get_rank
    result = self.db.execute(cmd)
sqlite3.OperationalError: no such column: "6656" - should this be a string literal in single-quotes?
/usr/local/lib/python3.9/site-packages/tables/file.py:113: UnclosedFileWarning: Closing remaining open file: /cvmfs/data.galaxyproject.org/byhand/omamer/LUCA-v2.0.0.h5
  warnings.warn(UnclosedFileWarning(msg))`
  
  A similar error has been corrected: https://github.com/etetoolkit/ete/pull/770

Thank you and have a nice day!
Romane