### PR TITLE
Update r-pathosurveilr to v0.4.2

### DIFF
--- a/recipes/r-pathosurveilr/meta.yaml
+++ b/recipes/r-pathosurveilr/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = '0.4.1' %}
-{% set sha256 = '739a2a1d7da6782b4c7957a79aab27fcd10672428385b131aa9fddfc4a7ee04d' %}
+{% set version = '0.4.2' %}
+{% set sha256 = '8cc688c43a788ba8fc57076d2a393bc8bc33ca03180da61b13b678e8fe0905c9' %}
 
 package:
   name: r-pathosurveilr
@@ -47,6 +47,7 @@ requirements:
     - r-webshot2
     - r-xml2
     - r-yaml
+    - r-heattree
   run:
     - r-base
     - r-ape
@@ -74,6 +75,7 @@ requirements:
     - r-webshot2
     - r-xml2
     - r-yaml
+    - r-heattree
 
 test:
   commands:


### PR DESCRIPTION
Updates dependencies. Fixes the problem with the auto-bump. 