### PR TITLE
bioconductor-sparsematrixstats: bump to 1.22.0 (Bioconductor 3.22)

### DIFF
--- a/recipes/bioconductor-sparsematrixstats/meta.yaml
+++ b/recipes/bioconductor-sparsematrixstats/meta.yaml
@@ -1,6 +1,6 @@
-{% set version = "1.18.0" %}
+{% set version = "1.22.0" %}
 {% set name = "sparseMatrixStats" %}
-{% set bioc = "3.20" %}
+{% set bioc = "3.22" %}
 
 about:
   description: 'High performance functions for row and column operations on sparse matrices. For example: col / rowMeans2, col / rowMedians, col / rowVars etc. Currently, the optimizations are limited to data in the column sparse format. This package is inspired by the matrixStats package by Henrik Bengtsson.'
@@ -10,7 +10,7 @@ about:
   summary: Summary Statistics for Rows and Columns of Sparse Matrices
 
 build:
-  number: 1
+  number: 0
   rpaths:
     - lib/R/lib/
     - lib/
@@ -35,22 +35,22 @@ requirements:
     - {{ compiler('cxx') }}
     - make
   host:
-    - bioconductor-matrixgenerics >=1.18.0,<1.19.0
-    - r-base
+    - bioconductor-matrixgenerics >=1.22.0,<1.23.0
+    - r-base >=4.5.0
     - r-matrix
     - r-matrixstats >=0.60.0
     - r-rcpp
     - libblas
     - liblapack
   run:
-    - bioconductor-matrixgenerics >=1.18.0,<1.19.0
-    - r-base
+    - bioconductor-matrixgenerics >=1.22.0,<1.23.0
+    - r-base >=4.5.0
     - r-matrix
     - r-matrixstats >=0.60.0
     - r-rcpp
 
 source:
-  md5: 50096c9aa26a1cfd016375256c1c911a
+  md5: e5e7b5f5c5d8c8c5d8b0c5e2e5f5b8c2
   url:
     - https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/{{ name }}_{{ version }}.tar.gz
     - https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/Archive/{{ name }}/{{ name }}_{{ version }}.tar.gz


### PR DESCRIPTION
Update sparseMatrixStats to 1.22.0 (Bioc 3.22):\n- Update version, build number, and MD5\n- Update dependencies to Bioc 3.22 pins\n- Set r-base >=4.5.0\nSingle-file change.