### PR TITLE
Update epiweeks: require Python >=3.10

### DIFF
--- a/recipes/epiweeks/meta.yaml
+++ b/recipes/epiweeks/meta.yaml
@@ -18,10 +18,10 @@ build:
 
 requirements:
   host:
-    - python >=3.8
+    - python >=3.10
     - pip
   run:
-    - python >=3.8
+    - python >=3.10
 
 test:
   imports:


### PR DESCRIPTION
The epiweeks 2.4.0 package's `pyproject.toml` requires Python >=3.10, but the recipe specified >=3.8. This caused the PEP 517 metadata build step to fail on Linux CI.

  This PR updates the `host` and `run` Python requirements to match the upstream package requirement.

  Supersedes #61774 (automated bump that lacked the Python version fix).