### PR TITLE
Add covsnap: coverage inspector for targeted sequencing QC

### DIFF
--- a/recipes/covsnap/meta.yaml
+++ b/recipes/covsnap/meta.yaml
@@ -12,8 +12,6 @@ source:
 build:
   number: 0
   noarch: python
-  entry_points:
-    - covsnap = covsnap.cli:main
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --no-cache-dir -vvv
   run_exports:
     - {{ pin_subpackage(name, max_pin="x.x") }}
@@ -63,6 +61,3 @@ about:
 extra:
   recipe-maintainers:
     - enes-ak
-  additional-platforms:
-    - linux-aarch64
-    - osx-arm64


### PR DESCRIPTION
## Summary
- Add new recipe for **covsnap**, a coverage inspector for targeted sequencing QC (hg38)
- Pure Python `noarch` package, MIT licensed
- Uses bundled GENCODE v44 hg38 gene index — no internet or GTF files required at runtime

## Features
- Computes per-target and per-exon depth metrics from BAM/CRAM files
- Produces machine-readable raw TSV and human-readable interpreted report with PASS/FAIL classifications
- Supports gene symbols, genomic regions, and BED files as input
- Engines: samtools (required), mosdepth (optional)

## Test plan
- [x] Import tests: `covsnap`, `covsnap.cli`, `covsnap.engines`, `covsnap.annotation`
- [x] CLI test: `covsnap --version`
- [x] Functional test: synthetic BAM generation + gene symbol query (BRCA1) + region query
- [x] Output verification: TSV columns and report sections validated
- [x] Local `conda build` passes all tests

## Links
- **Homepage**: https://github.com/enes-ak/covsnap
- **License**: MIT