### PR TITLE
Set the version of samtools to >=1.2 for TEtrimmer package

### DIFF
--- a/recipes/tetrimmer/meta.yaml
+++ b/recipes/tetrimmer/meta.yaml
@@ -8,7 +8,7 @@ source:
   url: https://github.com/qjiangzhao/TEtrimmer/archive/v{{ version }}.tar.gz
   sha256: {{ sha256 }}
 build:
-  number: 0
+  number: 1
   noarch: generic
   run_exports:
     - {{ pin_subpackage('tetrimmer', max_pin="x") }}

--- a/recipes/tetrimmer/meta.yaml
+++ b/recipes/tetrimmer/meta.yaml
@@ -38,7 +38,7 @@ requirements:
     - repeatmodeler  
     - repeatmasker
     - requests
-    - samtools
+    - samtools >=1.2
     - scikit-learn
     - tk
     - urllib3


### PR DESCRIPTION

This PR updates the samtools runtime dependency in the TEtrimmer recipe to >=1.2.

### Motivation
TEtrimmer relies on samtools faidx to index FASTA genomes. When older versions of samtools (e.g., 0.1.19) are used, segmentation faults (error code -11) can occur during indexing, as reported in downstream usage.

By requiring samtools >=1.2, we ensure compatibility with current samtools versions (e.g., 1.20) and avoid runtime failures in TEtrimmer workflows.

### Changes
- Updated meta.yaml:
  
yaml
  - samtools >=1.2

### Bot commands for PR management

@BiocondaBot please add label
