### PR TITLE
Update: Bump umi-transfer to v.1.6.0

### DIFF
--- a/recipes/umi-transfer/meta.yaml
+++ b/recipes/umi-transfer/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "1.5.0" %}
-{% set sha256 = "eeacc6c12aea055f624a29623c96b9396e6b412461f57a8ff9e19ba849c4538d" %}
+{% set version = "1.6.0" %}
+{% set sha256 = "6e07943e117e9c88e073d51000f375566590301beaacf6c7c07217f46d1c15db" %}
 
 package:
   name: umi-transfer
@@ -10,7 +10,7 @@ source:
   sha256: {{ sha256 }}
   
 build:
-  number: 1
+  number: 0
   run_exports:
     - {{ pin_subpackage('umi-transfer', max_pin="x") }}
 


### PR DESCRIPTION
In a bold move that defies conventional wisdom, I've decided to release v1.6.0 of umi-transfer on a Friday. This PR bumps the Bioconda recipe accordingly. In my defense, the code was feeling particularly well-behaved today and Karma will be restored by a failing CI on this pull request. 