### PR TITLE
Add alphagenome 0.5.1

### DIFF
--- a/recipes/alphagenome/meta.yaml
+++ b/recipes/alphagenome/meta.yaml
@@ -21,6 +21,7 @@ requirements:
     - python >=3.10
     - pip
     - hatchling
+    - grpcio-tools
   run:
     - python >=3.10
     - absl-py


### PR DESCRIPTION
Python SDK for Google DeepMind's AlphaGenome genomic foundation model (https://github.com/google-deepmind/alphagenome). Pure Python package, all runtime dependencies already available in conda-forge.