### PR TITLE
Add ete4 to amalgkit

### DIFF
--- a/recipes/amalgkit/meta.yaml
+++ b/recipes/amalgkit/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "amalgkit" %}
-{% set version = "0.12.19" %}
+{% set version = "0.12.20" %}
 
 package:
   name: "{{ name|lower }}"
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/kfuku52/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 188dccedd2d0d1972bd36833db52c5afb95a6cdf03c1a951ff8107e52500f36d
+  sha256: f7eac10913f0e8f0752d8b3db19b6373bde510030b042da110078c9774f6bb59
 
 build:
   number: 0
@@ -29,6 +29,7 @@ requirements:
     - numpy
     - pandas
     - lxml
+    - ete4
     # Additional dependencies for amalgkit
     - seqkit
     - parallel-fastq-dump


### PR DESCRIPTION
The ete4 dependency has been added to amalgkit.
