### PR TITLE
coot-headless: Enable generation of Python type stubs for `coot_headless_api`

### DIFF
--- a/recipes/coot-headless/build.sh
+++ b/recipes/coot-headless/build.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 set -exo pipefail
 
 export CPPFLAGS="${CPPFLAGS} -I${PREFIX}/include"
@@ -61,6 +62,7 @@ cmake -S . -B build -G Ninja \
   -DCLIPPER-CONTRIB_LIBRARY="${PREFIX}/lib/libclipper-contrib${SHLIB_EXT}" \
   -DCLIPPER-CIF_LIBRARY="${PREFIX}/lib/libclipper-cif${SHLIB_EXT}" \
   -DPYTHON_SITE_PACKAGES="${SP_DIR}" \
+  -DMAKE_COOT_HEADLESS_API_PYI=ON \
   -Wno-dev -Wno-deprecated --no-warn-unused-cli \
   ${CONFIG_ARGS}
 

--- a/recipes/coot-headless/build.sh
+++ b/recipes/coot-headless/build.sh
@@ -19,6 +19,10 @@ else
   export CXXFLAGS="${CXXFLAGS} -march=x86-64-v3"
 fi
 
+pushd api/doxy-sphinx
+doxygen coot-api-dox.cfg
+popd
+
 sed -i.bak '/find_package(RDKit CONFIG COMPONENTS RDGeneral REQUIRED)/a\
 set_target_properties(RDKit::rdkit_base PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${RDKit_INCLUDE_DIRS}")' CMakeLists.txt
 rm -rf *.bak

--- a/recipes/coot-headless/meta.yaml
+++ b/recipes/coot-headless/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: c6e2864023c0bc83278c6fd760af704fd955616a007f00d61452b015f892f463
 
 build:
-  number: 1
+  number: 2
   run_exports:
     # Minor version changes may be disruptive
     # Refer to https://github.com/pemsley/coot/issues/239#issuecomment-3031606299
@@ -21,6 +21,7 @@ requirements:
     - {{ compiler("c") }}
     - {{ compiler("cxx") }}
     - cmake
+    - doxygen
     - ninja
     - pkg-config
     - sed  # [osx]


### PR DESCRIPTION
This pull request updates the `coot-headless` build process to improve API documentation generation and Python interface typing, as well as incrementing the build number. The most significant changes are grouped below:

**API Documentation and Typing Improvements:**

* The build script now generates API documentation using Doxygen by running it in the `api/doxy-sphinx` directory (`recipes/coot-headless/build.sh`).
* The build process now enables generation of Python type stub files (`.pyi`) for the headless API by setting `-DMAKE_COOT_HEADLESS_API_PYI=ON` in the CMake configuration (`recipes/coot-headless/build.sh`).

**Build Requirements and Metadata Updates:**

* Added `doxygen` as a build dependency to ensure documentation can be generated (`recipes/coot-headless/meta.yaml`).
* Incremented the build number from 1 to 2 to reflect these changes (`recipes/coot-headless/meta.yaml`).

**Other:**

* Minor Bash script improvement: added a blank line after the shebang for clarity (`recipes/coot-headless/build.sh`).

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
