### PR TITLE
GTDB-tk is not compatible with Python 3.14

### DIFF
--- a/recipes/gtdbtk/meta.yaml
+++ b/recipes/gtdbtk/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 3b4a9622dcad5404678176c6776061aca3f478f5910999407df3fc7cc207370e
 
 build:
-  number: 1
+  number: 2
   noarch: python
   entry_points:
     - gtdbtk = gtdbtk.__main__:main


### PR DESCRIPTION
GTDB-tk is not compatible with Python 3.14
https://github.com/Ecogenomics/GTDBTk/issues/683

I forgot to pin Python to < 3.14 in the "run" requirements in the previous PR (#61817).
Sorry about that.