### PR TITLE
Update harpy preprocessing selector

### DIFF
--- a/recipes/harpy/meta.yaml
+++ b/recipes/harpy/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: '{{ sha256 }}'
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script_env:
     - SETUPTOOLS_SCM_PRETEND_VERSION={{ version }}
@@ -29,7 +29,7 @@ requirements:
     - pip
     - setuptools-scm >=3.4
   run:
-    - apptainer  # [linux]
+    - apptainer  # [not osx]
     - bcftools =1.22
     - conda >24.7
     - htslib =1.22

--- a/recipes/harpy/meta.yaml
+++ b/recipes/harpy/meta.yaml
@@ -1,27 +1,28 @@
+{% set name = "harpy" %}
 {% set version = "2.5.0" %}
 {% set sha256 = "81cf7eb16808efe13ae39c80c6ddf70fb475c3df34d2b163f50a65bdd3bc013f" %}
 
 package:
-  name: harpy
-  version: '{{ version }}'
+  name: {{ name }}
+  version: {{ version }}
 
 source:
   url: https://github.com/pdimens/harpy/releases/download/{{ version }}/harpy.{{ version }}.tar.gz
-  sha256: '{{ sha256 }}'
+  sha256: {{ sha256 }}
 
 build:
   number: 1
-  noarch: python
+  noarch: generic
   script_env:
     - SETUPTOOLS_SCM_PRETEND_VERSION={{ version }}
-  run_exports:
-    - {{ pin_subpackage('harpy', max_pin="x") }}
   script: |
     mkdir -p ${PREFIX}/bin
     ${PYTHON} -m pip install . --no-deps --no-build-isolation --no-cache-dir -vvv
     install -v -m 0755 harpy/bin/* ${PREFIX}/bin
   entry_points:
     - harpy = harpy.__main__:cli
+  run_exports:
+    - {{ pin_subpackage('harpy', max_pin="x") }}
 
 requirements:
   host:


### PR DESCRIPTION
@mencian I noticed that despite adding the `# [linux]` preprocessing selector to `apptainer`, it still tries to install it on a macOS system. Not sure if this will work or why it's still acting up, maybe you have ideas? See this log (Conda v25.5.1):
```
(base) person@hostname-MacBook-Pro ~ % conda create -n harpy -c bioconda -c conda-forge harpy=2.5.0
2 channel Terms of Service accepted
Channels:
 - bioconda
 - conda-forge
 - defaults
Platform: osx-arm64
Collecting package metadata (repodata.json): done
Solving environment: failed

LibMambaUnsatisfiableError: Encountered problems while solving:
  - nothing provides apptainer needed by harpy-2.5.0-pyhdfd78af_0

Could not solve for environment specs
The following package could not be installed
└─ harpy =2.5.0 * is not installable because it requires
   └─ apptainer =* *, which does not exist (perhaps a missing channel).
```

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
