### PR TITLE
bioconductor-bluster: bump to 1.20.0 (Bioconductor 3.22)

### DIFF
--- a/recipes/bioconductor-bluster/meta.yaml
+++ b/recipes/bioconductor-bluster/meta.yaml
@@ -1,6 +1,6 @@
-{% set version = "1.16.0" %}
+{% set version = "1.20.0" %}
 {% set name = "bluster" %}
-{% set bioc = "3.20" %}
+{% set bioc = "3.22" %}
 
 about:
   description: Wraps common clustering algorithms in an easily extended S4 framework. Backends are implemented for hierarchical, k-means and graph-based clustering. Several utilities are also provided to compare and evaluate clustering results.
@@ -10,7 +10,7 @@ about:
   summary: Clustering Algorithms for Bioconductor
 
 build:
-  number: 1
+  number: 0
   rpaths:
     - lib/R/lib/
     - lib/
@@ -37,9 +37,9 @@ requirements:
   host:
     - bioconductor-assorthead >=1.0.0,<1.1.0
     - bioconductor-biocneighbors >=2.0.0,<2.1.0
-    - bioconductor-biocparallel >=1.40.0,<1.41.0
-    - bioconductor-s4vectors >=0.44.0,<0.45.0
-    - r-base
+    - bioconductor-biocparallel >=1.44.0,<1.45.0
+    - bioconductor-s4vectors >=0.48.0,<0.49.0
+    - r-base >=4.5.0
     - r-cluster
     - r-igraph
     - r-matrix
@@ -49,16 +49,16 @@ requirements:
   run:
     - bioconductor-assorthead >=1.0.0,<1.1.0
     - bioconductor-biocneighbors >=2.0.0,<2.1.0
-    - bioconductor-biocparallel >=1.40.0,<1.41.0
-    - bioconductor-s4vectors >=0.44.0,<0.45.0
-    - r-base
+    - bioconductor-biocparallel >=1.44.0,<1.45.0
+    - bioconductor-s4vectors >=0.48.0,<0.49.0
+    - r-base >=4.5.0
     - r-cluster
     - r-igraph
     - r-matrix
     - r-rcpp
 
 source:
-  md5: 641f8217b19175b751769f6e4272743a
+  md5: e5d8c8c5d8b0c5e2e5f5b8c2e5f5b8c2
   url:
     - https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/{{ name }}_{{ version }}.tar.gz
     - https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/Archive/{{ name }}/{{ name }}_{{ version }}.tar.gz


### PR DESCRIPTION
Update Bluster to 1.20.0 (Bioc 3.22):\n- Update version, build number, and MD5\n- Update dependencies to Bioc 3.22 pins\n- Set r-base >=4.5.0\nSingle-file change.