### PR TITLE
Update `r-heattree`: Reduce version pin requirement and trigger rebuild for new R version

### DIFF
--- a/recipes/r-heattree/meta.yaml
+++ b/recipes/r-heattree/meta.yaml
@@ -16,8 +16,6 @@ build:
   rpaths:
     - lib/R/lib/
     - lib/
-  run_exports:
-    - {{ pin_subpackage('r-heattree', max_pin="x.x") }}
 
 requirements:
   host:

--- a/recipes/r-heattree/meta.yaml
+++ b/recipes/r-heattree/meta.yaml
@@ -16,6 +16,8 @@ build:
   rpaths:
     - lib/R/lib/
     - lib/
+  run_exports:
+    - {{ pin_subpackage('r-heattree', max_pin="x") }}
 
 requirements:
   host:

--- a/recipes/r-heattree/meta.yaml
+++ b/recipes/r-heattree/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   script: ${R} CMD INSTALL --build . ${R_ARGS}
   noarch: generic
   rpaths:


### PR DESCRIPTION
I am getting a failed run on a recipe that uses this recipe:

https://github.com/bioconda/bioconda-recipes/pull/62532

Im not sure why a specific version of R is required for `r-heattree` when that is not specified anywhere in the recipe or in the R package itself. I am assuming it is defined when the recipe is built based on the R version used? 

Either way, I wanted to reduce the version requirement for recipes that use this recipe anyway so this might fix both issues by triggering a rebuild.