### PR TITLE
art_modern and art_modern-openmpi: Dropped dependency Abseil.

### DIFF
--- a/recipes/art_modern-openmpi/build.sh
+++ b/recipes/art_modern-openmpi/build.sh
@@ -11,7 +11,6 @@ env -C "${TMPDIR}" cmake \
     -DUSE_MALLOC=NOP \
     -DUSE_HTSLIB=hts \
     -DUSE_LIBFMT=fmt \
-    -DUSE_ABSL=SYSTEM \
     -DWITH_MPI=ON \
     ${CMAKE_ARGS} \
     -DCMAKE_BUILD_TYPE=RelWithDebInfo \

--- a/recipes/art_modern-openmpi/meta.yaml
+++ b/recipes/art_modern-openmpi/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: b609b52e2565e657580cc7c60eb8441659fcb719f68639508501b355b2a0e94c
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage('art_modern-openmpi', max_pin="x.x") }}
 
@@ -29,7 +29,6 @@ requirements:
     # Boost version copied from package ProMod3 at bioconda recepies ver. 0ff2abb3f8
     - libboost-devel >=1.86,<1.87
     - zlib
-    - abseil-cpp
     - openmpi
     - htslib # samtools does not specify HTSLib version, so do us.
     - fmt

--- a/recipes/art_modern/build.sh
+++ b/recipes/art_modern/build.sh
@@ -11,7 +11,6 @@ env -C "${TMPDIR}" cmake \
     -DUSE_MALLOC=NOP \
     -DUSE_HTSLIB=hts \
     -DUSE_LIBFMT=fmt \
-    -DUSE_ABSL=SYSTEM \
     ${CMAKE_ARGS} \
     -DCMAKE_BUILD_TYPE=RelWithDebInfo \
     -DCMAKE_INSTALL_LIBDIR=lib/art_modern/lib \

--- a/recipes/art_modern/meta.yaml
+++ b/recipes/art_modern/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: b609b52e2565e657580cc7c60eb8441659fcb719f68639508501b355b2a0e94c
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage('art_modern', max_pin="x.x") }}
 
@@ -29,7 +29,6 @@ requirements:
     # Boost version copied from package ProMod3 at bioconda recepies ver. 0ff2abb3f8
     - libboost-devel >=1.86,<1.87
     - zlib
-    - abseil-cpp
     - htslib # samtools does not specify HTSLib version, so do us.
     - fmt
     # Conda do not have moodycamel-concurrentqueue, so using the bundled one.


### PR DESCRIPTION
This revision dropped the Abseil dependency, which is used in `art_modern`/`art_modern-openmpi` before 1.3.0 and is no longer used afterwards.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
