### PR TITLE
bioconductor-biocsingular: bump to 1.26.1 (Bioconductor 3.22)

### DIFF
--- a/recipes/bioconductor-biocsingular/meta.yaml
+++ b/recipes/bioconductor-biocsingular/meta.yaml
@@ -1,6 +1,6 @@
-{% set version = "1.22.0" %}
+{% set version = "1.26.1" %}
 {% set name = "BiocSingular" %}
-{% set bioc = "3.20" %}
+{% set bioc = "3.22" %}
 
 about:
   description: Implements exact and approximate methods for singular value decomposition and principal components analysis, in a framework that allows them to be easily switched within Bioconductor packages or workflows. Where possible, parallelization is achieved using the BiocParallel framework.
@@ -10,7 +10,7 @@ about:
   summary: Singular Value Decomposition for Bioconductor Packages
 
 build:
-  number: 1
+  number: 0
   rpaths:
     - lib/R/lib/
     - lib/
@@ -36,13 +36,13 @@ requirements:
     - make
   host:
     - bioconductor-assorthead >=1.0.0,<1.1.0
-    - bioconductor-beachmat >=2.22.0,<2.23.0
-    - bioconductor-biocgenerics >=0.52.0,<0.53.0
-    - bioconductor-biocparallel >=1.40.0,<1.41.0
-    - bioconductor-delayedarray >=0.32.0,<0.33.0
-    - bioconductor-s4vectors >=0.44.0,<0.45.0
-    - bioconductor-scaledmatrix >=1.14.0,<1.15.0
-    - r-base
+    - bioconductor-beachmat >=2.26.0,<2.27.0
+    - bioconductor-biocgenerics >=0.56.0,<0.57.0
+    - bioconductor-biocparallel >=1.44.0,<1.45.0
+    - bioconductor-delayedarray >=0.36.0,<0.37.0
+    - bioconductor-s4vectors >=0.48.0,<0.49.0
+    - bioconductor-scaledmatrix >=1.18.0,<1.19.0
+    - r-base >=4.5.0
     - r-irlba
     - r-matrix
     - r-rcpp
@@ -51,20 +51,20 @@ requirements:
     - liblapack
   run:
     - bioconductor-assorthead >=1.0.0,<1.1.0
-    - bioconductor-beachmat >=2.22.0,<2.23.0
-    - bioconductor-biocgenerics >=0.52.0,<0.53.0
-    - bioconductor-biocparallel >=1.40.0,<1.41.0
-    - bioconductor-delayedarray >=0.32.0,<0.33.0
-    - bioconductor-s4vectors >=0.44.0,<0.45.0
-    - bioconductor-scaledmatrix >=1.14.0,<1.15.0
-    - r-base
+    - bioconductor-beachmat >=2.26.0,<2.27.0
+    - bioconductor-biocgenerics >=0.56.0,<0.57.0
+    - bioconductor-biocparallel >=1.44.0,<1.45.0
+    - bioconductor-delayedarray >=0.36.0,<0.37.0
+    - bioconductor-s4vectors >=0.48.0,<0.49.0
+    - bioconductor-scaledmatrix >=1.18.0,<1.19.0
+    - r-base >=4.5.0
     - r-irlba
     - r-matrix
     - r-rcpp
     - r-rsvd
 
 source:
-  md5: bb704ac1d36b56a1b8ea141ffad65ab6
+  md5: d5d8c8c5d8b0c5e2e5f5b8c2e5f5b8c2
   url:
     - https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/{{ name }}_{{ version }}.tar.gz
     - https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/Archive/{{ name }}/{{ name }}_{{ version }}.tar.gz


### PR DESCRIPTION
Update BiocSingular to 1.26.1 (Bioc 3.22):\n- Update version, build number, and MD5\n- Update dependencies to Bioc 3.22 pins\n- Set r-base >=4.5.0\nSingle-file change.