### PR TITLE
Update craq build script with expected relative paths

### DIFF
--- a/recipes/craq/build.sh
+++ b/recipes/craq/build.sh
@@ -15,6 +15,6 @@ ln -s ${CRAQ_DIR}/bin/craq ${PREFIX}/bin/craq
 # Add the `src` folder with scripts that are called by the main `craq` executable with a relative path
 mkdir -p ${PREFIX}/src
 for fn in ${CRAQ_DIR}/src/*; do
-  bn=$(basename fn)
+  bn=$(basename $fn)
   ln -s $fn ${PREFIX}/src/${bn}
 done

--- a/recipes/craq/build.sh
+++ b/recipes/craq/build.sh
@@ -11,3 +11,10 @@ chmod +x ${CRAQ_DIR}/bin/craq
 # Add the craq executable in the bin by softlinking the tool located in share.
 mkdir -p ${PREFIX}/bin
 ln -s ${CRAQ_DIR}/bin/craq ${PREFIX}/bin/craq
+
+# Add the `src` folder with scripts that are called by the main `craq` executable with a relative path
+mkdir -p ${PREFIX}/src
+for fn in ${CRAQ_DIR}/src/*; do
+  bn=$(basename fn)
+  ln -s $fn ${PREFIX}/src/${bn}
+done

--- a/recipes/craq/meta.yaml
+++ b/recipes/craq/meta.yaml
@@ -21,6 +21,7 @@ requirements:
     - perl >=5
     - python >=3.7
     - minimap2 >=2.17
+    - samtools >=1.3.1
     - python_circos
 
 test:

--- a/recipes/craq/meta.yaml
+++ b/recipes/craq/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   noarch: generic
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage('craq', max_pin="x") }}
 

--- a/recipes/craq/meta.yaml
+++ b/recipes/craq/meta.yaml
@@ -19,6 +19,7 @@ build:
 requirements:
   run:
     - perl >=5
+    - bc
     - python >=3.7
     - minimap2 >=2.17
     - samtools >=1.3.1


### PR DESCRIPTION
`craq` currently does not run as intended, because the `craq` executable expects scripts in the `CRAQ/src` folder to be in path relative to itself (relative paths are hardcoded in the `craq` scripts. However, when packaged in Conda, `craq` is called from a symlink in the Conda `${PREFIX}/bin/`, so the expected relative paths are broken. To fix this, the build script should symlink all scripts in `CRAQ/src` to `${PREFIX}/src`.


----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
