### PR TITLE
Fix omark build

### DIFF
--- a/recipes/omark/meta.yaml
+++ b/recipes/omark/meta.yaml
@@ -20,6 +20,7 @@ requirements:
   host:
     - python
     - pip
+    - uv-build
   run:
     - python
     - biopython


### PR DESCRIPTION
fixes an issue with the omark build recipe after a new release (missing uv-build backend dependency)

Supersedes #61078
