### PR TITLE
Add piaso v1.0.3

### DIFF
--- a/recipes/piaso/meta.yaml
+++ b/recipes/piaso/meta.yaml
@@ -40,8 +40,6 @@ requirements:
 test:
   imports:
     - piaso
-  commands:
-    - python -c "import piaso; print(piaso.__version__)"
 
 about:
   home: https://piaso.org


### PR DESCRIPTION
Add piaso v1.0.3

PIASO (Precise Integrative Analysis of Single-cell Omics) is a Python toolkit 
for single-cell RNA-seq, single-cell ATAC-seq and spatial transcriptomics data analysis.

- PyPI: https://pypi.org/project/piaso-tools/
- Documentation: https://piaso.org
- GitHub: https://github.com/genecell/PIASO

`run_exports` is included in the recipe with `max_pin="x.x"` for semantic versioning.
