### PR TITLE
Update rhinotype

### DIFF
--- a/recipes/rhinotype/meta.yaml
+++ b/recipes/rhinotype/meta.yaml
@@ -12,6 +12,8 @@ source:
 build:
   noarch: python
   number: 0
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x.x") }}
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:
     - rhinotype = rhinotype.main:main


### PR DESCRIPTION
> Updates rhinotype to version 2.5.0.
  >
  > Changes:
  > - Bumps version to 2.5.0.
  > - Adds plotly as a new dependency for interactive SNP visualization.
  > - Updates minimum versions for numpy, pandas, scipy, and biopython to match pyproject.toml.
  > - Updated SHA256 hash for the new PyPI source.