### PR TITLE
bioconductor-decontam: bump to 1.30.0 (Bioconductor 3.22)

### DIFF
--- a/recipes/bioconductor-decontam/meta.yaml
+++ b/recipes/bioconductor-decontam/meta.yaml
@@ -33,7 +33,7 @@ requirements:
     - r-ggplot2 >=2.1.0
     - r-reshape2 >=1.4.1
 source:
-  md5: 58c7f5c3f5e8c8c5d8b0c5e2e5f5b8c2
+  md5: 9f2a022e5853c63e8dc43b0339f1113f
   url:
     - https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/{{ name }}_{{ version }}.tar.gz
     - https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/Archive/{{ name }}/{{ name }}_{{ version }}.tar.gz


### PR DESCRIPTION
Update Decontam to 1.30.0 (Bioc 3.22):\n- Update version and MD5\n- Set r-base >=4.5.0\nSingle-file change.