### PR TITLE
Add fastqpacker v0.8.0

### DIFF
--- a/recipes/fastqpacker/build.sh
+++ b/recipes/fastqpacker/build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -o xtrace -o nounset -o pipefail -o errexit
+
+export CGO_ENABLED=0
+export GOPATH=$PWD
+export GOCACHE=$PWD/.cache/
+
+mkdir -p "${GOCACHE}"
+mkdir -p "${PREFIX}/bin"
+
+go build -trimpath -o="${PREFIX}/bin/fqpack" -ldflags="-s -w -X main.version=v${PKG_VERSION}" -tags netgo ./cmd/fqpack

--- a/recipes/fastqpacker/meta.yaml
+++ b/recipes/fastqpacker/meta.yaml
@@ -1,0 +1,39 @@
+{% set name = "fastqpacker" %}
+{% set version = "0.8.0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/vertti/fastqpacker/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 6b117530b68246b74e7426d2273418328a7d432d328bd2888d7907d1c1333ff2
+
+build:
+  number: 0
+  run_exports:
+    - {{ pin_subpackage('fastqpacker', max_pin="x.x") }}
+
+requirements:
+  build:
+    - {{ compiler('go') }}
+    - go-licenses
+
+test:
+  commands:
+    - fqpack --version
+
+about:
+  home: "https://github.com/vertti/fastqpacker"
+  summary: "Speed-first FASTQ compressor with block-based parallel compression"
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  dev_url: "https://github.com/vertti/fastqpacker"
+
+extra:
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64
+  recipe-maintainers:
+    - vertti


### PR DESCRIPTION
## Summary

Add recipe for [fastqpacker](https://github.com/vertti/fastqpacker) — a speed-first FASTQ compressor with block-based parallel compression.

- Package name: `fastqpacker` (installs `fqpack` binary)
- Pure Go, builds with `compiler('go')`
- Supports linux-amd64, linux-aarch64, osx-amd64, osx-arm64