### PR TITLE
Update pyclone-vi to 0.2.0

### DIFF
--- a/recipes/pyclone-vi/meta.yaml
+++ b/recipes/pyclone-vi/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pyclone-vi" %}
-{% set version = "0.1.6" %}
+{% set version = "0.2.0" %}
 
 package:
   name: {{ name }}
@@ -7,35 +7,39 @@ package:
 
 source:
   url: https://github.com/Roth-Lab/pyclone-vi/archive/{{ version }}.tar.gz
-  sha256: 883ac95dd7903a9fb0418314e38a4bb5d028b5569942ab02135427201cef4f1f
+  sha256: 30075cd218f299b0c8b35fd7200e3a2fa695795ee5e0364b76e247c2d09a643c
 
 build:
   number: 0
   noarch: python
   script: "{{ PYTHON }} -m pip install . --no-deps --no-build-isolation --no-cache-dir -vvv"
   entry_points:
-    - pyclone-vi= pyclone_vi.cli:main
+    - pyclone-vi = pyclone_vi.cli:main
   run_exports:
     - {{ pin_subpackage('pyclone-vi', max_pin="x.x") }}
 
 requirements:
   host:
-    - python >=3.7
+    - python >=3.12
+    - setuptools >=77.0.3
     - pip
   run:
-    - python >=3.7
-    - click
-    - h5py
-    - numba
-    - numpy
-    - pandas
+    - python >=3.12
+    - numba >=0.61.2
+    - numpy >=2.0
     - scipy
+    - click >=8.3
+    - pandas >=2.2.2
+    - h5py >=3.0
+    - threadpoolctl >=3.6.0
 
 test:
   imports:
     - pyclone_vi
   commands:
     - pyclone-vi --help
+    - pyclone-vi fit --help
+    - pyclone-vi write-results-file --help
 
 about:
   home: https://github.com/Roth-Lab/pyclone-vi
@@ -48,5 +52,6 @@ about:
 extra:
   recipe-maintainers:
     - aroth85
+    - elhurtado
   identifiers:
     - doi:10.1186/s12859-020-03919-2


### PR DESCRIPTION
Updating PyClone-VI recipe to version 0.2.0

This PR contains recipe updates not captured in #62027 

----

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
