### PR TITLE
MultiQC: Skip Python 3.14.1

### DIFF
--- a/recipes/multiqc/meta.yaml
+++ b/recipes/multiqc/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: b6a5622f284f7de883784caf08dacc4e634bd17cff45b4e9f336273abd9e24e4
 
 build:
-  number: 1
+  number: 2
   noarch: python
   entry_points:
     - multiqc=multiqc.__main__:run_multiqc
@@ -20,11 +20,12 @@ build:
 
 requirements:
   host:
-    - python >=3.8
+    # Python 3.14.1 breaks upstream deps, see https://github.com/MultiQC/MultiQC/issues/3412
+    - python >=3.8,!=3.14.1
     - pip
     - setuptools
   run:
-    - python >=3.8
+    - python >=3.8,!=3.14.1
     - click
     - coloredlogs
     - humanize


### PR DESCRIPTION
cPython 3.14.1 has an issue that causes MultiQC upstream dependencies (`networkx`) to break.

See https://github.com/MultiQC/MultiQC/issues/3412 for more details.