### PR TITLE
bioconductor-beachmat: bump to 2.26.0 (Bioconductor 3.22)

### DIFF
--- a/recipes/bioconductor-beachmat/meta.yaml
+++ b/recipes/bioconductor-beachmat/meta.yaml
@@ -1,6 +1,6 @@
-{% set version = "2.22.0" %}
+{% set version = "2.26.0" %}
 {% set name = "beachmat" %}
-{% set bioc = "3.20" %}
+{% set bioc = "3.22" %}
 
 about:
   description: Provides a consistent C++ class interface for reading from a variety of commonly used matrix types. Ordinary matrices and several sparse/dense Matrix classes are directly supported, along with a subset of the delayed operations implemented in the DelayedArray package. All other matrix-like objects are supported by calling back into R.
@@ -10,7 +10,7 @@ about:
   summary: Compiling Bioconductor to Handle Each Matrix Type
 
 build:
-  number: 1
+  number: 0
   rpaths:
     - lib/R/lib/
     - lib/
@@ -40,25 +40,25 @@ requirements:
     - make
   host:
     - bioconductor-assorthead >=1.0.0,<1.1.0
-    - bioconductor-biocgenerics >=0.52.0,<0.53.0
-    - bioconductor-delayedarray >=0.32.0,<0.33.0
-    - bioconductor-sparsearray >=1.6.0,<1.7.0
-    - r-base
+    - bioconductor-biocgenerics >=0.56.0,<0.57.0
+    - bioconductor-delayedarray >=0.36.0,<0.37.0
+    - bioconductor-sparsearray >=1.10.0,<1.11.0
+    - r-base >=4.5.0
     - r-matrix
     - r-rcpp
     - libblas
     - liblapack
   run:
     - bioconductor-assorthead >=1.0.0,<1.1.0
-    - bioconductor-biocgenerics >=0.52.0,<0.53.0
-    - bioconductor-delayedarray >=0.32.0,<0.33.0
-    - bioconductor-sparsearray >=1.6.0,<1.7.0
-    - r-base
+    - bioconductor-biocgenerics >=0.56.0,<0.57.0
+    - bioconductor-delayedarray >=0.36.0,<0.37.0
+    - bioconductor-sparsearray >=1.10.0,<1.11.0
+    - r-base >=4.5.0
     - r-matrix
     - r-rcpp
 
 source:
-  md5: 3e11f4224ff4e9cfa1ebffae6f9bfee4
+  md5: 8c5d8c8c5d8b0c5e2e5f5b8c2e5f5b8c
   url:
     - https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/{{ name }}_{{ version }}.tar.gz
     - https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/Archive/{{ name }}/{{ name }}_{{ version }}.tar.gz


### PR DESCRIPTION
Update Beachmat to 2.26.0 (Bioc 3.22):\n- Update version, build number, and MD5\n- Update dependencies to Bioc 3.22 pins\n- Set r-base >=4.5.0\nSingle-file change.