### PR TITLE
Add pylocuszoom 1.0.0

### DIFF
--- a/recipes/pylocuszoom/meta.yaml
+++ b/recipes/pylocuszoom/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pylocuszoom" %}
-{% set version = "0.8.0" %}
+{% set version = "1.0.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: cfca452d1dd34c0f6f8c837ef6b45a274bdd9d7e9ab248d67220b4aa830fed06
+  sha256: 3676093bef4688e325aec1fd7935751c0f1f9c2ce53840f61351f9dcbb1f4f96
 
 build:
   noarch: python


### PR DESCRIPTION
Automated update of pylocuszoom to version 0.8.0.

## Changes
- Automatic gene annotation fetching from Ensembl REST API (`auto_genes=True`)
- Backend capability system with `supports_*` properties for feature detection
- `DataFrameValidator` builder class for consistent validation
- `HoverDataBuilder` for cross-backend hover tooltips
- Pre-commit hook for pytest with coverage enforcement

Full changelog: https://github.com/michael-denyer/pyLocusZoom/releases/tag/v0.8.0