### PR TITLE
add missing dependencies to snapatac2

### DIFF
--- a/recipes/snapatac2/meta.yaml
+++ b/recipes/snapatac2/meta.yaml
@@ -14,7 +14,7 @@ source:
     - pyproject.toml.patch
 
 build:
-  number: 1
+  number: 2
   skip: True  # [py < 39 or py > 312]
   run_exports:
     - {{ pin_subpackage('snapatac2', max_pin="x") }}


### PR DESCRIPTION
This PR adds three dependencies to snapatac2:
    - umap-learn
    - leidenalg
    - hdbscan
    - xgboost
### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
