### PR TITLE
Update sra-tools: add osx-arm64 support (build 1)

### DIFF
--- a/recipes/sra-tools/meta.yaml
+++ b/recipes/sra-tools/meta.yaml
@@ -15,7 +15,7 @@ source:
   folder: ncbi-vdb  # [osx]
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage(name, max_pin='x') }}
 
@@ -32,7 +32,7 @@ requirements:
     - ca-certificates
     - curl
     - ncbi-vdb >={{ version }}
-    - ossuuid
+    - ossuuid  # [linux]
     - perl
     - perl-xml-libxml
     - perl-uri
@@ -67,6 +67,7 @@ about:
 extra:
   additional-platforms:
     - linux-aarch64
+    - osx-arm64
   notes: 'After installation, you should run the configuration tool: ./vdb-config
     -i. This tool will setup your download/cache area for downloaded files and references.'
   identifiers:


### PR DESCRIPTION
### Summary
* Added `osx-arm64` to `extra.additional-platforms`
* Conditioned `ossuuid` with `# [linux]`
* Bumped `build:number` from 0 → 1

Local `bioconda-utils lint` and `bioconda-utils build` succeed on Apple-Silicon.

CC @bioconda/core