### PR TITLE
bioconductor-biocparallel: bump to 1.44.0 (Bioconductor 3.22)

### DIFF
--- a/recipes/bioconductor-biocparallel/meta.yaml
+++ b/recipes/bioconductor-biocparallel/meta.yaml
@@ -1,6 +1,6 @@
-{% set version = "1.40.0" %}
+{% set version = "1.44.0" %}
 {% set name = "BiocParallel" %}
-{% set bioc = "3.20" %}
+{% set bioc = "3.22" %}
 
 about:
   description: This package provides modified versions and novel implementation of functions for parallel evaluation, tailored to use with Bioconductor objects.
@@ -10,7 +10,7 @@ about:
   summary: Bioconductor facilities for parallel evaluation
 
 build:
-  number: 1
+  number: 0
   rpaths:
     - lib/R/lib/
     - lib/
@@ -41,7 +41,7 @@ requirements:
     - automake
     - make
   host:
-    - r-base
+    - r-base >=4.5.0
     - r-bh
     - r-codetools
     - r-cpp11
@@ -50,7 +50,7 @@ requirements:
     - libblas
     - liblapack
   run:
-    - r-base
+    - r-base >=4.5.0
     - r-bh
     - r-codetools
     - r-cpp11
@@ -58,7 +58,7 @@ requirements:
     - r-snow
 
 source:
-  md5: f2801ca5ef796a79de667cab673a4603
+  md5: 75ab7c6895d7c10cbf15f4335adc6f08
   url:
     - https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/{{ name }}_{{ version }}.tar.gz
     - https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/Archive/{{ name }}/{{ name }}_{{ version }}.tar.gz


### PR DESCRIPTION
Update BiocParallel to 1.44.0 (Bioc 3.22):\n- Update version and MD5\n- Set r-base >=4.5.0\nSingle-file change.