### PR TITLE
Bump shinyngs to 2.3.0

### DIFF
--- a/recipes/r-shinyngs/meta.yaml
+++ b/recipes/r-shinyngs/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = '2.2.4' %}
+{% set version = '2.3.0' %}
 {% set d3heatmap_version = '0.6.1.2' %}
 
 package:
@@ -7,14 +7,14 @@ package:
 
 source:
   - url: https://github.com/pinin4fjords/shinyngs/archive/refs/tags/v{{ version }}.tar.gz
-    sha256: "40a63e2095314f8208fdb3771f3b561674b470c5617871ead7663e5d582f895a"
+    sha256: "768a7d60240b42e24e705d5b5ced019176d69728cf208ffe0dbc5767984087f8"
     folder: shinyngs
   - url: https://github.com/cran/d3heatmap/archive/refs/tags/{{ d3heatmap_version }}.tar.gz 
     sha256: "bda213c4d335b199c38a48cb8e60027c929a8ba8ef6e14dc7de692967777c25a"
     folder: d3heatmap
 
 build:
-  number: 1
+  number: 0
   noarch: generic
 
   # This is required to make R link correctly on Linux.


### PR DESCRIPTION
Bump version in lieu of broken autobump on this recipe

## Summary
- Updates r-shinyngs from 2.2.4 to 2.3.0
- Resets build number to 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)