### PR TITLE
Add samtools dependency to PBSIM3

### DIFF
--- a/recipes/pbsim3/meta.yaml
+++ b/recipes/pbsim3/meta.yaml
@@ -26,7 +26,10 @@ requirements:
     - automake
     - m4
   host:
-
+    - samtools >=1.10
+  run:
+    - samtools >=1.10
+    
 test:
   commands:
     - "pbsim 2>&1 | grep -q 'USAGE: pbsim'"


### PR DESCRIPTION
This PR adds samtools (>=1.10) to both host and run requirements
to fix missing dependency in the conda package.