### PR TITLE
Update breakinator to 1.1.1 (Rewrite in Rust and added SAM/BAM support

### DIFF
--- a/recipes/breakinator/build.sh
+++ b/recipes/breakinator/build.sh
@@ -3,8 +3,6 @@
 set -ex
 
 # --- 1. Environment Setup ---
-# These ensure Rust links against the Conda-provided libraries
-# rather than compiling them from scratch.
 export HTSLIB_SYSTEM=1
 export OPENSSL_NO_VENDOR=1
 export OPENSSL_DIR=$PREFIX
@@ -12,7 +10,5 @@ export LIBZ_SYS_STATIC=0
 export PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig:${PREFIX}/share/pkgconfig:${PKG_CONFIG_PATH:-}"
 
 # --- 2. Build & Install ---
-# Cargo install handles building --release and moving the binary to $PREFIX/bin automatically.
-# We use --path . because usually the tarball unpacks exactly where Cargo.toml is.
 cargo install --path breakinator --root "${PREFIX}" --no-track --verbose
 

--- a/recipes/breakinator/meta.yaml
+++ b/recipes/breakinator/meta.yaml
@@ -10,9 +10,10 @@ source:
   sha256: 3961a4c77e356881335c83f740517269993e391260dc4958f2f34a43c82e0516
 
 build:
-  number: 0
-  # We removed the 'script' line here. 
-  # Conda automatically looks for build.sh in the same folder.
+  number: 1
+  run_exports:
+    - {{ pin_subpackage("breakinator", max_pin="x") }}
+
 
 requirements:
   build:
@@ -35,7 +36,6 @@ requirements:
 
 test:
   commands:
-    # This ensures the binary was actually installed to the path and runs
     - breakinator --help
 
 about:


### PR DESCRIPTION
This release marks a complete rewrite of the tool from Python to Rust.
-Added support for SAM/BAM/CRAM formatted files as well as PAF. 
-Incorporated additional error handling of incorrectly formatted files 
-Made the previously optional symmetry check a default setting that now needs to be turned off with `--no-sym`

Dependencies: Removed Python dependencies; added Rust toolchain, HTSlib, OpenSSL, etc.

Build: Added build.sh for cargo install.

Tests: Verified locally on Linux with conda build.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
