### PR TITLE
csubst 1.8.0: migrate ete3->ete4 and remove deprecated deps

### DIFF
--- a/recipes/csubst/meta.yaml
+++ b/recipes/csubst/meta.yaml
@@ -11,6 +11,7 @@ source:
 
 build:
   number: 0
+  skip: true  # [aarch64 or arm64]
   script:
     - export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib"
     - export CPPFLAGS="${CPPFLAGS} -I${PREFIX}/include -I$(python -c 'import numpy; print(numpy.get_include())')"
@@ -62,8 +63,5 @@ about:
 extra:
   recipe-maintainers:
     - kfuku52
-  additional-platforms:
-    - linux-aarch64
-    - osx-arm64
   identifiers:
     - doi:10.1038/s41559-022-01932-7


### PR DESCRIPTION
### Summary
- bump `csubst` from `1.4.20` to `1.8.0`
- update source tarball sha256 for `v1.8.0`
- migrate runtime dependency from `ete3` to `ete4 >=4.3.0`
- remove deprecated/stale runtime dependencies `threadpoolctl` and `joblib`
- align host/run Python floor to `>=3.10` (current tested support)

### Rationale
Recent `csubst` updates migrate tree handling to `ete4` and drop `threadpoolctl`/`joblib` from package requirements.
This recipe update follows the same dependency migration pattern used in recent Bioconda updates for related tooling.

Upstream release/tag used by this recipe:
- `https://github.com/kfuku52/csubst/releases/tag/v1.8.0`

### Notes
- kept optional runtime tools (`iqtree`, `pyvolve`, `biopython`, `pymol-open-source`, `mafft`) unchanged
- reset build number to `0` for the new upstream version
