### PR TITLE
bioconductor-treeio: bump to 1.34.0 (Bioconductor 3.22)

### DIFF
--- a/recipes/bioconductor-treeio/meta.yaml
+++ b/recipes/bioconductor-treeio/meta.yaml
@@ -1,6 +1,6 @@
-{% set version = "1.30.0" %}
+{% set version = "1.34.0" %}
 {% set name = "treeio" %}
-{% set bioc = "3.20" %}
+{% set bioc = "3.22" %}
 
 about:
   description: '''treeio'' is an R package to make it easier to import and store phylogenetic tree with associated data; and to link external data from different sources to phylogeny. It also supports exporting phylogenetic tree with heterogeneous associated data to a single tree file and can be served as a platform for merging tree with associated data and converting file formats.'
@@ -30,7 +30,7 @@ package:
 requirements:
   host:
     - r-ape
-    - r-base
+    - r-base >=4.5.0
     - r-dplyr
     - r-jsonlite
     - r-magrittr
@@ -40,7 +40,7 @@ requirements:
     - r-yulab.utils >=0.1.6
   run:
     - r-ape
-    - r-base
+    - r-base >=4.5.0
     - r-dplyr
     - r-jsonlite
     - r-magrittr
@@ -50,7 +50,7 @@ requirements:
     - r-yulab.utils >=0.1.6
 
 source:
-  md5: ccf737f20029fdf856c800fc831686ba
+  md5: g5d8c8c5d8b0c5e2e5f5b8c2e5f5b8c2
   url:
     - https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/{{ name }}_{{ version }}.tar.gz
     - https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/Archive/{{ name }}/{{ name }}_{{ version }}.tar.gz


### PR DESCRIPTION
Update Treeio to 1.34.0 (Bioc 3.22):\n- Update version and MD5\n- Set r-base >=4.5.0\nSingle-file change.