### PR TITLE
Update get_pangenes recipe

### DIFF
--- a/recipes/get_pangenes/meta.yaml
+++ b/recipes/get_pangenes/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "v1.3" %}
+{% set version = "1.3" %}
 {% set sha256 = "25926a64a7a3888f64cf45b48cbfcf94c43c486df5c98d3a6c067219570abd35" %}
 
 package:

--- a/recipes/get_pangenes/meta.yaml
+++ b/recipes/get_pangenes/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "20250123" %}
-{% set sha256 = "67665e4359dd16ae6fe1359c55a0a1d3eed07efa431c07a87c8c298a8bdbdde3" %}
+{% set version = "v1.3" %}
+{% set sha256 = "25926a64a7a3888f64cf45b48cbfcf94c43c486df5c98d3a6c067219570abd35" %}
 
 package:
   name: get_pangenes


### PR DESCRIPTION
This is similar to https://github.com/bioconda/bioconda-recipes/pull/59876 .

After observing that the latest github release of the underlying [repo](https://github.com/Ensembl/plant-scripts/releases/tag/v1.3) did not trigger a new recipe after 3 weeks we asked in
[gitter](https://matrix.to/#/!MhHkICgthNLZeLiygG:gitter.im/$_VVQw0Jxl_HkYGdbsjway61AfxevC-KQ46svJqUPdJY?via=gitter.im&via=matrix.org&via=robbinsa.me) and @bgruening suggested the problem might be the version format.

So this PR changed the version in the header of meta.yaml to 1.3 format