### PR TITLE
Add maintainer info to induce rebuild

### DIFF
--- a/recipes/ezfastq/meta.yaml
+++ b/recipes/ezfastq/meta.yaml
@@ -40,3 +40,7 @@ about:
   license_family: BSD
   summary: Organize FASTQs by sample for analysis
   dev_url: https://github.com/bioforensics/ezfastq/
+
+extra:
+  recipe-maintainers:
+    - standage


### PR DESCRIPTION
See https://github.com/bioconda/bioconda-recipes/pull/56429#issuecomment-2917532929: this PR adds a recipe maintainer block to induce a package rebuild that was apparently scuttled by an errant "skip ci" message in the commit logs. HT to @aliciaaevans for pointing out this issue.