### PR TITLE
bioconductor-genomicranges: bump to 1.62.1 (Bioconductor 3.22)

### DIFF
--- a/recipes/bioconductor-genomicranges/meta.yaml
+++ b/recipes/bioconductor-genomicranges/meta.yaml
@@ -1,6 +1,6 @@
-{% set version = "1.58.0" %}
+{% set version = "1.62.1" %}
 {% set name = "GenomicRanges" %}
-{% set bioc = "3.20" %}
+{% set bioc = "3.22" %}
 
 about:
   description: The ability to efficiently represent and manipulate genomic annotations and alignments is playing a central role when it comes to analyzing high-throughput sequencing data (a.k.a. NGS data). The GenomicRanges package defines general purpose containers for storing and manipulating genomic intervals and variables defined along a genome. More specialized containers for representing and manipulating short alignments against a reference genome, or a matrix-like summarization of an experiment, are defined in the GenomicAlignments and SummarizedExperiment packages, respectively. Both packages build on top of the GenomicRanges infrastructure.
@@ -9,7 +9,7 @@ about:
   summary: Representation and manipulation of genomic intervals
 
 build:
-  number: 2
+  number: 0
   rpaths:
     - lib/R/lib/
     - lib/
@@ -36,24 +36,24 @@ requirements:
     - {{ compiler('c') }}
     - make
   host:
-    - bioconductor-biocgenerics >=0.52.0,<0.53.0
-    - bioconductor-genomeinfodb >=1.42.0,<1.43.0
-    - bioconductor-iranges >=2.40.0,<2.41.0
-    - bioconductor-s4vectors >=0.44.0,<0.45.0
+    - bioconductor-biocgenerics >=0.56.0,<0.57.0
+    - bioconductor-genomeinfodb >=1.46.0,<1.47.0
+    - bioconductor-iranges >=2.44.0,<2.45.0
+    - bioconductor-s4vectors >=0.48.0,<0.49.0
     - bioconductor-xvector >=0.46.0,<0.47.0
-    - r-base
+    - r-base >=4.5.0
     - libblas
     - liblapack
   run:
-    - bioconductor-biocgenerics >=0.52.0,<0.53.0
-    - bioconductor-genomeinfodb >=1.42.0,<1.43.0
-    - bioconductor-iranges >=2.40.0,<2.41.0
-    - bioconductor-s4vectors >=0.44.0,<0.45.0
+    - bioconductor-biocgenerics >=0.56.0,<0.57.0
+    - bioconductor-genomeinfodb >=1.46.0,<1.47.0
+    - bioconductor-iranges >=2.44.0,<2.45.0
+    - bioconductor-s4vectors >=0.48.0,<0.49.0
     - bioconductor-xvector >=0.46.0,<0.47.0
-    - r-base
+    - r-base >=4.5.0
 
 source:
-  md5: cca337e05cca2a77511c410397e8d415
+  md5: aa38e9c50dd8981e4db04cc5beee8078
   url:
     - https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/{{ name }}_{{ version }}.tar.gz
     - https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/Archive/{{ name }}/{{ name }}_{{ version }}.tar.gz


### PR DESCRIPTION
Update GenomicRanges to 1.62.1 (Bioc 3.22):\n- Update version and MD5\n- Update dependency pins to 3.22 versions\n- Set r-base >=4.5.0\nSingle-file change.