### PR TITLE
Add ddquint recipe (v0.1.0)

### DIFF
--- a/recipes/ddquint/meta.yaml
+++ b/recipes/ddquint/meta.yaml
@@ -10,6 +10,9 @@ source:
   sha256: b4a9d5e0f5d53edc860a6e0516a23894bd13765b5a7a5150975d97574f029241
 
 build:
+  number: 0
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x.x") }}
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
 
@@ -26,7 +29,7 @@ requirements:
     - pandas >=1.0
     - scikit-learn >=0.24
     - hdbscan >=0.8.27
-    - matplotlib >=3.3
+    - matplotlib-base >=3.3
     - seaborn >=0.13
     - openpyxl >=3.0.5
     - wxpython >=4.1.0

--- a/recipes/ddquint/meta.yaml
+++ b/recipes/ddquint/meta.yaml
@@ -1,0 +1,50 @@
+{% set name = "ddquint" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: b4a9d5e0f5d53edc860a6e0516a23894bd13765b5a7a5150975d97574f029241
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - python >=3.10
+    - pip
+    - setuptools >=68
+    - wheel
+  run:
+    - python >=3.10
+    - numpy >=1.18
+    - scipy >=1.11
+    - pandas >=1.0
+    - scikit-learn >=0.24
+    - hdbscan >=0.8.27
+    - matplotlib >=3.3
+    - seaborn >=0.13
+    - openpyxl >=3.0.5
+    - wxpython >=4.1.0
+    - colorama >=0.4.4
+    - tqdm >=4.60.0
+    - send2trash >=1.8.2
+
+test:
+  commands:
+    - ddquint --help
+
+about:
+  home: https://github.com/globuzzz2000/ddQuint
+  license: MIT
+  license_file: LICENSE
+  summary: Droplet Digital PCR Multiplex Analysis for chromosomal copy number detection
+  dev_url: https://github.com/globuzzz2000/ddQuint
+
+extra:
+  recipe-maintainers:
+    - globuzzz2000


### PR DESCRIPTION
**Package name:** ddquint
**Version:** 0.1.0
**License:** MIT
**Summary:** Droplet Digital PCR Multiplex Analysis for chromosomal copy number detection
**Home:** https://github.com/globuzzz2000/ddQuint
**PyPI:** https://pypi.org/project/ddquint/
**Source:** https://pypi.io/packages/source/d/ddquint/ddquint-0.1.0.tar.gz
**SHA256:** b4a9d5e0f5d53edc860a6e0516a23894bd13765b5a7a5150975d97574f029241

**Build:**
- noarch: python
- installs from PyPI sdist via pip

**Run deps (conda):**
python>=3.10, numpy, scipy, pandas, scikit-learn, hdbscan, matplotlib, seaborn, openpyxl, wxpython, colorama, tqdm, send2trash

**Test:**
- `ddquint --help` passes locally with `conda mambabuild`