### PR TITLE
Add Clumppling v0.3.2

### DIFF
--- a/recipes/clumppling/meta.yaml
+++ b/recipes/clumppling/meta.yaml
@@ -11,10 +11,10 @@ source:
 
 build:
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --no-cache-dir -vvv
   number: 0
   run_exports:
-    - {{ pin_subpackage('clumppling', max_pin="y") }}
+    - {{ pin_subpackage('clumppling', max_pin="x.x") }}
 
 requirements:
   host:
@@ -35,16 +35,12 @@ requirements:
 test:
   imports:
     - clumppling
-  commands:
-    - pip check
-  requires:
-    - pip
 
 about:
-  home: "https://pypi.org/project/clumppling/"
+  home: "https://pypi.org/project/clumppling"
   license: MIT
   license_family: MIT
-  summary: "Cluster matching and permutation program with integer linear programming"
+  summary: "Cluster matching and permutation program with integer linear programming."
   description: |
     Clumppling (CLUster Matching and Permutation Program that uses integer Linear programmING) is a framework for aligning clustering results of population structure analysis.
   dev_url: "https://github.com/PopGenClustering/Clumppling"


### PR DESCRIPTION
This pull request adds [Clumppling](https://github.com/PopGenClustering/Clumppling), a program for inferring population structure from genetic data. Clumppling is a framework for aligning clustering results of population structure analysis. It adopts integer linear programming strategies to align a pair of mixed-membership clustering replicates with either the same or a different number of clusters.

@xr-cc - original author