### PR TITLE
update rseqc: explicitly declare cryptic Rscript dependency

### DIFF
--- a/recipes/rseqc/meta.yaml
+++ b/recipes/rseqc/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: b7f3996f3de0b0b0a09eec949281a8f3e665a20827fcb3cbbd7546b94574a088
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: "{{ PYTHON }} -m pip install . --no-deps --no-build-isolation --no-cache-dir -vvv"
   run_exports:
@@ -28,6 +28,7 @@ requirements:
     - pysam
     - python >=3.5
     - logomaker
+    - r-base # Rscript is an undeclared runtime dependency of a number of the rseqc scripts: https://github.com/snakemake-workflows/rna-seq-star-deseq2/pull/91#issuecomment-3253583847
 
 test:
   imports:
@@ -37,6 +38,7 @@ test:
   commands:
     - read_distribution.py 2>&1 | grep Usage > /dev/null
     - geneBody_coverage.py 2>&1 | grep Usage > /dev/null
+    - Rscript --help
 
 about:
   home: "https://rseqc.sourceforge.net"

--- a/recipes/rseqc/meta.yaml
+++ b/recipes/rseqc/meta.yaml
@@ -20,7 +20,7 @@ requirements:
   host:
     - pip
     - python >=3.5
-    - setuptools
+    - setuptools <81
   run:
     - bx-python
     - numpy


### PR DESCRIPTION
rseqc needs `r-base` at runtime, as multiple of its python scripts actually call `Rscript` internally, see here for a current list:
https://github.com/snakemake-workflows/rna-seq-star-deseq2/pull/91#issuecomment-3253583847

Also, there is more context in the comment above:
https://github.com/snakemake-workflows/rna-seq-star-deseq2/pull/91#issuecomment-3253559667

And I just added the new constraint `setuptools <81` following the linting recommendation:

> /opt/mambaforge/envs/bioconda/lib/python3.12/site-packages/bioconda_utils/utils.py:43: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.


----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
