### PR TITLE
bioconductor-biostrings: bump to 2.78.0 (Bioconductor 3.22)

### DIFF
--- a/recipes/bioconductor-biostrings/meta.yaml
+++ b/recipes/bioconductor-biostrings/meta.yaml
@@ -1,6 +1,6 @@
-{% set version = "2.74.0" %}
+{% set version = "2.78.0" %}
 {% set name = "Biostrings" %}
-{% set bioc = "3.20" %}
+{% set bioc = "3.22" %}
 
 about:
   description: Memory efficient string containers, string matching algorithms, and other utilities, for fast manipulation of large biological sequences or sets of sequences.
@@ -9,7 +9,7 @@ about:
   summary: Efficient manipulation of biological strings
 
 build:
-  number: 1
+  number: 0
   rpaths:
     - lib/R/lib/
     - lib/
@@ -37,26 +37,26 @@ requirements:
     - {{ compiler('c') }}
     - make
   host:
-    - bioconductor-biocgenerics >=0.52.0,<0.53.0
-    - bioconductor-genomeinfodb >=1.42.0,<1.43.0
-    - bioconductor-iranges >=2.40.0,<2.41.0
-    - bioconductor-s4vectors >=0.44.0,<0.45.0
+    - bioconductor-biocgenerics >=0.56.0,<0.57.0
+    - bioconductor-genomeinfodb >=1.46.0,<1.47.0
+    - bioconductor-iranges >=2.44.0,<2.45.0
+    - bioconductor-s4vectors >=0.48.0,<0.49.0
     - bioconductor-xvector >=0.46.0,<0.47.0
-    - r-base
+    - r-base >=4.5.0
     - r-crayon
     - libblas
     - liblapack
   run:
-    - bioconductor-biocgenerics >=0.52.0,<0.53.0
-    - bioconductor-genomeinfodb >=1.42.0,<1.43.0
-    - bioconductor-iranges >=2.40.0,<2.41.0
-    - bioconductor-s4vectors >=0.44.0,<0.45.0
+    - bioconductor-biocgenerics >=0.56.0,<0.57.0
+    - bioconductor-genomeinfodb >=1.46.0,<1.47.0
+    - bioconductor-iranges >=2.44.0,<2.45.0
+    - bioconductor-s4vectors >=0.48.0,<0.49.0
     - bioconductor-xvector >=0.46.0,<0.47.0
-    - r-base
+    - r-base >=4.5.0
     - r-crayon
 
 source:
-  md5: 9c1fa1b00da834f1dc7c2976af36b00c
+  md5: 8c4f4c94d7a1e23eb30fc80bbc55e4ed
   url:
     - https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/{{ name }}_{{ version }}.tar.gz
     - https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/Archive/{{ name }}/{{ name }}_{{ version }}.tar.gz


### PR DESCRIPTION
Update Biostrings to 2.78.0 (Bioc 3.22):\n- Update version, build number, and MD5\n- Update dependencies to Bioc 3.22 pins\n- Set r-base >=4.5.0\nSingle-file change.