### PR TITLE
Update pasta to change build.sh and 1.9.3

### DIFF
--- a/recipes/giatools/meta.yaml
+++ b/recipes/giatools/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "giatools" %}
-{% set version = "0.4.0" %}
+{% set version = "0.4.1" %}
 
 package:
   name: "{{ name }}"
@@ -7,7 +7,7 @@ package:
 
 source:
   url: "https://github.com/BMCV/giatools/archive/refs/tags/{{ version }}.zip"
-  sha256: d98b99e33a6bdf0033b043eb5e9f46571589af07e68671f614f24e1a8a08ab48
+  sha256: 6d5d119d31cbe495ce5266828c762f4f6adabb70045047872a96b82d97247586
 
 build:
   number: 0

--- a/recipes/pasta/build.sh
+++ b/recipes/pasta/build.sh
@@ -15,8 +15,7 @@ then
 fi
 
 # Handle a PASTA bug.
-ln -sf $PREFIX/bin/hmmalign $PREFIX/bin/hmmeralign
-ln -sf $PREFIX/bin/hmmbuild $PREFIX/bin/hmmerbuild
+cp -fv $SRC_DIR/resources/scripts/hmmeralign $PREFIX/bin/hmmeralign
 
 # copy files for tests to shared conda directory
 mkdir -p $PREFIX/share/pasta/data/

--- a/recipes/pasta/meta.yaml
+++ b/recipes/pasta/meta.yaml
@@ -13,7 +13,7 @@ source:
     - mpstart.patch  # issue in OSX py38 (not in Linux nor OSX py37): RuntimeError: An attempt has been made to start a new process before the current process has finished its bootstrapping phase.
 
 build:
-  number: 6
+  number: 0
   run_exports:
     - {{ pin_subpackage('pasta', max_pin="x") }}
 

--- a/recipes/pasta/meta.yaml
+++ b/recipes/pasta/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "1.9.2" %}
-{% set sha256 = "06c20f022765d2c1daab13a916ec2ea2277c5ef43afcf3e54c6a7ade7aed0944" %}
+{% set version = "1.9.3" %}
+{% set sha256 = "4bbd77b148c7a0954e1103d0b6e834e3a507c3ada9ba556e2731109beb3d92fe" %}
 
 package:
   name: pasta
@@ -13,7 +13,7 @@ source:
     - mpstart.patch  # issue in OSX py38 (not in Linux nor OSX py37): RuntimeError: An attempt has been made to start a new process before the current process has finished its bootstrapping phase.
 
 build:
-  number: 5
+  number: 6
   run_exports:
     - {{ pin_subpackage('pasta', max_pin="x") }}
 


### PR DESCRIPTION
The recipe for PASTA has an issue. It was using the wrong `hmmeralign` file. We have fixed that. We also move PASTA one version ahead. 

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
