### PR TITLE
fix: pin python-kaleido==0.2.1 for stability

### DIFF
--- a/recipes/wakhan/meta.yaml
+++ b/recipes/wakhan/meta.yaml
@@ -14,7 +14,7 @@ build:
     - wakhan = src.main:main
   noarch: python
   script: {{ PYTHON }} -m pip install . -vvv --no-deps --no-build-isolation --no-cache-dir
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage(name, max_pin="x.x") }}
 

--- a/recipes/wakhan/meta.yaml
+++ b/recipes/wakhan/meta.yaml
@@ -37,7 +37,7 @@ requirements:
     - scipy ==1.9.2
     - ruptures
     - parse-vcf
-    - python-kaleido
+    - python-kaleido ==0.2.1
     - vcf_parser
 
 test:

--- a/recipes/wakhan/meta.yaml
+++ b/recipes/wakhan/meta.yaml
@@ -37,7 +37,7 @@ requirements:
     - scipy ==1.9.2
     - ruptures
     - parse-vcf
-    - python-kaleido ==0.2.1
+    - python-kaleido <1.0
     - vcf_parser
 
 test:


### PR DESCRIPTION
Pinned python-kaleido ==0.2.1 to ensure compatibility with plotly ==5.24.1

When creating conda environments, newer versions of python-kaleido (v1.0.0+) were being automatically installed, causing incompatibility with the pinned Plotly version (5.24.1). This resulted in wakhan crashing during PDF generation with the following error:

```
Warning: You have Plotly version 5.24.1, which is not compatible with this version of Kaleido (1.0.0).

This means that static image generation (e.g. `fig.write_image()`) will not work.

Please upgrade Plotly to version 6.1.1 or greater, or downgrade Kaleido to version 0.2.1.


Traceback (most recent call last):
  File "/home/fvillena/miniforge3/envs/wakhan_test/bin/wakhan", line 10, in <module>
    sys.exit(main())
  File "/home/fvillena/miniforge3/envs/wakhan_test/lib/python3.10/site-packages/src/main.py", line 331, in main
    wakhan_all(args) #hapcorrect + cna
  File "/home/fvillena/miniforge3/envs/wakhan_test/lib/python3.10/site-packages/src/main.py", line 343, in wakhan_all
    main_process(args)  # hapcorrect
  File "/home/fvillena/miniforge3/envs/wakhan_test/lib/python3.10/site-packages/src/hapcorrect/src/main_hapcorrect.py", line 215, in main_process
    plot_coverage_data(html_graphs, args, chrom, ref_start_values, ref_end_values, 
  File "/home/fvillena/miniforge3/envs/wakhan_test/lib/python3.10/site-packages/src/hapcorrect/src/plots.py", line 55, in plot_coverage_data
    print_chromosome_pdf(fig, chrom, args.out_dir_plots+'/phasing_output')
  File "/home/fvillena/miniforge3/envs/wakhan_test/lib/python3.10/site-packages/src/hapcorrect/src/plots.py", line 128, in print_chromosome_pdf
    plotly.io.write_image(fig,  filename, format='pdf')
  File "/home/fvillena/miniforge3/envs/wakhan_test/lib/python3.10/site-packages/plotly/io/_kaleido.py", line 266, in write_image
    img_data = to_image(
  File "/home/fvillena/miniforge3/envs/wakhan_test/lib/python3.10/site-packages/plotly/io/_kaleido.py", line 132, in to_image
    raise ValueError(
ValueError: 
Image export using the "kaleido" engine requires the kaleido package,
which can be installed using pip:
    $ pip install -U kaleido
```
----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
