### PR TITLE
Add pangbank-cli

### DIFF
--- a/recipes/pangbank-cli/meta.yaml
+++ b/recipes/pangbank-cli/meta.yaml
@@ -44,7 +44,7 @@ test:
 
 about:
   home: https://github.com/labgem/{{ name|lower }}
-  license: CeCiLL 2.1
+  license: CECILL-2.1
   license_file: LICENCE
   summary: "Command-line tool for retrieving pangenomes using the PanGBank API."
 


### PR DESCRIPTION
Add pangbank-cli to bioconda. 

pangbank-cli ommand-line tool for retrieving pangenomes using the PanGBank API. 


### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
