### PR TITLE
Update picrust2 dependencies

### DIFF
--- a/recipes/picrust2/meta.yaml
+++ b/recipes/picrust2/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   run_exports:
         - {{ pin_subpackage('picrust2', max_pin="x") }}
-  number: 0
+  number: 1
   noarch: python
   script: "{{ PYTHON }} -m pip install . --no-deps --no-build-isolation --no-cache-dir -vvv"
 
@@ -23,13 +23,13 @@ requirements:
     - python >=3.5
   run:
     - biom-format >=2.1.10
-    - dendropy 4.5.2
+    - dendropy >=5.0.1, <=5.0.6
     - epa-ng 0.3.8
     - ete3
     - gappa >=0.8.0,<=0.8.5
     - glpk >=4.65
     - h5py >=2.10.0
-    - hmmer >=3.1b2,<=3.2.1
+    - hmmer >=3.1b2,<3.5.0a0
     - jinja2 >=2.11.3
     - joblib >=1.0.1
     - numpy >=1.19.5
@@ -40,7 +40,7 @@ requirements:
     - r-base >=3.5.1
     - r-castor >=1.7.2
     - scipy >=1.2.1
-    - sepp 4.4.0
+    - sepp 4.5.5
     - wget
 
 test:


### PR DESCRIPTION
Sepp dependency for picrust2 updated from 4.4.0 to 4.5.5 (as in picrust2 [`picrust2-env.yaml`](https://github.com/picrust/picrust2/blob/master/picrust2-env.yaml)). Dendropy was updated to version 5 as well.

Main issue for me was installing on python 3.10, picrust2 doesn't install because of older sepp dependency version pin which requires 3.9, which is an end-of-life python version.

The dependency for hmmer was also updated in accordance with the updated SEPP version.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
