### PR TITLE
Add fastdup

### DIFF
--- a/recipes/fastdup/build.sh
+++ b/recipes/fastdup/build.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -ex
+
+export LIBRARY_PATH="${PREFIX}/lib"
+export CPATH="${PREFIX}/include"
+export CPPFLAGS="${CPPFLAGS} -I${PREFIX}/include"
+export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib"
+export CXXFLAGS="${CXXFLAGS} -O2"
+
+mkdir -p $PREFIX/bin
+
+cmake -S . -B build -DCMAKE_INSTALL_PREFIX="${PREFIX}" -DCMAKE_BUILD_TYPE=Release \
+	-DEXTRA_FLAGS="${EXTRA_FLAGS}" -DCMAKE_CXX_COMPILER="${CXX}" \
+	-DCMAKE_CXX_FLAGS="${CXXFLAGS}" -DCMAKE_C_COMPILER="${CC}" \
+	-DCMAKE_C_FLAGS="${CFLAGS}" -Wno-dev -Wno-deprecated --no-warn-unused-cli \
+	"${CONFIG_ARGS}"
+cmake --build build --clean-first --target install -j "${CPU_COUNT}"
+
+# Libraries aren't getting installed
+#mkdir -p $PREFIX/lib
+
+#ls $SRC_DIR/build/lib/* -lh
+
+#cp -f $SRC_DIR/build/lib/libwfa2* $PREFIX/lib
+#cp -f $SRC_DIR/build/lib/libwflign* $PREFIX/lib
+
+install -v -m 0755 build/bin/* $PREFIX/bin
+#cp -f scripts/split_approx_mappings_in_chunks.py $PREFIX/bin

--- a/recipes/fastdup/meta.yaml
+++ b/recipes/fastdup/meta.yaml
@@ -1,0 +1,43 @@
+{% set version = "1.0.0" %}
+{% set name = "fastdup" %}
+
+package:
+  name: fastdup
+  version: {{ version }}
+
+source:
+  - url: https://github.com/zzhofict/FastDup/archive/refs/tags/v{{ version }}.tar.gz
+    sha256: ef73e08d7217157bdf259b91ea32013c6b124ea9ec0e144bd289d6b2ed1cec95
+
+
+build:
+  number: 0
+  run_exports:
+    - {{ pin_subpackage("fastdup", max_pin="x.x") }}
+
+requirements:
+  build:
+    - make
+    - cmake
+    - {{ compiler('cxx') }}
+  host:
+    - htslib
+    - ncurses
+    - zlib
+    - xz
+
+test:
+  commands:
+    - fastdup --help
+    - fastdup --version
+
+about:
+  home: https://github.com/zzhofict/FastDup
+  license: MIT
+  license_file: LICENSE
+  summary: A Scalable Duplicate Marking Tool using Speculation-and-Test Mechanism
+
+extra:
+  identifiers:
+    - biotools:fastdup
+    - usegalaxy-eu:fastdup


### PR DESCRIPTION
Add fastdup, a tool to mark duplicate for coordinate sorted sam/bam with ultra fast speed.
----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
