### PR TITLE
Add permucn v0.1.0

### DIFF
--- a/recipes/permucn/meta.yaml
+++ b/recipes/permucn/meta.yaml
@@ -13,7 +13,6 @@ build:
   number: 0
   run_exports:
     - {{ pin_subpackage('permucn', max_pin="x.x") }}
-  entry_points:
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:


### PR DESCRIPTION
Hi Bioconda maintainers,

This PR adds a new recipe for **permucn**.

- Package: `permucn`
- Version: `0.1.0`
- Source: PyPI sdist
- Build: `noarch: python`
- Entry point: `permucn`
- License: MIT
- Test commands:
  - `python -c "import permucn"`
  - `permucn --help`

`permucn` is a CLI tool for testing associations between trait transitions and gene-family copy-number evolution from CAFE outputs.

I am the upstream author/maintainer and will maintain this recipe.

Thanks for your review.