### PR TITLE
Add DeConveil

### DIFF
--- a/recipes/deconveil/meta.yaml
+++ b/recipes/deconveil/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "DeConveil" %}
-{% set version = "0.1.3" %}
+{% set version = "0.1.4" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/deconveil-{{ version }}.tar.gz
-  sha256: c4023629145698e8e6cefbba09a3593f2f5dbde0c332d7ff06f0edd30836ae05
+  sha256: adbd68807b5e69078813d2cba594f152b356656f763a7bae7db3d2ffc7762186
 
 build:
   noarch: python


### PR DESCRIPTION
Add DeConveil method, an extention of PyDESeq2/DESeq2, for Differential Gene expression test and analysis by accounting for genome aneuploidy: https://github.com/caravagnalab/DeConveil

This package includes a forked version.


