### PR TITLE
tirank: fix runtime deps for 1.0.2 (build 1)

### DIFF
--- a/recipes/jbrowse2/meta.yaml
+++ b/recipes/jbrowse2/meta.yaml
@@ -1,12 +1,12 @@
 # When updating, check the @jbrowse/cli version in build.sh too
-{% set version = "4.0.4" %}
+{% set version = "4.1.1" %}
 
 package:
   name: jbrowse2
   version: {{ version }}
 
 source:
-  sha256: e74ff4d82b967378365739b9b3a8656600e4d57e1e1ab486bed3b2ddebfb4eb4
+  sha256: 87c82031fe2a97f79582706ae64aebfb591d0fe78752512bb71b5470ef3a6b6e
   url: https://github.com/GMOD/jbrowse-components/releases/download/v{{ version }}/jbrowse-web-v{{ version }}.zip
 
 build:


### PR DESCRIPTION
* `tirank` 1.0.2 is already on master; this PR only fixes missing runtime dependencies.
* Bumps `build:number` to trigger rebuild of 1.0.2 with corrected deps.
* Adds missing deps: `python-igraph`, `snakemake`.