### PR TITLE
Update deacon recipe to use portable target-cpu

### DIFF
--- a/recipes/deacon/meta.yaml
+++ b/recipes/deacon/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "deacon" %}
-{% set version = "0.13.1" %}
+{% set version = "0.13.2" %}
 
 package:
   name: {{ name }}
@@ -7,11 +7,17 @@ package:
 
 source:
   url: https://github.com/bede/{{ name }}/archive/{{ version }}.tar.gz
-  sha256: 29526dc0f00d7eea69a5cdc99829a8546e3730a4323d5aa5a7dbe2ecfee3f1e9
+  sha256: c80c8424f2236a984393e8ec542b3abcc35a3e8eb45650c4bc36ecb1f2413cb2
 
 build:
-  number: 0
-  script: "cargo install --no-track --locked --verbose --root \"${PREFIX}\" --path ."
+  number: 1
+  script:
+    # The default config.toml has target-cpu=native,
+    # but we don't want that for portable CI builds.
+    # Instead, use x86-64-v3 for x64, apple-m14 (=M1) for macos,
+    # and the default otherwise.
+    - mv .cargo/config-portable.toml .cargo/config.toml
+    - cargo install --no-track --locked --verbose --root "${PREFIX}" --path .
   run_exports:
     - {{ pin_subpackage('deacon', max_pin="x") }}
 


### PR DESCRIPTION
Updates the `deacon` `.cargo/config.toml` to replace `target-cpu=native` by more portable choices:
- For x64: x86-64-v3. Since good performance depends on AVX2, which has widespread support. The binary does a run-time check for this on startup.
- For macos M-series: apple-a14, which corresponds to m1.
- For everything else: the safe Rust default.

@bede 