### PR TITLE
Add psipred v3.5

### DIFF
--- a/recipes/psipred/build.sh
+++ b/recipes/psipred/build.sh
@@ -12,7 +12,7 @@ sed -i \
     -e '/^void[[:space:]]\+\*calloc.*malloc.*;/d' \
     -e 's|main|int main|' \
     sspred_avpred.c
-make
+make -j "${CPU_COUNT}"
 make install
 popd
 install -m 755 bin/* "${PREFIX}/bin"

--- a/recipes/psipred/build.sh
+++ b/recipes/psipred/build.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+mkdir -p "${PREFIX}/share/${PKG_NAME}/data"
+install -m 644 data/* "${PREFIX}/share/${PKG_NAME}/data"
+mkdir -p "${PREFIX}/bin"
+rm bin/*
+
+pushd src
+sed -i \
+    -e '1i#include <stdlib.h>' \
+    -e '/^void[[:space:]]\+\*calloc.*malloc.*;/d' \
+    -e 's|main|int main|' \
+    sspred_avpred.c
+make
+make install
+popd
+install -m 755 bin/* "${PREFIX}/bin"
+
+sed -i \
+  -e 's|#!/bin/tcsh|#!/usr/bin/env tcsh|' \
+  -e 's|set execdir = ./bin|set execdir = $CONDA_PREFIX/bin|' \
+  -e 's|set datadir = ./data|set datadir = $CONDA_PREFIX/share/psipred/data|' \
+  runpsipred_single
+
+sed -i \
+  -e 's|#!/bin/tcsh|#!/usr/bin/env tcsh|' \
+  -e 's|set ncbidir = /usr/local/bin|set ncbidir = $CONDA_PREFIX/bin|' \
+  -e 's|set execdir = ./bin|set execdir = $CONDA_PREFIX/bin|' \
+  -e 's|set datadir = ./data|set datadir = $CONDA_PREFIX/share/psipred/data|' \
+  runpsipred
+
+sed -i \
+  -e 's|#!/bin/tcsh|#!/usr/bin/env tcsh|' \
+  -e 's|set ncbidir = /usr/local/bin|set ncbidir = $CONDA_PREFIX/bin|' \
+  -e 's|set execdir = ../bin|set execdir = $CONDA_PREFIX/bin|' \
+  -e 's|set datadir = ../data|set datadir = $CONDA_PREFIX/share/psipred/data|' \
+  BLAST+/runpsipredplus
+
+install -m 755 runpsipred_single runpsipred BLAST+/runpsipredplus "${PREFIX}/bin"

--- a/recipes/psipred/build.sh
+++ b/recipes/psipred/build.sh
@@ -6,6 +6,7 @@ mkdir -p "${PREFIX}/bin"
 rm bin/*
 
 pushd src
+sed -i '/CC.*= cc/d' Makefile
 sed -i \
     -e '1i#include <stdlib.h>' \
     -e '/^void[[:space:]]\+\*calloc.*malloc.*;/d' \

--- a/recipes/psipred/meta.yaml
+++ b/recipes/psipred/meta.yaml
@@ -59,3 +59,5 @@ extra:
     - osx-arm64
   identifiers:
     - doi:10.1006/jmbi.1999.3091
+  recipe-maintainers:
+    - eunos-1128

--- a/recipes/psipred/meta.yaml
+++ b/recipes/psipred/meta.yaml
@@ -1,0 +1,61 @@
+{% set name = "PSIPRED" %}
+{% set version = "3.5" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/psipred/{{ name|lower }}/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 4b6e30b213354989101176b336ada4221560f47d6dde0723c74f19629e7f1ba4
+
+build:
+  number: 0
+  run_exports: []
+
+requirements:
+  build:
+    - {{ compiler("c") }}
+    - make
+    - sed  # [osx]
+  run:
+    - blast-legacy
+    - tcsh
+
+test:
+  commands:
+    - chkparse 2>&1 | grep -q 'chkparse'
+    - pfilt 2>&1 | grep -q 'pfilt'
+    - psipass2 2>&1 | grep -q 'psipass2'
+    - psipred 2>&1 | grep -q 'psipred'
+    - seq2mtx 2>&1 | grep -q 'seq2psi'
+  source_files:
+    - example/*
+
+about:
+  home: https://bioinf.cs.ucl.ac.uk/psipred
+  dev_url: https://github.com/psipred/psipred
+  doc_url: https://github.com/psipred/psipred/blob/v{{ version }}/README
+  license: "CUSTOM (academic-only)"
+  license_family: OTHER
+  license_file: LICENSE
+  summary: "Protein Secondary Structure Predictor"
+  description: |
+    PSIPRED is a  simple and accurate secondary structure prediction method, incorporating two feed-forward neural networks which perform an analysis on output obtained from
+    [PSI-BLAST](http://www.ncbi.nlm.nih.gov/blast) (Position Specific Iterated - BLAST).
+    Using a very stringent cross validation method to evaluate the method's performance, PSIPRED 3.2 achieves an average Q3 score of 81.6%.
+    Predictions produced by PSIPRED were also submitted to the [CASP4](http://predictioncenter.llnl.gov/casp4/) evaluation and assessed during the CASP4 meeting, which took place in December 2000 at Asilomar.
+    PSIPRED 2.0 achieved an average Q3 score of 80.6% across all 40 submitted target domains with no obvious sequence similarity to structures present in PDB, which ranked PSIPRED top out of 20 evaluated methods
+    (an earlier version of PSIPRED was also ranked top in CASP3 held in 1998).
+    It is important to realise, however, that due to the small sample sizes, the results from CASP are not statistically significant, although they do give a rough guide as to the current "state of the art".
+    For a more reliable evaluation, the [EVA](http://pdg.cnb.uam.es/eva/) web site at Columbia University provides a continuous evaluation. NOTE that at the time of writing, the EVA site is no longer being updated.
+    Downloads: The PSIPRED V3.2 software can be downloaded from [HERE](http://bioinfadmin.cs.ucl.ac.uk/downloads/psipred/).
+    Please note that you should read the license terms given in the [README](http://bioinfadmin.cs.ucl.ac.uk/downloads/psipred/README) file if you wish to incorporate PSIPRED in another program or Web server.
+    Older releases of PSIPRED can be downloaded here [HERE](http://bioinfadmin.cs.ucl.ac.uk/downloads/psipred/old/).
+
+extra:
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64
+  identifiers:
+    - doi:10.1006/jmbi.1999.3091

--- a/recipes/psipred/run_test.sh
+++ b/recipes/psipred/run_test.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env tcsh
+
+runpsipred_single example/example.fasta
+cat example.ss2
+cat example.horiz


### PR DESCRIPTION
This pull request adds a new conda recipe for the PSIPRED protein secondary structure prediction tool, enabling it to be built and installed within a conda environment. The new recipe includes build scripts, metadata, and tests to ensure correct installation and operation. The most important changes are grouped below:

**Recipe and Build System Integration:**

* Added a new `meta.yaml` file describing the PSIPRED package, its dependencies, source, license, and test commands for conda packaging.
* Introduced a `build.sh` script to automate building, patching, and installing PSIPRED binaries and data files in the correct conda locations, including adapting scripts for conda environments.

**Testing and Validation:**

* Added a `run_test.sh` script to verify that PSIPRED runs correctly after installation by processing an example FASTA file and displaying output files.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
