### PR TITLE
Patch bcftools to install recently added misc/ scripts

### DIFF
--- a/recipes/bcftools/meta.yaml
+++ b/recipes/bcftools/meta.yaml
@@ -5,13 +5,15 @@ package:
   version: {{ version }}
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage("bcftools", max_pin="x") }}
 
 source:
   url: https://github.com/samtools/bcftools/releases/download/{{ version }}/bcftools-{{ version }}.tar.bz2
   sha256: f2ab9e2f605b1203a7e9cbfb0a3eb7689322297f8c34b45dc5237fe57d98489f
+  patches:
+    - miscscripts.patch
 
 requirements:
   build:

--- a/recipes/bcftools/miscscripts.patch
+++ b/recipes/bcftools/miscscripts.patch
@@ -1,0 +1,14 @@
+diff --git a/Makefile b/Makefile
+index 0b936b2c..14a0b3ee 100644
+--- a/Makefile
++++ b/Makefile
+@@ -75,7 +75,9 @@ MISC_SCRIPTS = \
+     misc/guess-ploidy.py \
+     misc/plot-vcfstats \
+     misc/plot-roh.py \
++    misc/roh-viz \
+     misc/run-roh.pl \
++    misc/vrfs-variances \
+     misc/vcfutils.pl
+ TEST_PROGRAMS = test/test-rbuf test/test-regidx
+ 


### PR DESCRIPTION
Install _roh-viz_ and _vrfs-variances_ scripts. See https://github.com/samtools/bcftools/issues/2375#issuecomment-2970293311.

----

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
