### PR TITLE
Fix ribocode version string and add Python constraint

### DIFF
--- a/recipes/ribocode/fix-version.patch
+++ b/recipes/ribocode/fix-version.patch
@@ -1,0 +1,9 @@
+diff --git a/RiboCode/__init__.py b/RiboCode/__init__.py
+--- a/RiboCode/__init__.py
++++ b/RiboCode/__init__.py
+@@ -1,4 +1,4 @@
+ #!/usr/bin/env python
+ # -*- coding:UTF-8 -*-
+ __author__ = 'Zhengtao Xiao'
+-__version__ = "1.2.14"
++__version__ = "1.2.15"

--- a/recipes/ribocode/meta.yaml
+++ b/recipes/ribocode/meta.yaml
@@ -8,10 +8,14 @@ package:
 source:
   url: "https://github.com/zhengtaoxiao/RiboCode/archive/refs/tags/v{{ version }}.tar.gz"
   sha256: {{ sha256 }}
+  patches:
+    - fix-version.patch
 
 build:
-  number: 0
+  number: 1
   noarch: python
+  run_exports:
+    - {{ pin_subpackage('ribocode', max_pin='x.x') }}
   entry_points:
     - RiboCode=RiboCode.RiboCode:main
     - RiboCode_onestep=RiboCode.RiboCode_onestep:main
@@ -23,7 +27,7 @@ build:
 
 requirements:
   host:
-    - python
+    - python >=3.8,<3.11
     - pip
     - setuptools
     - numpy
@@ -37,7 +41,7 @@ requirements:
     - minepy
     - statsmodels
   run:
-    - python
+    - python >=3.8,<3.11
     - numpy
     - pysam >0.8.4
     - matplotlib-base
@@ -66,4 +70,5 @@ about:
   home: https://github.com/xryanglab/RiboCode
   license: MIT
   license_family: MIT
+  license_file: LICENSE
   summary: A package for detecting the actively translated ORFs using ribosome-profiling data


### PR DESCRIPTION
## Summary
- Add patch to fix `__version__` (was "1.2.14", should be "1.2.15")
- Add Python `>=3.8,<3.11` constraint (minepy not available for 3.11+)
- Add `license_file: LICENSE`
- Bump build number to 1

## Background

### Version string bug
The v1.2.15 tag in the upstream repo (`zhengtaoxiao/RiboCode`) was created without updating `__version__` in `RiboCode/__init__.py`, causing `RiboCode --version` to report "1.2.14" instead of "1.2.15".

### Python constraint
The `minepy` dependency doesn't have builds for Python 3.11+, so we need to constrain ribocode to Python 3.8-3.10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)