### PR TITLE
Update Virmet 2.0.0 to 2.0.1 for bug fixes

### DIFF
--- a/recipes/virmet/meta.yaml
+++ b/recipes/virmet/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "2.0.0" %}
-{% set sha256 = "d56e87fa27719c11d175e1d8d99c95fba7df1d56d350228c23c116fcddb37123" %}
+{% set version = "2.0.1" %}
+{% set sha256 = "d7a60c3c5b893208872b9b1cf120b92fb0a383ead5cd2055b65453392923d6ba" %}
 
 package:
   name: virmet
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 2
+  number: 0
   run_exports:
     - {{ pin_subpackage('virmet') }}
   script: 


### PR DESCRIPTION
This PR updates the `virmet` package to version **2.0.1**.

**Changes:**
- Updated version to `2.0.1`.
- Updated SHA256 checksum for the new PyPI release.
- Reset `build number` to 0.

**Reason for update:**
This release includes a minor bug fix, specifically:
- Fixes a bug excluding certain viruses (e.g. Rhinoviruses) from coverage plots.

**Verification:**
- The source tarball is available on PyPI.
- `setuptools_scm` environment variable is preserved in the recipe to ensure correct versioning during build.

Thank you!
