### PR TITLE
Update alloshp recipe

### DIFF
--- a/recipes/alloshp/meta.yaml
+++ b/recipes/alloshp/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "2025.09.08d" %}
-{% set sha256 = "051d4cd81eccd78fc005d85d310c5fb4980baf0191e092521385febcf30928be" %}
+{% set version = "2025.09.12" %}
+{% set sha256 = "3caaf31db3d0bc4519a7fabf6cf290895351f2d704d6081409b2c17ce63ee218" %}
 
 package:
   name: alloshp


### PR DESCRIPTION
After observing that the latest github release of the underlying [repo](https://github.com/eead-csic-compbio/AlloSHP/releases/tag/2025.09.12) did not trigger a new recipe after 3 weeks we asked in 
[gitter](https://matrix.to/#/!MhHkICgthNLZeLiygG:gitter.im/$_VVQw0Jxl_HkYGdbsjway61AfxevC-KQ46svJqUPdJY?via=gitter.im&via=matrix.org&via=robbinsa.me) and @bgruening suggested the problem might be the version format.

So this PR changed the version in the header of meta.yaml to yyyy.mm.dd format

