### PR TITLE
bioconductor-matrixgenerics: bump to 1.22.0 (Bioconductor 3.22)

### DIFF
--- a/recipes/bioconductor-matrixgenerics/meta.yaml
+++ b/recipes/bioconductor-matrixgenerics/meta.yaml
@@ -1,6 +1,6 @@
-{% set version = "1.18.0" %}
+{% set version = "1.22.0" %}
 {% set name = "MatrixGenerics" %}
-{% set bioc = "3.20" %}
+{% set bioc = "3.22" %}
 
 about:
   description: S4 generic functions modeled after the 'matrixStats' API for alternative matrix implementations. Packages with alternative matrix implementation can depend on this package and implement the generic functions that are defined here for a useful set of row and column summary statistics. Other package developers can import this package and handle a different matrix implementations without worrying about incompatibilities.
@@ -20,13 +20,13 @@ package:
 # Suggests: Matrix, sparseMatrixStats, SparseArray, DelayedArray, DelayedMatrixStats, SummarizedExperiment, testthat (>= 2.1.0)
 requirements:
   host:
-    - r-base
+    - r-base >=4.5.0
     - r-matrixstats >=1.4.1
   run:
-    - r-base
+    - r-base >=4.5.0
     - r-matrixstats >=1.4.1
 source:
-  md5: be0b5a464be94a86963f7c1c30c8c3da
+  md5: f1d0d731b82aed99d77e403280a14deb
   url:
     - https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/{{ name }}_{{ version }}.tar.gz
     - https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/Archive/{{ name }}/{{ name }}_{{ version }}.tar.gz


### PR DESCRIPTION
Update MatrixGenerics to 1.22.0 (Bioc 3.22):\n- Update version and MD5\n- Set r-base >=4.5.0\nSingle-file change.