### PR TITLE
Update meta.yaml for mmlong2

### DIFF
--- a/recipes/mmlong2/meta.yaml
+++ b/recipes/mmlong2/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   noarch: generic
   run_exports:
     - {{ pin_subpackage('mmlong2', max_pin="x.x") }}


### PR DESCRIPTION
This PR updates the dependencies for mmlong2:
- Unpinned Snakemake version to ensure compatibility with future autobumps
- Added rsync as a dependency
- Updated the doi to the paper describing mmlong2