### PR TITLE
Update pyarrow version in PhaBOX2.1.13

### DIFF
--- a/recipes/phabox/meta.yaml
+++ b/recipes/phabox/meta.yaml
@@ -34,7 +34,7 @@ requirements:
     - numpy >=1.26
     - pandas >=2
     - prodigal-gv >=2.11.0
-    - pyarrow =16.1
+    - pyarrow =16.*
     - pytorch >=2.4
     - scipy >=1.14
     - seaborn-base >=0.13.2


### PR DESCRIPTION
Seems the pyarrow in the new installation will cause conflict. So, I try to restrict it in this revision.