### PR TITLE
Add QualiFilter 1.0.0 recipe

### DIFF
--- a/recipes/qualifilter/meta.yaml
+++ b/recipes/qualifilter/meta.yaml
@@ -2,40 +2,44 @@
 {% set version = "1.0.0" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
-build:
-  number: 0
-  noarch: python
-  script: "{{ PYTHON }} -m pip install . -vv"
-  run_exports:
-   - {{ pin_subpackage(name, max_pin="x.x") }}
-   
 source:
   url: https://github.com/buhlentozini/QualiFilter/archive/refs/tags/v1.0.0.tar.gz
   sha256: da3609142a24b143b73fe9acb60d7d7b9c7c28e36f604a114e0f955e173570fc
 
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --no-cache-dir -vvv
+  entry_points:
+    - qualifilter = qualifilter.cli:main
+  run_exports:
+   - {{ pin_subpackage(name, max_pin="x") }}
+
 requirements:
-  build:
+  host:
     - python
     - pip
-
   run:
     - python
-    - pandas
+    - pandas >=1.0
     - pyyaml
 
 test:
+  imports:
+    - qualifilter
   commands:
     - qualifilter --help
-    - qualifilter --list
 
 about:
-  home: https://github.com/buhlentozini/QualiFilter
+  home: "https://github.com/buhlentozini/QualiFilter"
   license: MIT
+  license_family: MIT
   license_file: LICENSE
   summary: "Generate a QC report summarizing key quality metrics and sample pass/fail status according to user-defined thresholds."
+  dev_url: "https://github.com/buhlentozini/QualiFilter"
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
This pull request adds a Bioconda recipe for **QualiFilter** (https://github.com/buhlentozini/QualiFilter
), a Python command-line tool for generating consolidated sequencing QC matrices and evaluating samples against user-defined thresholds.

Details:

- **Tool source:** https://github.com/buhlentozini/QualiFilter
- **Version:** 1.0.0
- **License:** MIT
- **Functionality:**
1. Extracts key QC metrics from tabular reports
2. Evaluates samples against thresholds and assigns Pass/Fail status
3. Supports configurable columns and renaming via YAML or JSON configuration files
- **Testing:** Passes all Bioconda lint checks and local testing
