### PR TITLE
add omero-annotate-ai recipe

### DIFF
--- a/recipes/omero-annotate-ai/meta.yaml
+++ b/recipes/omero-annotate-ai/meta.yaml
@@ -18,12 +18,12 @@ build:
 
 requirements:
   host:
-    - python >=3.10
+    - python
     - setuptools >=61.0
     - wheel
     - pip
   run:
-    - python >=3.10
+    - python
     # Core dependencies
     - numpy >=1.21.0,<2.0
     - pandas >=1.3.0


### PR DESCRIPTION
Summary

New recipe for [omero-annotate-ai](https://github.com/Leiden-Cell-Observatory/omero_annotate_ai), a Python package for reproducible image annotation workflows for AI model training using OMERO data repositories.

### Package description

omero-annotate-ai provides Jupyter widgets and tools for reproducible annotation, training, and inference using micro-SAM, Cellpose, and other AI models directly with OMERO datasets. 

### Motivation for bioconda

The package depends on `ezomero` (available on bioconda) and benefits from conda-only packages `zeroc-ice` and `micro-sam` (available on conda-forge). Submitting to bioconda allows all dependencies to be resolved from conda channels, providing a simpler installation experience for researchers compared to pip (where `zeroc-ice` and `micro-sam` are not available).

### Upstream

- PyPI: https://pypi.org/project/omero-annotate-ai/
- Repository: https://github.com/Leiden-Cell-Observatory/omero_annotate_ai
- License: Apache-2.0

### run_exports

Uses `{{ pin_subpackage('omero-annotate-ai', max_pin="x") }}` — the package follows semantic versioning.