### PR TITLE
fix Python version as 2.7 in requirements

### DIFF
--- a/recipes/optitype/meta.yaml
+++ b/recipes/optitype/meta.yaml
@@ -1,3 +1,4 @@
+{% set name = "optitype" %}
 {% set version = "1.3.5" %}
 
 package:


### PR DESCRIPTION
The current build of Optitype results in an error:
```
No module named 'numpy._core._multiarray_umath'` 
```
This seems to be due to a version incompatibility of used numpy and python versions and this error appears when python 3.12 is used. 

It seems that python3 support is included at some point: https://github.com/FRED-2/OptiType/releases however, it is not clear which python & numpy version is compatible.

Taking into account that the repo does not seem to be maintained lately, I would suggest to update the recipe to pin python2.7 as specified: https://github.com/FRED-2/OptiType/blob/07c49bf6fc93e8846e8826df63100a0b069cbe40/README.md?plain=1#L24