### PR TITLE
Revert "update pbstarphase and enabled linux-aarch64 "

### DIFF
--- a/recipes/pbstarphase/build.sh
+++ b/recipes/pbstarphase/build.sh
@@ -1,46 +1,7 @@
-#!/bin/bash
-set -euo pipefail
+#!/usr/bin/env bash
 
-cd source
-
-cat > Makefile << 'EOM'
-CXX ?= g++
-CXXFLAGS = -I${PREFIX}/include -std=c++11
-LDFLAGS = -L${PREFIX}/lib
-LIBS = -lz
-
-TARGET = pbstarphase
-SRC = main.cpp
-
-all: $(TARGET)
-
-$(TARGET): $(SRC)
-	$(CXX) $(CXXFLAGS) $(LDFLAGS) $^ -o $@ $(LIBS)
-
-clean:
-	rm -f $(TARGET)
-
-.PHONY: all clean
-EOM
-
-cat > main.cpp << EOM
-#include <iostream>
-#include <string>
-#include <zlib.h>
-#define VERSION "1.4.1"  
-
-int main(int argc, char* argv[]) {
-  if (argc < 2) {
-    std::cerr << "Usage: pbstarphase <input_file>\n";
-    std::cerr << "Version: " << VERSION << "\n";
-    return 1;
-  }
-  std::cout << "pbstarphase v" << VERSION << "\n";
-  return 0;
-}
-EOM
-
-make CXX=${CXX} -j${CPU_COUNT}
-
-install -d ${PREFIX}/bin
-install pbstarphase ${PREFIX}/bin/
+mkdir -p "${PREFIX}"/bin
+# bioconda auto-extract for us apparently
+# tar -xzf pbstarphase-*.tar.gz
+md5sum -c pbstarphase.md5
+cp pbstarphase "${PREFIX}"/bin/

--- a/recipes/pbstarphase/meta.yaml
+++ b/recipes/pbstarphase/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 2
   skip: True  # [osx]
   run_exports:
     - {{ pin_subpackage('pbstarphase', max_pin="x") }}

--- a/recipes/pbstarphase/meta.yaml
+++ b/recipes/pbstarphase/meta.yaml
@@ -7,36 +7,23 @@ package:
   version: {{ version }}
 
 source:
-  - url: https://github.com/PacificBiosciences/pb-StarPhase/archive/v{{ version }}.tar.gz
-    sha256: 6c7e409e472dd13861d63bbc0ac9a82ce9e50ca6560a796d8ccca75ca843904a
-    folder: source
+  url: https://github.com/PacificBiosciences/pb-StarPhase/releases/download/v{{ version }}/pbstarphase-v{{ version }}-x86_64-unknown-linux-gnu.tar.gz
+  sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 0
   skip: True  # [osx]
   run_exports:
-    - {{ pin_subpackage(name, max_pin="x") }}
-
-requirements:
-  build:
-    - {{ compiler('c') }}
-    - {{ compiler('cxx') }}
-    - make
-    - pkg-config
-  host:
-    - zlib
+    - {{ pin_subpackage('pbstarphase', max_pin="x") }}
 
 test:
   commands:
-    - test -f ${PREFIX}/bin/pbstarphase
-    - pbstarphase 2>&1 | grep "Usage"
-    - pbstarphase --help
+    - pbstarphase --version
 
 about:
-  home: "https://github.com/PacificBiosciences/pb-StarPhase"
-  license: "BSD-3-Clause-Clear"
-  summary: "A phase-aware pharmacogenomic diplotyper for PacBio sequencing data."
-  dev_url: "https://github.com/PacificBiosciences/pb-StarPhase"
+  home: https://github.com/PacificBiosciences/pb-StarPhase
+  license: BSD-3-Clause-Clear
+  summary: A phase-aware pharmacogenomic diplotyper for PacBio sequencing data
 
 extra:
   recipe-maintainers:
@@ -46,5 +33,3 @@ extra:
   skip-lints:
     - should_use_compilers
     - should_be_noarch_generic
-  additional-platforms:
-    - linux-aarch64


### PR DESCRIPTION
Reverts bioconda/bioconda-recipes#59255

We are receiving reports that this build does not work.  Upon inspection it appears to be completely gutting the actual install of pb-StarPhase, and is potentially malicious.  This reverts the change.