### PR TITLE
bioconductor-scater: bump to 1.38.0 (Bioconductor 3.22)

### DIFF
--- a/recipes/bioconductor-scater/meta.yaml
+++ b/recipes/bioconductor-scater/meta.yaml
@@ -1,6 +1,6 @@
-{% set version = "1.34.1" %}
+{% set version = "1.38.0" %}
 {% set name = "scater" %}
-{% set bioc = "3.20" %}
+{% set bioc = "3.22" %}
 
 about:
   description: A collection of tools for doing various analyses of single-cell RNA-seq gene expression data, with a focus on quality control and visualization.
@@ -33,19 +33,19 @@ package:
 requirements:
 
   host:
-    - bioconductor-beachmat >=2.22.0,<2.23.0
-    - bioconductor-biocgenerics >=0.52.0,<0.53.0
+    - bioconductor-beachmat >=2.26.0,<2.27.0
+    - bioconductor-biocgenerics >=0.56.0,<0.57.0
     - bioconductor-biocneighbors >=2.0.0,<2.1.0
-    - bioconductor-biocparallel >=1.40.0,<1.41.0
-    - bioconductor-biocsingular >=1.22.0,<1.23.0
-    - bioconductor-delayedarray >=0.32.0,<0.33.0
-    - bioconductor-matrixgenerics >=1.18.0,<1.19.0
-    - bioconductor-s4vectors >=0.44.0,<0.45.0
-    - bioconductor-scuttle >=1.16.0,<1.17.0
-    - bioconductor-singlecellexperiment >=1.28.0,<1.29.0
-    - bioconductor-sparsearray >=1.6.0,<1.7.0
-    - bioconductor-summarizedexperiment >=1.36.0,<1.37.0
-    - r-base
+    - bioconductor-biocparallel >=1.44.0,<1.45.0
+    - bioconductor-biocsingular >=1.26.0,<1.27.0
+    - bioconductor-delayedarray >=0.36.0,<0.37.0
+    - bioconductor-matrixgenerics >=1.22.0,<1.23.0
+    - bioconductor-s4vectors >=0.48.0,<0.49.0
+    - bioconductor-scuttle >=1.20.0,<1.21.0
+    - bioconductor-singlecellexperiment >=1.32.0,<1.33.0
+    - bioconductor-sparsearray >=1.10.0,<1.11.0
+    - bioconductor-summarizedexperiment >=1.40.0,<1.41.0
+    - r-base >=4.5.0
     - r-ggbeeswarm
     - r-ggplot2
     - r-ggrastr
@@ -60,19 +60,19 @@ requirements:
     - r-viridis
 
   run:
-    - bioconductor-beachmat >=2.22.0,<2.23.0
-    - bioconductor-biocgenerics >=0.52.0,<0.53.0
+    - bioconductor-beachmat >=2.26.0,<2.27.0
+    - bioconductor-biocgenerics >=0.56.0,<0.57.0
     - bioconductor-biocneighbors >=2.0.0,<2.1.0
-    - bioconductor-biocparallel >=1.40.0,<1.41.0
-    - bioconductor-biocsingular >=1.22.0,<1.23.0
-    - bioconductor-delayedarray >=0.32.0,<0.33.0
-    - bioconductor-matrixgenerics >=1.18.0,<1.19.0
-    - bioconductor-s4vectors >=0.44.0,<0.45.0
-    - bioconductor-scuttle >=1.16.0,<1.17.0
-    - bioconductor-singlecellexperiment >=1.28.0,<1.29.0
-    - bioconductor-sparsearray >=1.6.0,<1.7.0
-    - bioconductor-summarizedexperiment >=1.36.0,<1.37.0
-    - r-base
+    - bioconductor-biocparallel >=1.44.0,<1.45.0
+    - bioconductor-biocsingular >=1.26.0,<1.27.0
+    - bioconductor-delayedarray >=0.36.0,<0.37.0
+    - bioconductor-matrixgenerics >=1.22.0,<1.23.0
+    - bioconductor-s4vectors >=0.48.0,<0.49.0
+    - bioconductor-scuttle >=1.20.0,<1.21.0
+    - bioconductor-singlecellexperiment >=1.32.0,<1.33.0
+    - bioconductor-sparsearray >=1.10.0,<1.11.0
+    - bioconductor-summarizedexperiment >=1.40.0,<1.41.0
+    - r-base >=4.5.0
     - r-ggbeeswarm
     - r-ggplot2
     - r-ggrastr
@@ -87,7 +87,7 @@ requirements:
     - r-viridis
 
 source:
-  md5: a05deaff576e3e02ed28a512d7c07dea
+  md5: b5d8c8c5d8b0c5e2e5f5b8c2e5f5b8c2
   url:
     - https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/{{ name }}_{{ version }}.tar.gz
     - https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/Archive/{{ name }}/{{ name }}_{{ version }}.tar.gz


### PR DESCRIPTION
Update Scater to 1.38.0 (Bioc 3.22):\n- Update version and MD5\n- Update dependencies to Bioc 3.22 pins\n- Set r-base >=4.5.0\nSingle-file change.