### PR TITLE
Update repaq recipe, add explicit xz host dependency 

### DIFF
--- a/recipes/repaq/meta.yaml
+++ b/recipes/repaq/meta.yaml
@@ -12,7 +12,7 @@ source:
     - endian.patch
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage('repaq', max_pin="x.x") }}
 
@@ -23,6 +23,7 @@ requirements:
     - {{ compiler('cxx') }}
   host:
     - zlib
+    - xz
 
 test:
   commands:


### PR DESCRIPTION
The `repaq` tool requires the xz dependency, but it is currently not included in the Biocontainer. The default version that comes with the Busybox base image is too old:

```bash
docker pull quay.io/biocontainers/repaq:0.5.1--h5ca1c30_0
docker run --rm -it quay.io/biocontainers/repaq:0.5.1--h5ca1c30_0 repaq --help

# Download test data (or use any other FASTQ)
wget http://opengene.org/repaq/testdata/nova.R1.fq
wget http://opengene.org/repaq/testdata/nova.R2.fq

docker run --rm -it -v "$PWD":/home quay.io/biocontainers/repaq:0.5.1--h5ca1c30_0 repaq -c -i /home/nova.R1.fq -I /home/nova.R2.fq -o /home/out.rfq.xz
xz: invalid option -- 'z'
BusyBox v1.36.1 (2024-06-02 11:42:27 UTC) multi-call binary.

Usage: xz -d [-cfk] [FILE]...

Decompress FILEs (or stdin)

	-d	Decompress
	-c	Write to stdout
	-f	Force
	-k	Keep input files
	-t	Test integrity
ERROR: failed to call xz, please confirm that xz is installed in your system
```

In comparison, the [Seqera Containers](https://seqera.io/containers/?packages=bioconda::repaq=0.5.1+conda-forge::xz=5.8.1) image works normally:

```
docker pull community.wave.seqera.io/library/repaq_xz:8cc4449e511d56f3
docker run --rm -it community.wave.seqera.io/library/repaq_xz:8cc4449e511d56f3 repaq --help

docker run --rm -it -v "$PWD":/home community.wave.seqera.io/library/repaq_xz:8cc4449e511d56f3 repaq -c -i /home/nova.R1.fq -I /home/nova.R2.fq -o /home/out.rfq.xz
```

