### PR TITLE
Add evehap 0.1.0

### DIFF
--- a/recipes/evehap/meta.yaml
+++ b/recipes/evehap/meta.yaml
@@ -1,0 +1,55 @@
+{% set name = "evehap" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 2862fff0786f5184be5e7a0815f6938e475ffaad78696c9379679de6ec83b050
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  entry_points:
+    - evehap = evehap.cli:main
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x.x") }}
+
+requirements:
+  host:
+    - python >=3.8
+    - pip
+    - setuptools >=61.0
+  run:
+    - python >=3.8
+    - click >=8.0
+    - pysam >=0.21.0
+    - biopython >=1.80
+
+test:
+  imports:
+    - evehap
+  commands:
+    - evehap --help
+    - evehap version
+
+about:
+  home: https://github.com/trianglegrrl/eveHap
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: Universal mtDNA haplogroup classifier for ancient and modern DNA
+  description: |
+    eveHap is a universal mtDNA (mitochondrial DNA) haplogroup classifier.
+    It classifies ancient and modern DNA samples against phylogenetic haplogroup
+    references, supporting multiple input formats (BAM, VCF, FASTA, HSD, microarray)
+    and providing both high-coverage (Kulczynski scoring) and low-coverage
+    (tree traversal) classification methods.
+  dev_url: https://github.com/trianglegrrl/eveHap
+
+extra:
+  recipe-maintainers:
+    - trianglegrrl


### PR DESCRIPTION
## Description

Add new recipe for **evehap** - a universal mtDNA haplogroup classifier for ancient and modern DNA.

## Features

- Multiple input formats: BAM, VCF, FASTA, HSD, and consumer genotyping files
- Dual classification methods (Kulczynski scoring and tree traversal)
- Ancient DNA damage detection and filtering
- Bundled phylotree and reference files for offline use

## Links

- **PyPI**: https://pypi.org/project/evehap/0.1.0/
- **GitHub**: https://github.com/trianglegrrl/eveHap
- **Documentation**: https://github.com/trianglegrrl/eveHap#readme

## Checklist

- [x] Recipe follows bioconda guidelines
- [x] Package is on PyPI
- [x] `run_exports` specified for semantic versioning (0.x.x)
- [x] Tests include import and CLI help commands