### PR TITLE
Update PhaBOX's meta.yaml to solve a "ValueError" caused by the update of PyTorch

### DIFF
--- a/recipes/phabox/meta.yaml
+++ b/recipes/phabox/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 06745db0f1b7f2b8ae56af8099f14f476b38b20a3a6460c8959ee2f8c9b70b13
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: "{{ PYTHON }} -m pip install . --no-deps --no-build-isolation --no-cache-dir -vvv"
   entry_points:

--- a/recipes/phabox/meta.yaml
+++ b/recipes/phabox/meta.yaml
@@ -38,7 +38,7 @@ requirements:
     - pytorch >=2.4
     - scipy >=1.14
     - seaborn-base >=0.13.2
-    - transformers >=4
+    - transformers >=4.43
     - blast >=2.16.0
     - diamond =0.9.14
     - mcl >=22.282


### PR DESCRIPTION
Solve a "ValueError" caused by the update of PyTorch

```
ValueError: Due to a serious vulnerability issue in torch.load, even with weights_only=True, we now require users to upgrade torch to at least v2.6 in order to use the function. This version restriction does not apply when loading files with safetensors.
```
