### PR TITLE
Add babappalign 1.0.0

### DIFF
--- a/recipes/babappalign/meta.yaml
+++ b/recipes/babappalign/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/sinhakrishnendu/BABAPPAlign/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 0324830a3130c6e55980ff4b06eede2d849bce7952ff4d7196c8ddffb67ba9d1
+  sha256: 18ac0c4efd0a44b70aee9f2d1cd2afb04a4fc0a49cb64e90c259a4852b075aa0
 
 build:
   number: 0


### PR DESCRIPTION
- New Bioconda package: babappalign
- Deep learning–based progressive MSA engine
- CPU-only execution supported
- Optional GPU acceleration
- Learned scoring model downloaded at runtime
- No bundled binaries or pretrained models
