### PR TITLE
Upload linux-aarch64 biocontainers to Quay.io

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,6 +162,7 @@ jobs: # a basic unit of work in a run
             bioconda-utils handle-merged-pr recipes config.yml \
               --repo bioconda/bioconda-recipes \
               --git-range ${CIRCLE_SHA1}~1 ${CIRCLE_SHA1} \
+              --quay-upload-target biocontainers \
               --fallback build \
               --artifact-source circleci
 


### PR DESCRIPTION
### Upload linux-aarch64 biocontainers to Quay.io
This repository currently supports the build and distribution of `.conda`-formatted packages for multiple architectures, including linux-x64 and linux-aarch64.

Nevertheless, it only releases biocontainers for the linux-x64 architecture. With the growing number of developers adopting ARM environments for their work, biocontainers of inux-aarch64 should also be made available on Quay to serve users' needs.

### How `bioconda/biocomda-recipes` release biocontainers currently?
As we can see the [bioconda/biocomda-recipes](https://github.com/bioconda/bioconda-recipes) repository only releases linux-x64 biocontainers:

- linux-x64 merge workflow:
```
bioconda-utils handle-merged-pr recipes config.yml \
            --repo bioconda/bioconda-recipes \
            --git-range ${GITHUB_SHA}~1 ${GITHUB_SHA} \
            --quay-upload-target biocontainers \
            --fallback build \
            --artifact-source github-actions
```
where `--quay-upload-target biocontainers` is used for pushing linux-64 biocontainers to quay.io.

- linux-aarch64 merge workflow:
```
bioconda-utils handle-merged-pr recipes config.yml \
              --repo bioconda/bioconda-recipes \
              --git-range ${CIRCLE_SHA1}~1 ${CIRCLE_SHA1} \
              --fallback build \
              --artifact-source circleci
```
**_Since there is no `--quay-upload-target` used, `linux-aarch64` biocontainers will not be pushed._**

### Previous Works
Over the past few years, our team (e.g. @martin-g , @ZerryNi ) has worked with the community to adapt many software packages for linux-aarch64 format.

Moreover, in `build-and-test` stage of  [bioconda/biocomda-recipes](https://github.com/bioconda/bioconda-recipes) CI, we can see that it does build `linux-aarch64` biocontainers:
```
bioconda-utils build recipes config.yml \
                  --lint --docker --mulled-test \
                  --docker-base-image "quay.io/bioconda/bioconda-utils-build-env-cos7-$(arch):${BIOCONDA_UTILS_TAG#v}" \
                  --git-range origin/master HEAD
```
where `--mulled-test` is set to build `linux-aarch64` biocontainers, and this can be found from `circleci` artifacts:
(see https://app.circleci.com/pipelines/github/bioconda/bioconda-recipes/165751/workflows/85460b3f-0f6b-4ba9-b8bb-9c449b19ec07/jobs/301957?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link&utm_content=summary&invite=true#step-109-1902_77):
<img width="861" height="476" alt="image" src="https://github.com/user-attachments/assets/efc4f2d9-9a40-47bd-b004-0ea103b00e79" />

### Related PR
https://github.com/bioconda/bioconda-utils/pull/1066