### PR TITLE
update bamslice bumping release to v0.1.4

### DIFF
--- a/recipes/bamslice/meta.yaml
+++ b/recipes/bamslice/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "bamslice" %}
-{% set version = "0.1.2" %}
+{% set version = "0.1.4" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/nebiolabs/bamslice/archive/v{{ version }}.tar.gz
-  sha256: 7b56996826d277b93d1fd8db939f7475740b4807411cb4be4000bd6c6ef2653b
+  sha256: d2b9ec52385f065a35e981405ce5001cdfc0a59ffc71c943b280697a236e957c
 
 build:
   number: 0


### PR DESCRIPTION
simple version bump, voiding spurious v0.1.5 release
