### PR TITLE
Update nwkit to 0.21.1 (ete4 migration)

### DIFF
--- a/recipes/nwkit/meta.yaml
+++ b/recipes/nwkit/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - wheel
   run:
     - python >=3.9
-    - ete4 >=4.4.0
+    - ete4 >=4.3.0
     - biopython
     - pandas
     - requests


### PR DESCRIPTION
## Summary
- bump `nwkit` to `0.21.1`
- migrate runtime dependency from `ete3` to `ete4 >=4.4.0`
- align Python requirement with upstream (`>=3.9`)
- update source sha256 for `v0.21.1`

## Context
Autobump does not reliably capture dependency migrations, so this manual PR includes the required dependency updates with the version bump.