### PR TITLE
add bronko v0.0.1

### DIFF
--- a/recipes/bronko/build.sh
+++ b/recipes/bronko/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -euo
+
+# Add workaround for SSH-based Git connections from Rust/cargo.  See https://github.com/rust-lang/cargo/issues/2078 for details.
+# We set CARGO_HOME because we don't pass on HOME to conda-build, thus rendering the default "${HOME}/.cargo" defunct.
+export CARGO_NET_GIT_FETCH_WITH_CLI=true CARGO_HOME="$(pwd)/.cargo"
+
+# build statically linked binary with Rust
+RUST_BACKTRACE=1 cargo install --verbose --path . --root $PREFIX

--- a/recipes/bronko/meta.yaml
+++ b/recipes/bronko/meta.yaml
@@ -1,0 +1,43 @@
+{% set version = "0.0.1" %}
+
+package:
+  name: bronko
+  version: {{ version }}
+
+source:
+  url: "https://github.com/treangenlab/bronko/archive/refs/tags/v{{ version }}.tar.gz"
+  sha256: 67da0defb0b7d64d4cf1baa65b3474f256321de5bc149d81a927de36deb1daf3
+
+build:
+  number: 0
+  run_exports:
+    - {{ pin_subpackage('bronko', max_pin="x.x") }}
+
+test:
+  commands:
+    - bronko --help
+
+
+requirements:
+  build: 
+    - {{ compiler("rust") }}
+    - make
+  run:
+    - kmc >=3.2
+
+about:
+  home: "https://github.com/treangenlab/bronko"
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: "bronko is an ultra-rapid mapping free variant caller for viral amplicon sequencing data" 
+  doc_url: "https://github.com/treangenlab/bronko/blob/main/README.md"
+  dev_url: "https://github.com/treangenlab/bronko"
+
+extra:
+  recipe-maintainers:
+    - rdoughty10
+  additional-platforms:
+    -linux-aarch64
+    -osx-arm64
+


### PR DESCRIPTION
Add [bronko](https://github.com/treangenlab/bronko) (v0.0.1) 

Bronko is a viral variant caller that can rapidly detect most major and minor variants in any given sequencing dataset. bronko bypasses read mapping and variant calling and directly outputs a VCF from reads and a reference genome.