### PR TITLE
Add pylocuszoom 0.6.0

### DIFF
--- a/recipes/pylocuszoom/meta.yaml
+++ b/recipes/pylocuszoom/meta.yaml
@@ -1,0 +1,57 @@
+{% set name = "pylocuszoom" %}
+{% set version = "0.6.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 1597c2080e2e32019293aab67836d1b944c1cc0b2fe3e7cd94e82d9119175742
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python >=3.10
+    - pip
+    - hatchling
+  run:
+    - python >=3.10
+    - matplotlib-base >=3.5.0
+    - pandas >=1.4.0
+    - numpy >=1.21.0
+    - loguru >=0.7.0
+    - pyliftover >=0.4
+    - plotly >=5.15.0
+    - bokeh >=3.8.2
+    - python-kaleido >=0.2.0
+    - adjusttext >=0.8
+    - pydantic >=2.0.0
+    - requests >=2.25.0
+    - tqdm >=4.60.0
+
+test:
+  imports:
+    - pylocuszoom
+  commands:
+    - python -c "from pylocuszoom import LocusZoomPlotter"
+
+about:
+  home: https://github.com/michael-denyer/pylocuszoom
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  license_file: LICENSE
+  summary: Regional association plots for GWAS results with LD coloring
+  description: |
+    pyLocusZoom creates publication-quality regional association plots
+    for GWAS results with LD coloring, gene tracks, and recombination
+    rate overlays. Supports canine, feline, and custom species.
+  dev_url: https://github.com/michael-denyer/pylocuszoom
+
+extra:
+  recipe-maintainers:
+    - michael-denyer


### PR DESCRIPTION
## Description

Add new recipe for [pylocuszoom](https://github.com/michael-denyer/pylocuszoom) - publication-ready regional association plots for GWAS results with LD coloring, gene tracks, and recombination overlays.

## Features
- Regional association plots with LD coloring
- Gene and exon track visualization
- Recombination rate overlays
- Multiple backends: matplotlib (static), plotly (interactive), bokeh (dashboards)
- PheWAS and forest plot support
- File loaders for common GWAS/eQTL/fine-mapping formats

## Testing
- Package is available on PyPI: https://pypi.org/project/pylocuszoom/0.6.0/
- SHA256 verified from PyPI

## Checklist
- [x] Recipe has been tested locally
- [x] Recipe follows bioconda guidelines
- [x] License is GPL-3.0-or-later