### PR TITLE
Add bioconda recipe for varpubs 0.1.1

### DIFF
--- a/recipes/varpubs/meta.yaml
+++ b/recipes/varpubs/meta.yaml
@@ -1,0 +1,52 @@
+{% set name = "varpubs" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/koesterlab/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 0a1674e674e89f796235e61947315e2996b301737c4af8010d5d8bbad4e1e15f
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . --no-deps -vv
+
+requirements:
+  host:
+    - python >=3.11
+    - pip
+  run:
+    - python >=3.11
+    - sqlmodel >=0.0.24,<0.0.25
+    - sqlalchemy >=2.0.39,<3
+    - duckdb-engine >=0.15.0,<0.16
+    - duckdb >=1.2.1,<2
+    - typed-argument-parser >=1.10.1,<2
+    - simple-parsing
+    - biopython >=1.85,<2
+    - openai >=1.97.0,<2
+    - cyvcf2 >=0.31.1,<0.32
+
+test:
+  imports:
+    - varpubs
+  commands:
+    - varpubs --help
+
+about:
+  home: https://github.com/koesterlab/varpubs
+  license: MIT
+  license_file: LICENSE
+  summary: "Tool for finding PubMed evidence on genetic variants and generating LLM-based summaries"
+  maintainers:
+    - ilmaytas
+    - fxwiegand
+    - johanneskoester
+
+extra:
+  recipe-maintainers:
+    - fxwiegand
+    - johanneskoester

--- a/recipes/varpubs/meta.yaml
+++ b/recipes/varpubs/meta.yaml
@@ -20,6 +20,7 @@ requirements:
   host:
     - python >=3.11
     - pip
+    - hatchling
   run:
     - python >=3.11
     - sqlmodel >=0.0.24,<0.0.25

--- a/recipes/varpubs/meta.yaml
+++ b/recipes/varpubs/meta.yaml
@@ -13,6 +13,8 @@ build:
   number: 0
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps -vv
+  run_exports:
+      - {{ pin_subpackage(name, max_pin="x.x") }}
 
 requirements:
   host:

--- a/recipes/varpubs/meta.yaml
+++ b/recipes/varpubs/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "varpubs" %}
-{% set version = "0.1.0" %}
+{% set version = "0.1.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/koesterlab/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 0a1674e674e89f796235e61947315e2996b301737c4af8010d5d8bbad4e1e15f
+  sha256: 0eb542913c46df9d7e7b01ff72cdad5718d6009c3f61fecb70080d9499ed13eb
 
 build:
   number: 0


### PR DESCRIPTION
This pull request adds a new conda recipe for `varpubs`, which is a tool for finding PubMed evidence on genetic variants and generating LLM-based summaries.