### PR TITLE
Add recipe for cellpyability v0.1.0

### DIFF
--- a/recipes/cellpyability/meta.yaml
+++ b/recipes/cellpyability/meta.yaml
@@ -13,6 +13,8 @@ build:
   number: 0
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x.x") }}
 
 requirements:
   host:


### PR DESCRIPTION
Add recipe for cellpyability v0.1.0

CellPyAbility is a Python package for analyzing cell viability data, specifically designed for dose-response curves and drug interaction studies via nuclei counting.

- Source: PyPI
- License: MIT
- Tests: Import and help command check included.
- Author: James Elia