### PR TITLE
checkm-genome: bump required pplacer version - to bring in linux-aarch64/osx-arm64

### DIFF
--- a/recipes/checkm-genome/meta.yaml
+++ b/recipes/checkm-genome/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: "{{ PYTHON }} -m pip install . --no-deps --no-build-isolation --no-cache-dir --use-pep517 -vvv"
   run_exports:
@@ -31,7 +31,7 @@ requirements:
     - dendropy >=4.5.2
     - hmmer >=3.1b1
     - prodigal >=2.6.1
-    - pplacer ==1.1.alpha19
+    - pplacer ==1.1.alpha20
     - wget
 
 test:


### PR DESCRIPTION

* set required pplacer version to 1.1-alpha20,  to bring in linux-aarch64/osx-arm64

