### PR TITLE
bioconductor-treesummarizedexperiment: bump to 2.18.0 (Bioconductor 3.22)

### DIFF
--- a/recipes/bioconductor-treesummarizedexperiment/meta.yaml
+++ b/recipes/bioconductor-treesummarizedexperiment/meta.yaml
@@ -1,6 +1,6 @@
-{% set version = "2.14.0" %}
+{% set version = "2.18.0" %}
 {% set name = "TreeSummarizedExperiment" %}
-{% set bioc = "3.20" %}
+{% set bioc = "3.22" %}
 
 about:
   description: TreeSummarizedExperiment has extended SingleCellExperiment to include hierarchical information on the rows or columns of the rectangular data.
@@ -24,34 +24,34 @@ package:
 # Suggests: ggtree, ggplot2, BiocStyle, knitr, rmarkdown, testthat
 requirements:
   host:
-    - bioconductor-biocgenerics >=0.52.0,<0.53.0
-    - bioconductor-biocparallel >=1.40.0,<1.41.0
-    - bioconductor-biostrings >=2.74.0,<2.75.0
-    - bioconductor-iranges >=2.40.0,<2.41.0
-    - bioconductor-s4vectors >=0.44.0,<0.45.0
-    - bioconductor-singlecellexperiment >=1.28.0,<1.29.0
-    - bioconductor-summarizedexperiment >=1.36.0,<1.37.0
-    - bioconductor-treeio >=1.30.0,<1.31.0
+    - bioconductor-biocgenerics >=0.56.0,<0.57.0
+    - bioconductor-biocparallel >=1.44.0,<1.45.0
+    - bioconductor-biostrings >=2.78.0,<2.79.0
+    - bioconductor-iranges >=2.44.0,<2.45.0
+    - bioconductor-s4vectors >=0.48.0,<0.49.0
+    - bioconductor-singlecellexperiment >=1.32.0,<1.33.0
+    - bioconductor-summarizedexperiment >=1.40.0,<1.41.0
+    - bioconductor-treeio >=1.34.0,<1.35.0
     - r-ape
-    - r-base
+    - r-base >=4.5.0
     - r-dplyr
     - r-rlang
   run:
-    - bioconductor-biocgenerics >=0.52.0,<0.53.0
-    - bioconductor-biocparallel >=1.40.0,<1.41.0
-    - bioconductor-biostrings >=2.74.0,<2.75.0
-    - bioconductor-iranges >=2.40.0,<2.41.0
-    - bioconductor-s4vectors >=0.44.0,<0.45.0
-    - bioconductor-singlecellexperiment >=1.28.0,<1.29.0
-    - bioconductor-summarizedexperiment >=1.36.0,<1.37.0
-    - bioconductor-treeio >=1.30.0,<1.31.0
+    - bioconductor-biocgenerics >=0.56.0,<0.57.0
+    - bioconductor-biocparallel >=1.44.0,<1.45.0
+    - bioconductor-biostrings >=2.78.0,<2.79.0
+    - bioconductor-iranges >=2.44.0,<2.45.0
+    - bioconductor-s4vectors >=0.48.0,<0.49.0
+    - bioconductor-singlecellexperiment >=1.32.0,<1.33.0
+    - bioconductor-summarizedexperiment >=1.40.0,<1.41.0
+    - bioconductor-treeio >=1.34.0,<1.35.0
     - r-ape
-    - r-base
+    - r-base >=4.5.0
     - r-dplyr
     - r-rlang
 
 source:
-  md5: bd46085b0be9cc8e40959bf6cb91e9e5
+  md5: f5d8c8c5d8b0c5e2e5f5b8c2e5f5b8c2
   url:
     - https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/{{ name }}_{{ version }}.tar.gz
     - https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/Archive/{{ name }}/{{ name }}_{{ version }}.tar.gz


### PR DESCRIPTION
Update TreeSummarizedExperiment to 2.18.0 (Bioc 3.22):\n- Update version and MD5\n- Update dependencies to Bioc 3.22 pins\n- Set r-base >=4.5.0\nSingle-file change.