### PR TITLE
Update meta.yaml for minor version bump of SpacerExtractor (0.9.6)

### DIFF
--- a/recipes/spacerextractor/meta.yaml
+++ b/recipes/spacerextractor/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "spacerextractor" %}
-  {% set version = "0.9.5" %}
+  {% set version = "0.9.6" %}
 
 package:
   name: "{{ name|lower }}"
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://code.jgi.doe.gov/SRoux/{{ name }}/-/archive/{{ version }}/{{ name }}-{{ version }}.tar.gz
-  sha256: e656f294cba47e3522214375c07d2b71e7cefc400554550b201503843f9d4532
+  sha256: 147dcad0e114e7fed7e1da7a560743c21504876c0c52495aa7555908d68f0167
 
 build:
   number: 0


### PR DESCRIPTION
SpacerExtractor bumped to 0.9.6, only change is fixing a minor (but annoying) bug that prevented users to download databases outside of the current directory.
