### PR TITLE
ci: update CircleCI MacOS to M4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ executors:
   osx-arm64:
     macos:
       xcode: 15.4.0
-    resource_class: macos.m1.medium.gen1
+    resource_class: m4pro.medium
   linux-aarch64:
     machine:
       image: ubuntu-2404:current


### PR DESCRIPTION
Update osx-arm64 runner to `m4pro.medium`. CircleCI appears to have done the switchover automatically, and builds are succeeding. Update in the config to avoid confusion.

https://circleci.com/changelog/deprecation-of-mac-m1-and-m2-resource-classes/