### PR TITLE
Update excludonfinder to v0.1.6 - Bug fixes

### DIFF
--- a/recipes/excludonfinder/meta.yaml
+++ b/recipes/excludonfinder/meta.yaml
@@ -1,0 +1,42 @@
+{% set name = "excludonfinder" %}
+{% set version = "0.1.6" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/Alvarosmb/ExcludonFinder/archive/v{{ version }}.tar.gz
+  sha256: 6946813ae4a239c78b5ea58d40a7ceb7bcd97d9231fad46a0f13d036700790f5
+
+build:
+  number: 0
+  noarch: generic
+  script: |
+    mkdir -p ${PREFIX}/share/excludonfinder/scripts
+    cp scripts/*.R ${PREFIX}/share/excludonfinder/scripts/
+    cp scripts/main.sh ${PREFIX}/bin/ExcludonFinder
+    chmod +x ${PREFIX}/bin/ExcludonFinder
+
+requirements:
+  run:
+    - bwa-mem2
+    - samtools
+    - minimap2
+    - r-base >=4.0
+    - bioconductor-subread
+
+test:
+  commands:
+    - ExcludonFinder --help
+
+about:
+  home: https://github.com/Alvarosmb/ExcludonFinder
+  summary: A tool for identifying and analyzing excludons in genomic data using RNA-seq data
+  license: MIT
+  doc_url: https://github.com/Alvarosmb/ExcludonFinder/blob/main/README.md
+  dev_url: https://github.com/Alvarosmb/ExcludonFinder
+
+extra:
+  recipe-maintainers:
+    - Alvarosmb

--- a/recipes/excludonfinder/meta.yaml
+++ b/recipes/excludonfinder/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "excludonfinder" %}
-{% set version = "0.1.6" %}
+{% set version = "0.1.7" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/Alvarosmb/ExcludonFinder/archive/v{{ version }}.tar.gz
-  sha256: 6946813ae4a239c78b5ea58d40a7ceb7bcd97d9231fad46a0f13d036700790f5
+  sha256: 93963dbce1a3b4d1a190185ca5ecdbe2d64a2dcd5f41715523f52b9312489274
 
 build:
   number: 0


### PR DESCRIPTION
This PR updates excludonfinder from v0.1.5 to v0.1.6 with important bug fixes:

- **Fixed critical syntax error** in main.sh (missing 'fi' statement) that prevented the tool from running
- **Improved SCRIPTS_PATH detection** to work both from source code (git clone) and package installation
- **Auto-detection** of execution environment (source vs package)

These fixes ensure the tool works correctly for all users regardless of installation method.