### PR TITLE
Add sadie-antibody 2.0.0

### DIFF
--- a/recipes/sadie-antibody/meta.yaml
+++ b/recipes/sadie-antibody/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 0
   noarch: python
-  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vv"
+  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
   entry_points:
     - sadie = sadie.app:sadie
   run_exports:
@@ -24,7 +24,6 @@ requirements:
     - pip
   run:
     - python >=3.9,<3.14
-    - pip
     - biopython >=1.84
     - click >=8.0,<8.2
     - filetype >=1.2.0
@@ -33,6 +32,7 @@ requirements:
     - pydantic >=2.0.0,<3.0.0
     - python-levenshtein >=0.27.0
     - pyarrow >=20.0.0
+    - semantic-version >=2.10.0
     - pyyaml >=6.0
     - scikit-learn >=1.5.0
     - openpyxl >=3.1.0
@@ -63,3 +63,4 @@ about:
 extra:
   recipe-maintainers:
     - jwillis0720
+    - tmsincomb

--- a/recipes/sadie-antibody/meta.yaml
+++ b/recipes/sadie-antibody/meta.yaml
@@ -1,0 +1,65 @@
+{% set name = "sadie-antibody" %}
+{% set version = "2.0.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/jwillis0720/sadie/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 29b3390b86bb6d16468c5ce4446e5f79e1bd0d0958efbc045d60b46f8e950e60
+
+build:
+  number: 0
+  noarch: python
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vv"
+  entry_points:
+    - sadie = sadie.app:sadie
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x.x") }}
+
+requirements:
+  host:
+    - python >=3.9,<3.14
+    - pip
+  run:
+    - python >=3.9,<3.14
+    - pip
+    - biopython >=1.84
+    - click >=8.0,<8.2
+    - filetype >=1.2.0
+    - pandas >=2.3,<3
+    - requests >=2.32.0
+    - pydantic >=2.0.0,<3.0.0
+    - python-levenshtein >=0.27.0
+    - pyarrow >=20.0.0
+    - pyyaml >=6.0
+    - scikit-learn >=1.5.0
+    - openpyxl >=3.1.0
+    - yarl >=1.9.0
+    - ipython >=8.18.0
+    - pyhmmer >=0.11.1
+    - scipy >=1.11.0
+    - rich >=14.1.0
+
+test:
+  imports:
+    - sadie
+    - sadie.airr
+  commands:
+    - sadie --help
+  requires:
+    - pip
+
+about:
+  home: https://sadie.jordanrwillis.com
+  dev_url: https://github.com/jwillis0720/sadie
+  license: MIT
+  summary: "The Complete Antibody Library"
+  description: |
+    SADIE (Sequencing Analysis and Data library for Immunoinformatics Exploration) provides
+    command-line apps and a Python API for antibody/AIRR analyses.
+
+extra:
+  recipe-maintainers:
+    - jwillis0720

--- a/recipes/sadie-antibody/meta.yaml
+++ b/recipes/sadie-antibody/meta.yaml
@@ -66,3 +66,5 @@ extra:
   recipe-maintainers:
     - jwillis0720
     - tmsincomb
+    - kipkurui
+    

--- a/recipes/sadie-antibody/meta.yaml
+++ b/recipes/sadie-antibody/meta.yaml
@@ -22,6 +22,7 @@ requirements:
   host:
     - python >=3.9,<3.14
     - pip
+    - poetry-core
   run:
     - python >=3.9,<3.14
     - pip

--- a/recipes/sadie-antibody/meta.yaml
+++ b/recipes/sadie-antibody/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 0
   noarch: python
-  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vv"
   entry_points:
     - sadie = sadie.app:sadie
   run_exports:
@@ -24,6 +24,7 @@ requirements:
     - pip
   run:
     - python >=3.9,<3.14
+    - pip
     - biopython >=1.84
     - click >=8.0,<8.2
     - filetype >=1.2.0
@@ -32,7 +33,6 @@ requirements:
     - pydantic >=2.0.0,<3.0.0
     - python-levenshtein >=0.27.0
     - pyarrow >=20.0.0
-    - semantic-version >=2.10.0
     - pyyaml >=6.0
     - scikit-learn >=1.5.0
     - openpyxl >=3.1.0

--- a/recipes/sadie-antibody/meta.yaml
+++ b/recipes/sadie-antibody/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 0
   noarch: python
-  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vv"
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --no-cache-dir -vv
   entry_points:
     - sadie = sadie.app:sadie
   run_exports:
@@ -27,6 +27,7 @@ requirements:
     - python >=3.9,<3.14
     - pip
     - biopython >=1.84
+    - semantic_version
     - click >=8.0,<8.2
     - filetype >=1.2.0
     - pandas >=2.3,<3


### PR DESCRIPTION
## Summary
- Adds sadie-antibody v2.0.0 to bioconda
- SADIE (Sequencing Analysis and Data library for Immunoinformatics Exploration) provides command-line apps and a Python API for antibody/AIRR analyses

## Package Information
- **Homepage**: https://sadie.jordanrwillis.com
- **Source**: https://github.com/jwillis0720/sadie
- **License**: MIT
- **Version**: 2.0.0

## Notes
- Package installs from PyPI source tarball
- Removed semantic-version from conda dependencies (will be installed via pip)
- All other dependencies are available in conda-forge/bioconda

## Checklist
- [x] Recipe follows bioconda guidelines
- [x] Package builds locally with bioconda-utils
- [ ] CircleCI tests pass