### PR TITLE
Ease Java gatk restriction

### DIFF
--- a/recipes/gatk4/meta.yaml
+++ b/recipes/gatk4/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - r-reshape
     - gcnvkernel =0.9
   run:
-    - openjdk >=17,<18
+    - openjdk >=17
     - python
     - r-base =4.3.1
     - r-gplots


### PR DESCRIPTION
The OpenJDK version of Gatk4 seems fairly restrictive, and this causes installation issues with other packages that need newer java. Version 18 was released in 2022. I see other users have had similar issues: https://github.com/bioconda/bioconda-recipes/issues/35268

Is there a reason to restrict to v18? I propose relaxing the version requirement here. Thanks for your consideration!