### PR TITLE
Add afwdist

### DIFF
--- a/recipes/afwdist/meta.yaml
+++ b/recipes/afwdist/meta.yaml
@@ -1,0 +1,32 @@
+{% set name = "afwdist" %}
+{% set version = "1.0.0" %}
+{% set sha256 = "6ec8646f7117171b01b922500449da7e62ef05b2eb9b46eafdaf558c0b73df15" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: "https://github.com/PathoGenOmics-Lab/{{ name }}/archive/v{{ version }}.tar.gz"
+  sha256: "{{ sha256 }}"
+
+build:
+  number: 0
+  script: "cargo install --no-track --locked --verbose --root \"${PREFIX}\" --path ."
+  run_exports:
+    - pin_subpackage(name, max_pin="x.x")
+
+requirements:
+  build:
+    - {{ compiler('rust') }}
+
+test:
+  commands:
+    - afwdist --version
+
+about:
+  home: "https://github.com/PathoGenOmics-Lab/afwdist"
+  license: "GPL-3.0-only"
+  license_file: LICENSE
+  license_family: GPL3
+  summary: "A lightweight tool to calculate a pairwise distance metric based on fixed and non-fixed allele frequencies."


### PR DESCRIPTION
Add `afwdist`, a lightweight tool to calculate a pairwise distance metric based on fixed and non-fixed allele frequencies.
