### PR TITLE
Update cargo install to use --all-features flag

### DIFF
--- a/recipes/rust-gtars/build.sh
+++ b/recipes/rust-gtars/build.sh
@@ -10,4 +10,4 @@ popd
 
 # build statically linked binary with Rust
 RUST_BACKTRACE=1 
-cargo install --no-track --verbose --root "${PREFIX}" --path ./gtars
+cargo install --no-track --verbose --root "${PREFIX}" --path ./gtars --all-features


### PR DESCRIPTION
We are changing our rust-gtars crate to gatekeep some features behind feature flags. Therefore, we are changing the build command to use the --all-features flag.
