### PR TITLE
coot-headless: Add Doxygen python modules' documentation generation step

### DIFF
--- a/recipes/coot-headless/build.sh
+++ b/recipes/coot-headless/build.sh
@@ -19,6 +19,10 @@ else
   export CXXFLAGS="${CXXFLAGS} -march=x86-64-v3"
 fi
 
+pushd api/doxy-sphinx
+doxygen coot-api-dox.cfg
+popd
+
 sed -i.bak '/find_package(RDKit CONFIG COMPONENTS RDGeneral REQUIRED)/a\
 set_target_properties(RDKit::rdkit_base PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${RDKit_INCLUDE_DIRS}")' CMakeLists.txt
 rm -rf *.bak

--- a/recipes/coot-headless/meta.yaml
+++ b/recipes/coot-headless/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: c6e2864023c0bc83278c6fd760af704fd955616a007f00d61452b015f892f463
 
 build:
-  number: 1
+  number: 2
   run_exports:
     # Minor version changes may be disruptive
     # Refer to https://github.com/pemsley/coot/issues/239#issuecomment-3031606299
@@ -21,6 +21,7 @@ requirements:
     - {{ compiler("c") }}
     - {{ compiler("cxx") }}
     - cmake
+    - doxygen
     - ninja
     - pkg-config
     - sed  # [osx]


### PR DESCRIPTION
This pull request updates the `coot-headless` build process to generate API documentation using Doxygen and ensures the necessary build dependency is included. It also increments the build number to reflect these changes.

Build process and documentation improvements:
* The build script (`build.sh`) now runs Doxygen in the `api/doxy-sphinx` directory to generate API documentation before proceeding with the rest of the build steps.
* The `meta.yaml` file adds `doxygen` as a build dependency to guarantee that documentation generation can occur during the build.

Packaging and versioning:
* The build number in `meta.yaml` is incremented from 1 to 2 to reflect the new changes in the package.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
