### PR TITLE
bioconductor-delayedmatrixstats: bump to 1.32.0 (Bioconductor 3.22)

### DIFF
--- a/recipes/bioconductor-delayedmatrixstats/meta.yaml
+++ b/recipes/bioconductor-delayedmatrixstats/meta.yaml
@@ -1,6 +1,6 @@
-{% set version = "1.28.0" %}
+{% set version = "1.32.0" %}
 {% set name = "DelayedMatrixStats" %}
-{% set bioc = "3.20" %}
+{% set bioc = "3.22" %}
 
 about:
   description: A port of the 'matrixStats' API for use with DelayedMatrix objects from the 'DelayedArray' package. High-performing functions operating on rows and columns of DelayedMatrix objects, e.g. col / rowMedians(), col / rowRanks(), and col / rowSds(). Functions optimized per data type and for subsetted calculations such that both memory usage and processing time is minimized.
@@ -30,26 +30,26 @@ package:
 # Suggests: testthat, knitr, rmarkdown, BiocStyle, microbenchmark, profmem, HDF5Array, matrixStats (>= 1.0.0)
 requirements:
   host:
-    - bioconductor-delayedarray >=0.32.0,<0.33.0
-    - bioconductor-iranges >=2.40.0,<2.41.0
-    - bioconductor-matrixgenerics >=1.18.0,<1.19.0
-    - bioconductor-s4vectors >=0.44.0,<0.45.0
-    - bioconductor-sparsearray >=1.6.0,<1.7.0
-    - bioconductor-sparsematrixstats >=1.18.0,<1.19.0
-    - r-base
+    - bioconductor-delayedarray >=0.36.0,<0.37.0
+    - bioconductor-iranges >=2.44.0,<2.45.0
+    - bioconductor-matrixgenerics >=1.22.0,<1.23.0
+    - bioconductor-s4vectors >=0.48.0,<0.49.0
+    - bioconductor-sparsearray >=1.10.0,<1.11.0
+    - bioconductor-sparsematrixstats >=1.22.0,<1.23.0
+    - r-base >=4.5.0
     - r-matrix >=1.5-0
   run:
-    - bioconductor-delayedarray >=0.32.0,<0.33.0
-    - bioconductor-iranges >=2.40.0,<2.41.0
-    - bioconductor-matrixgenerics >=1.18.0,<1.19.0
-    - bioconductor-s4vectors >=0.44.0,<0.45.0
-    - bioconductor-sparsearray >=1.6.0,<1.7.0
-    - bioconductor-sparsematrixstats >=1.18.0,<1.19.0
-    - r-base
+    - bioconductor-delayedarray >=0.36.0,<0.37.0
+    - bioconductor-iranges >=2.44.0,<2.45.0
+    - bioconductor-matrixgenerics >=1.22.0,<1.23.0
+    - bioconductor-s4vectors >=0.48.0,<0.49.0
+    - bioconductor-sparsearray >=1.10.0,<1.11.0
+    - bioconductor-sparsematrixstats >=1.22.0,<1.23.0
+    - r-base >=4.5.0
     - r-matrix >=1.5-0
 
 source:
-  md5: 1417e01b05f813b1955f3bd2cc62043c
+  md5: b8e1a8f2eb6a62c6f61d7f5ae42a296a
   url:
     - https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/{{ name }}_{{ version }}.tar.gz
     - https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/Archive/{{ name }}/{{ name }}_{{ version }}.tar.gz


### PR DESCRIPTION
Update DelayedMatrixStats to 1.32.0 (Bioc 3.22):\n- Update version and MD5\n- Update dependencies to Bioc 3.22 pins\n- Set r-base >=4.5.0\nSingle-file change.