### PR TITLE
Add new recipe: biomatch 0.4.5 (git source tag v0.4.5)

### DIFF
--- a/recipes/biomatch/LICENSE
+++ b/recipes/biomatch/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 VonPoo
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/recipes/biomatch/build.sh
+++ b/recipes/biomatch/build.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install biomatch via pip from the checked-out source
+pip install .
+
+# Create shared resources directory for pipelines and scripts
+RES_DIR="$PREFIX/share/biomatch/resources"
+mkdir -p "$RES_DIR"
+
+# Copy optimized scripts and makefile used by downstream pipelines
+if [ -f "biomatch/resources/00_extractSNPsfromVCF.py" ]; then
+  cp biomatch/resources/00_extractSNPsfromVCF.py "$RES_DIR/"
+fi
+if [ -f "biomatch/resources/filterRepetiveSNP.py" ]; then
+  cp biomatch/resources/filterRepetiveSNP.py "$RES_DIR/"
+fi
+if [ -f "biomatch/resources/makefile.biomatch" ]; then
+  cp biomatch/resources/makefile.biomatch "$RES_DIR/makefile.biomatch"
+fi
+
+# Install reference panels to a shared location
+REF_DIR="$PREFIX/share/biomatch/kmer_ref_panels"
+mkdir -p "$REF_DIR"
+if [ -d "biomatch/resources/kmer_ref_panels" ]; then
+  cp -r biomatch/resources/kmer_ref_panels/* "$REF_DIR/" || true
+fi
+
+echo "BioMatch build script completed. Resources installed to $RES_DIR and $REF_DIR."

--- a/recipes/biomatch/meta.yaml
+++ b/recipes/biomatch/meta.yaml
@@ -6,11 +6,11 @@ package:
   version: "{{ version }}"
 
 source:
-  git_url: https://github.com/VonPoo/BioMatch.git
-  git_rev: v0.4.5
-  git_depth: 1
+  url: https://github.com/VonPoo/BioMatch/archive/refs/tags/v0.4.5.tar.gz
+  sha256: d5558cd419c8d46bdc958064cb97f963d1ea793866414c025906ec15033512ed
 
 build:
+  noarch: python
   number: 0
   entry_points:
     - biomatch = biomatch.biomatch:main
@@ -69,3 +69,5 @@ extra:
   recipe-maintainers:
     - VonPoo
     - fengbo
+  skip-lints:
+    - missing_run_exports

--- a/recipes/biomatch/meta.yaml
+++ b/recipes/biomatch/meta.yaml
@@ -1,0 +1,71 @@
+{% set name = "biomatch" %}
+{% set version = "0.4.5" %}
+
+package:
+  name: {{ name|lower }}
+  version: "{{ version }}"
+
+source:
+  git_url: https://github.com/VonPoo/BioMatch.git
+  git_rev: v0.4.5
+  git_depth: 1
+
+build:
+  number: 0
+  entry_points:
+    - biomatch = biomatch.biomatch:main
+
+requirements:
+  host:
+    - python
+    - pip
+    - setuptools
+  run:
+    - python
+    - pyfaidx
+    - pandas
+    - numpy
+    - biopython
+    - tqdm
+    - bwa
+    - r-base >=4.3
+    - r-deepkin >=0.1.0
+    - r-readr
+    - r-tidyverse
+    - r-caret
+    - r-e1071
+    - r-pls
+    - scikit-learn
+    - scipy
+    - pyvcf3
+    - parallel
+    - bcftools
+    - tabix
+    - samtools
+    - plink
+    - plink2
+    - ntsm
+    - perl
+
+test:
+  commands:
+    - biomatch --version
+    - python -c "import biomatch; import biomatch.biomatch as bm; print(bm.__version__)"
+
+about:
+  home: https://github.com/VonPoo/BioMatch
+  summary: BioMatch - A data-driven framework for comprehensive sample identification
+  description: |
+    BioMatch is a data-driven framework for comprehensive sample identification.
+    It provides functionality for generating k-mer panels, counting k-mers in samples,
+    and evaluating sample identity.
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  doc_url: https://github.com/VonPoo/BioMatch
+  dev_url: https://github.com/VonPoo/BioMatch
+
+extra:
+  recipe-maintainers:
+    - VonPoo
+    - fengbo

--- a/recipes/biomatch/meta.yaml
+++ b/recipes/biomatch/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - tqdm
     - bwa
     - r-base >=4.3
-    - r-deepkin >=0.1.0
+    - r-deepkin >=1.0.0
     - r-readr
     - r-tidyverse
     - r-caret

--- a/recipes/biomatch/post-link.sh
+++ b/recipes/biomatch/post-link.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Optional integration with ntsm-scripts if present in the environment
+RES_DIR="$PREFIX/share/biomatch/resources"
+
+if [ -d "$PREFIX/share/ntsm-scripts" ]; then
+  NTSM_DIR="$PREFIX/share/ntsm-scripts"
+  # Copy pipeline scripts and makefile
+  if [ -f "$RES_DIR/00_extractSNPsfromVCF.py" ]; then
+    cp "$RES_DIR/00_extractSNPsfromVCF.py" "$NTSM_DIR/"
+  fi
+  if [ -f "$RES_DIR/filterRepetiveSNP.py" ]; then
+    cp "$RES_DIR/filterRepetiveSNP.py" "$NTSM_DIR/"
+  fi
+  if [ -f "$RES_DIR/makefile.biomatch" ]; then
+    cp "$RES_DIR/makefile.biomatch" "$NTSM_DIR/"
+  fi
+  # Patch ntsm-scripts makefile to include BioMatch pipeline makefile
+  if [ -f "$NTSM_DIR/makefile" ] && [ -f "$RES_DIR/makefile.biomatch" ]; then
+    cat "$RES_DIR/makefile.biomatch" >> "$NTSM_DIR/makefile"
+  fi
+fi
+
+echo "BioMatch post-link completed. Optional integration with ntsm-scripts applied if present."

--- a/recipes/biomatch/resources/makefile
+++ b/recipes/biomatch/resources/makefile
@@ -1,0 +1,20 @@
+# BioMatch pipeline Makefile (scaffolded)
+
+# Parameters
+KMER ?= 21
+THREADS ?= 8
+REF_FASTA ?= reference.fa
+VCF ?= input.vcf.gz
+
+# Rules
+all: kmer_panels rotational_matrices
+
+kmer_panels:
+	@echo "Generating k-mer panels (K=$(KMER)) from $(VCF) against $(REF_FASTA)"
+	# Placeholder for actual commands; replaced in downstream projects
+
+rotational_matrices:
+	@echo "Generating PCA rotational matrices"
+	# Placeholder for actual commands; replaced in downstream projects
+
+.PHONY: all kmer_panels rotational_matrices

--- a/recipes/rde/r-deepkin/meta.yaml
+++ b/recipes/rde/r-deepkin/meta.yaml
@@ -32,7 +32,7 @@ test:
 
 about:
   home: https://github.com/qixininin/deepKin
-  summary: DeepKin: efficient and precise estimation for in-depth genetic relatedness
+  summary: "DeepKin: efficient and precise estimation for in-depth genetic relatedness"
   description: |
     DeepKin provides efficient and precise estimation methods for in-depth genetic relatedness
     analyses, with functions for estimation, classification, and summary of relatedness metrics.

--- a/recipes/rde/r-deepkin/meta.yaml
+++ b/recipes/rde/r-deepkin/meta.yaml
@@ -19,7 +19,9 @@ build:
   script: |
     set -euxo pipefail
     cd deepKin-{{ version }}
-    $R CMD INSTALL --build .
+    $R CMD build .
+    PKG_TGZ=$(ls -1t *.tar.gz | head -n1)
+    $R CMD INSTALL "$PKG_TGZ"
 
 requirements:
   host:

--- a/recipes/rde/r-deepkin/meta.yaml
+++ b/recipes/rde/r-deepkin/meta.yaml
@@ -7,8 +7,7 @@ package:
 
 source:
   git_url: https://github.com/qixininin/deepKin.git
-  git_rev: v{{ version }}
-  git_depth: 1
+  git_rev: main
 
 build:
   noarch: generic
@@ -20,10 +19,10 @@ build:
 
 requirements:
   host:
-    - r-base==4.3.2
+    - r-base >=4.3
     - r-readr
   run:
-    - r-base==4.3.2
+    - r-base >=4.3
     - r-readr
 
 test:

--- a/recipes/rde/r-deepkin/meta.yaml
+++ b/recipes/rde/r-deepkin/meta.yaml
@@ -8,6 +8,7 @@ package:
 source:
   url: https://codeload.github.com/qixininin/deepKin/tar.gz/refs/tags/v{{ version }}
   sha256: 8354d2223dbc07fd11fd39270610c2a5c43146f4150a4a92185ff0ffd2eefe40
+  folder: deepKin-{{ version }}
 
 build:
   noarch: generic
@@ -44,5 +45,3 @@ extra:
   recipe-maintainers:
     - VonPoo
     - fengbo
-  skip-lints:
-    - missing_hash

--- a/recipes/rde/r-deepkin/meta.yaml
+++ b/recipes/rde/r-deepkin/meta.yaml
@@ -1,0 +1,45 @@
+{% set name = "r-deepkin" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name }}
+  version: "{{ version }}"
+
+source:
+  git_url: https://github.com/qixininin/deepKin.git
+  git_rev: v{{ version }}
+  git_depth: 1
+
+build:
+  noarch: generic
+  number: 0
+
+requirements:
+  host:
+    - r-base==4.3.2
+    - r-readr
+  run:
+    - r-base==4.3.2
+    - r-readr
+
+test:
+  commands:
+    - $R -e "library('deepKin')"
+
+about:
+  home: https://github.com/qixininin/deepKin
+  summary: DeepKin: efficient and precise estimation for in-depth genetic relatedness
+  description: |
+    DeepKin provides efficient and precise estimation methods for in-depth genetic relatedness
+    analyses, with functions for estimation, classification, and summary of relatedness metrics.
+  license: GPL-3.0-or-later
+  license_family: GPL
+  doc_url: https://github.com/qixininin/deepKin
+  dev_url: https://github.com/qixininin/deepKin
+
+extra:
+  recipe-maintainers:
+    - VonPoo
+    - fengbo
+  skip-lints:
+    - uses_vcs_url

--- a/recipes/rde/r-deepkin/meta.yaml
+++ b/recipes/rde/r-deepkin/meta.yaml
@@ -13,6 +13,10 @@ source:
 build:
   noarch: generic
   number: 0
+  rpaths:
+    - lib/R/lib/
+    - lib/
+  script: $R CMD INSTALL --build .
 
 requirements:
   host:

--- a/recipes/rde/r-deepkin/meta.yaml
+++ b/recipes/rde/r-deepkin/meta.yaml
@@ -16,7 +16,10 @@ build:
   rpaths:
     - lib/R/lib/
     - lib/
-  script: $R CMD INSTALL --build .
+  script: |
+    set -euxo pipefail
+    cd deepKin-{{ version }}
+    $R CMD INSTALL --build .
 
 requirements:
   host:

--- a/recipes/rde/r-deepkin/meta.yaml
+++ b/recipes/rde/r-deepkin/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "r-deepkin" %}
-{% set version = "0.1.0" %}
+{% set version = "1.0.0" %}
 
 package:
   name: {{ name }}
   version: "{{ version }}"
 
 source:
-  git_url: https://github.com/qixininin/deepKin.git
-  git_rev: main
+  url: https://codeload.github.com/qixininin/deepKin/tar.gz/refs/tags/v{{ version }}
+  sha256: 8354d2223dbc07fd11fd39270610c2a5c43146f4150a4a92185ff0ffd2eefe40
 
 build:
   noarch: generic
@@ -45,4 +45,4 @@ extra:
     - VonPoo
     - fengbo
   skip-lints:
-    - uses_vcs_url
+    - missing_hash


### PR DESCRIPTION

**Summary**
- BioMatch is a data-driven, user-friendly, and computationally efficient framework for sample identification and genetic relationship inference in diploid multi-omics studies. This PR adds a Bioconda recipe under `recipes/biomatch` for version `0.4.5`, sourcing from the stable GitHub tag `v0.4.5`.

**Motivation**
- Large-scale genomic and multi-omics studies produce massive datasets where sample mislabeling and mix-ups are a pervasive, often overlooked issue, leading to irreproducible results and wasted resources. BioMatch addresses this with robust, scalable methods that support diverse inputs and deliver reliable QC outcomes.

**Key Contributions**
- Integrates a species-specific k-mer paneling strategy (from a k-mer reference panel database, kmer-db) with a variant-based approach to improve matching accuracy across challenging scenarios (e.g., WGBS; low-quality reference genomes).
- Supports multiple input formats (`FASTQ`, `VCF`, `PLINK`), ensuring compatibility across pipelines.
- Stores evaluated profiles in a database (`count-db`) after initial evaluation to enable fast future lookups and avoid redundant computation.
- Achieves comparable accuracy using 10–100× fewer markers than conventional variant-based methods, significantly reducing compute costs.
- Offers both a software package and a user-friendly web server: `http://alphaindex.zju.edu.cn/iDIGs2/`.
- Provides reliability scores for all relationship estimates to improve interpretability and confidence.

**Recipe Changes**
- Adds `recipes/biomatch/` with:
  - `meta.yaml`: `name=biomatch`, `version=0.4.5`, `source` via `git_url=https://github.com/VonPoo/BioMatch.git`, `git_rev=v0.4.5`, `git_depth=1`.
  - `build.sh`: installs via `pip install .`; copies pipeline resources to `share/biomatch`.
  - `post-link.sh`: optional integration with `ntsm-scripts` by copying resources and appending the BioMatch makefile.
  - `resources/makefile`: pipeline resource scaffold.
  - `LICENSE`: MIT license for `license_file`.

**Entry Points and Tests**
- Entry point: `biomatch = biomatch.biomatch:main`.
- Tests:
  - `biomatch --version`
  - `python -c "import biomatch; import biomatch.biomatch as bm; print(bm.__version__)"`

**Requirements**
- Host: `python`, `pip`, `setuptools`.
- Run (major):
  - Python: `pyfaidx`, `pandas`, `numpy`, `biopython`, `tqdm`, `scikit-learn`, `scipy`, `pyvcf3`, `parallel`.
  - Bioinformatics tools: `bwa`, `bcftools`, `samtools`, `tabix`, `plink`, `plink2`, `ntsm`, `perl`.
  - R stack: `r-base >=4.3`, `r-readr`, `r-tidyverse`, `r-caret`, `r-e1071`, `r-pls`, `r-deepkin >=0.1.0`.

**Non-Noarch**
- The package depends on platform-specific tools (R, plink, bwa, etc.), so it does not qualify for `noarch: python`.

**Maintainers**
- `@vonpoo`

**Checklist**
- `recipes/biomatch` added with version `0.4.5`.
- Source pinned to Git tag `v0.4.5` using `git_url + git_rev`.
- MIT `license_file` included.
- Lightweight tests verify install and entry point availability.
- Not `noarch` due to native dependencies.

**Notes for Reviewers**
- `r-base` is currently specified as `>=4.3`. If stricter pinning (e.g., `==4.3.2`) is preferred by maintainers, we can adjust accordingly.
- `r-deepkin >=0.1.0` is listed; if it is not yet available on Bioconda/conda-forge, we will submit a separate recipe for it or temporarily remove/replace it to ensure successful builds.

Thank you for considering this addition. BioMatch aims to help the community reduce QC burden, improve reliability in multi-omics studies, and provide accessible tooling both via command line and a web interface.
        