### PR TITLE
Add permutect v0.7.1

### DIFF
--- a/recipes/permutect/meta.yaml
+++ b/recipes/permutect/meta.yaml
@@ -1,0 +1,72 @@
+{% set name = "permutect" %}
+{% set version = "0.7.1" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/broadinstitute/{{ name }}/archive/v{{ version }}.tar.gz
+  sha256: 374a5fddc38aab21797c3ddf03ba8f1e9d19580fd944e273ad3b9c93f6ff3e84
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  entry_points:
+    - refine_artifact_model = permutect.tools.refine_artifact_model:main
+    - train_artifact_model = permutect.tools.train_artifact_model:main
+    - filter_variants = permutect.tools.filter_variants:main
+    - preprocess_dataset = permutect.tools.preprocess_dataset:main
+    - edit_dataset = permutect.tools.edit_dataset:main
+    - prune_dataset = permutect.tools.prune_dataset:main
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x.x") }}
+
+requirements:
+  host:
+    # upstream pyproject.toml caps requires-python at <3.13; pip enforces this
+    # during the build, so the python version must be pinned even for noarch.
+    - python >=3.10,<3.13
+    - pip
+    - setuptools >=64
+  run:
+    - python >=3.10,<3.13
+    - pytorch >=2.10,<2.11
+    - tensorboard >=2.8
+    - numpy >=1.26
+    - pymc >=5.28
+    - scikit-learn >=1.3
+    - matplotlib-base >=3.8
+    - cyvcf2 >=0.31.4,<0.32
+    - python-intervaltree >=3.1
+    - psutil >=5.9
+    - tqdm >=4.66
+    - dill >=0.3.7
+
+test:
+  imports:
+    - permutect
+  commands:
+    - filter_variants --help
+    - train_artifact_model --help
+    - preprocess_dataset --help
+
+about:
+  home: https://github.com/broadinstitute/{{ name }}
+  license: Apache-2.0
+  license_family: Apache
+  license_file: LICENSE
+  summary: "Deep learning architecture for somatic and germline variant calling"
+  description: |
+    Permutect is a pipeline for calling and filtering variants from genomic
+    sequencing data. It uses a permissive variant caller (Mutect2) followed by
+    a deep learning-based filtering model. Unlike Mutect2/FilterMutectCalls,
+    Permutect does not require a panel of normals and works across different
+    sequencing platforms for both somatic and germline variant calling.
+  dev_url: https://github.com/broadinstitute/{{ name }}
+  doc_url: https://github.com/broadinstitute/{{ name }}/blob/main/README.md
+
+extra:
+  recipe-maintainers:
+    - nh13


### PR DESCRIPTION
## Summary
- Add bioconda recipe for [Permutect](https://github.com/broadinstitute/permutect) v0.7.1
- Deep learning architecture for somatic and germline variant calling from the Broad Institute
- Pure Python package (`noarch: python`) using setuptools
- Provides 6 CLI tools: `filter_variants`, `train_artifact_model`, `preprocess_dataset`, `refine_artifact_model`, `edit_dataset`, `prune_dataset`

## Notes
- `license_file: LICENSE` is now included (upstream ships a LICENSE file as of v0.7.1).
- Run requirements were reconciled against v0.7.1's actual imports and `pyproject.toml` pins. Compared to earlier drafts this drops `pytorch-lightning`, `scipy`, `pandas`, `seaborn-base`, `pysam`, `biopython`, `pytensor`, `h5py`, `protobuf`, and `pytorch_scatter`, none of which are imported in 0.7.x.
- Key pins follow upstream: `pytorch >=2.10,<2.11`, `cyvcf2 >=0.31.4,<0.32`, `pymc >=5.28`, and `python >=3.10,<3.13`.

## Test plan
- [x] Builds locally via `conda build` (noarch, osx-arm64) with conda-forge + bioconda channels
- [x] `permutect` module imports
- [x] `filter_variants --help` works
- [x] `train_artifact_model --help` works
- [x] `preprocess_dataset --help` works
