### PR TITLE
Update SnpEff v5.0, v5.1, v5.2 to use AstraZeneca's repository

### DIFF
--- a/recipes/snpeff/5.0/astrazeneca.patch
+++ b/recipes/snpeff/5.0/astrazeneca.patch
@@ -1,0 +1,24 @@
+diff --git a/snpEff/snpEff.config b/snpEff/snpEff.config
+index 519c9a0..c7cc615 100644
+--- a/snpEff/snpEff.config
++++ b/snpEff/snpEff.config
+@@ -28,13 +28,17 @@ data.dir = ./data/
+ #database.repositoryKey = "?sv=2019-10-10&st=2020-09-01T00%3A00%3A00Z&se=2050-09-01T00%3A00%3A00Z&si=prod&sr=c&sig=isafOa9tGnYBAvsXFUMDGMTbsG2z%2FShaihzp7JE5dHw%3D"
+
+ # Primary Azure blob storage
+-database.repository = https://snpeff.blob.core.windows.net/databases/
++#database.repository = https://snpeff.blob.core.windows.net/databases/
++
++# AstraZeneca S3 bucket (ODSP: Oncology Data Science & AI)
++database.repository = https://snpeff.odsp.astrazeneca.com/databases
+
+ #---
+ # Latest version numbers. Check here if there is an update.
+ #---
+ #versions.url = https://pcingola.github.io/SnpEff/versions.txt
+-versions.url = https://snpeff.blob.core.windows.net/databases/versions.txt
++#versions.url = https://snpeff.blob.core.windows.net/databases/versions.txt
++versions.url = https://snpeff.odsp.astrazeneca.com/versions/versions.txt
+
+ #-------------------------------------------------------------------------------
+ # Third party databases

--- a/recipes/snpeff/5.0/build.sh
+++ b/recipes/snpeff/5.0/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+outdir=$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM
+mkdir -p "$outdir"
+mkdir -p "$PREFIX/bin"
+mv scripts/ snpEff.config snpEff.jar "$outdir/"
+cp "$RECIPE_DIR/snpeff.py" "$outdir/snpEff"
+chmod +x "$outdir/snpEff"
+
+ln -s "$outdir/snpEff" "$PREFIX/bin"

--- a/recipes/snpeff/5.0/meta.yaml
+++ b/recipes/snpeff/5.0/meta.yaml
@@ -1,0 +1,41 @@
+{% set snpeff_ver = "v5_0e" %}
+# NOTE: if the version contains a trailing letter, use the <d>.<d>.1<l> format
+# Please update recipes/snpsift as well!
+{% set version = "5.0" %}
+{% set sha256 = "85d907b5dd9e9008a0cf245956e3c9077a31e45f21a1b580d9b98a53fd8dcb9d" %}
+
+about:
+  home: 'http://snpeff.sourceforge.net/'
+  license: "LGPLv3"
+  summary: "Genetic variant annotation and effect prediction toolbox"
+
+package:
+  name: snpeff
+  version: {{ version }}
+
+build:
+  number: 2
+  noarch: generic
+  run_exports:
+    - {{ pin_compatible('snpeff', max_pin="x.x") }}
+
+source:
+  url: https://snpeff.odsp.astrazeneca.com/versions/snpEff_{{ snpeff_ver }}_core.zip
+  sha256: {{ sha256 }}
+  patches:
+    - astrazeneca.patch  # use AstraZeneca S3 bucket instead of Azure blob storage
+
+requirements:
+  run:
+    - openjdk
+    - zlib
+    - python
+
+test:
+  commands:
+    - snpEff -version
+
+extra:
+  notes: 'The tool is available as command `snpEff`. Note that the package version is slightly different from upstream, this is to make sure conda will order the package versions correctly.'
+  identifiers:
+    - biotools:snpeff

--- a/recipes/snpeff/5.0/snpeff.py
+++ b/recipes/snpeff/5.0/snpeff.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+#
+# Wrapper script for Java Conda packages that ensures that the java runtime
+# is invoked with the right options. Adapted from the bash script (http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in/246128#246128).
+
+#
+# Program Parameters
+#
+import os
+import subprocess
+import sys
+import shutil
+from os import access
+from os import getenv
+from os import X_OK
+
+jar_file = 'snpEff.jar'
+
+
+default_jvm_mem_opts = ['-Xms512m', '-Xmx1g']
+
+# !!! End of parameter section. No user-serviceable code below this line !!!
+
+
+def real_dirname(path):
+    """Return the symlink-resolved, canonicalized directory-portion of path."""
+    return os.path.dirname(os.path.realpath(path))
+
+
+def java_executable():
+    """Return the executable name of the Java interpreter."""
+    java_home = getenv('JAVA_HOME')
+    java_bin = os.path.join('bin', 'java')
+
+    if java_home and access(os.path.join(java_home, java_bin), X_OK):
+        return os.path.join(java_home, java_bin)
+    else:
+        return 'java'
+
+
+def jvm_opts(argv):
+    """Construct list of Java arguments based on our argument list.
+
+    The argument list passed in argv must not include the script name.
+    The return value is a 3-tuple lists of strings of the form:
+      (memory_options, prop_options, passthrough_options)
+    """
+    mem_opts = []
+    prop_opts = []
+    pass_args = []
+    exec_dir = None
+
+    for arg in argv:
+        if arg.startswith('-D'):
+            prop_opts.append(arg)
+        elif arg.startswith('-XX'):
+            prop_opts.append(arg)
+        elif arg.startswith('-Xm'):
+            mem_opts.append(arg)
+        elif arg.startswith('--exec_dir='):
+            exec_dir = arg.split('=')[1].strip('"').strip("'")
+            if not os.path.exists(exec_dir):
+                shutil.copytree(real_dirname(sys.argv[0]), exec_dir, symlinks=False, ignore=None)
+        else:
+            pass_args.append(arg)
+
+    # In the original shell script the test coded below read:
+    #   if [ "$jvm_mem_opts" == "" ] && [ -z ${_JAVA_OPTIONS+x} ]
+    # To reproduce the behaviour of the above shell code fragment
+    # it is important to explictly check for equality with None
+    # in the second condition, so a null envar value counts as True!
+
+    if mem_opts == [] and getenv('_JAVA_OPTIONS') is None:
+        mem_opts = default_jvm_mem_opts
+
+    return (mem_opts, prop_opts, pass_args, exec_dir)
+
+
+def main():
+    java = java_executable()
+    """
+    PeptideShaker updates files relative to the path of the jar file.
+    In a multiuser setting, the option --exec_dir="exec_dir"
+    can be used as the location for the peptide-shaker distribution.
+    If the exec_dir dies not exist,
+    we copy the jar file, lib, and resources to the exec_dir directory.
+    """
+    (mem_opts, prop_opts, pass_args, exec_dir) = jvm_opts(sys.argv[1:])
+    jar_dir = exec_dir if exec_dir else real_dirname(sys.argv[0])
+
+    if pass_args != [] and pass_args[0].startswith('eu'):
+        jar_arg = '-cp'
+    else:
+        jar_arg = '-jar'
+
+    jar_path = os.path.join(jar_dir, jar_file)
+
+    java_args = [java] + mem_opts + prop_opts + [jar_arg] + [jar_path] + pass_args
+
+    sys.exit(subprocess.call(java_args))
+
+
+if __name__ == '__main__':
+    main()

--- a/recipes/snpeff/5.1/astrazeneca.patch
+++ b/recipes/snpeff/5.1/astrazeneca.patch
@@ -1,0 +1,24 @@
+diff --git a/snpEff/snpEff.config b/snpEff/snpEff.config
+index 71938ef..0ddcc22 100644
+--- a/snpEff/snpEff.config
++++ b/snpEff/snpEff.config
+@@ -28,13 +28,17 @@ data.dir = ./data/
+ #database.repositoryKey = "?sv=2019-10-10&st=2020-09-01T00%3A00%3A00Z&se=2050-09-01T00%3A00%3A00Z&si=prod&sr=c&sig=isafOa9tGnYBAvsXFUMDGMTbsG2z%2FShaihzp7JE5dHw%3D"
+
+ # Primary Azure blob storage
+-database.repository = https://snpeff.blob.core.windows.net/databases/
++#database.repository = https://snpeff.blob.core.windows.net/databases/
++
++# AstraZeneca S3 bucket (ODSP: Oncology Data Science & AI)
++database.repository = https://snpeff.odsp.astrazeneca.com/databases
+
+ #---
+ # Latest version numbers. Check here if there is an update.
+ #---
+ #versions.url = https://pcingola.github.io/SnpEff/versions.txt
+-versions.url = https://snpeff.blob.core.windows.net/databases/versions.txt
++#versions.url = https://snpeff.blob.core.windows.net/databases/versions.txt
++versions.url = https://snpeff.odsp.astrazeneca.com/versions/versions.txt
+
+ #-------------------------------------------------------------------------------
+ # Third party databases

--- a/recipes/snpeff/5.1/build.sh
+++ b/recipes/snpeff/5.1/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+outdir=$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM
+mkdir -p "$outdir"
+mkdir -p "$PREFIX/bin"
+mv scripts/ snpEff.config snpEff.jar "$outdir/"
+cp "$RECIPE_DIR/snpeff.py" "$outdir/snpEff"
+chmod +x "$outdir/snpEff"
+
+ln -s "$outdir/snpEff" "$PREFIX/bin"

--- a/recipes/snpeff/5.1/meta.yaml
+++ b/recipes/snpeff/5.1/meta.yaml
@@ -1,0 +1,41 @@
+{% set snpeff_ver = "v5_1d" %}
+# NOTE: if the version contains a trailing letter, use the <d>.<d>.1<l> format
+# Please update recipes/snpsift as well!
+{% set version = "5.1" %}
+{% set sha256 = "919e0595c08e86d1dd82279723c83cb872070244ee4ce0cb3167bde2b272893b" %}
+
+about:
+  home: 'http://snpeff.sourceforge.net/'
+  license: "LGPLv3"
+  summary: "Genetic variant annotation and effect prediction toolbox"
+
+package:
+  name: snpeff
+  version: {{ version }}
+
+build:
+  number: 3
+  noarch: generic
+  run_exports:
+    - {{ pin_compatible('snpeff', max_pin="x.x") }}
+
+source:
+  url: https://snpeff.odsp.astrazeneca.com/versions/snpEff_{{ snpeff_ver }}_core.zip
+  sha256: {{ sha256 }}
+  patches:
+    - astrazeneca.patch  # use AstraZeneca S3 bucket instead of Azure blob storage
+
+requirements:
+  run:
+    - openjdk >=11
+    - zlib
+    - python
+
+test:
+  commands:
+    - snpEff -version
+
+extra:
+  notes: 'The tool is available as command `snpEff`. Note that the package version is slightly different from upstream, this is to make sure conda will order the package versions correctly.'
+  identifiers:
+    - biotools:snpeff

--- a/recipes/snpeff/5.1/snpeff.py
+++ b/recipes/snpeff/5.1/snpeff.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+#
+# Wrapper script for Java Conda packages that ensures that the java runtime
+# is invoked with the right options. Adapted from the bash script (http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in/246128#246128).
+
+#
+# Program Parameters
+#
+import os
+import subprocess
+import sys
+import shutil
+from os import access
+from os import getenv
+from os import X_OK
+
+jar_file = 'snpEff.jar'
+
+
+default_jvm_mem_opts = ['-Xms512m', '-Xmx1g']
+
+# !!! End of parameter section. No user-serviceable code below this line !!!
+
+
+def real_dirname(path):
+    """Return the symlink-resolved, canonicalized directory-portion of path."""
+    return os.path.dirname(os.path.realpath(path))
+
+
+def java_executable():
+    """Return the executable name of the Java interpreter."""
+    java_home = getenv('JAVA_HOME')
+    java_bin = os.path.join('bin', 'java')
+
+    if java_home and access(os.path.join(java_home, java_bin), X_OK):
+        return os.path.join(java_home, java_bin)
+    else:
+        return 'java'
+
+
+def jvm_opts(argv):
+    """Construct list of Java arguments based on our argument list.
+
+    The argument list passed in argv must not include the script name.
+    The return value is a 3-tuple lists of strings of the form:
+      (memory_options, prop_options, passthrough_options)
+    """
+    mem_opts = []
+    prop_opts = []
+    pass_args = []
+    exec_dir = None
+
+    for arg in argv:
+        if arg.startswith('-D'):
+            prop_opts.append(arg)
+        elif arg.startswith('-XX'):
+            prop_opts.append(arg)
+        elif arg.startswith('-Xm'):
+            mem_opts.append(arg)
+        elif arg.startswith('--exec_dir='):
+            exec_dir = arg.split('=')[1].strip('"').strip("'")
+            if not os.path.exists(exec_dir):
+                shutil.copytree(real_dirname(sys.argv[0]), exec_dir, symlinks=False, ignore=None)
+        else:
+            pass_args.append(arg)
+
+    # In the original shell script the test coded below read:
+    #   if [ "$jvm_mem_opts" == "" ] && [ -z ${_JAVA_OPTIONS+x} ]
+    # To reproduce the behaviour of the above shell code fragment
+    # it is important to explictly check for equality with None
+    # in the second condition, so a null envar value counts as True!
+
+    if mem_opts == [] and getenv('_JAVA_OPTIONS') is None:
+        mem_opts = default_jvm_mem_opts
+
+    return (mem_opts, prop_opts, pass_args, exec_dir)
+
+
+def main():
+    java = java_executable()
+    """
+    PeptideShaker updates files relative to the path of the jar file.
+    In a multiuser setting, the option --exec_dir="exec_dir"
+    can be used as the location for the peptide-shaker distribution.
+    If the exec_dir dies not exist,
+    we copy the jar file, lib, and resources to the exec_dir directory.
+    """
+    (mem_opts, prop_opts, pass_args, exec_dir) = jvm_opts(sys.argv[1:])
+    jar_dir = exec_dir if exec_dir else real_dirname(sys.argv[0])
+
+    if pass_args != [] and pass_args[0].startswith('eu'):
+        jar_arg = '-cp'
+    else:
+        jar_arg = '-jar'
+
+    jar_path = os.path.join(jar_dir, jar_file)
+
+    java_args = [java] + mem_opts + prop_opts + [jar_arg] + [jar_path] + pass_args
+
+    sys.exit(subprocess.call(java_args))
+
+
+if __name__ == '__main__':
+    main()

--- a/recipes/snpeff/5.1d/astrazeneca.patch
+++ b/recipes/snpeff/5.1d/astrazeneca.patch
@@ -1,0 +1,24 @@
+diff --git a/snpEff/snpEff.config b/snpEff/snpEff.config
+index 71938ef..0ddcc22 100644
+--- a/snpEff/snpEff.config
++++ b/snpEff/snpEff.config
+@@ -28,13 +28,17 @@ data.dir = ./data/
+ #database.repositoryKey = "?sv=2019-10-10&st=2020-09-01T00%3A00%3A00Z&se=2050-09-01T00%3A00%3A00Z&si=prod&sr=c&sig=isafOa9tGnYBAvsXFUMDGMTbsG2z%2FShaihzp7JE5dHw%3D"
+
+ # Primary Azure blob storage
+-database.repository = https://snpeff.blob.core.windows.net/databases/
++#database.repository = https://snpeff.blob.core.windows.net/databases/
++
++# AstraZeneca S3 bucket (ODSP: Oncology Data Science & AI)
++database.repository = https://snpeff.odsp.astrazeneca.com/databases
+
+ #---
+ # Latest version numbers. Check here if there is an update.
+ #---
+ #versions.url = https://pcingola.github.io/SnpEff/versions.txt
+-versions.url = https://snpeff.blob.core.windows.net/databases/versions.txt
++#versions.url = https://snpeff.blob.core.windows.net/databases/versions.txt
++versions.url = https://snpeff.odsp.astrazeneca.com/versions/versions.txt
+
+ #-------------------------------------------------------------------------------
+ # Third party databases

--- a/recipes/snpeff/5.1d/build.sh
+++ b/recipes/snpeff/5.1d/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+outdir=$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM
+mkdir -p "$outdir"
+mkdir -p "$PREFIX/bin"
+mv scripts/ snpEff.config snpEff.jar "$outdir/"
+cp "$RECIPE_DIR/snpeff.py" "$outdir/snpEff"
+chmod +x "$outdir/snpEff"
+
+ln -s "$outdir/snpEff" "$PREFIX/bin"

--- a/recipes/snpeff/5.1d/meta.yaml
+++ b/recipes/snpeff/5.1d/meta.yaml
@@ -1,0 +1,41 @@
+{% set snpeff_ver = "v5_1d" %}
+# NOTE: if the version contains a trailing letter, use the <d>.<d>.1<l> format
+# Please update recipes/snpsift as well!
+{% set version = "5.1d" %}
+{% set sha256 = "919e0595c08e86d1dd82279723c83cb872070244ee4ce0cb3167bde2b272893b" %}
+
+about:
+  home: 'http://snpeff.sourceforge.net/'
+  license: "LGPLv3"
+  summary: "Genetic variant annotation and effect prediction toolbox"
+
+package:
+  name: snpeff
+  version: {{ version }}
+
+build:
+  number: 1
+  noarch: generic
+  run_exports:
+    - {{ pin_compatible('snpeff', max_pin="x.x") }}
+
+source:
+  url: https://snpeff.odsp.astrazeneca.com/versions/snpEff_{{ snpeff_ver }}_core.zip
+  sha256: {{ sha256 }}
+  patches:
+    - astrazeneca.patch  # use AstraZeneca S3 bucket instead of Azure blob storage
+
+requirements:
+  run:
+    - openjdk >=11
+    - zlib
+    - python
+
+test:
+  commands:
+    - snpEff -version
+
+extra:
+  notes: 'The tool is available as command `snpEff`. Note that the package version is slightly different from upstream, this is to make sure conda will order the package versions correctly.'
+  identifiers:
+    - biotools:snpeff

--- a/recipes/snpeff/5.1d/snpeff.py
+++ b/recipes/snpeff/5.1d/snpeff.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+#
+# Wrapper script for Java Conda packages that ensures that the java runtime
+# is invoked with the right options. Adapted from the bash script (http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in/246128#246128).
+
+#
+# Program Parameters
+#
+import os
+import subprocess
+import sys
+import shutil
+from os import access
+from os import getenv
+from os import X_OK
+
+jar_file = 'snpEff.jar'
+
+
+default_jvm_mem_opts = ['-Xms512m', '-Xmx1g']
+
+# !!! End of parameter section. No user-serviceable code below this line !!!
+
+
+def real_dirname(path):
+    """Return the symlink-resolved, canonicalized directory-portion of path."""
+    return os.path.dirname(os.path.realpath(path))
+
+
+def java_executable():
+    """Return the executable name of the Java interpreter."""
+    java_home = getenv('JAVA_HOME')
+    java_bin = os.path.join('bin', 'java')
+
+    if java_home and access(os.path.join(java_home, java_bin), X_OK):
+        return os.path.join(java_home, java_bin)
+    else:
+        return 'java'
+
+
+def jvm_opts(argv):
+    """Construct list of Java arguments based on our argument list.
+
+    The argument list passed in argv must not include the script name.
+    The return value is a 3-tuple lists of strings of the form:
+      (memory_options, prop_options, passthrough_options)
+    """
+    mem_opts = []
+    prop_opts = []
+    pass_args = []
+    exec_dir = None
+
+    for arg in argv:
+        if arg.startswith('-D'):
+            prop_opts.append(arg)
+        elif arg.startswith('-XX'):
+            prop_opts.append(arg)
+        elif arg.startswith('-Xm'):
+            mem_opts.append(arg)
+        elif arg.startswith('--exec_dir='):
+            exec_dir = arg.split('=')[1].strip('"').strip("'")
+            if not os.path.exists(exec_dir):
+                shutil.copytree(real_dirname(sys.argv[0]), exec_dir, symlinks=False, ignore=None)
+        else:
+            pass_args.append(arg)
+
+    # In the original shell script the test coded below read:
+    #   if [ "$jvm_mem_opts" == "" ] && [ -z ${_JAVA_OPTIONS+x} ]
+    # To reproduce the behaviour of the above shell code fragment
+    # it is important to explictly check for equality with None
+    # in the second condition, so a null envar value counts as True!
+
+    if mem_opts == [] and getenv('_JAVA_OPTIONS') is None:
+        mem_opts = default_jvm_mem_opts
+
+    return (mem_opts, prop_opts, pass_args, exec_dir)
+
+
+def main():
+    java = java_executable()
+    """
+    PeptideShaker updates files relative to the path of the jar file.
+    In a multiuser setting, the option --exec_dir="exec_dir"
+    can be used as the location for the peptide-shaker distribution.
+    If the exec_dir dies not exist,
+    we copy the jar file, lib, and resources to the exec_dir directory.
+    """
+    (mem_opts, prop_opts, pass_args, exec_dir) = jvm_opts(sys.argv[1:])
+    jar_dir = exec_dir if exec_dir else real_dirname(sys.argv[0])
+
+    if pass_args != [] and pass_args[0].startswith('eu'):
+        jar_arg = '-cp'
+    else:
+        jar_arg = '-jar'
+
+    jar_path = os.path.join(jar_dir, jar_file)
+
+    java_args = [java] + mem_opts + prop_opts + [jar_arg] + [jar_path] + pass_args
+
+    sys.exit(subprocess.call(java_args))
+
+
+if __name__ == '__main__':
+    main()

--- a/recipes/snpeff/5.2/astrazeneca.patch
+++ b/recipes/snpeff/5.2/astrazeneca.patch
@@ -1,0 +1,24 @@
+diff --git a/snpEff/snpEff.config b/snpEff/snpEff.config
+index 7a9dff6..652a7f1 100644
+--- a/snpEff/snpEff.config
++++ b/snpEff/snpEff.config
+@@ -28,13 +28,17 @@ data.dir = ./data/
+ #database.repositoryKey = "?sv=2019-10-10&st=2020-09-01T00%3A00%3A00Z&se=2050-09-01T00%3A00%3A00Z&si=prod&sr=c&sig=isafOa9tGnYBAvsXFUMDGMTbsG2z%2FShaihzp7JE5dHw%3D"
+
+ # Primary Azure blob storage
+-database.repository = https://snpeff.blob.core.windows.net/databases/
++#database.repository = https://snpeff.blob.core.windows.net/databases/
++
++# AstraZeneca S3 bucket (ODSP: Oncology Data Science & AI)
++database.repository = https://snpeff.odsp.astrazeneca.com/databases
+
+ #---
+ # Latest version numbers. Check here if there is an update.
+ #---
+ #versions.url = https://pcingola.github.io/SnpEff/versions.txt
+-versions.url = https://snpeff.blob.core.windows.net/databases/versions.txt
++#versions.url = https://snpeff.blob.core.windows.net/databases/versions.txt
++versions.url = https://snpeff.odsp.astrazeneca.com/versions/versions.txt
+
+ #-------------------------------------------------------------------------------
+ # Third party databases

--- a/recipes/snpeff/5.2/build.sh
+++ b/recipes/snpeff/5.2/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+outdir=$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM
+mkdir -p "$outdir"
+mkdir -p "$PREFIX/bin"
+mv scripts/ snpEff.config snpEff.jar "$outdir/"
+cp "$RECIPE_DIR/snpeff.py" "$outdir/snpEff"
+chmod +x "$outdir/snpEff"
+
+ln -s "$outdir/snpEff" "$PREFIX/bin"

--- a/recipes/snpeff/5.2/meta.yaml
+++ b/recipes/snpeff/5.2/meta.yaml
@@ -1,0 +1,42 @@
+{% set snpeff_ver = "v5_2" %}
+# NOTE: if the version contains a trailing letter, use the <d>.<d>.1<l> format
+# Please update recipes/snpsift as well!
+{% set version = "5.2" %}
+{% set sha256 = "60ad2eec66c4f086b8cc7812e5654dce2dd500dd218774da490326e6a4e585f7" %}
+
+package:
+  name: snpeff
+  version: {{ version }}
+
+build:
+  number: 2
+  noarch: generic
+  run_exports:
+    - {{ pin_compatible('snpeff', max_pin="x.x") }}
+
+source:
+  url: https://snpeff.odsp.astrazeneca.com/versions/snpEff_{{ snpeff_ver }}_core.zip
+  sha256: {{ sha256 }}
+  patches:
+    - astrazeneca.patch  # use AstraZeneca S3 bucket instead of Azure blob storage
+
+requirements:
+  run:
+    - openjdk >=11
+    - zlib
+    - python
+
+test:
+  commands:
+    - snpEff -help --dry-run
+    - snpEff -version
+
+about:
+  home: 'http://snpeff.sourceforge.net/'
+  license: "LGPLv3"
+  summary: "Genetic variant annotation and effect prediction toolbox"
+
+extra:
+  notes: 'The tool is available as command `snpEff`. Note that the package version is slightly different from upstream, this is to make sure conda will order the package versions correctly.'
+  identifiers:
+    - biotools:snpeff

--- a/recipes/snpeff/5.2/snpeff.py
+++ b/recipes/snpeff/5.2/snpeff.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python
+#
+# Wrapper script for Java Conda packages that ensures that the java runtime
+# is invoked with the right options. Adapted from the bash script (http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in/246128#246128).
+
+#
+# Program Parameters
+#
+import os
+import subprocess
+import sys
+import shutil
+from os import access
+from os import getenv
+from os import X_OK
+
+jar_file = 'snpEff.jar'
+
+# Phone home has been disabled due to usage of an unregistered domain
+# If in the future the "phone home" feature becomes "opt-in" (e.g. -Log)
+# please remove the below to allow users to opt in
+disable_phone_home_opts = ['-noLog']
+
+default_jvm_mem_opts = ['-Xms512m', '-Xmx1g']
+
+# !!! End of parameter section. No user-serviceable code below this line !!!
+
+
+def real_dirname(path):
+    """Return the symlink-resolved, canonicalized directory-portion of path."""
+    return os.path.dirname(os.path.realpath(path))
+
+
+def java_executable():
+    """Return the executable name of the Java interpreter."""
+    java_home = getenv('JAVA_HOME')
+    java_bin = os.path.join('bin', 'java')
+
+    if java_home and access(os.path.join(java_home, java_bin), X_OK):
+        return os.path.join(java_home, java_bin)
+    else:
+        return 'java'
+
+
+def jvm_opts(argv):
+    """Construct list of Java arguments based on our argument list.
+
+    The argument list passed in argv must not include the script name.
+    The return value is a 3-tuple lists of strings of the form:
+      (memory_options, prop_options, passthrough_options)
+    """
+    mem_opts = []
+    prop_opts = []
+    pass_args = []
+    exec_dir = None
+    is_dryrun = False
+
+    for arg in argv:
+        if arg.startswith('-D'):
+            prop_opts.append(arg)
+        elif arg.startswith('-XX'):
+            prop_opts.append(arg)
+        elif arg.startswith('-Xm'):
+            mem_opts.append(arg)
+        elif arg.startswith('--exec_dir='):
+            exec_dir = arg.split('=')[1].strip('"').strip("'")
+            if not os.path.exists(exec_dir):
+                shutil.copytree(real_dirname(sys.argv[0]), exec_dir, symlinks=False, ignore=None)
+        elif arg.startswith('--dry-run'):
+            is_dryrun = True
+        else:
+            pass_args.append(arg)
+
+    # In the original shell script the test coded below read:
+    #   if [ "$jvm_mem_opts" == "" ] && [ -z ${_JAVA_OPTIONS+x} ]
+    # To reproduce the behaviour of the above shell code fragment
+    # it is important to explictly check for equality with None
+    # in the second condition, so a null envar value counts as True!
+
+    if mem_opts == [] and getenv('_JAVA_OPTIONS') is None:
+        mem_opts = default_jvm_mem_opts
+
+    return (mem_opts, prop_opts, pass_args, exec_dir, is_dryrun)
+
+
+def main():
+    java = java_executable()
+    """
+    PeptideShaker updates files relative to the path of the jar file.
+    In a multiuser setting, the option --exec_dir="exec_dir"
+    can be used as the location for the peptide-shaker distribution.
+    If the exec_dir dies not exist,
+    we copy the jar file, lib, and resources to the exec_dir directory.
+    """
+    (mem_opts, prop_opts, pass_args, exec_dir, is_dryrun) = jvm_opts(sys.argv[1:])
+    jar_dir = exec_dir if exec_dir else real_dirname(sys.argv[0])
+
+    if pass_args != [] and pass_args[0].startswith('eu'):
+        jar_arg = '-cp'
+    else:
+        jar_arg = '-jar'
+
+    jar_path = os.path.join(jar_dir, jar_file)
+
+    java_args = [java] + mem_opts + prop_opts + [jar_arg] + [jar_path] + pass_args + disable_phone_home_opts
+
+    if is_dryrun:
+        sys.exit(print(java_args))
+    else:
+        sys.exit(subprocess.call(java_args))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Microsoft's SnpEff repository has been deactivated. Data has been migrated to a new repository provided by AstraZeneca.

URLs have been already updated in the configuration file of SnpEff v5.3, but older versions fail to run. Afaik, SnpSift only uses annotations from local files, so the recipes would not need to be updated.

This PR patches snpEff.config so that it points to the new URLs. 