### PR TITLE
optitype: pin pytables<3.10 for Python 3.13 compatibility

### DIFF
--- a/recipes/optitype/meta.yaml
+++ b/recipes/optitype/meta.yaml
@@ -6,7 +6,9 @@ package:
 
 build:
   noarch: generic
-  number: 2
+  number: 3
+  run_exports:
+    - {{ pin_subpackage('optitype', max_pin="x") }}
 
 source:
   url: https://github.com/FRED-2/OptiType/archive/v{{ version }}.tar.gz
@@ -18,7 +20,7 @@ requirements:
     - numpy
     - pyomo
     - hdf5
-    - pytables
+    - pytables <3.10  # Pin to avoid Python 3.13 HDF5 compatibility issues
     - pandas
     - pysam
     - matplotlib-base


### PR DESCRIPTION
## Summary

Pin `pytables<3.10` in optitype recipe to fix Python 3.13 compatibility issues.

## Problem

OptiType 1.3.5 uses HDF5 files via pandas HDFStore/PyTables. With Python 3.13 and pytables>=3.10, stricter byte/string type handling breaks OptiType's `alleles.h5` file loading with:

```
TypeError: a bytes-like object is required, not 'str'
  at pandas/io/pytables.py line 1866 in _create_storer
```

## Root Cause

PyTables 3.10.x introduced stricter type constraints: "only allowing bytes to be stored in VLStringAtom and only str in VLUnicodeAtom" (from [PyTables 3.10 release notes](https://www.pytables.org/release-notes/RELEASE_NOTES_v3.10.x.html)).

OptiType's HDF5 allele database files were created with older PyTables versions and have encoding that's incompatible with these stricter constraints.

## Solution

Pin `pytables<3.10` to maintain compatibility. This is necessary since OptiType upstream hasn't been updated since September 2020 and is unlikely to address this compatibility issue.

## Testing

This fix was validated in the nf-core/hlatyping pipeline where conda tests were failing with this error.