### PR TITLE
bioconductor-delayedarray: bump to 0.36.0 (Bioconductor 3.22)

### DIFF
--- a/recipes/bioconductor-delayedarray/meta.yaml
+++ b/recipes/bioconductor-delayedarray/meta.yaml
@@ -1,6 +1,6 @@
-{% set version = "0.32.0" %}
+{% set version = "0.36.0" %}
 {% set name = "DelayedArray" %}
-{% set bioc = "3.20" %}
+{% set bioc = "3.22" %}
 
 about:
   description: Wrapping an array-like object (typically an on-disk object) in a DelayedArray object allows one to perform common array operations on it without loading the object in memory. In order to reduce memory usage and optimize performance, operations on the object are either delayed or executed using a block processing mechanism. Note that this also works on in-memory array-like objects like DataFrame objects (typically with Rle columns), Matrix objects, ordinary arrays and, data frames.
@@ -9,7 +9,7 @@ about:
   summary: A unified framework for working transparently with on-disk and in-memory array-like datasets
 
 build:
-  number: 1
+  number: 0
   rpaths:
     - lib/R/lib/
     - lib/
@@ -34,28 +34,28 @@ requirements:
     - {{ compiler('c') }}
     - make
   host:
-    - bioconductor-biocgenerics >=0.52.0,<0.53.0
-    - bioconductor-iranges >=2.40.0,<2.41.0
-    - bioconductor-matrixgenerics >=1.18.0,<1.19.0
-    - bioconductor-s4arrays >=1.6.0,<1.7.0
-    - bioconductor-s4vectors >=0.44.0,<0.45.0
-    - bioconductor-sparsearray >=1.6.0,<1.7.0
-    - r-base
+    - bioconductor-biocgenerics >=0.56.0,<0.57.0
+    - bioconductor-iranges >=2.44.0,<2.45.0
+    - bioconductor-matrixgenerics >=1.22.0,<1.23.0
+    - bioconductor-s4arrays >=1.10.0,<1.11.0
+    - bioconductor-s4vectors >=0.48.0,<0.49.0
+    - bioconductor-sparsearray >=1.10.0,<1.11.0
+    - r-base >=4.5.0
     - r-matrix
     - libblas
     - liblapack
   run:
-    - bioconductor-biocgenerics >=0.52.0,<0.53.0
-    - bioconductor-iranges >=2.40.0,<2.41.0
-    - bioconductor-matrixgenerics >=1.18.0,<1.19.0
-    - bioconductor-s4arrays >=1.6.0,<1.7.0
-    - bioconductor-s4vectors >=0.44.0,<0.45.0
-    - bioconductor-sparsearray >=1.6.0,<1.7.0
-    - r-base
+    - bioconductor-biocgenerics >=0.56.0,<0.57.0
+    - bioconductor-iranges >=2.44.0,<2.45.0
+    - bioconductor-matrixgenerics >=1.22.0,<1.23.0
+    - bioconductor-s4arrays >=1.10.0,<1.11.0
+    - bioconductor-s4vectors >=0.48.0,<0.49.0
+    - bioconductor-sparsearray >=1.10.0,<1.11.0
+    - r-base >=4.5.0
     - r-matrix
 
 source:
-  md5: 518800dac5483993eae24c728967cb7d
+  md5: 57b2fd485d73f5dc5fcb65ec23e16429
   url:
     - https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/{{ name }}_{{ version }}.tar.gz
     - https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/Archive/{{ name }}/{{ name }}_{{ version }}.tar.gz


### PR DESCRIPTION
Update DelayedArray to 0.36.0 (Bioc 3.22):\n- Update version, build number, and MD5\n- Update dependencies to Bioc 3.22 pins\n- Set r-base >=4.5.0\nSingle-file change.