### PR TITLE
Add vcf-reformatter v0.2.0

### DIFF
--- a/recipes/vcf-reformatter/build.sh
+++ b/recipes/vcf-reformatter/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -euxo pipefail
+
+# Install using cargo
+cargo install --locked --root $PREFIX --path .

--- a/recipes/vcf-reformatter/meta.yaml
+++ b/recipes/vcf-reformatter/meta.yaml
@@ -1,0 +1,42 @@
+{% set name = "vcf-reformatter" %}
+{% set version = "0.2.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/flalom/vcf-reformatter/archive/v{{ version }}.tar.gz
+  sha256: 55328e241b61a3a399355fb243c20fd67720eaa43ad1b8ca564e0cdf3594ba36 
+
+build:
+  number: 0
+  skip: True  # [not linux and not osx]
+
+requirements:
+  build:
+    - {{ compiler('rust') }}
+    - cargo-bundle-licenses
+
+test:
+  commands:
+    - {{ name }} --help
+    - {{ name }} --version
+
+about:
+  home: https://github.com/flalom/vcf-reformatter
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: 'Fast VCF file parser and reformatter with VEP and SnpEff annotation support'
+  description: |
+    A Rust command-line tool for parsing and reformatting VCF (Variant Call Format) files, 
+    with support for VEP (Variant Effect Predictor) and SnpEff annotations. 
+    This tool flattens complex VCF files into tab-separated values (TSV) format 
+    for easier downstream analysis.
+  doc_url: https://github.com/flalom/vcf-reformatter/blob/main/README.md
+  dev_url: https://github.com/flalom/vcf-reformatter
+
+extra:
+  recipe-maintainers:
+    - flalom


### PR DESCRIPTION
This PR adds vcf-reformatter v0.2.0, a fast Rust tool for parsing and reformatting VCF files with VEP and SnpEff annotation support.

## Package Info
- **Homepage:** https://github.com/flalom/vcf-reformatter
- **License:** MIT
- **Summary:** Fast VCF file parser and reformatter with VEP and SnpEff annotation support

## Tests
- [x] Recipe builds successfully on macOS arm64
- [x] `vcf-reformatter --help` works
- [x] `vcf-reformatter --version` works

## Notes
This tool flattens complex VCF files into TSV format for easier downstream analysis in Excel, R, Python, etc.

## Additional Info
- Supports both VEP (CSQ) and SnpEff (ANN) annotations
- Built with Rust for high performance
- Available on crates.io: https://crates.io/crates/vcf-reformatter
