### PR TITLE
Update gem2 with additional source URL in meta.yaml

### DIFF
--- a/recipes/gem2/meta.yaml
+++ b/recipes/gem2/meta.yaml
@@ -7,7 +7,8 @@ package:
 
 source:
   - url: https://paoloribeca.science/gem/gem2.{{ version }}.Linux-amd64.tar.xz  # [linux]
-    md5: 8254255f5bc8f4ee53bb9f34a6c5122c  # [linux]
+  - url: https://depot.galaxyproject.org/software/gem2/gem2_{{ version }}_src_all.tar.xz # [linux]
+md5: 8254255f5bc8f4ee53bb9f34a6c5122c  # [linux]
 
 build:
   skip: True  # [osx]


### PR DESCRIPTION
Old url has become unreachable.

