### PR TITLE
Update remag to 0.3.1

### DIFF
--- a/recipes/remag/meta.yaml
+++ b/recipes/remag/meta.yaml
@@ -15,6 +15,8 @@ build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
     - remag = remag.cli:main
+  run_exports:
+    - {{ pin_subpackage('remag', max_pin="x.x") }}
 
 requirements:
   host:


### PR DESCRIPTION
This PR updates remag to v0.3.1, which fixes issues found in v0.3.0.

## Fixes in v0.3.1:

- **Removes `remag.xgbclass` import test**: The xgbclass module was removed in v0.3.0 when the XGBoost classifier was replaced with a HyenaDNA LLM-based model
- **Removes xgboost dependency**: No longer used in v0.3.0+
- **Adds missing dependencies**: biopython, einops, transformers (required for the HyenaDNA classifier)
- **Updates setuptools requirement to >=77.0**: For proper SPDX license handling

## Related to:

This PR supersedes #60192 (Update remag to 0.3.0), which fails testing due to the xgbclass import issue. The v0.3.1 release includes fixes to the bioconda generation script to prevent this issue in future releases.