### PR TITLE
Update: hyphy to restore the ability of running the MPI version inside the container

### DIFF
--- a/recipes/hyphy/meta.yaml
+++ b/recipes/hyphy/meta.yaml
@@ -1,8 +1,9 @@
+{% set name = "hyphy" %}
 {% set version = "2.5.83" %}
 {% set sha256 = "d0b14a8d1522f31006475aa321833b261c130de8c921beb53f2d19264eb0af25" %}
 
 package:
-  name: hyphy
+  name: {{ name }}
   version: {{ version }}
 
 source:
@@ -12,7 +13,7 @@ source:
 build:
   number: 1
   run_exports:
-    - {{ pin_subpackage("hyphy", max_pin="x") }}
+    - {{ pin_subpackage(name, max_pin="x") }}
 
 requirements:
   build:
@@ -21,14 +22,13 @@ requirements:
     - {{ compiler("cxx") }}
     - pkg-config
   host:
-    - libcurl
-    - libblas
     - llvm-openmp  # [osx]
     - libgomp      # [linux]
     - openmpi
+    - libcurl
+    - libblas
     - zlib
   run:
-    - libblas
     - llvm-openmp  # [osx]
     - libgomp      # [linux]
     - openmpi
@@ -51,9 +51,28 @@ about:
 
 extra:
   container:
+    # mpirun won't run with ssh present, which is not included in the base image
     extended-base: True
   additional-platforms:
     - linux-aarch64
     - osx-arm64
   identifiers:
+    - biotools:HyPhy
+    - usegalaxy-eu:hyphy_busted
+    - usegalaxy-eu:hyphy_bgm
+    - usegalaxy-eu:hyphy_gard
+    - usegalaxy-eu:hyphy_absrel
+    - usegalaxy-eu:hyphy_fubar
+    - usegalaxy-eu:hyphy_fade
+    - usegalaxy-eu:hyphy_sm19
+    - usegalaxy-eu:hyphy_meme
+    - usegalaxy-eu:hyphy_prime
+    - usegalaxy-eu:hyphy_slac
+    - usegalaxy-eu:hyphy_fel
+    - usegalaxy-eu:hyphy_relax
+    - usegalaxy-eu:hyphy_cfel
+    - usegalaxy-eu:hyphy_summary
+    - usegalaxy-eu:hyphy_conv
+    - doi:10.1093/bioinformatics/bti079
     - doi:10.1093/molbev/msz197
+    - doi:10.1007/978-1-4939-8736-8_6


### PR DESCRIPTION
Starting with version 2.5.82 of HyPhy, the MPI-enabled version is built by default and is a part of the image (at some point it was there, then removed, now restored again). `mpirun` won't run with `ssh` present, which is not included in the base image

Describe your pull request here

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
