### PR TITLE
Add platonyzer v2.0.5

### DIFF
--- a/recipes/platonyzer/build.sh
+++ b/recipes/platonyzer/build.sh
@@ -2,6 +2,10 @@
 
 set -exo pipefail
 
+if [[ "${target_platform}" == "osx-"* ]]; then
+    export CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
+fi
+
 # Workaround for CMakeLists.txt to find FastFloat package
 sed -i.bak '/^cmake_minimum_required(VERSION/a\
 find_package(FastFloat REQUIRED CONFIG)
@@ -16,6 +20,7 @@ sed -i.bak 's|find_package(libmcfp|find_package(mcfp|g' CMakeLists.txt
 sed -i.bak 's|libmcfp::libmcfp|mcfp::mcfp|g' CMakeLists.txt
 
 cmake -S . -B build ${CMAKE_ARGS} -G Ninja \
+    -DCMAKE_CXX_FLAGS="${CXXFLAGS}" \
     -DBUILD_SHARED_LIBS=ON \
     -DFastFloat_DIR="${PREFIX}/share/cmake/FastFloat" \
     -DFFTW2_INCLUDE_DIRS="${PREFIX}/fftw2/include" \

--- a/recipes/platonyzer/build.sh
+++ b/recipes/platonyzer/build.sh
@@ -5,26 +5,13 @@ set -exo pipefail
 # Prevent static linking for GNU compilers
 sed -i.bak '/if(NOT MSVC AND "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")/,/endif()/d' CMakeLists.txt
 
-# # Ensure expected CMake config locations exist and create compatible symlinks
-# mkdir -p "${PREFIX}/lib/cmake/mcfp" "${PREFIX}/lib/cmake/libmcfp"
-# if [[ -f "${PREFIX}/lib/cmake/mcfp/mcfpConfig.cmake" ]]; then
-#   # Provide both libmcfpConfig.cmake and libmcfp-config.cmake in a directory CMake searches
-#   ln -sfn "${PREFIX}/lib/cmake/mcfp/mcfpConfig.cmake" "${PREFIX}/lib/cmake/libmcfp/libmcfpConfig.cmake"
-#   ln -sfn "${PREFIX}/lib/cmake/mcfp/mcfpConfig.cmake" "${PREFIX}/lib/cmake/libmcfp/libmcfp-config.cmake"
-#   # Keep a copy next to the original for backwards compatibility
-#   ln -sfn "${PREFIX}/lib/cmake/mcfp/mcfpConfig.cmake" "${PREFIX}/lib/cmake/mcfp/libmcfpConfig.cmake"
-#   # Also ensure mcfpTargets.cmake is available where libmcfpConfig expects it
-#   if [[ -f "${PREFIX}/lib/cmake/mcfp/mcfpTargets.cmake" ]]; then
-#     ln -sfn "${PREFIX}/lib/cmake/mcfp/mcfpTargets.cmake" "${PREFIX}/lib/cmake/libmcfp/mcfpTargets.cmake"
-#   fi
-# fi
-
 sed -i.bak 's|libmcfp_FOUND|mcfp_FOUND|g' CMakeLists.txt
 sed -i.bak 's|TARGET libmcfp)|TARGET mcfp)|g' CMakeLists.txt
 sed -i.bak 's|find_package(libmcfp|find_package(mcfp|g' CMakeLists.txt
 sed -i.bak 's|libmcfp::libmcfp|mcfp::mcfp|g' CMakeLists.txt
 
 cmake -S . -B build ${CMAKE_ARGS} \
+    -DBUILD_SHARED_LIBS=ON \
     -DFFTW2_INCLUDE_DIRS="${PREFIX}/fftw2/include" \
     -DFFTW2_LIBRARY="${PREFIX}/fftw2/lib/libfftw${SHLIB_EXT}" \
     -DRFFTW2_LIBRARY="${PREFIX}/fftw2/lib/librfftw${SHLIB_EXT}" \

--- a/recipes/platonyzer/build.sh
+++ b/recipes/platonyzer/build.sh
@@ -2,6 +2,11 @@
 
 set -exo pipefail
 
+# Workaround for CMakeLists.txt to find FastFloat package
+sed -i.bak '/^cmake_minimum_required(VERSION/a\
+find_package(FastFloat REQUIRED CONFIG)
+' CMakeLists.txt
+
 # Prevent static linking for GNU compilers
 sed -i.bak '/if(NOT MSVC AND "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")/,/endif()/d' CMakeLists.txt
 

--- a/recipes/platonyzer/build.sh
+++ b/recipes/platonyzer/build.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -exo pipefail
+
+# Prevent static linking for GNU compilers
+sed -i.bak '/if(NOT MSVC AND "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")/,/endif()/d' CMakeLists.txt
+
+# # Ensure expected CMake config locations exist and create compatible symlinks
+# mkdir -p "${PREFIX}/lib/cmake/mcfp" "${PREFIX}/lib/cmake/libmcfp"
+# if [[ -f "${PREFIX}/lib/cmake/mcfp/mcfpConfig.cmake" ]]; then
+#   # Provide both libmcfpConfig.cmake and libmcfp-config.cmake in a directory CMake searches
+#   ln -sfn "${PREFIX}/lib/cmake/mcfp/mcfpConfig.cmake" "${PREFIX}/lib/cmake/libmcfp/libmcfpConfig.cmake"
+#   ln -sfn "${PREFIX}/lib/cmake/mcfp/mcfpConfig.cmake" "${PREFIX}/lib/cmake/libmcfp/libmcfp-config.cmake"
+#   # Keep a copy next to the original for backwards compatibility
+#   ln -sfn "${PREFIX}/lib/cmake/mcfp/mcfpConfig.cmake" "${PREFIX}/lib/cmake/mcfp/libmcfpConfig.cmake"
+#   # Also ensure mcfpTargets.cmake is available where libmcfpConfig expects it
+#   if [[ -f "${PREFIX}/lib/cmake/mcfp/mcfpTargets.cmake" ]]; then
+#     ln -sfn "${PREFIX}/lib/cmake/mcfp/mcfpTargets.cmake" "${PREFIX}/lib/cmake/libmcfp/mcfpTargets.cmake"
+#   fi
+# fi
+
+sed -i.bak 's|libmcfp_FOUND|mcfp_FOUND|g' CMakeLists.txt
+sed -i.bak 's|TARGET libmcfp)|TARGET mcfp)|g' CMakeLists.txt
+sed -i.bak 's|find_package(libmcfp|find_package(mcfp|g' CMakeLists.txt
+sed -i.bak 's|libmcfp::libmcfp|mcfp::mcfp|g' CMakeLists.txt
+
+cmake -S . -B build ${CMAKE_ARGS} \
+    -DFFTW2_INCLUDE_DIRS="${PREFIX}/fftw2/include" \
+    -DFFTW2_LIBRARY="${PREFIX}/fftw2/lib/libfftw${SHLIB_EXT}" \
+    -DRFFTW2_LIBRARY="${PREFIX}/fftw2/lib/librfftw${SHLIB_EXT}" \
+    -Wno-dev -Wno-deprecated --no-warn-unused-cli
+cmake --build build --parallel ${CPU_COUNT}
+cmake --install build --parallel ${CPU_COUNT}

--- a/recipes/platonyzer/build.sh
+++ b/recipes/platonyzer/build.sh
@@ -12,6 +12,7 @@ sed -i.bak 's|libmcfp::libmcfp|mcfp::mcfp|g' CMakeLists.txt
 
 cmake -S . -B build ${CMAKE_ARGS} -G Ninja \
     -DBUILD_SHARED_LIBS=ON \
+    -DFastFloat_DIR="${PREFIX}/share/cmake/FastFloat" \
     -DFFTW2_INCLUDE_DIRS="${PREFIX}/fftw2/include" \
     -DFFTW2_LIBRARY="${PREFIX}/fftw2/lib/libfftw${SHLIB_EXT}" \
     -DRFFTW2_LIBRARY="${PREFIX}/fftw2/lib/librfftw${SHLIB_EXT}" \

--- a/recipes/platonyzer/build.sh
+++ b/recipes/platonyzer/build.sh
@@ -10,7 +10,7 @@ sed -i.bak 's|TARGET libmcfp)|TARGET mcfp)|g' CMakeLists.txt
 sed -i.bak 's|find_package(libmcfp|find_package(mcfp|g' CMakeLists.txt
 sed -i.bak 's|libmcfp::libmcfp|mcfp::mcfp|g' CMakeLists.txt
 
-cmake -S . -B build ${CMAKE_ARGS} \
+cmake -S . -B build ${CMAKE_ARGS} -G Ninja \
     -DBUILD_SHARED_LIBS=ON \
     -DFFTW2_INCLUDE_DIRS="${PREFIX}/fftw2/include" \
     -DFFTW2_LIBRARY="${PREFIX}/fftw2/lib/libfftw${SHLIB_EXT}" \

--- a/recipes/platonyzer/conda_build_config.yaml
+++ b/recipes/platonyzer/conda_build_config.yaml
@@ -1,0 +1,2 @@
+c_stdlib_version:  # [osx]
+  - 13.3           # [osx]

--- a/recipes/platonyzer/conda_build_config.yaml
+++ b/recipes/platonyzer/conda_build_config.yaml
@@ -1,2 +1,0 @@
-c_stdlib_version:  # [osx]
-  - 13.3           # [osx]

--- a/recipes/platonyzer/meta.yaml
+++ b/recipes/platonyzer/meta.yaml
@@ -20,7 +20,6 @@ requirements:
     - ninja
   host:
     - eigen
-    - fast_float
     - cpp-filesystem
     - libmcfp
     - libpdb-redo >=2.0.2

--- a/recipes/platonyzer/meta.yaml
+++ b/recipes/platonyzer/meta.yaml
@@ -17,6 +17,7 @@ requirements:
   build:
     - {{ compiler("cxx") }}
     - cmake
+    - ninja
   host:
     - eigen
     - cpp-filesystem

--- a/recipes/platonyzer/meta.yaml
+++ b/recipes/platonyzer/meta.yaml
@@ -11,7 +11,8 @@ source:
 
 build:
   number: 0
-  run_exports: []
+  # There seems destructive changes (e.g. # https://github.com/PDB-REDO/platonyzer/commit/f4c631013a9058fb6ed02041c9209f191b59b31c)
+  run_exports: {{ pin_subpackage(name, max_pin="x.x.x") }}  
 
 requirements:
   build:

--- a/recipes/platonyzer/meta.yaml
+++ b/recipes/platonyzer/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - ninja
   host:
     - eigen
+    - fast_float
     - cpp-filesystem
     - libmcfp
     - libpdb-redo >=2.0.2

--- a/recipes/platonyzer/meta.yaml
+++ b/recipes/platonyzer/meta.yaml
@@ -26,6 +26,9 @@ requirements:
     - libpdb-redo >=2.0.2
     - newuoa-cpp
     - zlib
+  run:
+    # Requires macOS 13.3+ for std::to_chars floating-point support
+    - __osx >=13.3  # [osx]
 
 test:
   commands:

--- a/recipes/platonyzer/meta.yaml
+++ b/recipes/platonyzer/meta.yaml
@@ -1,0 +1,49 @@
+{% set name = "platonyzer" %}
+{% set version = "2.0.5" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/PDB-REDO/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 88162f45bac70a38455d8c212e8aaa13ed97e644201a834865c13fa321ea3f14
+
+build:
+  number: 0
+  run_exports: []
+
+requirements:
+  build:
+    - {{ compiler("cxx") }}
+    - cmake
+  host:
+    - eigen
+    - cpp-filesystem
+    - libmcfp
+    - libpdb-redo >=2.0.2
+    - newuoa-cpp
+    - zlib
+
+test:
+  commands:
+    - platonyzer --help
+    - platonyzer --version
+
+about:
+  home: https://github.com/PDB-REDO/platonyzer
+  dev_url:  https://github.com/PDB-REDO/platonyzer
+  summary: "An application to create restraints for metal sites"
+  license: BSD-2-Clause
+  license_family: BSD
+  license_file: LICENSE
+  description: >
+    This is the repository for platonyzer, an application to create restraints for metal sites.
+    This program is part of the [PDB-REDO](https://pdb-redo.eu/) suite of programs.
+
+extra:
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64
+  recipe-maintainers:
+    - eunos-1128


### PR DESCRIPTION
This pull request introduces a new conda recipe for the `platonyzer` application, which generates restraints for metal sites and is part of the PDB-REDO suite. The changes include the addition of both the build script and the recipe metadata, ensuring proper build configuration and dependency management.

New recipe addition:

* Added `recipes/platonyzer/meta.yaml` to define the conda package, including metadata, dependencies, test commands, and platform support.

Build configuration:

* Added `recipes/platonyzer/build.sh` to customize the build process, including patching `CMakeLists.txt` for dependency naming consistency and configuring the build with CMake and relevant library paths.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
