### PR TITLE
Update mosdepth to use a different garbage collector

### DIFF
--- a/recipes/mosdepth/build.sh
+++ b/recipes/mosdepth/build.sh
@@ -20,9 +20,9 @@ if [[ "$(uname -m)" == "arm64" ]]; then
 	echo "gcc.options.linker %= \"\${gcc.options.linker} ${LDFLAGS}\"" >>  nim-2.2.*/config/nim.cfg
 	cat nim-2.2.*/config/nim.cfg
 
-	nimble --localdeps build -y --verbose -d:release
+	nimble --localdeps build -y --verbose -d:release --mm:refc
 else
-	nimble --localdeps build -y --verbose -d:release
+	nimble --localdeps build -y --verbose -d:release --mm:refc
 fi
 
 install -v -m 0755 mosdepth "${PREFIX}/bin"

--- a/recipes/mosdepth/meta.yaml
+++ b/recipes/mosdepth/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 4becd1e74a81ed590588ed2745ef7f1443d0a5aad35f9880a2d452d56a7227ff
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage('mosdepth', max_pin="x.x") }}
 


### PR DESCRIPTION
have mosdepth use the refc garbage collector since that's where it's tested.
----

