### PR TITLE
bioconductor-s4vectors: bump to 0.48.0 (Bioconductor 3.22)

### DIFF
--- a/recipes/bioconductor-s4vectors/meta.yaml
+++ b/recipes/bioconductor-s4vectors/meta.yaml
@@ -1,6 +1,6 @@
-{% set version = "0.44.0" %}
+{% set version = "0.48.0" %}
 {% set name = "S4Vectors" %}
-{% set bioc = "3.20" %}
+{% set bioc = "3.22" %}
 
 about:
   description: The S4Vectors package defines the Vector and List virtual classes and a set of generic functions that extend the semantic of ordinary vectors and lists in R. Package developers can easily implement vector-like or list-like objects as concrete subclasses of Vector or List. In addition, a few low-level concrete subclasses of general interest (e.g. DataFrame, Rle, Factor, and Hits) are implemented in the S4Vectors package itself (many more are implemented in the IRanges package and in other Bioconductor infrastructure packages).
@@ -9,7 +9,7 @@ about:
   summary: Foundation of vector-like and list-like containers in Bioconductor
 
 build:
-  number: 2
+  number: 0
   rpaths:
     - lib/R/lib/
     - lib/
@@ -37,16 +37,16 @@ requirements:
     - {{ compiler('c') }}
     - make
   host:
-    - bioconductor-biocgenerics >=0.52.0,<0.53.0
-    - r-base
+    - bioconductor-biocgenerics >=0.56.0,<0.57.0
+    - r-base >=4.5.0
     - libblas
     - liblapack
   run:
-    - bioconductor-biocgenerics >=0.52.0,<0.53.0
-    - r-base
+    - bioconductor-biocgenerics >=0.56.0,<0.57.0
+    - r-base >=4.5.0
 
 source:
-  md5: 6f87d627de90deccd2bc907b36d6d75d
+  md5: 630961a4e2d96366a617dcc35f058105
   url:
     - https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/{{ name }}_{{ version }}.tar.gz
     - https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/Archive/{{ name }}/{{ name }}_{{ version }}.tar.gz


### PR DESCRIPTION
Update S4Vectors to 0.48.0 (Bioc 3.22):\n- Update version/bioc and MD5\n- Update BiocGenerics pins to 0.56.x\n- Set r-base >=4.5.0\nSingle-file change.