### PR TITLE
upgrading iphop to v1.4.2 (minor version update)

### DIFF
--- a/recipes/iphop/meta.yaml
+++ b/recipes/iphop/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "iphop" %}
-  {% set version = "1.4.1" %}
+  {% set version = "1.4.2" %}
 
 package:
   name: "{{ name|lower }}"
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://bitbucket.org/srouxjgi/iphop/downloads/{{ name }}-{{ version }}.tar.gz
-  sha256: b320b2cc478033139a26724a7076eebafa3fb8b90fa07a709b1c25b01265bf81
+  sha256: 26f6ee5b04d09d3a3558df4758d0ff69fda610f7c656048234e6057f9ff16b95
 
 build:
   number: 0


### PR DESCRIPTION
Upgrading iphop to v1.4.2
Minor version update: This release adds an option to specify a number of threads for the WIsH step, independently from the overall number of threads used in the rest of iPHoP stesp. This is to help cases in which a high number of threads leads to iPHoP getting stalled at the WIsH step.