### PR TITLE
Update snakemake-storage-plugin-cached-http to 0.2.1

### DIFF
--- a/recipes/snakemake-storage-plugin-cached-http/meta.yaml
+++ b/recipes/snakemake-storage-plugin-cached-http/meta.yaml
@@ -29,6 +29,7 @@ requirements:
     - snakemake-interface-common >=1.14,<2.dev0
     - snakemake-interface-storage-plugins >=4.2,<5.0
     - snakemake-storage-plugin-http >=0.3,<1.dev0
+    - zstandard >=0.25.0,<0.26.0
     - tqdm-loggable >=0.2,<1.dev0
     - typing_extensions >=4.15,<5.dev0
 


### PR DESCRIPTION
Updates snakemake-storage-plugin-cached-http to version 0.2.1 and adds @lkstrp  as new maintainer.

@lkstrp Can you please confirm in a message, that you are fine being listed as a maintainer, too!
