### PR TITLE
Add yasma

### DIFF
--- a/recipes/yasma/meta.yaml
+++ b/recipes/yasma/meta.yaml
@@ -18,6 +18,7 @@ build:
 requirements:
   build:
     - python >=3.12
+    - setuptools
     - pip
   run:
     - python >=3.12


### PR DESCRIPTION
Adding yasma software to bioconda. YASMA is a sRNA annotation suite, built around an annotator module (doi: 10.1016/j.csbj.2025.05.045). Requisite software should allow for seemless analysis with tested-settings for commonly-used tools.

Details:

- Adds yasma suite with meta.yaml and build.sh files.
- build.sh is required for installing one python package only available in pip