### PR TITLE
Bump bioconda-repodata-patches for new htslib release

### DIFF
--- a/recipes/bioconda-repodata-patches/gen_patch_json.py
+++ b/recipes/bioconda-repodata-patches/gen_patch_json.py
@@ -169,7 +169,7 @@ def _gen_new_index(repodata, subdir):
         if has_dep(record, 'htslib'):
             # skip deps prior to 1.10, which was the first with soversion 3
             # TODO adjust replacement (exclusive) upper bound with each new compatible HTSlib
-            _pin_looser(fn, record, 'htslib', min_lower_bound='1.10', upper_bound='1.22')
+            _pin_looser(fn, record, 'htslib', min_lower_bound='1.10', upper_bound='1.23')
 
         # future libdeflate versions are compatible until they bump their soversion; relax dependencies accordingly
         if record_name in ['htslib', 'staden_io_lib', 'fastp', 'pysam'] and has_dep(record, 'libdeflate'):

--- a/recipes/bioconda-repodata-patches/meta.yaml
+++ b/recipes/bioconda-repodata-patches/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: bioconda-repodata-patches
-  version: 20250516  # ensure that this is the "current" date, and always higher than the latest version in master
+  version: 20250603  # ensure that this is the "current" date, and always higher than the latest version in master
 
 source:
   path: .


### PR DESCRIPTION
Bump the patching to include #56518's new HTSlib release. As usual, this release does not change libhts's soversion. (Resubmission of #56587.)

----

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
