### PR TITLE
Add setuptools to GUNC requirements

### DIFF
--- a/recipes/gunc/meta.yaml
+++ b/recipes/gunc/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - numpy
     - pandas
     - python >=3.6
-    - setuptools < 81
+    - setuptools <81
     - scipy
     - requests >=2.22.0
     - plotly


### PR DESCRIPTION
GUNC relies on pkg_resources from setuptools (see reference: gunc/get_scores.py#L9). When GUNC is installed via miniconda, setuptools is automatically included, but this does not happen when installing via miniforge.

This PR adds setuptools to the recipe and pins it to <81, since pkg_resources has been deprecated in newer versions of setuptools.