### PR TITLE
Add humanfilt 0.1.0

### DIFF
--- a/recipes/humanfilt/meta.yaml
+++ b/recipes/humanfilt/meta.yaml
@@ -20,7 +20,7 @@ requirements:
       - python >=3.10
       - pip
       - setuptools
-  run:
+    run:
       - python >=3.10
       - bwa
       - samtools


### PR DESCRIPTION
humanfilt 0.1.0 — a CLI to remove human reads from WGS FASTQ using
  mapping (bwa, minimap2, bowtie2) or classification (Kraken2). Supports
  auto‑downloaded references (GRCh38, CHM13/T2T, HPRC, UniVec) and manually curated human kraken2 database, outputs filtered  FASTQs and a CSV report.

  - Package: humanfilt 0.1.0
  - Upstream: https://github.com/jprehn-lab/humanfilt
  - Source: https://github.com/jprehn-lab/humanfilt/archive/refs/tags/v0.1.0.tar.gz
  - License: MIT 
  - Build: noarch Python; pip install; entry point humanfilt=humanfilt.cli:main
  - Tests: humanfilt --help and import humanfilt (no network/downloads in tests)
  - Runtime deps: bwa, minimap2, bowtie2, kraken2, samtools, trim-galore, bbmap,
  fastuniq, seqkit, pigz
  - Maintainer: @marsfro
  - Run exports: not applicable (CLI application, no importable API for
  downstream packages)

