### PR TITLE
Update repository URLs in meta.yaml

### DIFF
--- a/recipes/tpmcalculator/meta.yaml
+++ b/recipes/tpmcalculator/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/NLM-DIR/TPMCalculator/archive/{{ version }}.tar.gz
-  sha256: 29aa167a35bb006b2e912d2f7a53f7a9a265308f919906336fc3fe2ee3abece6
+  sha256: 34a37e1aca15494d9b5fb7ee150f50d41dfe2dc0d777f9a58e573c92846a9bea
 
 build:
   number: 0


### PR DESCRIPTION
TPMCalculator project was moved from NCBI github organization to a new NLM-DIR organization.

