### PR TITLE
Add yallhap 0.4.0

### DIFF
--- a/recipes/yallhap/meta.yaml
+++ b/recipes/yallhap/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/trianglegrrl/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: 0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5
+  sha256: 2c4b42853b0d1a8e9d4493d757eb69995b5fa7f69601400b9ee623340ac9f711
 
 build:
   number: 0


### PR DESCRIPTION
Add yallhap 0.4.0

yallHap is a pipeline-friendly tool for Y-chromosome haplogroup classification 
supporting modern and ancient DNA with probabilistic confidence scoring. It uses 
the YFull phylogenetic tree and supports multiple reference genomes including 
T2T-CHM13v2.0.

- Homepage: https://github.com/trianglegrrl/yallHap
- PyPI: https://pypi.org/project/yallhap/
- License: Polyform Noncommercial License 1.0.0
- Semantic versioning (0.x.x format): uses `max_pin="x.x"` in run_exports