### PR TITLE
Update gmm-demux: pin numpy to <2.4

### DIFF
--- a/recipes/gmm-demux/meta.yaml
+++ b/recipes/gmm-demux/meta.yaml
@@ -14,7 +14,7 @@ build:
     - GMM-demux = GMM_Demux.GMM_Demux:main
   noarch: python
   script: {{ PYTHON }} -m pip install . -vvv --no-deps --no-build-isolation
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage('gmm-demux', max_pin="x.x") }}
 
@@ -25,7 +25,7 @@ requirements:
   run:
     - python
     - pandas >=1.4.3
-    - numpy >=1.22.4
+    - numpy >=1.22.4,<2.4 # https://github.com/CHPGenetics/GMM-Demux/issues/12
     - scipy >=1.12.0
     - tabulate
     - bitvector


### PR DESCRIPTION
A numpy 2.4 update that removed a deprecated behavior broke GMM-demux: https://github.com/CHPGenetics/GMM-Demux/issues/12

Reference: https://numpy.org/devdocs/release/2.4.0-notes.html#raise-typeerror-on-attempt-to-convert-array-with-ndim-0-to-scalar

This PR proposes pinning numpy to < 2.4 until the issue has been resolved in GMM-demux.
