### PR TITLE
Bump version to 2.6.0 and update dependencies

### DIFF
--- a/recipes/gtdbtk/meta.yaml
+++ b/recipes/gtdbtk/meta.yaml
@@ -7,7 +7,7 @@ package:
   
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: c7a665eb842ea67cf62adbf9fc4bb8b980bf0b35656c96ee6646f9c30a26059a
+  sha256: 794fb6eadd9555d336b1a2702927b8794b911f53232c43909504db4e4e0f7a34
 
 build:
   number: 0


### PR DESCRIPTION
This pull request updates the `gtdbtk` recipe to use the latest version and refreshes some of its dependencies for improved compatibility and stability.

Version and dependency updates:

* Updated the `gtdbtk` package version from `2.5.2` to `2.6.0` and changed the corresponding source `sha256` hash to match the new release.
* Updated the `pplacer` dependency to require exactly version `1.1.alpha19` instead of any version greater than or equal to `1.1.alpha17`.
* Updated the `skani` dependency to require at least version `0.3.0` instead of `0.2.0`.