### PR TITLE
Update Hostile to remove problematic optional dependency

### DIFF
--- a/recipes/hostile/meta.yaml
+++ b/recipes/hostile/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage('hostile', max_pin="x.x") }}
   entry_points:
@@ -26,7 +26,6 @@ requirements:
     - bowtie2 ==2.5.4
     - defopt >=6.4.0
     - dnaio >=1.2.0
-    - gawk >=5.3.1
     - httpx >=0.24.1
     - minimap2 >=2.28
     - platformdirs >=3.5.1


### PR DESCRIPTION
Remove optional dependency gawk which seems to be causing installation issues recently and increment build number.

```
Solving environment: |
Found conflicts! Looking for incompatible packages.
This can take several minutes.  Press CTRL-C to abort.                                                                                                                 failed

UnsatisfiableError: The following specifications were found to be incompatible with your system:

  - feature:/linux-64::__glibc==2.35=0
  - hostile -> gawk[version='>=5.3.1'] -> __glibc[version='>=2.17,<3.0.a0']
```