### PR TITLE
Update cuna 0.3.0 pin pyarrow

### DIFF
--- a/recipes/cuna/meta.yaml
+++ b/recipes/cuna/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "CUNA" %}
-{% set version = "0.2.0" %}
+{% set version = "0.3.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/iris1901/CUNA/archive/v{{ version }}.tar.gz
-  sha256: 45d3b82daa2b50d3aeb82b608e91e899792b4d4adab2249aaa309dcb3bc75939
+  sha256: f013ddfdf48948bcc5918f014bda7c6269793951b0c45147de6973a1108edc84
 
 build:
   number: 0
@@ -36,7 +36,8 @@ requirements:
     - pandas
     - scipy
     - scikit-learn
-    - pod5
+    - pyarrow =20.0.0
+    - pod5 =0.3.23
 
 test:
   commands:

--- a/recipes/cuna/meta.yaml
+++ b/recipes/cuna/meta.yaml
@@ -37,7 +37,7 @@ requirements:
     - scipy
     - scikit-learn
     - pyarrow =20.0.0
-    - pod5 =0.3.23
+    - pod5
 
 test:
   commands:


### PR DESCRIPTION
- Pin pyarrow =20.0.0 to avoid incompatibilities.
- Keep pod5 without version to use default available in bioconda/conda-forge.