### PR TITLE
Update ESME to PSMPI-5.12.1

### DIFF
--- a/recipes/esme/conda_build_config.yaml
+++ b/recipes/esme/conda_build_config.yaml
@@ -5,5 +5,5 @@ mpi:
 # - mpich=4.3.1
 # - mpich=4.3.0
 # - mpich=4.2.3
-# - psmpi=5.10.0
-  - mvapich=4.0
+# - mvapich=4.0
+  - psmpi=5.12.1

--- a/recipes/esme/meta.yaml
+++ b/recipes/esme/meta.yaml
@@ -5,12 +5,12 @@
 {% set netcdf_fortran_version = "4.6.2" %}
 {% set pio_version = "2.6.6" %}
 {% set pio_pkg_version = pio_version.replace('.', '_') %}
-{% set esmf_version = "8.8.1" %}
+{% set esmf_version = "8.9.0" %}
 {% set omb_version = "7.5.1" %}
 {% set build = 0 %}
 
 # BUILD TRIGGER - manually change this for each MPI variant to force bioconda rebuild
-{% set build_trigger = "mvapich_ofi" %}  # Change to: openmpi, mpich, psmpi or mvapich_ucx/mvapich_ofi
+{% set build_trigger = "psmpi" %}  # Change to: openmpi, mpich, psmpi or mvapich_ucx/mvapich_ofi
 
 # Simple type-safe parsing
 {% if mpi and mpi is string %}
@@ -48,7 +48,7 @@ package:
 build:
   number: {{ build }}
   string: {{ mpi_name }}_{{ mpi_build_variant }}_h{{ PKG_HASH }}_{{ build }}
-  skip: true  # [not (linux and (x86_64 or aarch64))]
+  skip: true  # [not ((linux and (build_trigger != 'psmpi') and (x86_64 or aarch64)) or (linux and (build_trigger == 'psmpi') and (x86_64)))]
   ignore_run_exports:
     - libacl
     - libstdcxx
@@ -73,7 +73,7 @@ source:
     sha256: e32e018a521d38c9424940c7cfa7e9b1931b605f3511ee7ab3a718b69faeeb04  # 2.6.6
     folder: esme_pio
   - url: https://github.com/esmf-org/esmf/archive/refs/tags/v{{ esmf_version }}.tar.gz
-    sha256: b0acb59d4f000bfbdfddc121a24819bd2a50997c7b257b0db2ceb96f3111b173  # 8.8.1
+    sha256: 586e0101d76ff9842d9ad43567fae50317ee794d80293430d9f1847dec0eefa5  # 8.9.0
     folder: esme_esmf
   - url: https://mvapich.cse.ohio-state.edu/download/mvapich/osu-micro-benchmarks-{{ omb_version }}.tar.gz
     sha256: 160d0d5e3c3cb022520ecb247e9875bb0973b1d3cadccd6c17624f8407c52e22  # 7.5.1


### PR DESCRIPTION
This pull request is to update ESME to the latest version of PSMPI (5.12.1) that has been rebuilt on conda-forge with sysroot pinning to glibc 2.17 for CentOS 7 compatibility.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
