### PR TITLE
Update CUNA to version 0.3.0

### DIFF
--- a/recipes/cuna/meta.yaml
+++ b/recipes/cuna/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "CUNA" %}
-{% set version = "0.2.0" %}
+{% set version = "0.3.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/iris1901/CUNA/archive/v{{ version }}.tar.gz
-  sha256: 45d3b82daa2b50d3aeb82b608e91e899792b4d4adab2249aaa309dcb3bc75939
+  sha256: b7b81595967c95956ab43014f8845aa7ecc80f2d097decc3fc873dbef9b37c56
 
 build:
   number: 0
@@ -36,7 +36,6 @@ requirements:
     - pandas
     - scipy
     - scikit-learn
-    - pod5
 
 test:
   commands:


### PR DESCRIPTION
Removed pod5 from dependencies to avoid compatibility issues with outdated Bioconda version