### PR TITLE
Update cuna to 0.3.0: PIN POD5=0.3.23 AND PYARROW=20.0.0

### DIFF
--- a/recipes/cuna/meta.yaml
+++ b/recipes/cuna/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "CUNA" %}
-{% set version = "0.2.0" %}
+{% set version = "0.3.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/iris1901/CUNA/archive/v{{ version }}.tar.gz
-  sha256: 45d3b82daa2b50d3aeb82b608e91e899792b4d4adab2249aaa309dcb3bc75939
+  sha256: f013ddfdf48948bcc5918f014bda7c6269793951b0c45147de6973a1108edc84
 
 build:
   number: 0
@@ -36,7 +36,8 @@ requirements:
     - pandas
     - scipy
     - scikit-learn
-    - pod5
+    - pyarrow =20.0.0
+    - pod5 =0.3.23
 
 test:
   commands:


### PR DESCRIPTION
### Update CUNA to v0.3.0

**Motivation:**
- Fix bug in main script from previous release.
- Prevent incompatibility issues with newer pod5/pyarrow.

**Changes in this PR:**
- Updated to upstream release v0.3.0.
- Pinned runtime dependencies:
  - pod5 =0.3.23
  - pyarrow =20.0.0
- These versions are known to work together without API/ABI issues.

**Testing:**
- Clean env resolves and CLI runs.
- `cuna --help` OK.
- `import pyarrow, pod5` prints 20.0.0 and 0.3.23.