### PR TITLE
Add meta.yaml for flashdeconv version 0.1.3

### DIFF
--- a/recipes/flashdeconv/meta.yaml
+++ b/recipes/flashdeconv/meta.yaml
@@ -1,0 +1,48 @@
+{% set name = "flashdeconv" %}
+{% set version = "0.1.3" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 2231d065a4dd977b1f1904b06dd65a47adf95ee5f879f7c1c72754d67674c799
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python >=3.9
+    - pip
+    - setuptools
+  run:
+    - python >=3.9
+    - numpy >=1.21
+    - scipy >=1.7
+    - numba >=0.56
+
+test:
+  imports:
+    - flashdeconv
+
+about:
+  home: https://github.com/cafferychen777/flashdeconv
+  license: GPL-3.0-only
+  license_family: GPL
+  license_file: LICENSE
+  summary: Ultra-fast spatial transcriptomics deconvolution using structure-preserving randomized sketching
+  description: |
+    FlashDeconv is a high-performance spatial transcriptomics deconvolution method 
+    designed for atlas-scale and subcellular-resolution platforms (Visium HD, Stereo-seq, Xenium). 
+    It leverages structure-preserving randomized sketching to estimate cell type proportions 
+    with linear scalability—processing 1 million spots in ~3 minutes on commodity hardware.
+  dev_url: https://github.com/cafferychen777/flashdeconv
+  doc_url: https://github.com/cafferychen777/flashdeconv
+
+extra:
+  recipe-maintainers:
+    - cafferychen777


### PR DESCRIPTION
## Summary

Add new recipe for **flashdeconv** - a high-performance spatial transcriptomics deconvolution tool.

### Package Information
- **Name:** flashdeconv
- **Version:** 0.1.3
- **License:** GPL-3.0-only
- **PyPI:** https://pypi.org/project/flashdeconv/
- **GitHub:** https://github.com/cafferychen777/flashdeconv
- **Paper:** https://doi.org/10.64898/2025.12.22.696108

### Description
FlashDeconv is a high-performance spatial transcriptomics deconvolution method designed for atlas-scale and subcellular-resolution platforms (Visium HD, Stereo-seq, Xenium). It leverages structure-preserving randomized sketching to estimate cell type proportions with linear scalability—processing 1 million spots in ~3 minutes on commodity hardware.

### Dependencies
- python >=3.9
- numpy >=1.21
- scipy >=1.7
- numba >=0.56

### Test
- Basic import test included

---

This is a new recipe submission. The package is already published on PyPI and has been tested locally.