### PR TITLE
Update r-cobrar to 0.2.3 with new dependency

### DIFF
--- a/recipes/r-cobrar/meta.yaml
+++ b/recipes/r-cobrar/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "cobrar" %}
-{% set version = '0.2.2' %}
+{% set version = '0.2.3' %}
 {% set github = "https://github.com/Waschina/cobrar" %}
-{% set sha256 = '0f3858ec0caaabd9c95405ee3d325ae28d41e9c13bde5b89e96e519d2eff10a3' %}
+{% set sha256 = '30d4901ab8069c155078258608e509d6458da5c5d4ede82bbb58bb4d41decdbd' %}
 
 package:
   name: r-{{ name }}
@@ -32,6 +32,7 @@ requirements:
     - r-rcpp
     - r-rcpparmadillo
     - r-matrix
+    - r-jsonlite
   run:
     - glpk >=4.65
     - libsbml >=5.18.0
@@ -39,6 +40,7 @@ requirements:
     - r-rcpp
     - r-rcpparmadillo
     - r-matrix
+    - r-jsonlite
 
 test:
   commands:


### PR DESCRIPTION
Update [`r-cobrar`](https://bioconda.github.io/recipes/r-cobrar/README.html): **0.2.2** → **0.2.3**

This PR fixes the failed autobump in #61762 by adding the missing runtime dependency [`r-jsonlite`](https://anaconda.org/conda-forge/r-jsonlite).