### PR TITLE
bioconductor-biocgenerics: set r-base >=4.5.0 (Bioconductor 3.22)

### DIFF
--- a/recipes/bioconductor-biocgenerics/meta.yaml
+++ b/recipes/bioconductor-biocgenerics/meta.yaml
@@ -9,7 +9,7 @@ about:
   summary: S4 generic functions used in Bioconductor
 build:
   noarch: generic
-  number: 0
+  number: 1
   rpaths:
     - lib/R/lib/
     - lib/


### PR DESCRIPTION
Update r-base constraint to >=4.5.0 in bioconductor-biocgenerics to match Bioconductor 3.22.\n\n- Single-file change: recipes/bioconductor-biocgenerics/meta.yaml\n- Ensures downstream 3.22 packages resolve against R 4.5.x.\n- r-base 4.5.x is available on conda-forge.