### PR TITLE
humanfilt 1.0.0

### DIFF
--- a/recipes/humanfilt/LICENSE
+++ b/recipes/humanfilt/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Mariia Frolova
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/recipes/humanfilt/meta.yaml
+++ b/recipes/humanfilt/meta.yaml
@@ -1,0 +1,45 @@
+package:
+  name: humanfilt
+  version: 0.1.0
+
+source:
+  url: https://github.com/your-org/humanfilt/archive/refs/tags/v0.1.0.tar.gz
+  sha256: 0f9f96e41e019181bcc15fa0bad0d8c2494032c9fb6d0a8d9bd00799715e8824
+
+build:
+  noarch: python
+  number: 0
+  entry_points:
+    - humanfilt=humanfilt.cli:main
+
+requirements:
+  host:
+    - python >=3.10
+    - pip
+    - setuptools
+  run:
+    - python >=3.10
+    - bwa
+    - samtools
+    - minimap2
+    - bowtie2
+    - kraken2
+    - trim-galore
+    - bbmap     # bbduk.sh, dedupe.sh
+    - fastuniq
+    - seqkit
+    - pigz
+
+test:
+  commands:
+    - humanfilt --help
+    - humanfilt run --mode wgs --input . --output . --report _noop.csv --threads 1 --no-auto-setup || true
+
+about:
+  home: https://github.com/jprehn-lab/humanfilt
+  license: MIT
+  summary: WGS human read filtering with auto-downloaded references (GRCh38/T2T/HPRC/UniVec + Kraken2).
+
+extra:
+  recipe-maintainers:
+    - marsfro

--- a/recipes/humanfilt/meta.yaml
+++ b/recipes/humanfilt/meta.yaml
@@ -1,45 +1,48 @@
 package:
-  name: humanfilt
-  version: 0.1.0
+    name: humanfilt
+    version: 0.1.0
 
 source:
-  url: https://github.com/your-org/humanfilt/archive/refs/tags/v0.1.0.tar.gz
-  sha256: 0f9f96e41e019181bcc15fa0bad0d8c2494032c9fb6d0a8d9bd00799715e8824
+    url: https://github.com/jprehn-lab/humanfilt/archive/refs/tags/v0.1.0.tar.gz
+    sha256: 0f9f96e41e019181bcc15fa0bad0d8c2494032c9fb6d0a8d9bd00799715e8824
 
 build:
-  noarch: python
-  number: 0
-  entry_points:
-    - humanfilt=humanfilt.cli:main
+    noarch: python
+    number: 0
+    script: {{ PYTHON }} -m pip install . -vv
+    entry_points:
+      - humanfilt=humanfilt.cli:main
 
 requirements:
-  host:
-    - python >=3.10
-    - pip
-    - setuptools
+    host:
+      - python >=3.10
+      - pip
+      - setuptools
   run:
-    - python >=3.10
-    - bwa
-    - samtools
-    - minimap2
-    - bowtie2
-    - kraken2
-    - trim-galore
-    - bbmap     # bbduk.sh, dedupe.sh
-    - fastuniq
-    - seqkit
-    - pigz
+      - python >=3.10
+      - bwa
+      - samtools
+      - minimap2
+      - bowtie2
+      - kraken2
+      - trim-galore
+      - bbmap     # bbduk.sh, dedupe.sh
+      - fastuniq
+      - seqkit
+      - pigz
 
 test:
-  commands:
-    - humanfilt --help
-    - humanfilt run --mode wgs --input . --output . --report _noop.csv --threads 1 --no-auto-setup || true
+    commands:
+      - humanfilt --help
+    imports:
+      - humanfilt
 
 about:
-  home: https://github.com/jprehn-lab/humanfilt
-  license: MIT
-  summary: WGS human read filtering with auto-downloaded references (GRCh38/T2T/HPRC/UniVec + Kraken2).
+    home: https://github.com/jprehn-lab/humanfilt
+    license: MIT
+    summary: WGS human read filtering with auto-downloaded references (GRCh38/T2T/HPRC/UniVec + Kraken2).
 
 extra:
-  recipe-maintainers:
-    - marsfro
+    recipe-maintainers:
+      - marsfro   
+

--- a/recipes/humanfilt/meta.yaml
+++ b/recipes/humanfilt/meta.yaml
@@ -39,6 +39,7 @@ test:
 about:
     home: https://github.com/jprehn-lab/humanfilt
     license: MIT
+    license_file: LICENSE
     summary: WGS human read filtering with auto-downloaded references (GRCh38/T2T/HPRC/UniVec + Kraken2).
 
 extra:

--- a/recipes/humanfilt/meta.yaml
+++ b/recipes/humanfilt/meta.yaml
@@ -1,17 +1,19 @@
 package:
     name: humanfilt
-    version: 0.1.0
+    version: "0.1.0"
 
 source:
     url: https://github.com/jprehn-lab/humanfilt/archive/refs/tags/v0.1.0.tar.gz
     sha256: 0f9f96e41e019181bcc15fa0bad0d8c2494032c9fb6d0a8d9bd00799715e8824
 
 build:
-    noarch: python
     number: 0
-    script: {{ PYTHON }} -m pip install . -vv
+    noarch: python
+    script: {{ PYTHON }} -m pip install . --no-build-isolation --no-deps --no-cache-dir -vvv
     entry_points:
-      - humanfilt=humanfilt.cli:main
+      - humanfilt = humanfilt.cli:main
+    run_exports:
+      - {{ pin_subpackage('humanfilt', max_pin="x.x") }}
 
 requirements:
     host:
@@ -40,9 +42,8 @@ test:
 about:
     home: https://github.com/jprehn-lab/humanfilt
     license: MIT
-    summary: WGS human read filtering with auto-downloaded references (GRCh38/T2T/HPRC/UniVec + Kraken2).
+    summary: "WGS human read filtering with auto-downloaded references (GRCh38/T2T/HPRC/UniVec + Kraken2)."
 
 extra:
     recipe-maintainers:
       - marsfro   
-

--- a/recipes/humanfilt/meta.yaml
+++ b/recipes/humanfilt/meta.yaml
@@ -1,48 +1,50 @@
 package:
-    name: humanfilt
-    version: 0.1.1
+  name: humanfilt
+  version: 0.1.1
 
 source:
-    url: https://github.com/jprehn-lab/humanfilt/archive/refs/tags/v0.1.1.tar.gz
-    sha256: 4a1d9c99e6b383fc5a85c7d941e22f7faccd2431e175342ce63a6523f4616acd
+  url: https://github.com/jprehn-lab/humanfilt/archive/refs/tags/v0.1.1.tar.gz
+  sha256: 4a1d9c99e6b383fc5a85c7d941e22f7faccd2431e175342ce63a6523f4616acd
+
 build:
-    noarch: python
-    number: 0
-    script: "{{ PYTHON }} -m pip install . -vv"
-    entry_points:
-      - humanfilt=humanfilt.cli:main
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+  entry_points:
+    - humanfilt=humanfilt.cli:main
 
 requirements:
-    host:
-      - python >=3.10
-      - pip
-      - setuptools
+  host:
+    - python >=3.10
+    - pip
+    - setuptools
   run:
-      - python >=3.10
-      - bwa
-      - samtools
-      - minimap2
-      - bowtie2
-      - kraken2
-      - trim-galore
-      - bbmap     # bbduk.sh, dedupe.sh
-      - fastuniq
-      - seqkit
-      - pigz
+    - python >=3.10
+    - bwa
+    - samtools
+    - minimap2
+    - bowtie2
+    - kraken2
+    - trim-galore
+    - bbmap
+    - fastuniq
+    - seqkit
+    - pigz
 
 test:
-    commands:
-      - humanfilt --help
-    imports:
-      - humanfilt
+  imports:
+    - humanfilt
+  commands:
+    - humanfilt --help
 
 about:
-    home: https://github.com/jprehn-lab/humanfilt
-    license: MIT
-    license_file: LICENSE
-    summary: WGS human read filtering with auto-downloaded references (GRCh38/T2T/HPRC/UniVec + Kraken2).
+  home: https://github.com/jprehn-lab/humanfilt
+  license: MIT
+  license_file: LICENSE
+  summary: "WGS human-read filtering with auto-downloaded human references"
 
 extra:
-    recipe-maintainers:
-      - marsfro   
+  recipe-maintainers:
+    - marsfro
+  additional-platforms: []
 

--- a/recipes/humanfilt/meta.yaml
+++ b/recipes/humanfilt/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: humanfilt
-  version: 0.1.1
+  version: 1.0.0
 
 source:
-  url: https://github.com/jprehn-lab/humanfilt/archive/refs/tags/v0.1.1.tar.gz
-  sha256: 4a1d9c99e6b383fc5a85c7d941e22f7faccd2431e175342ce63a6523f4616acd
+  url: https://github.com/jprehn-lab/humanfilt/archive/refs/tags/v1.0.0.tar.gz
+  sha256: 28263a91b10f4a0085ea643bcfdf615c149a1a824c1854cddfedd540d8bd6e22
 
 build:
   noarch: python

--- a/recipes/humanfilt/meta.yaml
+++ b/recipes/humanfilt/meta.yaml
@@ -1,26 +1,23 @@
 package:
     name: humanfilt
-    version: "0.1.0"
+    version: 0.1.1
 
 source:
-    url: https://github.com/jprehn-lab/humanfilt/archive/refs/tags/v0.1.0.tar.gz
-    sha256: 0f9f96e41e019181bcc15fa0bad0d8c2494032c9fb6d0a8d9bd00799715e8824
-
+    url: https://github.com/jprehn-lab/humanfilt/archive/refs/tags/v0.1.1.tar.gz
+    sha256: 4a1d9c99e6b383fc5a85c7d941e22f7faccd2431e175342ce63a6523f4616acd
 build:
-    number: 0
     noarch: python
-    script: {{ PYTHON }} -m pip install . --no-build-isolation --no-deps --no-cache-dir -vvv
+    number: 0
+    script: "{{ PYTHON }} -m pip install . -vv"
     entry_points:
-      - humanfilt = humanfilt.cli:main
-    run_exports:
-      - {{ pin_subpackage('humanfilt', max_pin="x.x") }}
+      - humanfilt=humanfilt.cli:main
 
 requirements:
     host:
       - python >=3.10
       - pip
       - setuptools
-    run:
+  run:
       - python >=3.10
       - bwa
       - samtools
@@ -42,8 +39,9 @@ test:
 about:
     home: https://github.com/jprehn-lab/humanfilt
     license: MIT
-    summary: "WGS human read filtering with auto-downloaded references (GRCh38/T2T/HPRC/UniVec + Kraken2)."
+    summary: WGS human read filtering with auto-downloaded references (GRCh38/T2T/HPRC/UniVec + Kraken2).
 
 extra:
     recipe-maintainers:
       - marsfro   
+

--- a/recipes/humanfilt/meta.yaml
+++ b/recipes/humanfilt/meta.yaml
@@ -20,7 +20,7 @@ requirements:
       - python >=3.10
       - pip
       - setuptools
-  run:
+    run:
       - python >=3.10
       - bwa
       - samtools


### PR DESCRIPTION
First stable release of humanfilt. Major performance and reliability improvements over 0.2.0.

- Tag: https://github.com/jprehn-lab/humanfilt/releases/tag/v1.0.0
- Compare: https://github.com/jprehn-lab/humanfilt/compare/v0.2.0...v1.0.0

**Changes**
- Speed: ~[X×7 faster] on WGS paired Illumina data pipeline).
- Tests/CLI: `humanfilt --version` reports `1.0.0`.

**Packaging (Bioconda)**
- Bump version to `1.0.0`
- Update `source.url` to GitHub tag `v1.0.0`
- Update `sha256`
- License/Home unchanged

