### PR TITLE
Update Harpy build deps

### DIFF
--- a/recipes/harpy/meta.yaml
+++ b/recipes/harpy/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 2
   noarch: python
   script_env:
     - SETUPTOOLS_SCM_PRETEND_VERSION={{ version }}
@@ -53,7 +53,7 @@ requirements:
     - htslib >=1.22
     - pysam >=0.23
     - rich-click >=1.9.3
-    - snakemake-minimal >=9.10
+    - snakemake-minimal >9.10,<9.15
     - samtools >=1.22
     - seqtk
 


### PR DESCRIPTION
This update only sets an upper bound on the `snakemake-minimal` dependency and increments the build number.