### PR TITLE
Update MiST typing - missing dependency

### DIFF
--- a/recipes/mist_typing/meta.yaml
+++ b/recipes/mist_typing/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   entry_points:
     - mist_download=mist.scripts.mist_download:main
     - mist_index=mist.scripts.mist_index:main


### PR DESCRIPTION
Added missing bs4 dependency and bumped build number.
