### PR TITLE
Update nwkit to 0.19.2

### DIFF
--- a/recipes/nwkit/meta.yaml
+++ b/recipes/nwkit/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "nwkit" %}
-{% set version = "0.18.2" %} 
+{% set version = "0.19.2" %}
 
 package:
   name: "{{ name|lower }}"
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://github.com/kfuku52/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: f62842ce56f98007efcf5c88b69e9ce310d7f513745edd21c91f93b0a1b88ef2
+  sha256: a89e1cc9f3762a0386cecf983ecfb4541b5f79657b589ea165afaf7be5357bb5
 
 build:
-  number: 1
+  number: 0
   noarch: python
   script: "{{ PYTHON }} -m pip install . --no-build-isolation --no-deps -vv"
   run_exports:
@@ -27,6 +27,8 @@ requirements:
     - ete3
     - biopython
     - pandas
+    - requests
+    - numpy
 
 test:
   commands:


### PR DESCRIPTION
## Changes

- Update nwkit from 0.18.2 to 0.19.2
- Add missing runtime dependencies: `requests`, `numpy`
- Reset build number to 0

## Upstream changes (since 0.18.2)

- Add `--resolve_polytomy` option to `nwkit sanitize` ([kfuku52/nwkit#2](https://github.com/kfuku52/nwkit/issues/2))
- Fix TimeTree API endpoint URL ([kfuku52/nwkit#12](https://github.com/kfuku52/nwkit/issues/12))
- Add GitHub Actions CI with pytest (Python 3.9–3.12)
- Add `requests` and `numpy` to `install_requires` in setup.py