### PR TITLE
Pupmapper updated to v0.1.0

### DIFF
--- a/pupmapper/meta.yaml
+++ b/pupmapper/meta.yaml
@@ -1,0 +1,47 @@
+{% set name = "pupmapper" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/pupmapper-{{ version }}.tar.gz
+  sha256: 12eacaf6482b06a16556b3bc6d129614d34fe356de775846895ea1e393e73c6f
+
+build:
+  entry_points:
+    - pupmapper = pupmapper.__init__:main
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python >=3.8
+    - hatchling
+    - pip
+  run:
+    - python >=3.8
+    - pandas
+    - numpy
+    - tqdm
+    - bioframe >=0.7.2
+
+test:
+  imports:
+    - pupmapper
+  commands:
+    - pip check
+    - pupmapper --help
+  requires:
+    - pip
+
+about:
+  summary: Tool & python package for calculating genome wide pileup mappability
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - max

--- a/recipes/pupmapper/meta.yaml
+++ b/recipes/pupmapper/meta.yaml
@@ -13,8 +13,10 @@ build:
   entry_points:
     - pupmapper = pupmapper.__init__:main
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  script: {{ PYTHON }} -m pip install . -vvv --no-deps --no-build-isolation --no-cache-dir
   number: 0
+  run_exports:
+    - {{ pin_subpackage('pupmapper', max_pin="x.x.x") }}
 
 requirements:
   host:
@@ -27,21 +29,21 @@ requirements:
     - numpy
     - tqdm
     - bioframe >=0.7.2
-    - genmap = 1.3
+    - genmap =1.3
     - bigtools
 
 test:
   imports:
     - pupmapper
   commands:
-    - pip check
     - pupmapper --help
-  requires:
-    - pip
 
 about:
-  summary: Tool & python package for calculating genome wide pileup mappability
+  home: https://github.com/maxgmarin/pupmapper
+  dev_url: https://github.com/maxgmarin/pupmapper
+  summary: "Tool & python package for calculating genome wide pileup mappability."
   license: MIT
+  license_family: MIT
   license_file: LICENSE
 
 extra:

--- a/recipes/pupmapper/meta.yaml
+++ b/recipes/pupmapper/meta.yaml
@@ -1,0 +1,49 @@
+{% set name = "pupmapper" %}
+{% set version = "0.0.9" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/pupmapper-{{ version }}.tar.gz
+  sha256: 392f055a232f6ca5ebc789a61e4ab67c5e532b38b2eb9f5f176ac35d3dc28935
+
+build:
+  entry_points:
+    - pupmapper = pupmapper.__init__:main
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python >=3.8
+    - hatchling
+    - pip
+  run:
+    - python >=3.8
+    - pandas
+    - numpy
+    - tqdm
+    - bioframe >=0.7.2
+    - genmap = 1.3
+    - bigtools
+
+test:
+  imports:
+    - pupmapper
+  commands:
+    - pip check
+    - pupmapper --help
+  requires:
+    - pip
+
+about:
+  summary: Tool & python package for calculating genome wide pileup mappability
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - maxgmarin


### PR DESCRIPTION
Update recipe for pupmapper to use version 0.1.0 from pypi.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please update</code></td>
    <td>Merge the master branch into a PR.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
