### PR TITLE
Update circleseeker to 1.1.1 with corrected dependencies

### DIFF
--- a/recipes/circleseeker/meta.yaml
+++ b/recipes/circleseeker/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "circleseeker" %}
-{% set version = "1.0.0" %}
+{% set version = "1.1.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/leoxqy/CircleSeeker/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 3c13aa469d3deb826d3ea3a8e6bdf497c212086142ba1d43da795c4696fae606
+  sha256: 87b0ff52e61f24486f229c15a6986cdd9cd9914d70529505c074b556db22f316
 
 build:
   noarch: python
@@ -25,7 +25,6 @@ requirements:
     - pip
     - setuptools >=68
     - wheel
-    - setuptools-scm
   run:
     - python >=3.9
     - click >=8.1
@@ -37,15 +36,15 @@ requirements:
     - networkx >=3.0
     - packaging >=23
     - intervaltree >=3.1
+    # Built-in SplitReads-Core dependencies
+    - mappy >=2.26
+    - pybedtools >=0.9.0
     # External bioinformatics tools
     - tidehunter
     - minimap2
     - samtools
     - cd-hit
-    - last  # High-accuracy CeccDNA detection
-    - bcftools
-    - varlociraptor
-    - cyrcular
+    - last  # Required for CeccDNA detection
 
 test:
   requires:
@@ -67,15 +66,16 @@ about:
   license: GPL-3.0-only
   license_family: GPL
   license_file: LICENSE
-  summary: Comprehensive eccDNA detection from PacBio HiFi sequencing data with dual-engine support
+  summary: Comprehensive eccDNA detection from PacBio HiFi sequencing data
   description: |
     CircleSeeker is a specialized bioinformatics pipeline designed for the
     identification, classification, and characterization of extrachromosomal
     circular DNA (eccDNA) from PacBio HiFi long-read sequencing data.
 
     Key features:
-    - Dual-engine support: Cresil (preferred) and Cyrcular (fallback) with intelligent auto-selection
-    - Hybrid detection strategy combining tandem repeat detection with Split-Read assembly
+    - CtcReads-Core: TideHunter-based confirmed eccDNA detection
+    - SplitReads-Core: Built-in split-read inference (HiFi optimized)
+    - Hybrid detection strategy combining tandem repeat detection with split-read assembly
     - Comprehensive eccDNA classification (UeccDNA, MeccDNA, CeccDNA, XeccDNA)
     - Automated pipeline with checkpoint and resumption capabilities
     - Detailed HTML reports and comprehensive output formats


### PR DESCRIPTION
## Summary

Update circleseeker to v1.1.1 with corrected dependencies.

**Note:** This PR supersedes the auto-generated #62226 which had incorrect dependencies.

## Dependency Changes

| Dependency | Before | After | Reason |
|------------|--------|-------|--------|
| `setuptools-scm` | ✓ | ✗ | Not used by project |
| `mappy` | ✗ | ✓ | Required for SplitReads-Core |
| `pybedtools` | ✗ | ✓ | Required for SplitReads-Core |
| `bcftools` | ✓ | ✗ | No longer needed (built-in inference) |
| `varlociraptor` | ✓ | ✗ | No longer needed (built-in inference) |
| `cyrcular` | ✓ | ✗ | No longer needed (built-in inference) |

## v1.1.1 Changes

- Fix overly broad exception handling
- Remove unused imports  
- Optimize iterrows to itertuples/vectorized (3-6x speedup)
- Add step dependency validation with cycle detection

## Test

- All 1194 unit tests pass
- All 26 integration tests pass
- Pipeline benchmark: F1=98.49% (Precision=98.99%, Recall=98.00%)