### PR TITLE
Add stellarscope

### DIFF
--- a/recipes/stellarscope/meta.yaml
+++ b/recipes/stellarscope/meta.yaml
@@ -1,0 +1,58 @@
+{% set name = "stellarscope" %}
+{% set version = "1.5" %}
+{% set sha256 = "cb8f4aceeac0ddbe591846aabc7da17e1086a221c84ec65f601516e75ea34c88" %}
+
+package:
+    name: {{ name|lower }}
+    version: {{ version }}
+
+source:
+    url: https://github.com/nixonlab/stellarscope/archive/refs/tags/{{ version }}.tar.gz
+    sha256: {{ sha256 }}
+
+build:
+    number: 0
+    skip: True  # [py2k]  
+    script: |
+        export SETUPTOOLS_SCM_PRETEND_VERSION={{ version }}
+        {{ PYTHON }} -m pip install . -vv
+    run_exports:
+        - {{ pin_subpackage("stellarscope", max_pin="x.x") }}
+
+requirements:
+    build:
+        - {{ compiler('c') }}    
+    host:
+        - python
+        - pip    
+        - setuptools
+        - cython
+        - pysam >=0.19
+        - setuptools_scm
+    run:
+        - python
+        - future >=0.17.1
+        - pyyaml >=5.1    
+        - {{ pin_compatible('numpy') }}
+        - scipy >=1.2.1
+        - pysam >=0.19
+        - intervaltree >=3.0.2
+        - pandas
+        - packaging
+        - samtools >=1.16
+
+test:
+    commands:
+        - stellarscope --version
+
+about:
+    home: 'https://github.com/nixonlab/stellarscope'
+    license: MIT
+    license_family: MIT
+    license_file: LICENSE
+    summary: Single-cell Transposable Element Locus Level Analysis of scRNA Sequencing
+
+extra:
+    identifiers:
+        - doi:10.1016/j.crmeth.2025.101086
+


### PR DESCRIPTION
Add [stellarscope](https://doi.org/10.1016/j.crmeth.2025.101086), a python package for locus-specific quantification of transposable element expression in single cell RNA-seq gene expression datasets. The package provides a single command-line entry point (`stellarscope`) with the following subcommands:

- **cellsort**  -  Sort and filter BAM file according to cell barcode
- **assign**  -  Reassign ambiguous fragments that map to repetitive elements
- **resume**  -  Resume previous run from checkpoint file
- **resolve**  -  Resolve UMIs that overlap TEs and CGs
- **merge**  -  Merge CG and TE UMI count matrices.

