### PR TITLE
Add recipe: psqtl 1.3.7

### DIFF
--- a/recipes/psqtl/build.sh
+++ b/recipes/psqtl/build.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+mkdir -p $PREFIX/bin
+
+cp psQTL_prep.py $PREFIX/bin/psQTL_prep.py
+cp psQTL_prep.py $PREFIX/bin/psQTL_prep
+cp psQTL_proc.py $PREFIX/bin/psQTL_proc.py
+cp psQTL_proc.py $PREFIX/bin/psQTL_proc
+cp psQTL_post.py $PREFIX/bin/psQTL_post.py
+cp psQTL_post.py $PREFIX/bin/psQTL_post
+cp _version.py $PREFIX/bin/_version.py
+
+mkdir -p $PREFIX/bin/modules
+cp -r modules/* $PREFIX/bin/modules/
+
+mkdir -p $PREFIX/bin/tests
+cp -r tests/* $PREFIX/bin/tests/
+
+mkdir -p $PREFIX/bin/utilities
+cp utilities/integrative_splsda.R $PREFIX/bin/utilities/integrative_splsda.R
+cp utilities/windowed_splsda.R $PREFIX/bin/utilities/windowed_splsda.R
+
+chmod a+x $PREFIX/bin/psQTL_prep
+chmod a+x $PREFIX/bin/psQTL_proc
+chmod a+x $PREFIX/bin/psQTL_post

--- a/recipes/psqtl/meta.yaml
+++ b/recipes/psqtl/meta.yaml
@@ -1,0 +1,54 @@
+{% set name = "psqtl" %}
+{% set version = "1.3.7" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/zkstewart/psQTL/archive/v{{ version }}.tar.gz
+  sha256: 262ee79aaf746afb3e05987d7c1f4dfd32272e37150dba0a9e9b909a5f9e0ca6
+
+build:
+  number: 0
+  noarch: generic
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x") }}
+
+requirements:
+  run:
+    - python >=3.11,<=3.13
+    - numpy
+    - biopython
+    - pandas
+    - matplotlib-base
+    - pycirclize
+    - qt6-wayland
+    - samtools
+    - bcftools
+    - vt
+    - ncls >=0.0.68
+    - r-base >=4.3.0
+    - r-argparser
+    - r-dplyr
+    - r-stringr
+    - r-biocmanager
+    - bioconductor-biocparallel
+    - bioconductor-mixomics >=6.26.0
+
+test:
+  commands:
+    - psQTL_prep -h
+    - psQTL_proc -h
+    - psQTL_post -h
+    - Rscript $PREFIX/bin/utilities/windowed_splsda.R -h
+    - Rscript $PREFIX/bin/utilities/integrative_splsda.R -h
+
+about:
+  home: https://github.com/zkstewart/psQTL
+  dev_url: https://github.com/zkstewart/psQTL
+  doc_url: https://github.com/zkstewart/psQTL/wiki
+  license: GPL-3
+  license_file: LICENSE
+  summary: A collection of Python scripts to predict QTLs using per-sample sequencing.
+  license_family: GPL


### PR DESCRIPTION
Pull request to add a new recipe for the `psqtl` software available from https://github.com/zkstewart/psQTL.

This tool is intended for quantitative trait loci (QTL) prediction in biparental mapping populations, although it applies statistics flexibly and can be used in other experimental designs.

Pull request involves build from program version 1.3.7 as tagged/released in the repository.