### PR TITLE
Add recon-para: performance-optimized RECON fork

### DIFF
--- a/recipes/recon-para/build.sh
+++ b/recipes/recon-para/build.sh
@@ -10,7 +10,7 @@ make CC="${CC}" CFLAGS="${CFLAGS}" -j"${CPU_COUNT}"
 cp imagespread eledef eleredef edgeredef famdef ${PREFIX}/bin/
 
 cd ../scripts/
-sed -i "s|\$path = \"\";|\$path = \"${PREFIX}/bin\";|" recon.pl
+sed -i.bak "s|\$path = \"\";|\$path = \"${PREFIX}/bin\";|" recon.pl && rm -f recon.pl.bak
 install -v -m 0755 recon.pl ${PREFIX}/bin/
 install -v -m 0755 MSPCollect.pl ${PREFIX}/bin/
 

--- a/recipes/recon-para/meta.yaml
+++ b/recipes/recon-para/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/unavailable-2374/RECON/archive/refs/tags/v1.05-opt1.tar.gz
-  sha256: d79dc8a0fb1797380fbf327c7a0d6e541411b9d5b8cbd7be6d8180674baacdae
+  sha256: 306963ad225caf016ec5d73a5a6d56dcddb66f47e7a16b2fbfa8923024783f53
 
 build:
   number: 0


### PR DESCRIPTION
## Summary
- Adds `recon-para`, a performance-optimized fork of RECON v1.05 for de novo repeat family identification
- Named `recon-para` to avoid conflict with the existing `recon` package (v1.08 from RepeatMasker)
- Provides 10-50x speedup through algorithm fixes, buffered I/O, memory pool allocation, and parallel sorting
- Pure C binaries with no external library dependencies; runtime requires `perl` and `coreutils` (for `sort --parallel` and `nproc`)
- Source: https://github.com/unavailable-2374/RECON

## Test plan
- [x] `imagespread 2>&1 | grep -i "usage"` passes (prints usage info on no-arg invocation)
- [ ] CI build succeeds on linux-64
- [ ] `conda install recon-para` installs all 5 binaries and 2 Perl scripts to `$PREFIX/bin`
- [ ] `recon.pl` has `$path` correctly set to `$PREFIX/bin`

## Reference
Bao Z. and Eddy S.R. (2002) "Automated de novo Identification of Repeat Sequence Families in Sequenced Genomes." *Genome Research*. doi:10.1101/gr.88502

🤖 Generated with [Claude Code](https://claude.com/claude-code)