### PR TITLE
Pin antiSMASH diamond dependency to >= 2.1.21

### DIFF
--- a/recipes/antismash/meta.yaml
+++ b/recipes/antismash/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script:
     - echo "include antismash/detection/genefinding/data/train_crypto" >> MANIFEST.in
@@ -51,7 +51,8 @@ requirements:
     - scikit-learn ==1.6.1
     # moods 1.9.4.1 does not have builds for python 3.11-3.12
     - moods ==1.9.4.2
-    - diamond
+    # diamond 2.1.19 and 2.1.20 have a memory corruption error leading to crashes.
+    - diamond >=2.1.21
     - fasttree
     - hmmer2
     - hmmer


### PR DESCRIPTION
Based our debugging of crashing runs reported by our users, diamond 2.1.19 and 2.1.20 have a memory corruption bug that occasionally crashes the tool during antiSMASH runs. Downgrading to diamond 2.1.18 fixes the issue, so make that the default for now.