### PR TITLE
meme 4.11.2: reenable and add linux-aarch64

### DIFF
--- a/build-fail-blacklist
+++ b/build-fail-blacklist
@@ -135,7 +135,6 @@ recipes/bedtools/2.26.0
 recipes/opsin/1.4.0
 recipes/opsin/2.1.0
 recipes/meme/4.11.1
-recipes/meme/4.11.2
 recipes/meme/4.8.1
 recipes/bcftools-gtc2vcf-plugin/1.9
 recipes/panx/1.6.0

--- a/recipes/meme/4.11.2/meta.yaml
+++ b/recipes/meme/4.11.2/meta.yaml
@@ -72,4 +72,4 @@ extra:
     # openmpi needs ssh/rsh
     extended-base: true
   additional-platforms:
-    linux-aarch64
+    - linux-aarch64

--- a/recipes/meme/4.11.2/meta.yaml
+++ b/recipes/meme/4.11.2/meta.yaml
@@ -38,6 +38,7 @@ requirements:
     - perl-xml-simple
     - perl-html-template
     - perl-cgi
+    - liblzma-devel
   run:
     - yaml
     - expat

--- a/recipes/meme/4.11.2/meta.yaml
+++ b/recipes/meme/4.11.2/meta.yaml
@@ -14,8 +14,10 @@ source:
     - 2to3.patch
 
 build:
-  number: 8
+  number: 9
   detect_binary_files_with_prefix: True
+  run_exports:
+    - {{ pin_subpackage("meme", max_pin="x") }}
 
 requirements:
   build:
@@ -68,3 +70,5 @@ extra:
   container:
     # openmpi needs ssh/rsh
     extended-base: true
+  additional-platforms:
+    linux-aarch64


### PR DESCRIPTION
This is needed for antismash-lite. 
Package was missing liblzma-devel but now builds on linux-aarch64.
build-fail-blacklist entry removed. 