### PR TITLE
Add YAME v1.0.0

### DIFF
--- a/recipes/yame/meta.yaml
+++ b/recipes/yame/meta.yaml
@@ -1,0 +1,40 @@
+{% set name = "yame" %}
+{% set version = "1.0.0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/zhou-lab/YAME/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 50c57fe1749f010e5a46083e1167f3c7f33344a9bd0e34028ad8a97a6167de9f
+
+build:
+  number: 0
+  script: |
+    make
+    mkdir -p $PREFIX/bin
+    cp yame $PREFIX/bin/
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - make
+  run:
+    - libgcc-ng  # or libcxx if it's C++
+
+test:
+  commands:
+    - yame --help
+
+about:
+  home: https://github.com/zhou-lab/YAME
+  license: MIT
+  license_file: LICENSE
+  summary: "YAME: Yet Another Methylation Extractor."
+
+extra:
+  recipe-maintainers:
+    - Hongxiang2023
+
+


### PR DESCRIPTION
### Description
Add Bioconda recipe for [YAME](https://github.com/zhou-lab/YAME), a command-line tool for extracting methylation information.

### Test
- Linted with `bioconda-utils lint`
- Built and passed local test: `yame --help`

### License
MIT

Maintainer: @Hongxiang2023
