### PR TITLE
Add: `ipcr` 1.1.0 — pure‑Go in‑silico PCR CLI

### DIFF
--- a/recipes/ipcr/LICENSE
+++ b/recipes/ipcr/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Gennerick J Samera
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/recipes/ipcr/build.sh
+++ b/recipes/ipcr/build.sh
@@ -2,7 +2,6 @@
 set -euxo pipefail
 
 export CGO_ENABLED=0
-# Reproducible builds; use vendor mode only if vendor/ exists.
 export GOFLAGS="${GOFLAGS:-} -trimpath -buildvcs=false"
 if [ -d vendor ]; then
   export GOFLAGS="$GOFLAGS -mod=vendor"
@@ -12,5 +11,7 @@ mkdir -p "${PREFIX}/bin"
 go version
 go build -o "${PREFIX}/bin/ipcr" ./cmd/ipcr
 
-# smoke test
-"${PREFIX}/bin/ipcr" --help >/dev/null
+# smoke test: use a zero-exit flag
+"${PREFIX}/bin/ipcr" --version >/dev/null
+# if you want to keep a help check too, do it non-fatal:
+# "${PREFIX}/bin/ipcr" --help >/dev/null 2>&1 || true

--- a/recipes/ipcr/build.sh
+++ b/recipes/ipcr/build.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+export CGO_ENABLED=0
+# Reproducible builds; use vendor mode only if vendor/ exists.
+export GOFLAGS="${GOFLAGS:-} -trimpath -buildvcs=false"
+if [ -d vendor ]; then
+  export GOFLAGS="$GOFLAGS -mod=vendor"
+fi
+
+mkdir -p "${PREFIX}/bin"
+go version
+go build -o "${PREFIX}/bin/ipcr" ./cmd/ipcr
+
+# smoke test
+"${PREFIX}/bin/ipcr" --help >/dev/null

--- a/recipes/ipcr/meta.yaml
+++ b/recipes/ipcr/meta.yaml
@@ -7,13 +7,12 @@ package:
 
 source:
   url: https://github.com/KPU-AGC/ipcr/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: d5558cd419c8d46bdc958064cb97f963d1ea793866414c025906ec15033512ed
+  sha256: 9c8810d95b7c4353a5ac3461d56ff1f77bd8c45e324a3b436d738a0cf84c73bc
 
 build:
   number: 0
-  # Bioconda doesn't build on Windows
-  skip: true  # [win]
-  script: bash build.sh
+  skip: true  # [win]        # Go binary is not built on Windows
+  binary_relocation: false    # plain CLI, no rpaths
 
 requirements:
   build:
@@ -22,7 +21,6 @@ requirements:
 test:
   commands:
     - ipcr --version
-    - ipcr --help | head -n 1
 
 about:
   home: https://github.com/KPU-AGC/ipcr
@@ -34,3 +32,7 @@ about:
 extra:
   recipe-maintainers:
     - ericksamera
+  skip-lints:
+    - should_be_noarch_generic
+    - missing_run_exports
+    - should_use_compilers

--- a/recipes/ipcr/meta.yaml
+++ b/recipes/ipcr/meta.yaml
@@ -1,0 +1,36 @@
+{% set name = "ipcr" %}
+{% set version = "1.1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/KPU-AGC/ipcr/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: d5558cd419c8d46bdc958064cb97f963d1ea793866414c025906ec15033512ed
+
+build:
+  number: 0
+  # Bioconda doesn't build on Windows
+  skip: true  # [win]
+  script: bash build.sh
+
+requirements:
+  build:
+    - go >=1.21
+
+test:
+  commands:
+    - ipcr --version
+    - ipcr --help | head -n 1
+
+about:
+  home: https://github.com/KPU-AGC/ipcr
+  license: MIT
+  license_file: LICENSE
+  summary: "In-silico PCR with mismatch thresholds and pretty alignment output."
+  dev_url: https://github.com/KPU-AGC/ipcr
+
+extra:
+  recipe-maintainers:
+    - ericksamera

--- a/recipes/ipcr/meta.yaml
+++ b/recipes/ipcr/meta.yaml
@@ -11,8 +11,6 @@ source:
 
 build:
   number: 0
-  skip: true  # [win]        # Go binary is not built on Windows
-  binary_relocation: false    # plain CLI, no rpaths
 
 requirements:
   build:


### PR DESCRIPTION
**Summary**

* Packages `ipcr`, a fast in‑silico PCR tool with mismatch thresholds, 3′ terminal window policy, and a human‑readable `--pretty` alignment view.
* CLI provides `--forward/--reverse`, FASTA input, text/JSON/FASTA outputs, and deterministic `--sort`. `--mode realistic` defaults to a 3‑nt terminal window.&#x20;

**Upstream**
Repo: [https://github.com/KPU-AGC/ipcr](https://github.com/KPU-AGC/ipcr)
License: MIT (included)
Version: 1.1.0 (CLI prints `ipcr version 1.1.0`).&#x20;

**Build / recipe notes**

* Language: Go (CGO disabled). Build from source via `build.sh` using `go build -trimpath -buildvcs=false`.
* No third‑party Go modules; vendoring not required (script uses `-mod=vendor` only if `vendor/` exists).
* Platforms: linux‑64 (local build OK); CI will build osx‑64 / osx‑arm64. Windows skipped.
* Tests: `ipcr --version` (help currently exits non‑zero by design).&#x20;

**Lint exceptions (intentional)**

* `should_be_noarch_generic`: Go produces arch‑specific binaries.
* `missing_run_exports`: CLI tool, no downstream ABI/API pinning.
* `should_use_compilers`: uses Go toolchain (not C/C++ compilers).

**Checksum**

* Pinned to tag tarball `v1.1.0` with recorded SHA256 in `meta.yaml`.

**Usage example**

```bash
mamba install -c bioconda -c conda-forge ipcr
ipcr --version
```