### PR TITLE
Bump gtdbtk version to 2.5.1 and update hash

### DIFF
--- a/recipes/gtdbtk/meta.yaml
+++ b/recipes/gtdbtk/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "gtdbtk" %}
-{% set version = "2.5.0" %}
+{% set version = "2.5.1" %}
 
 package:
   name: {{ name }}
@@ -7,10 +7,10 @@ package:
   
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: d38b77d33efbfefcd6502a7c413996cd951664345e2854dfcc5976b0a52c58af
+  sha256: d1e23593bd1801a4c41007e58cefa58837d62521b628d9c34efb8baacda737a9
 
 build:
-  number: 1
+  number: 0
   noarch: python
   entry_points:
     - gtdbtk = gtdbtk.__main__:main


### PR DESCRIPTION

Version and source update:

* Updated the `gtdbtk` version from `2.5.0` to `2.5.1` in `recipes/gtdbtk/meta.yaml` to pull in the latest release.
* Changed the source `sha256` hash to match the new version's tarball for verification.

Build configuration:

* Reset the build `number` from `1` to `0`, which is standard when bumping the package version.