### PR TITLE
Update minute 0.12.1 environment

### DIFF
--- a/recipes/minute/meta.yaml
+++ b/recipes/minute/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 502d4eae1bd7182f5bf3c8b993fe2d6ba01d713ee07bff014a9bfd59029f9d78
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: "{{ PYTHON }} -m pip install . --no-deps --no-build-isolation --no-cache-dir -vvv"
   run_exports:


### PR DESCRIPTION
This update includes recent changes in the conda enviornment for minute 0.12.1.

- Removed stale dependency igvtools
- Updated software to more recent versions: cutadapt, MultiQC, bowtie2 and picard.
- Pinned click to 8.2.1: 8.2.2 triggers an issue in MultiQC 1.30 possibly similar to https://github.com/MultiQC/MultiQC/issues/3292 
