### PR TITLE
adding Scatac fragment tools

### DIFF
--- a/recipes/scatac-fragment-tools/meta.yaml
+++ b/recipes/scatac-fragment-tools/meta.yaml
@@ -11,7 +11,6 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<38]
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
   run_exports: {{ pin_compatible("scatac-fragment-tools", max_pin="x.x.x") }}
 


### PR DESCRIPTION
Adds scatac_fragment_tools requiered for https://github.com/bioconda/bioconda-recipes/pull/58864

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
