### PR TITLE
Add tirank v0.1.3 recipe

### DIFF
--- a/recipes/tirank/meta.yaml
+++ b/recipes/tirank/meta.yaml
@@ -34,8 +34,8 @@ requirements:
     - optuna >=3.5
     - lifelines >=0.28
     - imbalanced-learn >=0.11
-    - seaborn >=0.13
-    - matplotlib >=3.8
+    - seaborn-base >=0.13
+    - matplotlib-base >=3.8
     - pillow >=10.2
     - tqdm
     - timm >=0.9


### PR DESCRIPTION
### Add TiRank v0.1.3 (noarch, python>=3.9)

**Summary**

This PR adds the **TiRank** package (v0.1.3), a Python-based toolkit for transferring phenotype information from **bulk transcriptomic data** to **single-cell** or **spatial transcriptomic data**.  
The package integrates statistical learning and deep learning modules for phenotype projection, feature ranking, and model interpretation.

---

**Build Information**
- **Type**: `noarch: python`
- **License**: MIT
- **Source**: [https://github.com/LenisLin/TiRank/archive/refs/tags/v0.1.3.tar.gz](https://github.com/LenisLin/TiRank/archive/refs/tags/v0.1.3.tar.gz)
- **Tested locally on**: `Ubuntu 22.04`, `Python 3.9`
- **Hardware**: NVIDIA RTX 3090 ×4 GPUs, CUDA Driver 12.4
- **Build verified with**: `conda-build` (no errors, import test passed)

---

**Dependencies**
- `numpy`, `scipy`, `pandas`, `scikit-learn`, `statsmodels`
- `scanpy`, `gseapy`, `optuna`
- `lifelines`, `imbalanced-learn`, `matplotlib`, `seaborn`
- `dash`, `dash-bootstrap-components`
- GPU acceleration via `torch>=2.1` and `torchvision>=0.16` (installed manually per CUDA env)

---

**Notes**
- The package is pure Python (`noarch`).
- All tests including `import tirank` passed successfully.
- No `build.sh` file is required since the recipe uses the `script:` field.

---

**Checklist**
- [x] Added new recipe under `recipes/tirank`
- [x] Verified `sha256` checksum for v0.1.3 tarball
- [x] Includes LICENSE file (MIT)
- [x] Local build and import test successful
- [x] Linting passes (`bioconda-lint`)

---

@BiocondaBot please add label