### PR TITLE
Add distree recipe

### DIFF
--- a/recipes/distree/meta.yaml
+++ b/recipes/distree/meta.yaml
@@ -1,0 +1,32 @@
+{% set name = "distree" %}
+{% set version = "1.0.0" %}
+{% set sha256 = "ac529cc942d854246b77fc0ebe808c20394bd42cb3c195d0c8578edf92616e92" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: "https://github.com/PathoGenOmics-Lab/{{ name }}/archive/v{{ version }}.tar.gz"
+  sha256: "{{ sha256 }}"
+
+build:
+  number: 0
+  script: "cargo install --no-track --verbose --root \"${PREFIX}\" --path ."
+  run_exports:
+    - pin_subpackage(name, max_pin="x.x")
+
+requirements:
+  build:
+    - {{ compiler('rust') }}
+
+test:
+  commands:
+    - distree --version
+
+about:
+  home: "https://github.com/PathoGenOmics-Lab/distree"
+  license: "GPL-3.0-only"
+  license_file: LICENSE
+  license_family: GPL3
+  summary: "A tool to calculate distances between phylogenetic trees."


### PR DESCRIPTION
Add distree,  a command-line tool written in Rust that extracts a distance matrix from a phylogenetic tree in Newick format. It is designed to handle large trees with thousands of sequences by using a low-memory, parallelized approach.

