### PR TITLE
Build bx-python with Python 3.13 as well

### DIFF
--- a/recipes/bx-python/conda_build_config.yaml
+++ b/recipes/bx-python/conda_build_config.yaml
@@ -1,0 +1,27 @@
+# Required for making Python 3.13 builds
+# Remove again once bioconda supports Python 3.13
+zip_keys:
+  - python
+  - python_impl
+  - numpy
+
+python:
+  - 3.9.* *_cpython
+  - 3.10.* *_cpython
+  - 3.11.* *_cpython
+  - 3.12.* *_cpython
+  - 3.13.* *_cp313*
+
+python_impl:
+  - cpython
+  - cpython
+  - cpython
+  - cpython
+  - cpython
+
+numpy:
+  - 1.26
+  - 1.26
+  - 1.26
+  - 1.26
+  - 2.1

--- a/recipes/bx-python/meta.yaml
+++ b/recipes/bx-python/meta.yaml
@@ -11,9 +11,9 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 2
   script:
-    - {{ PYTHON }} setup.py build_ext --force  # [py<39]
+    - export CFLAGS="${CFLAGS} -O3 -fno-define-target-os-macros"  # [osx]
     - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --no-cache-dir -vvv
   run_exports:
     - {{ pin_subpackage(name|lower, max_pin='x.x') }}
@@ -24,8 +24,7 @@ requirements:
   host:
     - python
     - cython
-    - numpy  # [py<39]
-    - numpy >=1.25  # [py>=39]
+    - numpy >=1.25
     - pip
     - setuptools
     - zlib


### PR DESCRIPTION
- **Remove py<39 guards as no longer supported**
- **Build bx-python for Python 3.13 as well**

I will remove the extra conda build config file once Python 3.13 is supported by Bioconda.

Bx-python is required by bcbio-gff which in turn is required by augur, hence making a Python 3.13 build now this manual way.
