### PR TITLE
Add fg-stitch v0.1.2

### DIFF
--- a/recipes/fg-stitch/build.sh
+++ b/recipes/fg-stitch/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -e
+
+cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
+
+cargo install --no-track --locked --verbose --root "${PREFIX}" --path fg-stitch-cli

--- a/recipes/fg-stitch/meta.yaml
+++ b/recipes/fg-stitch/meta.yaml
@@ -1,0 +1,44 @@
+{% set name = "fg-stitch" %}
+{% set version = "0.1.2" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/fulcrumgenomics/stitch/archive/v{{ version }}.tar.gz
+  sha256: 87ee634c7724e1c35417a6a567f2cc046bb3eabb4b6d49b168bb27fd157004cb
+
+build:
+  number: 0
+  run_exports:
+    - {{ pin_subpackage('fg-stitch', max_pin="x.x") }}
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('rust') }}
+    - cargo-bundle-licenses
+
+test:
+  commands:
+    - stitch --help
+
+about:
+  home: "https://github.com/fulcrumgenomics/stitch"
+  license: MIT
+  license_family: MIT
+  license_file:
+    - LICENSE
+    - THIRDPARTY.yml
+  summary: "An aligner for long reads against one or more reference/expected vector/plasmid/construct(s)."
+  dev_url: "https://github.com/fulcrumgenomics/stitch"
+  doc_url: "https://github.com/fulcrumgenomics/stitch/blob/v{{ version }}/README.md"
+
+extra:
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64
+  recipe-maintainers:
+    - nh13
+    - tfenne


### PR DESCRIPTION
## Summary
- Add bioconda recipe for fg-stitch v0.1.2
- An aligner for long reads against one or more reference/expected vector/plasmid/construct(s)
- Built from Rust source at https://github.com/fulcrumgenomics/stitch