### PR TITLE
Update Humann to version 4a

### DIFF
--- a/recipes/humann/4.0.0a/0001-env-config.patch
+++ b/recipes/humann/4.0.0a/0001-env-config.patch
@@ -1,0 +1,34 @@
+From 4f74f7814a440103e82f93487693b86f2ec47dbc Mon Sep 17 00:00:00 2001
+From: Nick Waters <nickp60@users.noreply.github.com>
+Date: Thu, 13 Nov 2025 15:20:05 -0500
+Subject: [PATCH] env-config
+
+---
+ humann/config.py | 10 +++++++---
+ 1 file changed, 7 insertions(+), 3 deletions(-)
+
+diff --git a/humann/config.py b/humann/config.py
+index 6d556d5..1cf196c 100644
+--- a/humann/config.py
++++ b/humann/config.py
+@@ -102,10 +102,14 @@ def log_settings():
+     logger.info("\nRun config settings: \n\n" + "\n".join(lines))
+ 
+ # User config file
+-user_edit_config_file="humann.cfg"
++# User config file
++if not os.environ.get("HUMANN_CONFIG"):
++    user_edit_config_file="humann.cfg"
+ 
+-full_path_user_edit_config_file=os.path.join(os.path.dirname(os.path.abspath(__file__)),
+-    user_edit_config_file)
++    full_path_user_edit_config_file=os.path.join(os.path.dirname(os.path.abspath(__file__)),
++                                                 user_edit_config_file)
++else:
++    full_path_user_edit_config_file=os.environ.get("HUMANN_CONFIG")
+ 
+ def update_user_edit_config_file_single_item(section,name,value):
+     """
+-- 
+2.39.5 (Apple Git-154)
+

--- a/recipes/humann/4.0.0a/meta.yaml
+++ b/recipes/humann/4.0.0a/meta.yaml
@@ -38,7 +38,7 @@ build:
     - humann_associate = humann.tools.humann_associate:main
     - humann_barplot = humann.tools.humann_barplot:main
     - humann_benchmark = humann.tools.humann_benchmark:main
-  script: "pip install . -vv --config-settings='--bypass-dependencies-install'"
+  script: "pip install . -vv --config-settings 'bypass-dependencies-install'=True "
 
 requirements:
   host:

--- a/recipes/humann/4.0.0a/meta.yaml
+++ b/recipes/humann/4.0.0a/meta.yaml
@@ -15,7 +15,7 @@ build:
   run_exports:
     - {{ pin_subpackage('humann', max_pin="x") }}
   number: 0
-  noarch: python
+  noarch: generic
   entry_points:
     - humann = humann.humann:main
     - humann_databases = humann.tools.humann_databases:main

--- a/recipes/humann/4.0.0a/meta.yaml
+++ b/recipes/humann/4.0.0a/meta.yaml
@@ -12,6 +12,8 @@ source:
     - 0001-env-config.patch
 
 build:
+  run_exports:
+    - {{ pin_subpackage('humann', max_pin="x") }}
   number: 1
   noarch: python
   entry_points:

--- a/recipes/humann/4.0.0a/meta.yaml
+++ b/recipes/humann/4.0.0a/meta.yaml
@@ -14,7 +14,7 @@ source:
 build:
   run_exports:
     - {{ pin_subpackage('humann', max_pin="x") }}
-  number: 1
+  number: 0
   noarch: python
   entry_points:
     - humann = humann.humann:main

--- a/recipes/humann/4.0.0a/meta.yaml
+++ b/recipes/humann/4.0.0a/meta.yaml
@@ -38,7 +38,7 @@ build:
     - humann_associate = humann.tools.humann_associate:main
     - humann_barplot = humann.tools.humann_barplot:main
     - humann_benchmark = humann.tools.humann_benchmark:main
-  script: "pip install . -vv --install-option='--bypass-dependencies-install'"
+  script: "pip install . -vv --config-settings='--bypass-dependencies-install'"
 
 requirements:
   host:

--- a/recipes/humann/4.0.0a/meta.yaml
+++ b/recipes/humann/4.0.0a/meta.yaml
@@ -1,0 +1,90 @@
+{% set name = "humann" %}
+{% set version = "4.0.0.a" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: "https://github.com/biobakery/{{ name }}/archive/refs/tags/4.0.0.alpha.1-final.tar.gz"
+  sha256: aea99bdafef1cbe5d1aaa405ad392ffd1f5bcf9d14fff612f26cf6dbaa693b1c
+  patches:
+    - 0001-env-config.patch
+
+build:
+  number: 1
+  noarch: python
+  entry_points:
+    - humann = humann.humann:main
+    - humann_databases = humann.tools.humann_databases:main
+    - humann_config = humann.tools.humann_config:main
+    - humann_join_tables = humann.tools.join_tables:main
+    - humann_split_table = humann.tools.split_table:main
+    - humann_rename_table = humann.tools.rename_table:main
+    - humann_renorm_table = humann.tools.renorm_table:main
+    - humann_regroup_table = humann.tools.regroup_table:main
+    - humann_infer_taxonomy = humann.tools.infer_taxonomy:main
+    - humann_humann1_kegg = humann.tools.humann_humann1_kegg:main
+    - humann_rna_dna_norm = humann.tools.rna_dna_norm:main
+    - humann_strain_profiler = humann.tools.strain_profiler:main
+    - humann_reduce_table = humann.tools.reduce_table:main
+    - humann_unpack_pathways = humann.tools.merge_abundance:main
+    - humann_test = humann.tests.humann_test:main
+    - humann_build_custom_database = humann.tools.build_custom_database:main
+    - humann_genefamilies_genus_level = humann.tools.genefamilies_genus_level:main
+    - humann_split_stratified_table = humann.tools.split_stratified_table:main
+    - humann_associate = humann.tools.humann_associate:main
+    - humann_barplot = humann.tools.humann_barplot:main
+    - humann_benchmark = humann.tools.humann_benchmark:main
+  script: "pip install . -vv --install-option='--bypass-dependencies-install'"
+
+requirements:
+  host:
+    - pip
+    - python
+  run:
+    - python
+    - metaphlan ==4.0.6
+    - diamond >=0.9.36
+    - glpk
+    - bowtie2 >2.5
+    #- minpath
+
+test:
+  imports:
+    - humann
+    - humann.quantify
+    - humann.search
+    - humann.tests
+    - humann.tools
+  commands:
+    - humann --help
+    - humann_databases --help
+    - humann_config --help
+    - humann_join_tables --help
+    - humann_split_table --help
+    - humann_rename_table --help
+    - humann_renorm_table --help
+    - humann_regroup_table --help
+    #- humann_infer_taxonomy --help
+    - humann_humann1_kegg --help
+    - humann_rna_dna_norm --help
+    - humann_strain_profiler --help
+    - humann_reduce_table --help
+    - humann_unpack_pathways --help
+    - humann_test --help
+    - humann_build_custom_database --help
+    - humann_genefamilies_genus_level --help
+    - humann_split_stratified_table --help
+    - humann_associate --help
+    - humann_barplot --help
+    - humann_benchmark --help
+    - humann_test
+
+about:
+  home: "http://huttenhower.sph.harvard.edu/humann"
+  license: MIT
+  license_family: MIT
+  summary: "HUMAnN: The HMP Unified Metabolic Analysis Network, version 4"
+  doc_url: http://huttenhower.sph.harvard.edu/humann
+  dev_url: https://github.com/biobakery/humann


### PR DESCRIPTION
This PR adds the alpha version of HUMAnN 4.  I'm not sure how best to structure the versions, but since this is an alpha release I decided to have it in its own subdirectory.  

Also included is a patch to allow alternative locations of the tool's config file.  This has been discussed [on the forum](https://forum.biobakery.org/t/humann-biocontainer-unable-to-write-to-the-humann-config-file/5224/4), as it becomes problematic during containerized execution. If I have structured it properly, I'm happy to submit patches for version 3.1 and 3.9 as well.
