### PR TITLE
bioconductor-decipher: bump to 3.6.0 (Bioconductor 3.22)

### DIFF
--- a/recipes/bioconductor-decipher/meta.yaml
+++ b/recipes/bioconductor-decipher/meta.yaml
@@ -1,6 +1,6 @@
-{% set version = "3.2.0" %}
+{% set version = "3.6.0" %}
 {% set name = "DECIPHER" %}
-{% set bioc = "3.20" %}
+{% set bioc = "3.22" %}
 
 about:
   description: A toolset for deciphering and managing biological sequences.
@@ -10,7 +10,7 @@ about:
   summary: Tools for curating, analyzing, and manipulating biological sequences
 
 build:
-  number: 1
+  number: 0
   rpaths:
     - lib/R/lib/
     - lib/
@@ -37,24 +37,24 @@ requirements:
     - {{ compiler('c') }}
     - make
   host:
-    - bioconductor-biostrings >=2.74.0,<2.75.0
-    - bioconductor-iranges >=2.40.0,<2.41.0
-    - bioconductor-s4vectors >=0.44.0,<0.45.0
+    - bioconductor-biostrings >=2.78.0,<2.79.0
+    - bioconductor-iranges >=2.44.0,<2.45.0
+    - bioconductor-s4vectors >=0.48.0,<0.49.0
     - bioconductor-xvector >=0.46.0,<0.47.0
-    - r-base
+    - r-base >=4.5.0
     - r-dbi
     - libblas
     - liblapack
   run:
-    - bioconductor-biostrings >=2.74.0,<2.75.0
-    - bioconductor-iranges >=2.40.0,<2.41.0
-    - bioconductor-s4vectors >=0.44.0,<0.45.0
+    - bioconductor-biostrings >=2.78.0,<2.79.0
+    - bioconductor-iranges >=2.44.0,<2.45.0
+    - bioconductor-s4vectors >=0.48.0,<0.49.0
     - bioconductor-xvector >=0.46.0,<0.47.0
-    - r-base
+    - r-base >=4.5.0
     - r-dbi
 
 source:
-  md5: 4c8df0ce5a47a0dd9cda5c3231fa35ab
+  md5: a6eda9ab8093fde3c60b45f5a94f19c6
   url:
     - https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/{{ name }}_{{ version }}.tar.gz
     - https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/Archive/{{ name }}/{{ name }}_{{ version }}.tar.gz


### PR DESCRIPTION
Update DECIPHER to 3.6.0 (Bioc 3.22):\n- Update version, build number, and MD5\n- Update dependencies to Bioc 3.22 pins\n- Set r-base >=4.5.0\nSingle-file change.