### PR TITLE
Update pyfastg to v0.2.0 (and add build_exports and update the summary)

### DIFF
--- a/recipes/pyfastg/meta.yaml
+++ b/recipes/pyfastg/meta.yaml
@@ -20,6 +20,7 @@ requirements:
   host:
     - networkx >=2
     - pip
+    - setuptools
     - python >=3.6
   run:
     - networkx >=2


### PR DESCRIPTION
This adds a `build_exports` field, which I think should fix the issue in #61786. Thanks!