### PR TITLE
Update PARM to version 0.1.0

### DIFF
--- a/recipes/parm/meta.yaml
+++ b/recipes/parm/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "0.0.7" %}
-{% set sha256 = "5f6a94d86ba026ac816eae8e27fbec00d2b25a7c5f5729101474f758d7dcbcc9" %}
+{% set version = "0.1.0" %}
+{% set sha256 = "ebb888a3292383a96a3458519db65c43406919a66093760615f504973e28bca0" %}
 
 package:
   name: parm


### PR DESCRIPTION
We made a significant rework on PARM and now introduce **version 0.1.0**. 

### Key changes

* Make available all nine pre-trained models: AGS, HAP1, HCT116, HEK116, HepG2, K562, LNCaP, MCF7, and U2OS.
* Update the settings for input model: now, PARM deals with one cell/model at a time.
* Implement a batch system that significantly speeds up the prediction time.

### Other changes
* Add extra parameters for user-trained models (`type_loss`, `filter_size`)
* Improve logging and progress bar