### PR TITLE
Add tagra

### DIFF
--- a/recipes/tagra/meta.yaml
+++ b/recipes/tagra/meta.yaml
@@ -12,8 +12,8 @@ source:
 build:
   number: 0
   noarch: python
-  entry_points:
-    - tagra = ta_gra:main
+  #entry_points:
+    #- tagra = ta_gra:main
   script: {{ PYTHON }} -m pip install . -vvv --no-deps --no-build-isolation --no-cache-dir
   run_exports:
     - {{ pin_subpackage(name, max_pin="x.x") }}
@@ -35,8 +35,8 @@ requirements:
 test:
   imports:
     - tagra
-  commands:
-    - tagra --help
+  #commands:
+    #- tagra --help
 
 about:
   home: "https://github.com/davidetorre92/TaGra"


### PR DESCRIPTION
Adding tagra, a package available on PyPI.

The lint passes all checks, but conda build encounters an error. After investigating the build script at miniconda/base/envs/bioconda-build/conda-bld/tagra_(token)/work/conda_build.sh, I discovered that the command python -m pip install tagra==0.2.5 fails to install the package, reporting that the package is not found. This is puzzling since I can successfully install the package using the same command in many different environments.
Here's the landing page to PyPI: https://pypi.org/project/tagra/ 