### PR TITLE
Try to enable DMRcate for 3.20

### DIFF
--- a/enable-dmrcate
+++ b/enable-dmrcate
@@ -14,7 +14,6 @@ recipes/r-dowser
 recipes/bioconductor-chipxpressdata
 recipes/bioconductor-chipxpress
 recipes/bioconductor-meal
-recipes/bioconductor-dmrcate
 recipes/bioconductor-methylgsa
 recipes/bioconductor-champ
 recipes/bioconductor-appreci8r


### PR DESCRIPTION
Remove `bioconductor-dmrcate` from the blacklist, to enable a build, and hopefully have it succeed for 3.20.
