### PR TITLE
bioconductor-singlecellexperiment: bump to 1.32.0 (Bioconductor 3.22)

### DIFF
--- a/recipes/bioconductor-singlecellexperiment/meta.yaml
+++ b/recipes/bioconductor-singlecellexperiment/meta.yaml
@@ -1,6 +1,6 @@
-{% set version = "1.28.0" %}
+{% set version = "1.32.0" %}
 {% set name = "SingleCellExperiment" %}
-{% set bioc = "3.20" %}
+{% set bioc = "3.22" %}
 
 about:
   description: Defines a S4 class for storing data from single-cell experiments. This includes specialized methods to store and retrieve spike-in information, dimensionality reduction coordinates and size factors for each cell, along with the usual metadata for genes and libraries.
@@ -30,22 +30,22 @@ package:
 # Suggests: testthat, BiocStyle, knitr, rmarkdown, Matrix, scRNAseq (>= 2.9.1), Rtsne
 requirements:
   host:
-    - bioconductor-biocgenerics >=0.52.0,<0.53.0
-    - bioconductor-delayedarray >=0.32.0,<0.33.0
-    - bioconductor-genomicranges >=1.58.0,<1.59.0
-    - bioconductor-s4vectors >=0.44.0,<0.45.0
-    - bioconductor-summarizedexperiment >=1.36.0,<1.37.0
-    - r-base
+    - bioconductor-biocgenerics >=0.56.0,<0.57.0
+    - bioconductor-delayedarray >=0.36.0,<0.37.0
+    - bioconductor-genomicranges >=1.62.0,<1.63.0
+    - bioconductor-s4vectors >=0.48.0,<0.49.0
+    - bioconductor-summarizedexperiment >=1.40.0,<1.41.0
+    - r-base >=4.5.0
   run:
-    - bioconductor-biocgenerics >=0.52.0,<0.53.0
-    - bioconductor-delayedarray >=0.32.0,<0.33.0
-    - bioconductor-genomicranges >=1.58.0,<1.59.0
-    - bioconductor-s4vectors >=0.44.0,<0.45.0
-    - bioconductor-summarizedexperiment >=1.36.0,<1.37.0
-    - r-base
+    - bioconductor-biocgenerics >=0.56.0,<0.57.0
+    - bioconductor-delayedarray >=0.36.0,<0.37.0
+    - bioconductor-genomicranges >=1.62.0,<1.63.0
+    - bioconductor-s4vectors >=0.48.0,<0.49.0
+    - bioconductor-summarizedexperiment >=1.40.0,<1.41.0
+    - r-base >=4.5.0
 
 source:
-  md5: 2471847d91e0cd67873f5928daedbcd1
+  md5: 44c2e2e01236d96d48f73e1c1c89e42f
   url:
     - https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/{{ name }}_{{ version }}.tar.gz
     - https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/Archive/{{ name }}/{{ name }}_{{ version }}.tar.gz


### PR DESCRIPTION
Update SingleCellExperiment to 1.32.0 (Bioc 3.22):\n- Update version and MD5\n- Update dependencies to Bioc 3.22 pins\n- Set r-base >=4.5.0\nSingle-file change.