### PR TITLE
CryptoGenotyper build 1 v1.5.0 with post-link database init added 

### DIFF
--- a/recipes/cryptogenotyper/meta.yaml
+++ b/recipes/cryptogenotyper/meta.yaml
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://github.com/phac-nml/CryptoGenotyper/archive/{{ version }}.tar.gz
-  sha256: 34c7580712cfda94c207ba4099f445d3385a6e5fffa237f4b0e0c257538c006b
+  sha256: b565f85eaeae3fac8bdff8e599f620a2c0b7ec29e314024ee109a7f0174a086f
 
 build:
-  number: 0 
+  number: 1 
   noarch: python
   script: {{ PYTHON }} -m pip install --no-deps --no-build-isolation --no-cache-dir . -vvv
   entry_points:

--- a/recipes/cryptogenotyper/post_link.sh
+++ b/recipes/cryptogenotyper/post_link.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+cryptogenotyper_init


### PR DESCRIPTION
Added automatic init of databases via `post_link.sh` file. Previous build was automatically generated by the bot