### PR TITLE
Update amplirust to 0.2.0

### DIFF
--- a/recipes/amplirust/meta.yaml
+++ b/recipes/amplirust/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "amplirust" %}
-{% set version = "0.1.2" %}
+{% set version = "0.2.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/erdikilic/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
-  sha256: 5056d0545829d93528240c5759384220460f951c170cc06017fb1be39bf7f787
+  sha256: 04b92cb2744fe6bc9414d93d5e5e1100f5661f613d2c5fa64690a658ae039e85
 
 build:
   number: 0


### PR DESCRIPTION
Update amplirust from 0.1.2 to 0.2.0.

Generated with `bioconda-utils autobump`.