### PR TITLE
update pegas to version 1.2.0

### DIFF
--- a/recipes/pegas/meta.yaml
+++ b/recipes/pegas/meta.yaml
@@ -37,12 +37,14 @@ outputs:
       run:
         - python >=3.10
         - conda >=24.7.1
+        - jinja2 >=3.0
         - plotly >=5.0.0,<6
         - pandas >=1.3.5
         - tqdm >=4.66.5
         - matplotlib-base >=3.9.2
         - networkx >=3.2
         - beautifulsoup4 >=4.12.3
+        - numpy
 
     test:
       commands:


### PR DESCRIPTION
### What changed
- Converted the recipe to a **multi‑output** package with two outputs: `pegas` and `pegas-lite`.
- `pegas-lite` now builds the Python package and provides the `pegas-lite` CLI.
- `pegas` is now a thin meta package that depends on `pegas-lite` and adds the `pegas` CLI plus Snakemake.
- Added per‑output entry points in the recipe and removed `console_scripts` from `setup.py` so each output only exposes the intended CLI.
- Updated the source SHA256 for the v1.2.0 release tarball.

### Why
- Users can choose between:
  - **`pegas`**: Snakemake‑based pipeline (full workflow manager)
  - **`pegas-lite`**: direct runner without Snakemake
- This cleanly separates dependencies and avoids forcing Snakemake on users who only want the lite mode.
- Entry points are isolated so `pegas-lite` installs only its CLI and doesn’t expose the Snakemake command.