### PR TITLE
Adding biogl package

### DIFF
--- a/recipes/biogl/meta.yaml
+++ b/recipes/biogl/meta.yaml
@@ -1,0 +1,43 @@
+{% set name = "biogl" %}
+{% set version = "2.3.0" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  sha256: 3e8bdc1643980d3cfec235ffb73e68b921800a506b14b9edf7b2faec53e29be9
+
+build:
+  noarch: python
+  run_exports:
+    - {{ pin_subpackage('biogl', max_pin='x.x.x') }}
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - pip
+    - python
+    - smart_open
+  run:
+    - python
+    - smart_open
+
+test:
+  imports:
+    - biogl
+
+about:
+  home: "https://github.com/glarue/biogl"
+  license: MIT
+  license_family: MIT
+  license_file: 
+  summary: "A collection of (semi) useful bioinformatics functions"
+  doc_url: https://github.com/glarue/biogl
+  dev_url: https://github.com/glarue/biogl
+
+extra:
+  recipe-maintainers:
+    - ReverendCasy


### PR DESCRIPTION
**Name**: biogl
**Version**: 2.3.0
**New package or update**: New package
**Description**: This is a Conda build for package biogl by @glarue . The package is used extensively by IntronIC, a tool for U2/U12 intron classification which is widely used in genome annotation pipelines. Package version has been set to 2.3.0 to facilitate compatibility with newer Python versions.

**Checklist**:
* Source URL is stable: No (no tarballs available on Github for this version)
* ha256 or md5 hash included for source download: Yes
* Appropriate build number: Yes
* `.bat` file for Windows removed: Yes
* Remove unnecessary comments: Yes
* Adequate tests included: Yes
* Files created by the recipe follow the FSH: Yes
* License allows redistribution and license is indicated in `meta.yaml`: Yes
* Package does not already exist in the defaults or conda-forge channels with some exceptions: No, it does not
* Package is appropriate for bioconda: Yes
* If the recipe installs custom wrapper scripts, usage notes should be added to `extra` -> notes in the `meta.yaml`: Not applicable
* Recipes that contain pure Python packages should be marked as a “noarch”: Yes
* When patching a recipe, please provide details on how you tried to address the problem upstream: Not applicable