### PR TITLE
Update verkko v2.3 to enforce max networkX version

### DIFF
--- a/recipes/verkko/meta.yaml
+++ b/recipes/verkko/meta.yaml
@@ -14,7 +14,7 @@ source:
     - function.patch
 
 build:
-  number: 0
+  number: 1
   run_exports:
       - {{ pin_subpackage('verkko', max_pin="2.3") }}
 
@@ -42,7 +42,7 @@ requirements:
     - perl >=5.6
     - seqtk
     - parasail-python >=1.3.3
-    - networkx >=2.6.3
+    - networkx >=2.6.3,<=3.5
     - biopython
     - pysam
     - snakemake-minimal >=7.8.0,<8.0


### PR DESCRIPTION
NetworkX version 3.6.1 introduced breaking API changes so force Verkko to use version 3.5 or older. This would fix verkko issue: https://github.com/marbl/verkko/issues/346