### PR TITLE
Add Ratatoskr v1.0.2

### DIFF
--- a/recipes/ratatoskr/meta.yaml
+++ b/recipes/ratatoskr/meta.yaml
@@ -57,3 +57,4 @@ about:
 extra:
   recipe-maintainers:
     - Fabian-Bastiaanssen
+


### PR DESCRIPTION
Initial Bioconda recipe for ratatoskr (v1.0.2), a bioinformatics command-line
tool and Python API for collecting and downloading microbial taxonomic
type strain data from biological databases.

Includes run_exports to ensure downstream compatibility.
