### PR TITLE
Update isoquant to 3.12.2

### DIFF
--- a/recipes/isoquant/build.sh
+++ b/recipes/isoquant/build.sh
@@ -1,9 +1,3 @@
 #!/bin/bash
 
-OUTDIR=$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM
-mkdir -p $OUTDIR
-mkdir -p $PREFIX/bin
-chmod a+x *.py
-cp -rp * "$OUTDIR/"
-cd $PREFIX/bin
-ln -sf "../${OUTDIR#$PREFIX}"/*.py .
+$PYTHON -m pip install . --no-deps --no-build-isolation --ignore-installed -vv

--- a/recipes/isoquant/meta.yaml
+++ b/recipes/isoquant/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "IsoQuant" %}
-{% set version = "3.12.0" %}
-{% set sha256 = "0fa7f7b46bda19f3b542ef488c5367c6a98dd3675f135e18771c0b849e1594fc" %}
+{% set version = "3.12.1" %}
+{% set sha256 = "80d786038c580113ffc39629faed40efb1c2efd8f030d09782f510943b4299eb" %}
 
 package:
   name: {{ name|lower }}

--- a/recipes/isoquant/meta.yaml
+++ b/recipes/isoquant/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "IsoQuant" %}
-{% set version = "3.12.1" %}
-{% set sha256 = "80d786038c580113ffc39629faed40efb1c2efd8f030d09782f510943b4299eb" %}
+{% set version = "3.12.2" %}
+{% set sha256 = "184d1970694536a24f9214095908fef6b22743a0f8722784adcecd06969d5e8f" %}
 
 package:
   name: {{ name|lower }}

--- a/recipes/isoquant/meta.yaml
+++ b/recipes/isoquant/meta.yaml
@@ -12,11 +12,15 @@ source:
 
 build:
   number: 0
-  noarch: generic
+  noarch: python
   run_exports:
     - {{ pin_subpackage(name|lower, max_pin="x") }}
 
 requirements:
+  host:
+    - python
+    - pip
+    - setuptools >=64
   run:
     - python
     - argcomplete >=1.11.1
@@ -42,9 +46,9 @@ requirements:
 
 test:
   source_files:
-    - tests
+    - isoquant_tests
   commands:
-    - isoquant.py --test
+    - isoquant --test
     - rm -rf isoquant_test
 
 about:


### PR DESCRIPTION
- updates isoquant to 3.12.2
- switches to pip-based installation