### PR TITLE
Add predted: fast approximate Tree Edit Distance for RNA structures

### DIFF
--- a/recipes/predted/build.sh
+++ b/recipes/predted/build.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -ex
+
+# 1) Install the Python package
+${PYTHON} -m pip install . -vv --no-deps --no-build-isolation
+
+# 2) Generate model.h from the shipped model file
+xxd -i predted/model.txt > c_src/model.h
+# Fix variable names to match what predTED.c expects
+sed -i.bak 's/predted_model_txt/model_txt/g' c_src/model.h
+rm -f c_src/model.h.bak
+
+# 3) Build the CLI binary
+mkdir -p "${PREFIX}/bin"
+${CC} ${CFLAGS} -O2 -Wall -Ic_src \
+    $(pkg-config --cflags-only-I LightGBM 2>/dev/null || true) \
+    -fopenmp \
+    -o "${PREFIX}/bin/predted" \
+    c_src/predTED.c c_src/predted_features.c \
+    $(pkg-config --libs LightGBM 2>/dev/null || echo "-lLightGBM") \
+    -lm ${LDFLAGS}

--- a/recipes/predted/meta.yaml
+++ b/recipes/predted/meta.yaml
@@ -6,33 +6,39 @@ package:
   version: "{{ version }}"
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 0f7dac26d24d309435f1ecabcd9edce20c5c710e7c1797d0afdd7092f7c93e1b
+  url: https://github.com/syseitz/predTED/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 1bb0492a7d8d9acd8f1b6015b36017cea5ed0ccc1a8e76a5ee7ca9f55d020e72
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  skip: true  # [py<39]
+  skip: true  # [py<39 or win]
   run_exports:
     - {{ pin_subpackage("predted", max_pin="x.x") }}
 
 requirements:
   build:
     - {{ compiler('c') }}
+    - pkg-config
+    - llvm-openmp  # [osx]
   host:
     - python
     - pip
     - setuptools >=64
     - numpy
+    - lightgbm
+    - llvm-openmp  # [osx]
   run:
     - python >=3.9
     - numpy
     - lightgbm
+    - llvm-openmp  # [osx]
 
 test:
   imports:
     - predted
     - predted.features
+  commands:
+    - predted --version
 
 about:
   home: https://github.com/syseitz/predTED
@@ -40,6 +46,12 @@ about:
   license_family: MIT
   license_file: LICENSE
   summary: Fast approximate Tree Edit Distance prediction for RNA secondary structures
+  description: |
+    predTED uses structural features and a LightGBM model to approximate
+    pairwise Tree Edit Distances between RNA secondary structures without
+    running the expensive exact algorithm. Includes a Python library and
+    a standalone CLI binary with OpenMP parallelisation.
+  dev_url: https://github.com/syseitz/predTED
 
 extra:
   additional-platforms:


### PR DESCRIPTION
## Summary

Add new recipe for **predted**, a Python package that predicts pairwise Tree Edit Distances (TED) between RNA secondary structures using structural features and a LightGBM model.

- **Homepage:** https://github.com/syseitz/predTED
- **PyPI:** https://pypi.org/project/predted/
- **License:** MIT
- **Version:** 0.1.0

### What it does

predTED approximates the expensive exact Tree Edit Distance computation (~O(n⁴)) with a machine learning approach (~O(n)), achieving R²=0.93 correlation with exact TED values. It extracts 36 structural features from dot-bracket notation and combines them into 144 pairwise features for prediction.

### Dependencies

- Python >=3.9
- numpy
- lightgbm
- Optional C extension for ~30x faster feature computation (falls back to pure Python)

### Tests

- `import predted` and `import predted.features`