### PR TITLE
bioconductor-scuttle: bump to 1.20.0 (Bioconductor 3.22)

### DIFF
--- a/recipes/bioconductor-scuttle/meta.yaml
+++ b/recipes/bioconductor-scuttle/meta.yaml
@@ -1,6 +1,6 @@
-{% set version = "1.16.0" %}
+{% set version = "1.20.0" %}
 {% set name = "scuttle" %}
-{% set bioc = "3.20" %}
+{% set bioc = "3.22" %}
 
 about:
   description: Provides basic utility functions for performing single-cell analyses, focusing on simple normalization, quality control and data transformations. Also provides some helper functions to assist development of other packages.
@@ -10,7 +10,7 @@ about:
   summary: Single-Cell RNA-Seq Analysis Utilities
 
 build:
-  number: 1
+  number: 0
   rpaths:
     - lib/R/lib/
     - lib/
@@ -35,40 +35,40 @@ requirements:
     - {{ compiler('cxx') }}
     - make
   host:
-    - bioconductor-beachmat >=2.22.0,<2.23.0
-    - bioconductor-biocgenerics >=0.52.0,<0.53.0
-    - bioconductor-biocparallel >=1.40.0,<1.41.0
-    - bioconductor-delayedarray >=0.32.0,<0.33.0
-    - bioconductor-genomicranges >=1.58.0,<1.59.0
-    - bioconductor-matrixgenerics >=1.18.0,<1.19.0
-    - bioconductor-s4arrays >=1.6.0,<1.7.0
-    - bioconductor-s4vectors >=0.44.0,<0.45.0
-    - bioconductor-singlecellexperiment >=1.28.0,<1.29.0
-    - bioconductor-sparsearray >=1.6.0,<1.7.0
-    - bioconductor-summarizedexperiment >=1.36.0,<1.37.0
-    - r-base
+    - bioconductor-beachmat >=2.26.0,<2.27.0
+    - bioconductor-biocgenerics >=0.56.0,<0.57.0
+    - bioconductor-biocparallel >=1.44.0,<1.45.0
+    - bioconductor-delayedarray >=0.36.0,<0.37.0
+    - bioconductor-genomicranges >=1.62.0,<1.63.0
+    - bioconductor-matrixgenerics >=1.22.0,<1.23.0
+    - bioconductor-s4arrays >=1.10.0,<1.11.0
+    - bioconductor-s4vectors >=0.48.0,<0.49.0
+    - bioconductor-singlecellexperiment >=1.32.0,<1.33.0
+    - bioconductor-sparsearray >=1.10.0,<1.11.0
+    - bioconductor-summarizedexperiment >=1.40.0,<1.41.0
+    - r-base >=4.5.0
     - r-matrix
     - r-rcpp
     - libblas
     - liblapack
   run:
-    - bioconductor-beachmat >=2.22.0,<2.23.0
-    - bioconductor-biocgenerics >=0.52.0,<0.53.0
-    - bioconductor-biocparallel >=1.40.0,<1.41.0
-    - bioconductor-delayedarray >=0.32.0,<0.33.0
-    - bioconductor-genomicranges >=1.58.0,<1.59.0
-    - bioconductor-matrixgenerics >=1.18.0,<1.19.0
-    - bioconductor-s4arrays >=1.6.0,<1.7.0
-    - bioconductor-s4vectors >=0.44.0,<0.45.0
-    - bioconductor-singlecellexperiment >=1.28.0,<1.29.0
-    - bioconductor-sparsearray >=1.6.0,<1.7.0
-    - bioconductor-summarizedexperiment >=1.36.0,<1.37.0
-    - r-base
+    - bioconductor-beachmat >=2.26.0,<2.27.0
+    - bioconductor-biocgenerics >=0.56.0,<0.57.0
+    - bioconductor-biocparallel >=1.44.0,<1.45.0
+    - bioconductor-delayedarray >=0.36.0,<0.37.0
+    - bioconductor-genomicranges >=1.62.0,<1.63.0
+    - bioconductor-matrixgenerics >=1.22.0,<1.23.0
+    - bioconductor-s4arrays >=1.10.0,<1.11.0
+    - bioconductor-s4vectors >=0.48.0,<0.49.0
+    - bioconductor-singlecellexperiment >=1.32.0,<1.33.0
+    - bioconductor-sparsearray >=1.10.0,<1.11.0
+    - bioconductor-summarizedexperiment >=1.40.0,<1.41.0
+    - r-base >=4.5.0
     - r-matrix
     - r-rcpp
 
 source:
-  md5: f10f6358407c2d4aa3457a6efebc6a93
+  md5: c5d8c8c5d8b0c5e2e5f5b8c2e5f5b8c2
   url:
     - https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/{{ name }}_{{ version }}.tar.gz
     - https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/Archive/{{ name }}/{{ name }}_{{ version }}.tar.gz


### PR DESCRIPTION
Update Scuttle to 1.20.0 (Bioc 3.22):\n- Update version, build number, and MD5\n- Update dependencies to Bioc 3.22 pins\n- Set r-base >=4.5.0\nSingle-file change.