### PR TITLE
Add papa2: Python-first amplicon denoising (DADA2 port)

### DIFF
--- a/recipes/papa2/build.sh
+++ b/recipes/papa2/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -xe
+
+# Build the C/C++ shared library using conda's compilers
+export LDFLAGS="-L${PREFIX}/lib ${LDFLAGS}"
+export CPATH="${PREFIX}/include:${CPATH}"
+make -j${CPU_COUNT} libpapa2.so
+
+# Install the Python package
+${PYTHON} -m pip install . --no-deps --no-build-isolation -vvv

--- a/recipes/papa2/meta.yaml
+++ b/recipes/papa2/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - {{ compiler('cxx') }}
     - make
   host:
-    - python >=3.10
+    - python
     - pip
     - setuptools >=68
     - wheel

--- a/recipes/papa2/meta.yaml
+++ b/recipes/papa2/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/rec3141/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 6902f4f81eae3c70d2d5afc879b8fbd4dff860cca38f5453b6d23bd2c625155a
+  sha256: 031e4f4424e593886942a024084cebecc392dc57c13febb0e0f4b2c837e2f2d0
 
 build:
   number: 0

--- a/recipes/papa2/meta.yaml
+++ b/recipes/papa2/meta.yaml
@@ -41,7 +41,7 @@ test:
 
 about:
   home: https://github.com/rec3141/papa2
-  license: MIT
+  license: LGPL-3.0-only
   license_file: LICENSE
   summary: "Python-first amplicon denoising — byte-identical to R's DADA2"
   description: |

--- a/recipes/papa2/meta.yaml
+++ b/recipes/papa2/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/rec3141/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 2691dd5106281ad17ea7a1783f80af41f337f8883ec48d52668b86d46129c4d3
+  sha256: 20c7ab4eb578c7a572a7e3a5a125efda8ee28943ac9823874dff7707d9ba6281
 
 build:
   number: 0

--- a/recipes/papa2/meta.yaml
+++ b/recipes/papa2/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/rec3141/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: b2100688cdf5c65f753ab578c356f7c56ef1c28a7751ff013d76af644c8885a8
+  sha256: 6902f4f81eae3c70d2d5afc879b8fbd4dff860cca38f5453b6d23bd2c625155a
 
 build:
   number: 0

--- a/recipes/papa2/meta.yaml
+++ b/recipes/papa2/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/rec3141/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 031e4f4424e593886942a024084cebecc392dc57c13febb0e0f4b2c837e2f2d0
+  sha256: 2691dd5106281ad17ea7a1783f80af41f337f8883ec48d52668b86d46129c4d3
 
 build:
   number: 0

--- a/recipes/papa2/meta.yaml
+++ b/recipes/papa2/meta.yaml
@@ -12,6 +12,8 @@ source:
 build:
   number: 0
   skip: true  # [win]
+  entry_points:
+    - papa2 = papa2.cli:main
   run_exports:
     - {{ pin_subpackage(name, max_pin="x.x") }}
 
@@ -24,24 +26,23 @@ requirements:
     - python
     - pip
     - setuptools >=68
-    - wheel
     - numpy
     - zlib
   run:
     - python >=3.10
     - numpy
     - pandas
-    - zlib
 
 test:
   imports:
     - papa2
   commands:
     - python -c "import papa2; print(papa2.__version__)"
+    - papa2 --help
 
 about:
-  home: https://github.com/rec3141/papa2
-  license: LGPL-3.0-only
+  home: "https://github.com/rec3141/papa2"
+  license: "LGPL-3.0-only"
   license_file: LICENSE
   summary: "Python-first amplicon denoising — byte-identical to R's DADA2"
   description: |
@@ -50,11 +51,16 @@ about:
     with no R dependency. Includes quality filtering, dereplication, error
     learning, denoising, paired-end merging, chimera removal, and taxonomy
     assignment backed by a compiled C/C++ core.
-  doc_url: https://rec3141.github.io/papa2/
-  dev_url: https://github.com/rec3141/papa2
+  doc_url: "https://rec3141.github.io/papa2"
+  dev_url: "https://github.com/rec3141/papa2"
 
 extra:
   recipe-maintainers:
     - rec3141
   identifiers:
     - doi:10.1038/nmeth.3869
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64
+  skip-lints:
+    - compiler_needs_stdlib_c

--- a/recipes/papa2/meta.yaml
+++ b/recipes/papa2/meta.yaml
@@ -12,8 +12,6 @@ source:
 build:
   number: 0
   skip: true  # [win]
-  entry_points:
-    - papa2 = papa2.cli:main
   run_exports:
     - {{ pin_subpackage(name, max_pin="x.x") }}
 
@@ -29,7 +27,7 @@ requirements:
     - numpy
     - zlib
   run:
-    - python >=3.10
+    - python
     - numpy
     - pandas
 
@@ -38,7 +36,6 @@ test:
     - papa2
   commands:
     - python -c "import papa2; print(papa2.__version__)"
-    - papa2 --help
 
 about:
   home: "https://github.com/rec3141/papa2"

--- a/recipes/papa2/meta.yaml
+++ b/recipes/papa2/meta.yaml
@@ -1,0 +1,60 @@
+{% set name = "papa2" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/rec3141/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: b2100688cdf5c65f753ab578c356f7c56ef1c28a7751ff013d76af644c8885a8
+
+build:
+  number: 0
+  skip: true  # [win]
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x.x") }}
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - make
+  host:
+    - python >=3.10
+    - pip
+    - setuptools >=68
+    - wheel
+    - numpy
+    - zlib
+  run:
+    - python >=3.10
+    - numpy
+    - pandas
+    - zlib
+
+test:
+  imports:
+    - papa2
+  commands:
+    - python -c "import papa2; print(papa2.__version__)"
+
+about:
+  home: https://github.com/rec3141/papa2
+  license: MIT
+  license_file: LICENSE
+  summary: "Python-first amplicon denoising — byte-identical to R's DADA2"
+  description: |
+    papa2 is a complete Python port of the DADA2 amplicon denoising pipeline.
+    All 37 R functions have Python equivalents, producing byte-identical results
+    with no R dependency. Includes quality filtering, dereplication, error
+    learning, denoising, paired-end merging, chimera removal, and taxonomy
+    assignment backed by a compiled C/C++ core.
+  doc_url: https://rec3141.github.io/papa2/
+  dev_url: https://github.com/rec3141/papa2
+
+extra:
+  recipe-maintainers:
+    - rec3141
+  identifiers:
+    - doi:10.1038/nmeth.3869


### PR DESCRIPTION
## Summary

Add [papa2](https://github.com/rec3141/papa2) — a complete Python port of the [DADA2](https://github.com/benjjneb/dada2) amplicon denoising pipeline.

- **All 37 R dada2 functions** have Python equivalents
- **Byte-identical results** to R dada2 ([20/20 parity tests pass](https://github.com/rec3141/papa2/blob/main/tests/compare_with_r.py))
- No R dependency — standalone Python + compiled C/C++ core
- Full pipeline: filter & trim, dereplication, error learning, denoising, paired-end merging, chimera removal, taxonomy assignment
- Documentation: https://rec3141.github.io/papa2/

## Test

```bash
conda install -c bioconda papa2
python -c "import papa2; print(papa2.__version__)"
```

## Checklist

- [x] Recipe builds and tests pass
- [x] License file included (MIT)
- [x] Source is a tagged GitHub release (v0.1.0)
- [x] sha256 verified