### PR TITLE
Fix pyfasta Python 3.10+ compatibility

### DIFF
--- a/recipes/pyfasta/meta.yaml
+++ b/recipes/pyfasta/meta.yaml
@@ -12,7 +12,9 @@ source:
 
 build:
   noarch: python
-  number: 1
+  number: 2
+  run_exports:
+    - {{ pin_subpackage('pyfasta', max_pin='x.x') }}
   script: 2to3 -wn . && {{ PYTHON }} -m pip install . --ignore-installed --no-deps -vv
   entry_points:
     - pyfasta = pyfasta:main
@@ -21,6 +23,7 @@ requirements:
   host:
     - python >=3
     - pip
+    - setuptools
   run:
     - python >=3
     - numpy

--- a/recipes/pyfasta/patch
+++ b/recipes/pyfasta/patch
@@ -18,12 +18,17 @@ diff --git a/pyfasta/fasta.py b/pyfasta/fasta.py
 index 05d1fa1..99e4786 100644
 --- a/pyfasta/fasta.py
 +++ b/pyfasta/fasta.py
-@@ -5,7 +5,7 @@ from collections import Mapping
+@@ -1,11 +1,11 @@
+ from __future__ import print_function
+ import string
+ import os.path
+-from collections import Mapping
++from collections.abc import Mapping
  import sys
  import numpy as np
- 
+
 -from records import NpyFastaRecord
 +from pyfasta.records import NpyFastaRecord
- 
+
  # string.maketrans is bytes.maketrans in Python 3, but
  # we want to deal with strings instead of bytes


### PR DESCRIPTION
## Summary
- Update patch to import `Mapping` from `collections.abc` instead of `collections`
- Add `setuptools` as host dependency for modern pip compatibility
- Add `run_exports`
- Bump build number to 2

## Background
The abstract base classes (like `Mapping`) were moved to `collections.abc` in Python 3.3 and deprecated in `collections`. The old import location was removed entirely in Python 3.10, causing:

```
ImportError: cannot import name 'Mapping' from 'collections'
```

This breaks downstream tools like RiboCode when used with Python 3.10+.

The existing `python >=3` pin remains appropriate since `collections.abc` has been available since Python 3.3, and bioconda only builds for Python 3.8+.

🤖 Generated with [Claude Code](https://claude.com/claude-code)