### PR TITLE
Add igdtools

### DIFF
--- a/recipes/igdtools/meta.yaml
+++ b/recipes/igdtools/meta.yaml
@@ -16,7 +16,7 @@ build:
   script: "{{ PYTHON }} -m pip install . -vv"
   binary_relocation: False  # [linux]
   run_exports:
-    - {{ pin_subpackage('igdtools', max_pin="x") }}
+    - {{ pin_subpackage('igdtools', max_pin="x.x") }}
 
 requirements:
   build:


### PR DESCRIPTION
igdtools is a tool for manipulating IGD files, an alternative to VCF that scales better for really large datasets. For more information, see
https://picovcf.readthedocs.io/en/latest/igd_overview.html

