### PR TITLE
Fix Python host version in `pyhmmer` recipe

### DIFF
--- a/recipes/pyhmmer/meta.yaml
+++ b/recipes/pyhmmer/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - cmake >=3.20
     - make
   host:
-    - python >={{ python_min }}
+    - python
     - pip
     - cython >=3.0
     - scikit-build-core
@@ -32,7 +32,7 @@ requirements:
 
 test:
   requires:
-    - python >={{ python_min }}
+    - python
     - importlib_resources #[py36 or py37 or py38]
     - pip
   imports:

--- a/recipes/pyhmmer/meta.yaml
+++ b/recipes/pyhmmer/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: f83e9a7d80f31713c52291b5c888dddb98c1e765222e064c40d56e87ad91cc4e
 
 build:
-  number: 0
+  number: 1
   skip: True  # [py2k or win]
   script: "{{ PYTHON }} -m pip install . --no-deps --no-build-isolation --no-cache-dir --use-pep517 -vvv"
   run_exports:
@@ -22,7 +22,7 @@ requirements:
     - cmake >=3.20
     - make
   host:
-    - python {{ python_min }}
+    - python >={{ python_min }}
     - pip
     - cython >=3.0
     - scikit-build-core
@@ -32,7 +32,7 @@ requirements:
 
 test:
   requires:
-    - python {{ python_min }}
+    - python >={{ python_min }}
     - importlib_resources #[py36 or py37 or py38]
     - pip
   imports:


### PR DESCRIPTION


I'm not sure if this is the fix, but as reported in https://github.com/althonos/pyhmmer/issues/91 the latest update in Bioconda somehow only supports Python 3.9. I think this is because of the version pinning introduced in the autobump for the last release (#56020).

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
