### PR TITLE
Update gbdraw to v0.5.2

### DIFF
--- a/recipes/gbdraw/meta.yaml
+++ b/recipes/gbdraw/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "gbdraw" %}
-{% set version = "0.5.1" %}
+{% set version = "0.5.2" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/satoshikawato/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
-  sha256: 4fb4823ca4f3059a8b6ad8ac83b5f4d301294a865dbe117acabfc3ff5b899ff6
+  sha256: 0d43e0fe7f62ca32bb22ca7537f431fb09100651755129413f716cd91fbfd064
 
 
 


### PR DESCRIPTION
## What's Changed
* Fixed a packaging error where dependencies were not automatically installed when using `pip install`. This resolves the installation issue present in v0.5.0 and v0.5.1. 

**Full Changelog**: https://github.com/satoshikawato/gbdraw/compare/0.5.1...0.5.2