### PR TITLE
Update remag to v0.1.5

### DIFF
--- a/recipes/remag/meta.yaml
+++ b/recipes/remag/meta.yaml
@@ -15,6 +15,8 @@ build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
     - remag = remag.cli:main
+  run_exports:
+    - {{ pin_subpackage('remag', max_pin="x.x") }}
 
 requirements:
   host:

--- a/recipes/remag/meta.yaml
+++ b/recipes/remag/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "remag" %}
-{% set version = "0.1.3" %}
+{% set version = "0.1.4" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 0dccd45bf4cc199e5ef573f903a4241396a8e90e78341d75210e4e0f252dcf2a
+  sha256: 0ad94ba0205a7c6ea9ab4b4de6570a3605faaa675bdf871fb5e241f74e5a5980
 
 build:
   number: 0

--- a/recipes/remag/meta.yaml
+++ b/recipes/remag/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "remag" %}
-{% set version = "0.1.4.post1" %}
+{% set version = "0.1.5" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: a4ff5d6963865308c962f82c00f70672375c54b35e50d49ebecbffe5c34537c9
+  sha256: a9a56c8783d6ab2f8df319036a4e803a88f02b42cc678d1d01e871437c230bd9
 
 build:
   number: 0

--- a/recipes/remag/meta.yaml
+++ b/recipes/remag/meta.yaml
@@ -15,8 +15,6 @@ build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
     - remag = remag.cli:main
-  run_exports:
-    - {{ pin_subpackage('remag', max_pin='x.x') }}
 
 requirements:
   host:
@@ -55,9 +53,9 @@ about:
   home: https://github.com/danielzmbp/remag
   summary: 'Recovery of high-quality eukaryotic genomes from complex metagenomes'
   description: |
-    REMAG is a specialized metagenomic binning tool designed for recovering
-    high-quality eukaryotic genomes from mixed prokaryotic-eukaryotic samples.
-    It uses contrastive learning with Siamese neural networks to generate
+    REMAG is a specialized metagenomic binning tool designed for recovering 
+    high-quality eukaryotic genomes from mixed prokaryotic-eukaryotic samples. 
+    It uses contrastive learning with Siamese neural networks to generate 
     meaningful contig embeddings for clustering.
   license: MIT
   license_family: MIT

--- a/recipes/remag/meta.yaml
+++ b/recipes/remag/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "remag" %}
-{% set version = "0.1.4" %}
+{% set version = "0.1.4.post1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 0ad94ba0205a7c6ea9ab4b4de6570a3605faaa675bdf871fb5e241f74e5a5980
+  sha256: a4ff5d6963865308c962f82c00f70672375c54b35e50d49ebecbffe5c34537c9
 
 build:
   number: 0

--- a/recipes/remag/meta.yaml
+++ b/recipes/remag/meta.yaml
@@ -40,6 +40,8 @@ requirements:
     - xgboost >=1.6.0
     - joblib >=1.1.0
     - psutil >=5.8.0
+    - leidenalg >=0.9.0
+    - python-igraph >=0.10.0
     - biopython
 
 test:


### PR DESCRIPTION
**Supersedes #58368**

This PR updates REMAG to version v0.1.5 and fixes the failing tests by adding missing dependencies that were not included in the automated bump.

**Missing dependencies added:**
- `python-igraph >=0.10.0` - Required for Leiden clustering functionality  
- `leidenalg >=0.9.0` - Clustering algorithm

**Fixes:**
- Resolves `ModuleNotFoundError: No module named 'igraph'` that was causing test failures in #58368
- Updates to latest version with all required dependencies

REMAG is a specialized metagenomic binning tool designed for recovering high-quality eukaryotic genomes from mixed prokaryotic-eukaryotic samples.

- **homepage**: https://github.com/danielzmbp/remag
- **documentation**: https://github.com/danielzmbp/remag#readme
- **doi**: [10.5281/zenodo.16443991](https://doi.org/10.5281/zenodo.16443991)