### PR TITLE
Add gwaslab

### DIFF
--- a/recipes/gwaslab/0001-defer-sumstats-liftover-import.patch
+++ b/recipes/gwaslab/0001-defer-sumstats-liftover-import.patch
@@ -1,0 +1,31 @@
+--- a/src/gwaslab/hm/hm_liftover_v2.py
++++ b/src/gwaslab/hm/hm_liftover_v2.py
+@@ -16,9 +16,15 @@
+ try:
+     from sumstats_liftover import liftover_df
+ except ImportError:
+-    raise ImportError(
+-        "sumstats_liftover package is required. Install it with: pip install sumstats-liftover"
+-    )
++    liftover_df = None
++
++
++def _get_liftover_df():
++    if liftover_df is None:
++        raise ImportError(
++            "sumstats_liftover package is required. Install it with: pip install sumstats-liftover"
++        )
++    return liftover_df
+ 
+ 
+ def _normalize_chrom_name_vectorized(chrom_series: pd.Series, mapper: Optional[ChromosomeMapper] = None) -> pd.Series:
+@@ -253,7 +259,8 @@
+     original_chrom_normalized = _normalize_chrom_name_vectorized(sumstats[chrom], mapper=mapper)
+     
+     # Perform liftover using sumstats_liftover package
+-    sumstats = liftover_df(
++    liftover = _get_liftover_df()
++    sumstats = liftover(
+         df=sumstats,
+         chain_path=chain_path,
+         chrom_col=chrom,

--- a/recipes/gwaslab/meta.yaml
+++ b/recipes/gwaslab/meta.yaml
@@ -1,0 +1,60 @@
+{% set name = "gwaslab" %}
+{% set version = "4.1.2" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 618424c34745b0bec4131056eb73166acbc262b3ffb1cada239212465c154408
+  patches:
+    - 0001-defer-sumstats-liftover-import.patch
+
+build:
+  number: 0
+  noarch: python
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x") }}
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python >=3.9
+    - pip
+    - setuptools >=68
+    - wheel
+  run:
+    - python >=3.9
+    - pandas !=1.5,>=1.3,<=2.3.3
+    - numpy >=1.21.2,<2
+    - matplotlib-base >=3.8,<3.9
+    - seaborn >=0.12
+    - scipy >=1.12
+    - pysam ==0.22.1
+    - adjusttext >=0.7.3,<=0.8
+    - scikit-allel >=1.3.5
+    - h5py >=3.10.0
+    - pyarrow
+    - polars >=1.27.0
+    - requests
+    - pyyaml
+    - bitarray
+    - platformdirs
+
+test:
+  imports:
+    - gwaslab
+  commands:
+    - gwaslab --help
+
+about:
+  home: https://cloufield.github.io/gwaslab/
+  summary: Python toolkit for handling GWAS summary statistics
+  license: GPL-3.0-only
+  license_file: LICENSE
+  dev_url: https://github.com/Cloufield/gwaslab
+
+extra:
+  recipe-maintainers:
+    - lyh970817


### PR DESCRIPTION
Add Bioconda recipe for `gwaslab`, a Python toolkit for handling GWAS summary statistics.

This package is directly relevant to genomics workflows.

The recipe includes `run_exports` because `gwaslab` is intended for reuse as a downstream dependency.

The recipe also carries a small packaging patch to defer the optional `sumstats-liftover` import so `import gwaslab` and `gwaslab --help` work in standalone recipe CI without requiring an unpublished dependency.