### PR TITLE
Add ref-solver 0.1.0

### DIFF
--- a/recipes/ref-solver/build.sh
+++ b/recipes/ref-solver/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -e
+
+cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
+
+cargo install --no-track --verbose --root "${PREFIX}" --path .

--- a/recipes/ref-solver/meta.yaml
+++ b/recipes/ref-solver/meta.yaml
@@ -1,0 +1,41 @@
+{% set name = "ref-solver" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/fulcrumgenomics/{{ name }}/archive/v{{ version }}.tar.gz
+  sha256: ae6fe436c6885ad54fcc8a9a879eaf55a48290f4044333aa099ccd9a98f00962
+
+build:
+  number: 0
+  run_exports:
+    - {{ pin_subpackage('ref-solver', max_pin="x.x") }}
+
+requirements:
+  build:
+    - {{ compiler('rust') }}
+    - cargo-bundle-licenses
+
+test:
+  commands:
+    - ref-solver --help
+
+about:
+  home: "https://github.com/fulcrumgenomics/{{ name }}"
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: "Solve reference genome identification from BAM/SAM headers."
+  dev_url: "https://github.com/fulcrumgenomics/{{ name }}"
+  doc_url: "https://github.com/fulcrumgenomics/{{ name }}/blob/v{{ version }}/README.md"
+
+extra:
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64
+  recipe-maintainers:
+    - nh13
+    - tfenne


### PR DESCRIPTION
Add recipe for [ref-solver](https://github.com/fulcrumgenomics/ref-solver), a tool to solve reference genome identification from BAM/SAM headers.