### PR TITLE
bioconductor-sparsearray: bump to 1.10.8 (Bioconductor 3.22)

### DIFF
--- a/recipes/bioconductor-sparsearray/meta.yaml
+++ b/recipes/bioconductor-sparsearray/meta.yaml
@@ -1,6 +1,6 @@
-{% set version = "1.6.0" %}
+{% set version = "1.10.8" %}
 {% set name = "SparseArray" %}
-{% set bioc = "3.20" %}
+{% set bioc = "3.22" %}
 
 about:
   description: 'The SparseArray package provides array-like containers for efficient in-memory representation of multidimensional sparse data in R (arrays and matrices). The package defines the SparseArray virtual class and two concrete subclasses: COO_SparseArray and SVT_SparseArray. Each subclass uses its own internal representation of the nonzero multidimensional data: the "COO layout" and the "SVT layout", respectively. SVT_SparseArray objects mimic as much as possible the behavior of ordinary matrix and array objects in base R. In particular, they suppport most of the "standard matrix and array API" defined in base R and in the matrixStats package from CRAN.'
@@ -9,7 +9,7 @@ about:
   summary: High-performance sparse data representation and manipulation in R
 
 build:
-  number: 1
+  number: 0
   rpaths:
     - lib/R/lib/
     - lib/
@@ -30,30 +30,30 @@ requirements:
     - {{ compiler('c') }}
     - make
   host:
-    - bioconductor-biocgenerics >=0.52.0,<0.53.0
-    - bioconductor-iranges >=2.40.0,<2.41.0
-    - bioconductor-matrixgenerics >=1.18.0,<1.19.0
-    - bioconductor-s4arrays >=1.6.0,<1.7.0
-    - bioconductor-s4vectors >=0.44.0,<0.45.0
+    - bioconductor-biocgenerics >=0.56.0,<0.57.0
+    - bioconductor-iranges >=2.44.0,<2.45.0
+    - bioconductor-matrixgenerics >=1.22.0,<1.23.0
+    - bioconductor-s4arrays >=1.10.0,<1.11.0
+    - bioconductor-s4vectors >=0.48.0,<0.49.0
     - bioconductor-xvector >=0.46.0,<0.47.0
-    - r-base
+    - r-base >=4.5.0
     - r-matrix
     - r-matrixstats
     - libblas
     - liblapack
   run:
-    - bioconductor-biocgenerics >=0.52.0,<0.53.0
-    - bioconductor-iranges >=2.40.0,<2.41.0
-    - bioconductor-matrixgenerics >=1.18.0,<1.19.0
-    - bioconductor-s4arrays >=1.6.0,<1.7.0
-    - bioconductor-s4vectors >=0.44.0,<0.45.0
+    - bioconductor-biocgenerics >=0.56.0,<0.57.0
+    - bioconductor-iranges >=2.44.0,<2.45.0
+    - bioconductor-matrixgenerics >=1.22.0,<1.23.0
+    - bioconductor-s4arrays >=1.10.0,<1.11.0
+    - bioconductor-s4vectors >=0.48.0,<0.49.0
     - bioconductor-xvector >=0.46.0,<0.47.0
-    - r-base
+    - r-base >=4.5.0
     - r-matrix
     - r-matrixstats
 
 source:
-  md5: b57caafbc8b4ad3fa535a6b6180d0476
+  md5: 8dc81480e3e0186a7848fc105c78db8c
   url:
     - https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/{{ name }}_{{ version }}.tar.gz
     - https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/Archive/{{ name }}/{{ name }}_{{ version }}.tar.gz


### PR DESCRIPTION
Update SparseArray to 1.10.8 (Bioc 3.22):\n- Update version, build number, and MD5\n- Update dependencies to Bioc 3.22 pins\n- Set r-base >=4.5.0\nSingle-file change.