### PR TITLE
hybran: bump to version 1.9

### DIFF
--- a/recipes/hybran/meta.yaml
+++ b/recipes/hybran/meta.yaml
@@ -13,7 +13,7 @@ build:
   number: 0
   script: python -m pip install --no-deps --ignore-installed .
   run_exports:
-    - {{ pin_subpackage('hybran', max_pin=None) }}
+    - {{ pin_subpackage('hybran', max_pin='x') }}
 
 requirements:
   host:


### PR DESCRIPTION
I'm not letting the autobump handle this since this version has a new minimum Python interpreter dependency.
