### PR TITLE
bioconductor-dirichletmultinomial: bump to 1.52.0 (Bioconductor 3.22)

### DIFF
--- a/recipes/bioconductor-dirichletmultinomial/meta.yaml
+++ b/recipes/bioconductor-dirichletmultinomial/meta.yaml
@@ -1,6 +1,6 @@
-{% set version = "1.48.0" %}
+{% set version = "1.52.0" %}
 {% set name = "DirichletMultinomial" %}
-{% set bioc = "3.20" %}
+{% set bioc = "3.22" %}
 
 about:
   description: 'Dirichlet-multinomial mixture models can be used to describe variability in microbial metagenomic data. This package is an interface to code originally made available by Holmes, Harris, and Quince, 2012, PLoS ONE 7(2): 1-15, as discussed further in the man page for this package, ?DirichletMultinomial.'
@@ -10,7 +10,7 @@ about:
   summary: Dirichlet-Multinomial Mixture Model Machine Learning for Microbiome Data
 
 build:
-  number: 1
+  number: 0
   rpaths:
     - lib/R/lib/
     - lib/
@@ -39,22 +39,22 @@ requirements:
     - {{ compiler('c') }}
     - make
   host:
-    - bioconductor-biocgenerics >=0.52.0,<0.53.0
-    - bioconductor-iranges >=2.40.0,<2.41.0
-    - bioconductor-s4vectors >=0.44.0,<0.45.0
-    - r-base
+    - bioconductor-biocgenerics >=0.56.0,<0.57.0
+    - bioconductor-iranges >=2.44.0,<2.45.0
+    - bioconductor-s4vectors >=0.48.0,<0.49.0
+    - r-base >=4.5.0
     - libblas
     - liblapack
     - gsl
   run:
-    - bioconductor-biocgenerics >=0.52.0,<0.53.0
-    - bioconductor-iranges >=2.40.0,<2.41.0
-    - bioconductor-s4vectors >=0.44.0,<0.45.0
-    - r-base
+    - bioconductor-biocgenerics >=0.56.0,<0.57.0
+    - bioconductor-iranges >=2.44.0,<2.45.0
+    - bioconductor-s4vectors >=0.48.0,<0.49.0
+    - r-base >=4.5.0
     - gsl
 
 source:
-  md5: ff5ee6c605c511ad6e8f2e3e6ad1165c
+  md5: c097fc2d00e6f49eb8c45f58d6f8faef
   url:
     - https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/{{ name }}_{{ version }}.tar.gz
     - https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/Archive/{{ name }}/{{ name }}_{{ version }}.tar.gz


### PR DESCRIPTION
Update DirichletMultinomial to 1.52.0 (Bioc 3.22):\n- Update version, build number, and MD5\n- Update dependencies to Bioc 3.22 pins\n- Set r-base >=4.5.0\nSingle-file change.