### PR TITLE
Fix ena-webin-cli bug due to unsafe wrapper script not doing proper shell quoting

### DIFF
--- a/recipes/ena-webin-cli/ena_webin_cli.py
+++ b/recipes/ena-webin-cli/ena_webin_cli.py
@@ -60,7 +60,11 @@ def jvm_opts(argv):
       (memory_options, prop_options, passthrough_options)
     """
     mem_opts = []
-    prop_opts = []
+
+    # To avoid warnings in java >=24
+    # See https://github.com/enasequence/webin-cli/issues/157
+    prop_opts = ["--enable-native-access=ALL-UNNAMED"]
+
     pass_args = []
     exec_dir = None
 

--- a/recipes/ena-webin-cli/ena_webin_cli.py
+++ b/recipes/ena-webin-cli/ena_webin_cli.py
@@ -98,9 +98,25 @@ def main():
     jar_dir = exec_dir if exec_dir else real_dirname(sys.argv[0])
     jar_arg = "-jar"
     jar_path = find_jar_file(jar_dir)
-    java_args = [java] + mem_opts + prop_opts + [jar_arg] + [jar_path] + pass_args
-    command = " ".join(java_args)
-    sys.exit(os.system(command))
+    java_args = [java] + mem_opts + prop_opts + [jar_arg, jar_path] + pass_args
+
+    if os.getenv("WEBIN_LAUNCHER_DEBUG") == "1":
+        import shlex
+        print("[debug] exec:", shlex.join(java_args), file=sys.stderr)
+
+    try:
+        os.execvp(java, java_args)
+    except FileNotFoundError:
+        print(
+            "Error: could not execute 'java'. In bioconda environments, JAVA_HOME and PATH "
+            "should be configured automatically. If you see this, please open an issue at "
+            "https://github.com/bioconda/bioconda-recipes/issues (package: ena-webin-cli).",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    except OSError as e:
+        print(f"Error: failed to exec java: {e}", file=sys.stderr)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/recipes/ena-webin-cli/meta.yaml
+++ b/recipes/ena-webin-cli/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 build:
   noarch: generic
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage('ena-webin-cli', max_pin="x") }}
 


### PR DESCRIPTION
Fix bug in ena-webin-cli that results in errors when args contain parentheses

See:
- https://github.com/pathoplexus/ena-submission/issues/132
- https://github.com/enasequence/webin-cli/issues/156

Took me some time to figure out this was a bug in the bioconda wrapper.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
