### PR TITLE
Update hamronization: pin python <3.14

### DIFF
--- a/recipes/hamronization/meta.yaml
+++ b/recipes/hamronization/meta.yaml
@@ -14,17 +14,19 @@ build:
     - hamronize = hAMRonization.hamronize:main
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage(name|lower, max_pin='x.x') }}
 
 requirements:
   host:
-    - python >=3.7
+# <3.14 due to https://github.com/pha4ge/hAMRonization/issues/106
+    - python >=3.7,<3.14
     - pip
     - setuptools
   run:
-    - python >=3.7
+# < 3.14 due to https://github.com/pha4ge/hAMRonization/issues/106
+    - python >=3.7,<3.14
     - pandas
 
 test:


### PR DESCRIPTION
hamronization 1.1.9 (build pyhdfd78af_0)  currently fails on this example from the [README](https://github.com/pha4ge/hAMRonization?tab=readme-ov-file#installation)

```
$ hamronize rgi --input_file_name rgi_report --analysis_software_version 6.0.0 --reference_database_version 3.2.5 test/data/raw_outputs/rgi/rgi.txt test/data/raw_outputs/rgibwt/Kp11_bwtoutput.gene_mapping_data.txt
Traceback (most recent call last):
  File "/n/home12/nweeks/.conda/envs/ham/bin/hamronize", line 10, in <module>
    sys.exit(main())
             ~~~~^^
  File "/n/home12/nweeks/.conda/envs/ham/lib/python3.14/site-packages/hAMRonization/hamronize.py", line 7, in main
    hAMRonization.Interfaces.generic_cli_interface()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/n/home12/nweeks/.conda/envs/ham/lib/python3.14/site-packages/hAMRonization/Interfaces.py", line 298, in generic_cli_interface
    parsed_report.write(
    ~~~~~~~~~~~~~~~~~~~^
        report_number=report_number,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<2 lines>...
        output_format=args.format,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/n/home12/nweeks/.conda/envs/ham/lib/python3.14/site-packages/hAMRonization/Interfaces.py", line 126, in write
    fieldnames = first_result.__annotations__.keys()
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'hAMRonizedResult' object has no attribute '__annotations__'. Did you mean: '__annotate_func__'?
```

This is due to an incompatibility with Python 3.14, as mentioned in https://github.com/pha4ge/hAMRonization/issues/106

This PR suggests pinning python to <3.14 for hamronization 1.1.9.
