### PR TITLE
Bump snpeff minimum java version

### DIFF
--- a/recipes/snpeff/meta.yaml
+++ b/recipes/snpeff/meta.yaml
@@ -9,7 +9,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 0
+  number: 1
   noarch: generic
   run_exports:
     - {{ pin_compatible('snpeff', max_pin="x.x") }}
@@ -20,7 +20,7 @@ source:
 
 requirements:
   run:
-    - openjdk >=11
+    - openjdk >=21
     - zlib
     - python
 


### PR DESCRIPTION
SnpEff 5.3.0a install from bioconda.

On version 20 OpenJDK or below, getting:
```bash
snpEff -h
Error: LinkageError occurred while loading main class org.snpeff.SnpEff
        java.lang.UnsupportedClassVersionError: org/snpeff/SnpEff has been compiled by a more recent version of the Java Runtime (class file version 65.0), this version of the Java Runtime only recognizes class file versions up to 64.0
```

On version 21, it successfully runs.