### PR TITLE
Workaround CI timeouts when fetching conda install scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,13 @@ jobs: # a basic unit of work in a run
 
       - run:
           name: Fetch bioconda install script
-          command: wget https://raw.githubusercontent.com/bioconda/bioconda-common/master/{common,install-and-set-up-conda,configure-conda}.sh
+          command: |
+            git clone --depth=1 https://github.com/bioconda/bioconda-common.git
+
+            (cd bioconda-common && git checkout c7f3f523b39481225f912cbfc3937682b4342c4e)
+
+            mv bioconda-common/{install-and-set-up-conda,configure-conda,common}.sh .
+            rm -rf bioconda-common/
 
       - run:
           name: Install bioconda-utils
@@ -124,7 +130,13 @@ jobs: # a basic unit of work in a run
 
       - run:
           name: Fetch bioconda install script
-          command: wget https://raw.githubusercontent.com/bioconda/bioconda-common/master/{common,install-and-set-up-conda,configure-conda}.sh
+          command: |
+            git clone --depth=1 https://github.com/bioconda/bioconda-common.git
+
+            (cd bioconda-common && git checkout c7f3f523b39481225f912cbfc3937682b4342c4e)
+
+            mv bioconda-common/{install-and-set-up-conda,configure-conda,common}.sh .
+            rm -rf bioconda-common/
 
       - run:
           name: Install bioconda-utils
@@ -199,7 +211,13 @@ jobs: # a basic unit of work in a run
 
       - run:
           name: Fetch bioconda install script
-          command: wget https://raw.githubusercontent.com/bioconda/bioconda-common/bulk/{common,install-and-set-up-conda,configure-conda}.sh
+          command: |
+            git clone --depth=1 https://github.com/bioconda/bioconda-common.git
+
+            (cd bioconda-common && git checkout c7f3f523b39481225f912cbfc3937682b4342c4e)
+
+            mv bioconda-common/{install-and-set-up-conda,configure-conda,common}.sh .
+            rm -rf bioconda-common/
 
       - run:
           name: Install bioconda-utils
@@ -253,7 +271,13 @@ jobs: # a basic unit of work in a run
 
       - run:
           name: Fetch bioconda install script
-          command: wget https://raw.githubusercontent.com/bioconda/bioconda-common/bulk/{common,install-and-set-up-conda,configure-conda}.sh
+          command: |
+            git clone --depth=1 https://github.com/bioconda/bioconda-common.git
+
+            (cd bioconda-common && git checkout c7f3f523b39481225f912cbfc3937682b4342c4e)
+
+            mv bioconda-common/{install-and-set-up-conda,configure-conda,common}.sh .
+            rm -rf bioconda-common/
 
       - run:
           name: Install bioconda-utils

--- a/.github/workflows/Bulk.yml
+++ b/.github/workflows/Bulk.yml
@@ -42,6 +42,7 @@ jobs:
             common.sh
             configure-conda.sh
             install-and-set-up-conda.sh
+          fail-on-cache-miss: true
 
       - name: Set up bioconda-utils
         run: bash install-and-set-up-conda.sh
@@ -105,6 +106,7 @@ jobs:
             common.sh
             configure-conda.sh
             install-and-set-up-conda.sh
+          fail-on-cache-miss: true
 
       - name: Set up bioconda-utils
         run: bash install-and-set-up-conda.sh
@@ -172,6 +174,7 @@ jobs:
             common.sh
             configure-conda.sh
             install-and-set-up-conda.sh
+          fail-on-cache-miss: true
 
       - name: Set up bioconda-utils
         run: bash install-and-set-up-conda.sh

--- a/.github/workflows/Bulk.yml
+++ b/.github/workflows/Bulk.yml
@@ -4,10 +4,16 @@ on:
     branches:
       - bulk
 jobs:
+  cache-bioconda-common-scripts:
+    name: Cache bioconda/bioconda-common scripts
+    uses: bioconda/bioconda-recipes/.github/workflows/fetch-conda-install-script.yml@02ca87034ae53807685333342fd90abe4a65685a
+    with:
+      ref: c7f3f523b39481225f912cbfc3937682b4342c4e
   build-linux:
     name: Bulk Linux Builds
     if: "contains(github.event.head_commit.message, '[ci run]')"
     runs-on: ubuntu-22.04
+    needs: [ cache-bioconda-common-scripts ]
     strategy:
       fail-fast: false
       max-parallel: 6
@@ -28,9 +34,14 @@ jobs:
       - name: set path
         run: echo "/opt/mambaforge/bin" >> $GITHUB_PATH
 
-      - name: Fetch conda install script
-        run: |
-          wget https://raw.githubusercontent.com/bioconda/bioconda-common/bulk/{common,install-and-set-up-conda,configure-conda}.sh
+      - name: Fetch conda install scripts
+        uses: actions/cache/restore@v4
+        with:
+          key: ${{ needs.cache-bioconda-common-scripts.outputs.cache-key }}
+          path: |
+            common.sh
+            configure-conda.sh
+            install-and-set-up-conda.sh
 
       - name: Set up bioconda-utils
         run: bash install-and-set-up-conda.sh
@@ -66,6 +77,7 @@ jobs:
     name: Bulk OSX-64 Builds
     if: "contains(github.event.head_commit.message, '[ci run]')"
     runs-on: macos-13
+    needs: [ cache-bioconda-common-scripts ]
     strategy:
       fail-fast: false
       max-parallel: 3
@@ -85,9 +97,14 @@ jobs:
       - name: set path
         run: echo "/opt/mambaforge/bin" >> $GITHUB_PATH
 
-      - name: Fetch conda install script
-        run: |
-          wget https://raw.githubusercontent.com/bioconda/bioconda-common/bulk/{common,install-and-set-up-conda,configure-conda}.sh
+      - name: Fetch conda install scripts
+        uses: actions/cache/restore@v4
+        with:
+          key: ${{ needs.cache-bioconda-common-scripts.outputs.cache-key }}
+          path: |
+            common.sh
+            configure-conda.sh
+            install-and-set-up-conda.sh
 
       - name: Set up bioconda-utils
         run: bash install-and-set-up-conda.sh
@@ -127,6 +144,7 @@ jobs:
     name: Bulk OSX-ARM64 Builds
     if: "contains(github.event.head_commit.message, '[ci run]')"
     runs-on: macOS-14 # M1
+    needs: [ cache-bioconda-common-scripts ]
     strategy:
       fail-fast: false
       max-parallel: 1 # GHA free plan allows 5 concurrent Mac runners total, we still need most on osx-64.
@@ -146,9 +164,14 @@ jobs:
       - name: set path
         run: echo "/opt/mambaforge/bin" >> $GITHUB_PATH
 
-      - name: Fetch conda install script
-        run: |
-          wget https://raw.githubusercontent.com/bioconda/bioconda-common/bulk/{common,install-and-set-up-conda,configure-conda}.sh
+      - name: Fetch conda install scripts
+        uses: actions/cache/restore@v4
+        with:
+          key: ${{ needs.cache-bioconda-common-scripts.outputs.cache-key }}
+          path: |
+            common.sh
+            configure-conda.sh
+            install-and-set-up-conda.sh
 
       - name: Set up bioconda-utils
         run: bash install-and-set-up-conda.sh

--- a/.github/workflows/Bulk.yml
+++ b/.github/workflows/Bulk.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   cache-bioconda-common-scripts:
     name: Cache bioconda/bioconda-common scripts
-    uses: bioconda/bioconda-recipes/.github/workflows/fetch-conda-install-script.yml@02ca87034ae53807685333342fd90abe4a65685a
+    uses: bioconda/bioconda-recipes/.github/workflows/fetch-conda-install-script.yml@6a472404ba03004bd49256d2f8f831656440367a
     with:
       ref: c7f3f523b39481225f912cbfc3937682b4342c4e
   build-linux:

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -40,6 +40,7 @@ jobs:
             common.sh
             configure-conda.sh
             install-and-set-up-conda.sh
+          fail-on-cache-miss: true
 
       - name: Restore cache
         id: cache
@@ -131,6 +132,7 @@ jobs:
             common.sh
             configure-conda.sh
             install-and-set-up-conda.sh
+          fail-on-cache-miss: true
 
       - name: Restore cache
         id: cache
@@ -241,6 +243,7 @@ jobs:
             common.sh
             configure-conda.sh
             install-and-set-up-conda.sh
+          fail-on-cache-miss: true
 
       # This is required so actions/cache below will restore properly
       # See: https://github.com/actions/cache/issues/629#issuecomment-1189184648

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -6,9 +6,15 @@ concurrency:
   group: build-${{ github.event.pull_request.number || github.head_ref }}
   cancel-in-progress: true
 jobs:
+  cache-bioconda-common-scripts:
+    name: Cache bioconda/bioconda-common scripts
+    uses: bioconda/bioconda-recipes/.github/workflows/fetch-conda-install-script.yml@02ca87034ae53807685333342fd90abe4a65685a
+    with:
+      ref: c7f3f523b39481225f912cbfc3937682b4342c4e
   lint:
     name: Lint
     runs-on: ubuntu-22.04
+    needs: [ cache-bioconda-common-scripts ]
     strategy:
       fail-fast: true
       max-parallel: 13
@@ -26,9 +32,14 @@ jobs:
       - name: set path
         run: echo "/opt/mambaforge/bin" >> $GITHUB_PATH
 
-      - name: Fetch conda install script
-        run: |
-          wget https://raw.githubusercontent.com/bioconda/bioconda-common/master/{install-and-set-up-conda,configure-conda,common}.sh
+      - name: Fetch conda install scripts
+        uses: actions/cache/restore@v4
+        with:
+          key: ${{ needs.cache-bioconda-common-scripts.outputs.cache-key }}
+          path: |
+            common.sh
+            configure-conda.sh
+            install-and-set-up-conda.sh
 
       - name: Restore cache
         id: cache
@@ -74,7 +85,9 @@ jobs:
     strategy:
       fail-fast: true
       max-parallel: 13
-    needs: lint
+    needs:
+      - cache-bioconda-common-scripts
+      - lint
     steps:
       - name: Free space
         # HACK fixes 'No space left on device'
@@ -110,9 +123,14 @@ jobs:
       - name: set path
         run: echo "/opt/mambaforge/bin" >> $GITHUB_PATH
 
-      - name: Fetch conda install script
-        run: |
-          wget https://raw.githubusercontent.com/bioconda/bioconda-common/master/{install-and-set-up-conda,configure-conda,common}.sh
+      - name: Fetch conda install scripts
+        uses: actions/cache/restore@v4
+        with:
+          key: ${{ needs.cache-bioconda-common-scripts.outputs.cache-key }}
+          path: |
+            common.sh
+            configure-conda.sh
+            install-and-set-up-conda.sh
 
       - name: Restore cache
         id: cache
@@ -197,7 +215,9 @@ jobs:
       fail-fast: true
       max-parallel: 4
     # Limited concurrency for osx, so first make sure linux can pass
-    needs: build-linux
+    needs:
+      - cache-bioconda-common-scripts
+      - build-linux
     steps:
       - uses: actions/checkout@v4
       
@@ -213,9 +233,14 @@ jobs:
       - name: set path
         run: echo "/opt/mambaforge/bin" >> $GITHUB_PATH
 
-      - name: Fetch conda install script
-        run: |
-          wget https://raw.githubusercontent.com/bioconda/bioconda-common/master/{install-and-set-up-conda,configure-conda,common}.sh
+      - name: Fetch conda install scripts
+        uses: actions/cache/restore@v4
+        with:
+          key: ${{ needs.cache-bioconda-common-scripts.outputs.cache-key }}
+          path: |
+            common.sh
+            configure-conda.sh
+            install-and-set-up-conda.sh
 
       # This is required so actions/cache below will restore properly
       # See: https://github.com/actions/cache/issues/629#issuecomment-1189184648

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -8,7 +8,7 @@ concurrency:
 jobs:
   cache-bioconda-common-scripts:
     name: Cache bioconda/bioconda-common scripts
-    uses: bioconda/bioconda-recipes/.github/workflows/fetch-conda-install-script.yml@02ca87034ae53807685333342fd90abe4a65685a
+    uses: bioconda/bioconda-recipes/.github/workflows/fetch-conda-install-script.yml@6a472404ba03004bd49256d2f8f831656440367a
     with:
       ref: c7f3f523b39481225f912cbfc3937682b4342c4e
   lint:

--- a/.github/workflows/build-failures.yml
+++ b/.github/workflows/build-failures.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   cache-bioconda-common-scripts:
     name: Cache bioconda/bioconda-common scripts
-    uses: bioconda/bioconda-recipes/.github/workflows/fetch-conda-install-script.yml@02ca87034ae53807685333342fd90abe4a65685a
+    uses: bioconda/bioconda-recipes/.github/workflows/fetch-conda-install-script.yml@6a472404ba03004bd49256d2f8f831656440367a
     with:
       ref: c7f3f523b39481225f912cbfc3937682b4342c4e
   update-build-failure-page:

--- a/.github/workflows/build-failures.yml
+++ b/.github/workflows/build-failures.yml
@@ -11,10 +11,16 @@ on:
       - "**build_failure.*.yaml"
 
 jobs:
+  cache-bioconda-common-scripts:
+    name: Cache bioconda/bioconda-common scripts
+    uses: bioconda/bioconda-recipes/.github/workflows/fetch-conda-install-script.yml@02ca87034ae53807685333342fd90abe4a65685a
+    with:
+      ref: c7f3f523b39481225f912cbfc3937682b4342c4e
   update-build-failure-page:
     name: Update build failure page
     if: ${{ github.repository == 'bioconda/bioconda-recipes' && !contains(github.event.head_commit.message, '[ci skip]') }}
     runs-on: ubuntu-22.04
+    needs: [ cache-bioconda-common-scripts ]
     steps:
       - uses: actions/checkout@v4
 
@@ -29,9 +35,14 @@ jobs:
       - name: set path
         run: echo "/opt/mambaforge/bin" >> $GITHUB_PATH
 
-      - name: Fetch conda install script
-        run: |
-          wget https://raw.githubusercontent.com/bioconda/bioconda-common/master/{common,install-and-set-up-conda,configure-conda}.sh
+      - name: Fetch conda install scripts
+        uses: actions/cache/restore@v4
+        with:
+          key: ${{ needs.cache-bioconda-common-scripts.outputs.cache-key }}
+          path: |
+            common.sh
+            configure-conda.sh
+            install-and-set-up-conda.sh
 
       - name: Restore cache
         id: cache

--- a/.github/workflows/build-failures.yml
+++ b/.github/workflows/build-failures.yml
@@ -43,6 +43,7 @@ jobs:
             common.sh
             configure-conda.sh
             install-and-set-up-conda.sh
+          fail-on-cache-miss: true
 
       - name: Restore cache
         id: cache

--- a/.github/workflows/fetch-conda-install-script.yml
+++ b/.github/workflows/fetch-conda-install-script.yml
@@ -1,0 +1,69 @@
+name: Fetch conda install scripts
+
+on:
+  workflow_call:
+    outputs:
+      cache-key:
+        description: "Key to restore the cached install scripts."
+        value: ${{ jobs.fetch-bioconda-common.outputs.cache-key }}
+
+    inputs:
+      repository:
+        default: "bioconda/bioconda-common"
+        type: string
+        required: false
+        description: "Repository name with owner. For example, bioconda/bioconda-common."
+      ref:
+        type: string
+        required: true
+        description: "The branch, tag or SHA to checkout."
+
+jobs:
+  fetch-bioconda-common:
+    name: Fetch conda install scripts
+    if: github.repository == 'bioconda/bioconda-recipes'
+    runs-on: ubuntu-latest
+
+    outputs:
+      cache-key: ${{ steps.generate-cache-key.outputs.key }}
+
+    steps:
+      - name: Generate cache key
+        id: generate-cache-key
+        run: |
+          repository="$(echo '${{ inputs.repository }}' | tr -c '[:alnum:]._-' '-' | sed 's/-\+/-/g' | sed 's/-$//')"
+          ref="$(echo '${{ inputs.ref }}' | tr -c '[:alnum:]._-' '-' | sed 's/-\+/-/g' | sed 's/-$//')"
+          
+          echo "key=conda-install-scripts-$repository-$ref" | tee -a "$GITHUB_OUTPUT"
+
+      - name: Lookup cache key
+        id: lookup-cache
+        uses: actions/cache/restore@v4
+        with:
+          key: ${{ steps.generate-cache-key.outputs.key }}
+          path: |
+            common.sh
+            configure-conda.sh
+            install-and-set-up-conda.sh
+          lookup-only: true
+
+      - name: Checkout bioconda-common repo
+        if: steps.lookup-cache.outputs.cache-hit != 'true'
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
+          sparse-checkout: |
+            common.sh
+            configure-conda.sh
+            install-and-set-up-conda.sh
+
+      - name: Save cache
+        if: steps.lookup-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          key: ${{ steps.generate-cache-key.outputs.key }}
+          path: |
+            common.sh
+            configure-conda.sh
+            install-and-set-up-conda.sh

--- a/.github/workflows/fetch-conda-install-script.yml
+++ b/.github/workflows/fetch-conda-install-script.yml
@@ -47,6 +47,21 @@ jobs:
             install-and-set-up-conda.sh
           lookup-only: true
 
+      - name: Check files exist
+        if: steps.lookup-cache.outputs.cache-hit != 'true'
+        run: |
+          ok=true
+          for f in common.sh configure-conda.sh install-and-set-up-conda.sh; do
+            if [ ! -f "$f" ]; then
+              1>&2 echo "File \"$f\" is missing!"
+              ok=false
+            fi
+          done
+
+          if [ "$ok" != true ]; then
+            exit 1
+          fi
+
       - name: Checkout bioconda-common repo
         if: steps.lookup-cache.outputs.cache-hit != 'true'
         uses: actions/checkout@v4

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -4,10 +4,16 @@ on:
     branches:
       - master
 jobs:
+  cache-bioconda-common-scripts:
+    name: Cache bioconda/bioconda-common scripts
+    uses: bioconda/bioconda-recipes/.github/workflows/fetch-conda-install-script.yml@02ca87034ae53807685333342fd90abe4a65685a
+    with:
+      ref: c7f3f523b39481225f912cbfc3937682b4342c4e
   build-linux:
     name: Linux Upload
     if: github.repository == 'bioconda/bioconda-recipes'
     runs-on: ubuntu-22.04
+    needs: [ cache-bioconda-common-scripts ]
     strategy:
       fail-fast: false
       max-parallel: 13
@@ -20,9 +26,14 @@ jobs:
       - name: set path
         run: echo "/opt/mambaforge/bin" >> $GITHUB_PATH
 
-      - name: Fetch conda install script
-        run: |
-          wget https://raw.githubusercontent.com/bioconda/bioconda-common/master/{install-and-set-up-conda,configure-conda,common}.sh
+      - name: Fetch conda install scripts
+        uses: actions/cache/restore@v4
+        with:
+          key: ${{ needs.cache-bioconda-common-scripts.outputs.cache-key }}
+          path: |
+            common.sh
+            configure-conda.sh
+            install-and-set-up-conda.sh
 
       - name: Set up bioconda-utils
         run: bash install-and-set-up-conda.sh
@@ -56,6 +67,7 @@ jobs:
     name: OSX-64 Upload
     if: github.repository == 'bioconda/bioconda-recipes'
     runs-on: macos-13
+    needs: [ cache-bioconda-common-scripts ]
     strategy:
       fail-fast: false
       max-parallel: 4
@@ -68,9 +80,14 @@ jobs:
       - name: set path
         run: echo "/opt/mambaforge/bin" >> $GITHUB_PATH
 
-      - name: Fetch conda install script
-        run: |
-          wget https://raw.githubusercontent.com/bioconda/bioconda-common/master/{install-and-set-up-conda,configure-conda,common}.sh
+      - name: Fetch conda install scripts
+        uses: actions/cache/restore@v4
+        with:
+          key: ${{ needs.cache-bioconda-common-scripts.outputs.cache-key }}
+          path: |
+            common.sh
+            configure-conda.sh
+            install-and-set-up-conda.sh
 
       - name: Set up bioconda-utils
         run: bash install-and-set-up-conda.sh

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   cache-bioconda-common-scripts:
     name: Cache bioconda/bioconda-common scripts
-    uses: bioconda/bioconda-recipes/.github/workflows/fetch-conda-install-script.yml@02ca87034ae53807685333342fd90abe4a65685a
+    uses: bioconda/bioconda-recipes/.github/workflows/fetch-conda-install-script.yml@6a472404ba03004bd49256d2f8f831656440367a
     with:
       ref: c7f3f523b39481225f912cbfc3937682b4342c4e
   build-linux:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -34,6 +34,7 @@ jobs:
             common.sh
             configure-conda.sh
             install-and-set-up-conda.sh
+          fail-on-cache-miss: true
 
       - name: Set up bioconda-utils
         run: bash install-and-set-up-conda.sh
@@ -88,6 +89,7 @@ jobs:
             common.sh
             configure-conda.sh
             install-and-set-up-conda.sh
+          fail-on-cache-miss: true
 
       - name: Set up bioconda-utils
         run: bash install-and-set-up-conda.sh

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,6 +30,7 @@ jobs:
             common.sh
             configure-conda.sh
             install-and-set-up-conda.sh
+          fail-on-cache-miss: true
 
       - name: Set up bioconda-utils
         run: bash install-and-set-up-conda.sh

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   cache-bioconda-common-scripts:
     name: Cache bioconda/bioconda-common scripts
-    uses: bioconda/bioconda-recipes/.github/workflows/fetch-conda-install-script.yml@02ca87034ae53807685333342fd90abe4a65685a
+    uses: bioconda/bioconda-recipes/.github/workflows/fetch-conda-install-script.yml@6a472404ba03004bd49256d2f8f831656440367a
     with:
       ref: c7f3f523b39481225f912cbfc3937682b4342c4e
   nightly-osx-arm:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,10 +3,16 @@ on:
   schedule:
     - cron: "0 0 * * *"
 jobs:
+  cache-bioconda-common-scripts:
+    name: Cache bioconda/bioconda-common scripts
+    uses: bioconda/bioconda-recipes/.github/workflows/fetch-conda-install-script.yml@02ca87034ae53807685333342fd90abe4a65685a
+    with:
+      ref: c7f3f523b39481225f912cbfc3937682b4342c4e
   nightly-osx-arm:
     name: Nightly OSX-ARM64 Builds
     if: github.repository == 'bioconda/bioconda-recipes'
     runs-on: macOS-14 # M1
+    needs: [ cache-bioconda-common-scripts ]
     strategy:
       fail-fast: false
       max-parallel: 4
@@ -16,9 +22,14 @@ jobs:
       - name: set path
         run: echo "/opt/mambaforge/bin" >> $GITHUB_PATH
 
-      - name: Fetch conda install script
-        run: |
-          wget https://raw.githubusercontent.com/bioconda/bioconda-common/master/{install-and-set-up-conda,configure-conda,common}.sh
+      - name: Fetch conda install scripts
+        uses: actions/cache/restore@v4
+        with:
+          key: ${{ needs.cache-bioconda-common-scripts.outputs.cache-key }}
+          path: |
+            common.sh
+            configure-conda.sh
+            install-and-set-up-conda.sh
 
       - name: Set up bioconda-utils
         run: bash install-and-set-up-conda.sh

--- a/.github/workflows/update-conda-install-cache.yml
+++ b/.github/workflows/update-conda-install-cache.yml
@@ -2,8 +2,8 @@ name: Keep the cache entry for the conda install scripts up-to-date
 
 on:
   schedule:
-    # Run daily at 23:00 (1h before nightly.yml)
-    - cron: "0 23 * * *"
+    # Run every hour
+    - cron: "0 */1 * * *"
   workflow_dispatch:
     inputs:
       ref:
@@ -14,14 +14,14 @@ on:
 jobs:
   cache-bioconda-common-scripts-schedule:
     name: Cache bioconda/bioconda-common scripts (schedule)
-    if: github.event_name == 'workflow_dispatch'
-    uses: bioconda/bioconda-recipes/.github/workflows/fetch-conda-install-script.yml@02ca87034ae53807685333342fd90abe4a65685a
+    if: github.event_name == 'schedule'
+    uses: bioconda/bioconda-recipes/.github/workflows/fetch-conda-install-script.yml@6a472404ba03004bd49256d2f8f831656440367a
     with:
       ref: c7f3f523b39481225f912cbfc3937682b4342c4e
 
   cache-bioconda-common-scripts-manual:
     name: Cache bioconda/bioconda-common scripts (manual)
     if: github.event_name == 'workflow_dispatch'
-    uses: bioconda/bioconda-recipes/.github/workflows/fetch-conda-install-script.yml@02ca87034ae53807685333342fd90abe4a65685a
+    uses: bioconda/bioconda-recipes/.github/workflows/fetch-conda-install-script.yml@6a472404ba03004bd49256d2f8f831656440367a
     with:
       ref: ${{ inputs.ref }}

--- a/.github/workflows/update-conda-install-cache.yml
+++ b/.github/workflows/update-conda-install-cache.yml
@@ -1,0 +1,27 @@
+name: Keep the cache entry for the conda install scripts up-to-date
+
+on:
+  schedule:
+    # Run daily at 23:00 (1h before nightly.yml)
+    - cron: "0 23 * * *"
+  workflow_dispatch:
+    inputs:
+      ref:
+        type: string
+        required: true
+        description: "The branch, tag or SHA of the bioconda/bioconda-common repository to checkout."
+
+jobs:
+  cache-bioconda-common-scripts-schedule:
+    name: Cache bioconda/bioconda-common scripts (schedule)
+    if: github.event_name == 'workflow_dispatch'
+    uses: bioconda/bioconda-recipes/.github/workflows/fetch-conda-install-script.yml@02ca87034ae53807685333342fd90abe4a65685a
+    with:
+      ref: c7f3f523b39481225f912cbfc3937682b4342c4e
+
+  cache-bioconda-common-scripts-manual:
+    name: Cache bioconda/bioconda-common scripts (manual)
+    if: github.event_name == 'workflow_dispatch'
+    uses: bioconda/bioconda-recipes/.github/workflows/fetch-conda-install-script.yml@02ca87034ae53807685333342fd90abe4a65685a
+    with:
+      ref: ${{ inputs.ref }}


### PR DESCRIPTION
This should hopefully address https://github.com/bioconda/bioconda-recipes/issues/56282.

Here's an overview of the proposed changes:
- Introduce a GHA reusable workflow [fetch-conda-install-script.yml](https://github.com/robomics/bioconda-recipes/blob/fix/ci-timeouts/.github/workflows/fetch-conda-install-script.yml).
  This workflow does the following:
  - Fetch the required scripts using git through `actions/checkout@v4` (with this we should not run into timeouts)
  - Save a cache entry in the GHA cache registry. The cache key embeds the name of the repository (bioconda/bioconda-common by default) and a ref (i.e., a branch, tag, or SHA) used to fetch the scripts
  - If a cache entry for the given key is already available, the workflow returns immediately
  - Finally, the workflow outputs the restore key for the cache entry that has just been created (or that was already available)
- Introduce a GHA workflow [update-conda-install-cache](https://github.com/robomics/bioconda-recipes/blob/fix/ci-timeouts/.github/workflows/update-conda-install-cache.yml).
  This workflow runs every hour (and can also be manually triggered), and simply calls  [fetch-conda-install-script.yml](https://github.com/robomics/bioconda-recipes/blob/fix/ci-timeouts/.github/workflows/fetch-conda-install-script.yml).
  This is necessary to deal with the current [restrictions for accessing GHA cache entries](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache).
  In brief, cache entries generated from PR are not visible by other PRs or by the master branch, while cache entries generated from the default branch can be restored by workflows triggered by PRs and other branches.
- Update all existing workflows to replace steps like

  ```yml
        - name: Fetch conda install script
        run: |
          wget https://raw.githubusercontent.com/bioconda/bioconda-common/bulk/{common,install-and-set-up-conda,configure-conda}.sh
  ```
  with
  ```yml
        - name: Fetch conda install scripts
        uses: actions/cache/restore@v4
        with:
          key: ${{ needs.cache-bioconda-common-scripts.outputs.cache-key }}
          path: |
            common.sh
            configure-conda.sh
            install-and-set-up-conda.sh
          fail-on-cache-miss: true
  ```
- Update [.circleci/config.yml](https://github.com/robomics/bioconda-recipes/blob/fix/ci-timeouts/.circleci/config.yml) to do something similar without caching (I am not familiar with CircleCI, so I am not sure how caching artifacts works there).

Note that I was only able to test part of the changes on [this](https://github.com/robomics/bioconda-gha-workflows) mock repository, so it would be nice if someone from the bioconda team (ping @aliciaaevans, @nh13 :)) could have a look and test the new workflows on the real CI infrastructure.

