### PR TITLE
update bcftools

### DIFF
--- a/recipes/bcftools/meta.yaml
+++ b/recipes/bcftools/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 1
+  number: 2
   run_exports:
     - {{ pin_subpackage("bcftools", max_pin="x") }}
 
@@ -22,7 +22,7 @@ requirements:
   host:
     - htslib
     - zlib
-    - gsl
+    - gsl >=2.8,<2.9.0a0
   run:
     # Currently removed due to size and dependency issues
     #- matplotlib # for plot-vcfstats


### PR DESCRIPTION
When install pggb on the linux-aarch64 platform,there is a version conflict among the three software packages:bcftools,wfmash,ang smoothxg,regarding the GSL version.
<img width="1151" height="251" alt="image" src="https://github.com/user-attachments/assets/7dd49fca-2803-44b7-9e92-d00fed9e01a0" />
The changes made have been verified.
<img width="2233" height="983" alt="image" src="https://github.com/user-attachments/assets/de95d62b-4e5a-4e00-8be8-97d3bc4cb0d3" />
