### PR TITLE
Add fastq-fix-i5

### DIFF
--- a/recipes/fastq-fix-i5/build.sh
+++ b/recipes/fastq-fix-i5/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -xeuo
+
+cargo install --no-track --verbose --locked --root "${PREFIX}" --path .

--- a/recipes/fastq-fix-i5/meta.yaml
+++ b/recipes/fastq-fix-i5/meta.yaml
@@ -1,0 +1,39 @@
+{% set name = "fastq-fix-i5" %}
+{% set version = "1.0.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/ssciwr/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
+  sha256: b61d0d8fdf9fef14ff1ab26fa3caa5fe477a2d9195c1370b03219691697a7e41
+
+build:
+  number: 0
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x") }}
+
+requirements:
+  build:
+    - {{ compiler('rust') }}
+
+test:
+  commands:
+    - fastq-fix-i5 --help
+    - fastq-fix-i5 --version
+    - printf '@r1 1:N:0:AAAA+ACTAGCA\nACGT\n+\n!!!!\n' | fastq-fix-i5
+
+about:
+  home: https://github.com/ssciwr/fastq-fix-i5
+  license: MIT
+  license_file: LICENSE
+  summary: "Rewrite FASTQ headers by reverse-complementing the i5 (Index2/P5) barcode in :i7+i5"
+  description: |
+    A fast, streaming tool to rewrite FASTQ headers by reverse-complementing the i5 (Index2 / P5)
+    barcode, without modifying read sequences or quality scores. Headers are expected to end with the
+    standard Illumina `:<i7>+<i5>` format.
+
+extra:
+  recipe-maintainers:
+    - lkeegan


### PR DESCRIPTION
Add fastq-fix-i5

- a fast, streaming tool to rewrite FASTQ headers by reverse-complementing the i5 (Index2 / P5) barcode
- https://github.com/ssciwr/fastq-fix-i5

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
