### PR TITLE
Add recipe for cdst v0.2.1

### DIFF
--- a/recipes/cdst/meta.yaml
+++ b/recipes/cdst/meta.yaml
@@ -2,17 +2,19 @@
 {% set version = "0.2.1" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/c/cdst-genome/cdst-genome-{{ version }}.tar.gz
-  sha256: 5e6cd3827a54336679eba86be259de17ae9dfbba671e54ff60e9c257eb62271
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/cdst_genome-{{ version }}.tar.gz
+  sha256: 5e6cd3827a54336679eba86be259de17ae9dfbba671e54ff60e9c257eb62271c
 
 build:
-  noarch: python
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
+  noarch: python
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --no-cache-dir -vvv
+  entry_points:
+    - cdst = cdst.cli:main
   run_exports:
     - {{ pin_subpackage(name, max_pin="x.x") }}
 
@@ -20,6 +22,7 @@ requirements:
   host:
     - python >=3.9
     - pip
+    - setuptools
   run:
     - python >=3.9
     - biopython >=1.85
@@ -32,10 +35,12 @@ test:
     - cdst --help
 
 about:
-  home: https://github.com/l1-mh/CDST
-  license: GPL-3.0-only
+  home: "https://github.com/l1-mh/CDST"
+  license: "GPL-3.0-only"
+  license_family: GPL3
   license_file: LICENSE
   summary: "CoDing Sequence Typer (CDST): MD5 hash-based genome typing and clustering."
+  dev_url: "https://github.com/l1-mh/CDST"
 
 extra:
   recipe-maintainers:

--- a/recipes/cdst/meta.yaml
+++ b/recipes/cdst/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/cdst_genome-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/cdst_genome/cdst_genome-{{ version }}.tar.gz
   sha256: 5e6cd3827a54336679eba86be259de17ae9dfbba671e54ff60e9c257eb62271c
 
 build:

--- a/recipes/cdst/meta.yaml
+++ b/recipes/cdst/meta.yaml
@@ -1,0 +1,46 @@
+{% set name = "cdst" %}
+{% set version = "0.2.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/l1-mh/CDST/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 43572c9ee27fdf30c34d902aaa6219afc82742dda0d68cee2a314a8bbe0105c1
+
+build:
+  noarch: python
+  script: python -m pip install . --no-deps --ignore-installed -vvv
+
+requirements:
+  host:
+    - python >=3.8
+    - pip
+  run:
+    - python >=3.8
+    - biopython ==1.85
+    - pandas ==2.2.2
+    - scipy ==1.13.1
+    - scikit-learn ==1.5.1
+    - networkx ==3.3
+    - matplotlib >=3.9
+    - joblib ==1.4.*
+
+test:
+  commands:
+    - cdst --help
+
+about:
+  home: https://github.com/l1-mh/CDST
+  license: GPL-3.0
+  license_file: LICENSE
+  summary: "CoDing Sequence Typer (CDST): a decentralized, hash-based bacterial genome typing pipeline"
+  description: |
+    CDST is a fully decentralized MD5-hash–based framework that indexes predicted coding sequences (CDSs) 
+    and computes pairwise genomic distances without locus annotation or a central database.
+  dev_url: https://github.com/l1-mh/CDST
+
+extra:
+  recipe-maintainers:
+    - l1-mh

--- a/recipes/cdst/meta.yaml
+++ b/recipes/cdst/meta.yaml
@@ -7,10 +7,13 @@ package:
 
 source:
   url: https://github.com/l1-mh/CDST/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 43572c9ee27fdf30c34d902aaa6219afc82742dda0d68cee2a314a8bbe0105c1
+  sha256: <FILL-IN-SHA256-HERE>
 
 build:
   noarch: python
+  number: 0
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x.x") }}
   script: python -m pip install . --no-deps --ignore-installed -vvv
 
 requirements:
@@ -24,7 +27,7 @@ requirements:
     - scipy ==1.13.1
     - scikit-learn ==1.5.1
     - networkx ==3.3
-    - matplotlib >=3.9
+    - matplotlib-base >=3.9
     - joblib ==1.4.*
 
 test:
@@ -37,10 +40,10 @@ about:
   license_file: LICENSE
   summary: "CoDing Sequence Typer (CDST): a decentralized, hash-based bacterial genome typing pipeline"
   description: |
-    CDST is a fully decentralized MD5-hash–based framework that indexes predicted coding sequences (CDSs) 
+    CDST is a fully decentralized MD5-hash–based framework that indexes predicted coding sequences (CDSs)
     and computes pairwise genomic distances without locus annotation or a central database.
   dev_url: https://github.com/l1-mh/CDST
 
 extra:
   recipe-maintainers:
-    - l1-mh
+    - <your-github-username>

--- a/recipes/cdst/meta.yaml
+++ b/recipes/cdst/meta.yaml
@@ -14,12 +14,15 @@ build:
   number: 0
   run_exports:
     - {{ pin_subpackage(name, max_pin="x.x") }}
-  script: python -m pip install . --no-deps --ignore-installed -vvv
+  # 关键：关闭构建隔离，使用 host 里的 setuptools/wheel
+  script: python -m pip install . --no-deps --no-build-isolation -vvv
 
 requirements:
   host:
     - python >=3.8
     - pip
+    - setuptools >=61
+    - wheel
   run:
     - python >=3.8
     - biopython ==1.85
@@ -33,6 +36,8 @@ requirements:
 test:
   commands:
     - cdst --help
+  imports:
+    - cdst
 
 about:
   home: https://github.com/l1-mh/CDST

--- a/recipes/cdst/meta.yaml
+++ b/recipes/cdst/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/l1-mh/CDST/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: <FILL-IN-SHA256-HERE>
+  sha256: 43572c9ee27fdf30c34d902aaa6219afc82742dda0d68cee2a314a8bbe0105c1
 
 build:
   noarch: python

--- a/recipes/cdst/meta.yaml
+++ b/recipes/cdst/meta.yaml
@@ -1,53 +1,38 @@
 {% set name = "cdst" %}
-{% set version = "0.2.0" %}
+{% set version = "0.2.1" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://github.com/l1-mh/CDST/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 7147e4dae8e90d52fb79b03dd1131a730aedee06489f502638ab896f98da05df
+  url: https://pypi.io/packages/source/c/cdst-genome/cdst-genome-{{ version }}.tar.gz
+  sha256: 5e6cd3827a54336679eba86be259de17ae9dfbba671e54ff60e9c257eb62271c
 
 build:
   noarch: python
-  number: 0
-  run_exports:
-    - {{ pin_subpackage(name, max_pin="x.x") }}
-  # 关键：关闭构建隔离，使用 host 里的 setuptools/wheel
-  script: python -m pip install . --no-deps --no-build-isolation -vvv
+  script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
-    - python >=3.8
+    - python >=3.9
     - pip
-    - setuptools >=61
-    - wheel
   run:
-    - python >=3.8
-    - biopython ==1.85
-    - pandas ==2.2.2
-    - scipy ==1.13.1
-    - scikit-learn ==1.5.1
-    - networkx ==3.3
-    - matplotlib-base >=3.9
-    - joblib ==1.4.*
+    - python >=3.9
+    - biopython >=1.85
+    - pandas >=2.2
+    - networkx >=3.3
+    - scipy >=1.13
 
 test:
   commands:
     - cdst --help
-  imports:
-    - cdst
 
 about:
   home: https://github.com/l1-mh/CDST
-  license: GPL-3.0
+  license: GPL-3.0-only
   license_file: LICENSE
-  summary: "CoDing Sequence Typer (CDST): a decentralized, hash-based bacterial genome typing pipeline"
-  description: |
-    CDST is a fully decentralized MD5-hash–based framework that indexes predicted coding sequences (CDSs)
-    and computes pairwise genomic distances without locus annotation or a central database.
-  dev_url: https://github.com/l1-mh/CDST
+  summary: "CoDing Sequence Typer (CDST): MD5 hash-based genome typing and clustering."
 
 extra:
   recipe-maintainers:

--- a/recipes/cdst/meta.yaml
+++ b/recipes/cdst/meta.yaml
@@ -7,11 +7,14 @@ package:
 
 source:
   url: https://pypi.io/packages/source/c/cdst-genome/cdst-genome-{{ version }}.tar.gz
-  sha256: 5e6cd3827a54336679eba86be259de17ae9dfbba671e54ff60e9c257eb62271c
+  sha256: 5e6cd3827a54336679eba86be259de17ae9dfbba671e54ff60e9c257eb62271
 
 build:
   noarch: python
+  number: 0
   script: {{ PYTHON }} -m pip install . -vv
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x.x") }}
 
 requirements:
   host:
@@ -36,4 +39,4 @@ about:
 
 extra:
   recipe-maintainers:
-    - <your-github-username>
+    - l1-mh

--- a/recipes/cdst/meta.yaml
+++ b/recipes/cdst/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/l1-mh/CDST/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 43572c9ee27fdf30c34d902aaa6219afc82742dda0d68cee2a314a8bbe0105c1
+  sha256: 7147e4dae8e90d52fb79b03dd1131a730aedee06489f502638ab896f98da05df
 
 build:
   noarch: python


### PR DESCRIPTION
### Description
This PR adds a new Bioconda recipe for **CDST (CoDing Sequence Typer)**, version **v0.2.0**.

CDST is a decentralized, MD5-hash–based pipeline for bacterial genome typing and clustering.  
It bypasses allele annotation and central databases, computes pairwise distances directly from predicted coding sequences,  
and supports multi-scale clustering for outbreak, lineage, and population-level analysis.

- **Source code:** https://github.com/l1-mh/CDST  
- **License:** GPL-3.0  
- **Tested environment:** Python 3.12, Biopython 1.85, pandas 2.2.2, SciPy 1.13.1, scikit-learn 1.5.1, networkx 3.3, matplotlib 3.9, joblib 1.4  
- **Build type:** noarch: python  
