### PR TITLE
fix: disable vcs tracking, refactor, new tool

### DIFF
--- a/recipes/obitools4/build.sh
+++ b/recipes/obitools4/build.sh
@@ -2,6 +2,10 @@
 
 set -xe
 
+# The author provides the binaries and the source code in the tarball
+# There is a protection mechanism in GO that prevents re-builds. Disable it
+go env -w GOFLAGS=-buildvcs=false
+
 mkdir -p $PREFIX/bin
 
 if [ "$(uname)" == "Darwin" ]; then
@@ -11,34 +15,44 @@ else
 fi
 
 
-cp \
-    build/obiannotate \
-    build/obiclean \
-    build/obicleandb \
-    build/obicomplement \
-    build/obiconsensus \
-    build/obiconvert \
-    build/obicount \
-    build/obicsv \
-    build/obidemerge \
-    build/obidistribute \
-    build/obigrep \
-    build/obijoin \
-    build/obikmermatch \
-    build/obikmersimcount \
-    build/obilandmark \
-    build/obimatrix \
-    build/obimicrosat \
-    build/obimultiplex \
-    build/obipairing \
-    build/obipcr \
-    build/obireffamidx \
-    build/obirefidx \
-    build/obiscript \
-    build/obisplit \
-    build/obisummary \
-    build/obitag \
-    build/obitagpcr \
-    build/obitaxonomy \
-    build/obiuniq \
-    ${PREFIX}/bin/
+mkdir -p "$PREFIX/bin"
+
+tools=(
+    obiannotate
+    obiclean
+    obicleandb
+    obicomplement
+    obiconsensus
+    obiconvert
+    obicount
+    obicsv
+    obidemerge
+    obidistribute
+    obigrep
+    obijoin
+    obik
+    obikmermatch
+    obikmersimcount
+    obilandmark
+    obimatrix
+    obimicrosat
+    obimultiplex
+    obipairing
+    obipcr
+    obireffamidx
+    obirefidx
+    obiscript
+    obisplit
+    obisummary
+    obitag
+    obitagpcr
+    obitaxonomy
+    obiuniq 
+)
+
+for tool in "${tools[@]}" ; do
+
+    cp build/$tool ${PREFIX}/bin/$tool
+
+done
+

--- a/recipes/obitools4/meta.yaml
+++ b/recipes/obitools4/meta.yaml
@@ -28,36 +28,37 @@ requirements:
 
 
 test:
-  commands:  # --help returns exit code 1
-    - obiannotate --version
-    - obiclean --version
-    - obicleandb --version
-    - obicomplement --version
-    - obiconsensus --version
-    - obiconvert --version
-    - obicount --version
-    - obicsv --version
-    - obidemerge --version
-    - obidistribute --version
-    - obigrep --version
-    - obijoin --version
-    - obikmermatch --version
-    - obikmersimcount --version
-    - obilandmark --version
-    - obimatrix --version
-    - obimicrosat --version
-    - obimultiplex --version
-    - obipairing --version
-    - obipcr --version
-    # - obireffamidx --version  # works on master but not on release 4.4.0
-    # - obirefidx --version  # works on master but not on release 4.4.0
-    - obiscript --version
-    - obisplit --version
-    - obisummary --version
-    - obitag --version
-    - obitagpcr --version
-    - obitaxonomy --version
-    - obiuniq --version
+  commands:
+    - obiannotate --help
+    - obiclean --help
+    - obicleandb --help
+    - obicomplement --help
+    - obiconsensus --help
+    - obiconvert --help
+    - obicount --help
+    - obicsv --help
+    - obidemerge --help
+    - obidistribute --help
+    - obigrep --help
+    - obijoin --help
+    - obik --help
+    - obikmermatch --help
+    - obikmersimcount --help
+    - obilandmark --help
+    - obimatrix --help
+    - obimicrosat --help
+    - obimultiplex --help
+    - obipairing --help
+    - obipcr --help
+    - obireffamidx --help
+    - obirefidx --help
+    - obiscript --help
+    - obisplit --help
+    - obisummary --help
+    - obitag --help
+    - obitagpcr --help
+    - obitaxonomy --help
+    - obiuniq --help
 
   
 about:


### PR DESCRIPTION
Fix the building procedure

The tarball contains the compiled binaries, and go has a mechanism to prevent a re-build.