### PR TITLE
Bumped STAR version in STAR-Fusion recipe

### DIFF
--- a/recipes/star-fusion/meta.yaml
+++ b/recipes/star-fusion/meta.yaml
@@ -10,7 +10,7 @@ source:
   url: https://github.com/STAR-Fusion/STAR-Fusion/releases/download/STAR-Fusion-v{{ version }}/STAR-Fusion-v{{ version }}.FULL.tar.gz
   sha256: {{ sha256 }}
 build:
-  number: 0
+  number: 1
   noarch: generic
   run_exports:
     - {{ pin_subpackage('star-fusion', max_pin="x") }}
@@ -33,7 +33,7 @@ requirements:
     - perl-uri
     - python
     - samtools <1.10
-    - star ==2.7.11a
+    - star ==2.7.11b
     - trinity <2.9
 
 test:


### PR DESCRIPTION
This PR bumps the pinned version of STAR in the STAR-Fusion recipe. The current version of STAR is `v2.7.11b,` but the version is pinned to `v2.7.11a` in the recipe.

I don't think there is a way to match both versions in conda because of the `a/b` thing, so my best solution is to make a separate build.