### PR TITLE
Update epiweeks to 2.4.0

### DIFF
--- a/recipes/epiweeks/meta.yaml
+++ b/recipes/epiweeks/meta.yaml
@@ -18,10 +18,12 @@ build:
 
 requirements:
   host:
-    - python >=3.8
+    - python >=3.10
     - pip
+    - hatchling
+    - hatch-fancy-pypi-readme
   run:
-    - python >=3.8
+    - python >=3.10
 
 test:
   imports:


### PR DESCRIPTION
Update epiweeks to version 2.4.0.

  Changes:
  - Bump Python requirement to >=3.10 (required by upstream)
  - Add hatchling and hatch-fancy-pypi-readme to host (build dependencies)