### PR TITLE
Add chromoplot

### DIFF
--- a/recipes/chromoplot/meta.yaml
+++ b/recipes/chromoplot/meta.yaml
@@ -1,0 +1,59 @@
+{% set name = "chromoplot" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: fe2225ec4c3ee80db2f4a6af5cd9acc259dc9217c4dc1cdd4e9fcd4cb68b9d8c
+
+build:
+  number: 0
+  noarch: python
+  entry_points:
+    - chromoplot = chromoplot.cli.main:cli
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  run_exports:
+    - {{ pin_subpackage('chromoplot', max_pin="x.x") }}
+
+requirements:
+  host:
+    - python >=3.10
+    - pip
+    - hatchling
+  run:
+    - python >=3.10
+    - matplotlib-base >=3.5
+    - numpy >=1.21
+    - pandas >=1.3
+    - pyyaml >=6.0
+    - click >=8.0
+
+test:
+  imports:
+    - chromoplot
+    - chromoplot.core
+    - chromoplot.tracks
+    - chromoplot.io
+  commands:
+    - chromoplot --help
+
+about:
+  home: https://github.com/aseetharam/chromoplot
+  summary: "Publication-quality genome and chromosome visualization toolkit"
+  description: |
+    Chromoplot is a Python library for creating publication-quality genome 
+    visualizations. It provides a track-based system for plotting genomic 
+    features, haplotypes, gene models, alignments, coverage, and synteny.
+    Designed as a companion to haplophaser for polyploid genome analysis.
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  doc_url: https://github.com/aseetharam/chromoplot#readme
+  dev_url: https://github.com/aseetharam/chromoplot
+
+extra:
+  recipe-maintainers:
+    - aseetharam


### PR DESCRIPTION
Add chromoplot - Publication-quality genome and chromosome visualization toolkit.

## Summary

Chromoplot is a Python library for creating publication-quality genome visualizations with a track-based system. It serves as the visualization companion to haplophaser for polyploid genome analysis.

### Features
- Track-based visualization system (ideogram, genes, haplotypes, alignments, coverage, variants, synteny)
- Whole-genome and comparative layouts
- Publication-ready themes
- Maize NAM color palettes built-in
- CLI and Python API

### Links
- **PyPI:** https://pypi.org/project/chromoplot/
- **GitHub:** https://github.com/aseetharam/chromoplot

## Checklist

- [x] Recipe is `noarch: python`
- [x] License file (MIT) included
- [x] `run_exports` specified with `pin_subpackage("chromoplot", max_pin="x.x")` (semantic versioning, 0.x.x series)
- [x] Tests include imports and CLI check
- [x] Package available on PyPI

## Dependencies

All dependencies are available in conda-forge:
- matplotlib-base, numpy, pandas (conda-forge)
- pyyaml, click (conda-forge)

## Note on run_exports

Using `max_pin="x.x"` because this is a 0.x.x release where minor version bumps may include API changes.

## Related

This package is a dependency of haplophaser (PR to follow after this is merged).