### PR TITLE
Update kf2vec: Python package for k-mer embeddings in genomic sequences

### DIFF
--- a/recipes/kf2vec/meta.yaml
+++ b/recipes/kf2vec/meta.yaml
@@ -1,43 +1,27 @@
+{% set name = "kf2vec" %}
+{% set version = "0.1.3" %}
+
 package:
-  name: kf2vec
-  version: "0.1.3"
+  name: {{ name }}
+  version: {{ version }}
 
-
+source:
+  url: https://github.com/noraracht/kf2vec/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: bba1076b0125196cbf880ef1cb2311f6e0c228bec1bbf1977b3f9177cb92d16a
 
 build:
   number: 0
   noarch: python
-  script: $PYTHON -m pip install . --no-deps  --ignore-installed # install your Python code
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --no-cache-dir
+  entry_points:
+    - kf2vec = kf2vec.main:main
   run_exports:
-    - {{ pin_subpackage('kf2vec', max_pin="x.x") }}
+    - {{ pin_subpackage(name, max_pin="x.x") }}
 
 requirements:
-
-  build:
-    - python >=3.11,<3.12
-    - pip
-    - numpy >=1.22,<1.27
-    - setuptools
-    - make
-    - git
-    - zlib
-    - gcc_linux-64  # [linux]
-    - clang_osx-64  # [osx]
-    - treecluster >=1.0.3
-    - treeswift >=1.1.45
-
   host:
     - python >=3.11,<3.12
     - pip
-    - numpy >=1.22,<1.27
-    - pandas
-    - scikit-learn
-    - pytorch
-    - setuptools
-    - treecluster >=1.0.3
-    - treeswift >=1.1.45
-    - openmpi 4.*
-
   run:
     - python >=3.11,<3.12
     - numpy >=1.22,<1.27
@@ -49,20 +33,18 @@ requirements:
     - kmer-jellyfish
     - seqtk
     - seqkit
-    - pip
-    - openmpi 4.*
-
-
-about:
-  home: https://github.com/noraracht/kf2vec
-  license: MIT
-  summary: "K-mer frequency to vector tool."
-
-source:
-  url: https://github.com/noraracht/kf2vec/archive/refs/tags/v0.1.3.tar.gz
-  sha256: bba1076b0125196cbf880ef1cb2311f6e0c228bec1bbf1977b3f9177cb92d16a
-
+    - openmpi
 
 test:
   imports:
     - kf2vec
+  commands:
+    - kf2vec --help
+
+about:
+  home: "https://github.com/noraracht/kf2vec"
+  license: "Apache-2.0"
+  license_family: APACHE
+  license_file: LICENSE
+  summary: "K-mer frequency to vector tool."
+  dev_url: "https://github.com/noraracht/kf2vec"


### PR DESCRIPTION
## Package Info
**Name:** kf2vec  
**Version:** v0.1.3  
**Description:** Python package for learning embeddings from DNA kmer frequencies and phylogeneny.

## GitHub Repository
**Repo:** https://github.com/noraracht/kf2vec  
**Tag:** v0.1.3

## Dependencies
- python>=3.11,<3.12
- numpy>=1.22,<1.27
- pandas
- scikit-learn
- pytorch (GPU-enabled)
- treecluster >=1.0.3
- treeswift >=1.1.45
- kmer-jellyfish
- seqtk
- seqkit

## Testing
Tested locally on **osx-64** MacOS system
Package was built and  tested using the following channel priority: conda-forge > bioconda > pytorch > defaults
Installed locally using:
conda install kf2vec -c file:///Users/nora/anaconda3/envs/bioconda/conda-bld \
-c conda-forge -c bioconda -c pytorch -c defaults

## Additional Notes
- This is the second submission of `kf2vec` to Bioconda.
- The `meta.yaml` sources the v0.1.3 tag from GitHub.
- The recipe was built and tested using `bioconda-utils`.