### PR TITLE
Add mytaxa 1.2.0 (MyTaxa CLI; DB via MYTAXA_DB; utils downloader; skip win)

### DIFF
--- a/recipes/mytaxa/build.sh
+++ b/recipes/mytaxa/build.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+# Build MyTaxa
+make
+
+# Install MyTaxa binaries into the conda prefix
+mkdir -p "${PREFIX}/bin"
+
+# MyTaxa builds a binary named "mytaxa"
+# If this changes later, adjust this line accordingly
+cp -v MyTaxa "${PREFIX}/bin/"
+mkdir -p "${PREFIX}/share/mytaxa"
+cp -rv utils "${PREFIX}/share/mytaxa/"
+

--- a/recipes/mytaxa/build.sh
+++ b/recipes/mytaxa/build.sh
@@ -1,16 +1,8 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
-
-# Make sure the conda-provided C++ compiler is used
-# Replace any hard-coded 'g++' with '$(CXX)' in the Makefile
-# (portable sed usage for both GNU and BSD sed)
-if grep -qE '(^|\s)g\+\+(\s|$)' Makefile; then
-  sed -E -i.bak 's/(^|[[:space:]])g\+\+([[:space:]]|$)/\1\$(CXX)\2/g' Makefile
-fi
-
 # Build MyTaxa
-make CXX="${CXX:-c++}"
+make CC="${CXX:-c++}"
 
 # Install MyTaxa binaries into the conda prefix
 mkdir -p "${PREFIX}/bin"

--- a/recipes/mytaxa/build.sh
+++ b/recipes/mytaxa/build.sh
@@ -1,15 +1,22 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
+
+# Make sure the conda-provided C++ compiler is used
+# Replace any hard-coded 'g++' with '$(CXX)' in the Makefile
+# (portable sed usage for both GNU and BSD sed)
+if grep -qE '(^|\s)g\+\+(\s|$)' Makefile; then
+  sed -E -i.bak 's/(^|[[:space:]])g\+\+([[:space:]]|$)/\1\$(CXX)\2/g' Makefile
+fi
+
 # Build MyTaxa
-make
+make CXX="${CXX:-c++}"
 
 # Install MyTaxa binaries into the conda prefix
 mkdir -p "${PREFIX}/bin"
-
-# MyTaxa builds a binary named "mytaxa"
-# If this changes later, adjust this line accordingly
 cp -v MyTaxa "${PREFIX}/bin/"
+
+# Install utils
 mkdir -p "${PREFIX}/share/mytaxa"
 cp -rv utils "${PREFIX}/share/mytaxa/"
 

--- a/recipes/mytaxa/meta.yaml
+++ b/recipes/mytaxa/meta.yaml
@@ -12,6 +12,8 @@ source:
 build:
   number: 0
   skip: true # [win]
+  run_exports:
+    - mytaxa
 
 requirements:
   build:

--- a/recipes/mytaxa/meta.yaml
+++ b/recipes/mytaxa/meta.yaml
@@ -17,7 +17,7 @@ build:
 
 requirements:
   build:
-    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
     - make
 
   host:

--- a/recipes/mytaxa/meta.yaml
+++ b/recipes/mytaxa/meta.yaml
@@ -1,0 +1,65 @@
+{% set name = "mytaxa" %}
+{% set version = "1.2.0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/bio-miga/MyTaxa/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 568e186e0ea6a25baf6b8515872af919f7e76d684bb9003425485cb210eb4cb8
+
+build:
+  number: 0
+  skip: true # [win]
+  run_exports:
+    - {{ pin_subpackage() }}
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - make
+
+  host:
+
+  run:
+
+about:
+  home: https://github.com/bio-miga/MyTaxa
+  summary: "MyTaxa — Taxonomic classification of microbial genomes"
+  license: GPL-3.0-or-later
+  license_family: GPL
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - lmrodriguezr
+
+test:
+  commands:
+    - "command -v MyTaxa"
+    - "MyTaxa | grep Version:"
+
+notes: |
+    The MyTaxa reference database (~2.4 GB) is **not included** in the Bioconda package.
+
+    To download the database after installation, run:
+
+        python $CONDA_PREFIX/share/mytaxa/utils/download_db.py
+
+    This will create a `db/` directory containing the MyTaxa reference files.
+
+
+    After downloading, MyTaxa will look for the database directory in the
+    following order:
+
+      1. If the environment variable MYTAXA_DB is set and non-empty, MyTaxa
+         will use that directory.
+      2. Otherwise, it will fall back to the default location:
+         <directory_of_MyTaxa_executable>/db
+
+    Example usage:
+
+        export MYTAXA_DB=/path/to/mytaxa/db
+        MyTaxa -h
+

--- a/recipes/mytaxa/meta.yaml
+++ b/recipes/mytaxa/meta.yaml
@@ -12,8 +12,6 @@ source:
 build:
   number: 0
   skip: true # [win]
-  run_exports:
-    - {{ pin_subpackage() }}
 
 requirements:
   build:

--- a/recipes/mytaxa/meta.yaml
+++ b/recipes/mytaxa/meta.yaml
@@ -11,34 +11,35 @@ source:
 
 build:
   number: 0
-  skip: true # [win]
+  skip: True  # [win]
   run_exports:
-    - mytaxa
+    - {{ pin_subpackage(name, max_pin="x") }}
 
 requirements:
   build:
     - {{ compiler('cxx') }}
+    - {{ stdlib('c') }}
     - make
-
-  host:
-
-  run:
-
-about:
-  home: https://github.com/bio-miga/MyTaxa
-  summary: "MyTaxa — Taxonomic classification of microbial genomes"
-  license: GPL-3.0-or-later
-  license_family: GPL
-  license_file: LICENSE
-
-extra:
-  recipe-maintainers:
-    - lmrodriguezr
 
 test:
   commands:
     - "command -v MyTaxa"
     - "MyTaxa | grep Version:"
+
+about:
+  home: "https://github.com/bio-miga/MyTaxa"
+  summary: "MyTaxa — Taxonomic classification of microbial genomes"
+  license: "GPL-3.0-or-later"
+  license_family: GPL3
+  license_file: LICENSE
+  dev_url: "https://github.com/bio-miga/MyTaxa"
+
+extra:
+  recipe-maintainers:
+    - lmrodriguezr
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64
 
 notes: |
     The MyTaxa reference database (~2.4 GB) is **not included** in the Bioconda package.
@@ -62,4 +63,3 @@ notes: |
 
         export MYTAXA_DB=/path/to/mytaxa/db
         MyTaxa -h
-


### PR DESCRIPTION
Add MyTaxa 1.2.0

- Provides the MyTaxa CLI binary
- Ships the utils/ directory under $PREFIX/share/mytaxa
- Database (~2.4 GB) not included; users download it via:
```
python $CONDA_PREFIX/share/mytaxa/utils/download_db.py
```

- Database lookup order:
  1. $MYTAXA_DB environment variable (if set)
  2. <directory_of_MyTaxa>/db fallback (original behavior)
- Windows builds skipped
- Maintainer: @lmrodriguezr