### PR TITLE
Update: fix incorrect minimum python version for nf-core

### DIFF
--- a/recipes/nf-core/meta.yaml
+++ b/recipes/nf-core/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: "touch requirements.txt && {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --no-cache-dir -vvv"
   entry_points:
     - nf-core=nf_core.__main__:run_nf_core


### PR DESCRIPTION
This PR fixes the incorrect too high minimum version of python for the nf-core package.

Fixes https://github.com/nf-core/tools/issues/3843
