### PR TITLE
coot-headless: Update test script

### DIFF
--- a/recipes/coot-headless/run_test.py
+++ b/recipes/coot-headless/run_test.py
@@ -1,14 +1,14 @@
 import os
 
-import coot_headless_api as chapi
+import coot_headless_api
 
 
 os.chdir("data")
-coot = chapi.molecules_container_t(True)
-imol = coot.read_pdb("tutorial-modern.pdb")
-imol_map = coot.read_mtz("rnasa-1.8-all_refmac1.mtz", "FWT", "PHWT", "W", use_weight=False, is_a_difference_map=False)
-coot.auto_fit_rotamer(imol, "A", 44, "", "", imol_map)
-coot.set_imol_refinement_map(imol_map)
-coot.refine_residue_range(imol, chain_id="A", res_no_start=43, res_no_end=45, n_cycles=10)
-coot.write_coordinates(imol, "tutorial-modern-ref.pdb")
+chapi = coot_headless_api.molecules_container_t(True)
+imol = chapi.read_pdb("tutorial-modern.pdb")
+imol_map = chapi.read_mtz("rnasa-1.8-all_refmac1.mtz", "FWT", "PHWT", "W", use_weight=False, is_a_difference_map=False)
+chapi.auto_fit_rotamer(imol, "A", 44, "", "", imol_map)
+chapi.set_imol_refinement_map(imol_map)
+chapi.refine_residue_range(imol, chain_id="A", res_no_start=43, res_no_end=45, n_cycles=10)
+chapi.write_coordinates(imol, "tutorial-modern-ref.pdb")
 os.path.exists("tutorial-modern-ref.pdb")


### PR DESCRIPTION
This pull request updates the `run_test.py` script in the `recipes/coot-headless` directory to improve code clarity and consistency by directly using the `coot_headless_api` module instead of aliasing it as `chapi`.

Key change:

* Updated `run_test.py` to remove the alias `chapi` for `coot_headless_api` and directly use `coot_headless_api` for all method calls, improving code readability and reducing potential confusion.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
