### PR TITLE
New recipe for TIR-Learner4, a tool for identifying TIR transposable

### DIFF
--- a/recipes/tir-learner4/build.sh
+++ b/recipes/tir-learner4/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+
+# Install package files
+mkdir -p "$PREFIX/lib/tir-learner4"
+cp -r TIR-Learner4/* "$PREFIX/lib/tir-learner4/"
+
+# Fix shebang in main script (original has #!/usr/app/env python3, a typo)
+sed -i '1s|.*|#!/usr/bin/env python3|' "$PREFIX/lib/tir-learner4/TIR-Learner.py"
+
+# Create CLI wrapper
+mkdir -p "$PREFIX/bin"
+cat > "$PREFIX/bin/tirlearner4" << 'EOF'
+#!/bin/bash
+exec python3 "$(dirname "$(dirname "$(readlink -f "$0")")")/lib/tir-learner4/TIR-Learner.py" "$@"
+EOF
+chmod +x "$PREFIX/bin/tirlearner4"

--- a/recipes/tir-learner4/build.sh
+++ b/recipes/tir-learner4/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # Install package files
@@ -11,7 +11,7 @@ sed -i '1s|.*|#!/usr/bin/env python3|' "$PREFIX/lib/tir-learner4/TIR-Learner.py"
 # Create CLI wrapper
 mkdir -p "$PREFIX/bin"
 cat > "$PREFIX/bin/tirlearner4" << 'EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 exec python3 "$(dirname "$(dirname "$(readlink -f "$0")")")/lib/tir-learner4/TIR-Learner.py" "$@"
 EOF
 chmod +x "$PREFIX/bin/tirlearner4"

--- a/recipes/tir-learner4/meta.yaml
+++ b/recipes/tir-learner4/meta.yaml
@@ -1,13 +1,13 @@
-{% set name = "tir-learner4" %}
+{% set name = "TIR-Learner" %}
 {% set version = "1.0" %}
 {% set sha256 = "6f0f5725476576ae224211e7e11605cc7ddeb42a99cae28a02cedebb79cdac40" %}
 
 package:
-  name: {{ name }}
+  name: {{ name | lower }}
   version: {{ version }}
 
 source:
-  url: https://github.com/KGerhardt/TIR-Learner/archive/refs/tags/{{ version }}.tar.gz
+  url: https://github.com/KGerhardt/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:
@@ -34,10 +34,10 @@ test:
     - tirlearner4 --help
 
 about:
-  home: https://github.com/KGerhardt/TIR-Learner
+  home: https://github.com/KGerhardt/{{ name }}
   summary: "Accelerated tool for identifying TIR transposable elements"
   license: GPL-3.0-or-later
   license_family: GPL3
   license_file: LICENSE
-  dev_url: https://github.com/KGerhardt/TIR-Learner
-  doc_url: https://github.com/KGerhardt/TIR-Learner/blob/main/README.md
+  dev_url: https://github.com/KGerhardt/{{ name }}
+  doc_url: https://github.com/KGerhardt/{{ name }}/blob/main/README.md

--- a/recipes/tir-learner4/meta.yaml
+++ b/recipes/tir-learner4/meta.yaml
@@ -1,4 +1,4 @@
-{% set name = "TIR-Learner" %}
+{% set name = "tir-learner4" %}
 {% set version = "1.0" %}
 {% set sha256 = "6f0f5725476576ae224211e7e11605cc7ddeb42a99cae28a02cedebb79cdac40" %}
 
@@ -7,7 +7,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/KGerhardt/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
+  url: https://github.com/KGerhardt/TIR-Learner/archive/refs/tags/{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:
@@ -34,10 +34,10 @@ test:
     - tirlearner4 --help
 
 about:
-  home: https://github.com/KGerhardt/{{ name }}
+  home: https://github.com/KGerhardt/TIR-Learner
   summary: "Accelerated tool for identifying TIR transposable elements"
   license: GPL-3.0-or-later
   license_family: GPL3
   license_file: LICENSE
-  dev_url: https://github.com/KGerhardt/{{ name }}
-  doc_url: https://github.com/KGerhardt/{{ name }}/blob/main/README.md
+  dev_url: https://github.com/KGerhardt/TIR-Learner
+  doc_url: https://github.com/KGerhardt/TIR-Learner/blob/main/README.md

--- a/recipes/tir-learner4/meta.yaml
+++ b/recipes/tir-learner4/meta.yaml
@@ -1,0 +1,43 @@
+{% set name = "tir-learner4" %}
+{% set version = "1.0" %}
+{% set sha256 = "6f0f5725476576ae224211e7e11605cc7ddeb42a99cae28a02cedebb79cdac40" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/KGerhardt/TIR-Learner/archive/refs/tags/{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  noarch: generic
+  run_exports:
+    - {{ pin_subpackage('tir-learner4', max_pin='x') }}
+
+requirements:
+  run:
+    - python >=3.9,<3.13
+    - numpy
+    - pyfastx
+    - pywfa
+    - keras
+    - pytorch
+    - genometools-genometools
+    - genericrepeatfinder
+    - blast
+    - pigz
+
+test:
+  commands:
+    - tirlearner4 --help
+
+about:
+  home: https://github.com/KGerhardt/TIR-Learner
+  summary: "Accelerated tool for identifying TIR transposable elements"
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  license_file: LICENSE
+  dev_url: https://github.com/KGerhardt/TIR-Learner
+  doc_url: https://github.com/KGerhardt/TIR-Learner/blob/main/README.md

--- a/recipes/tir-learner4/meta.yaml
+++ b/recipes/tir-learner4/meta.yaml
@@ -1,20 +1,20 @@
-{% set name = "tir-learner4" %}
+{% set name = "TIR-Learner" %}
 {% set version = "1.0" %}
-{% set sha256 = "6f0f5725476576ae224211e7e11605cc7ddeb42a99cae28a02cedebb79cdac40" %}
+{% set sha256 = "125b3e8a4188c6e20d34b14539bfd2d74d5c8c031613267b3ab88d265aba34f8" %}
 
 package:
   name: {{ name | lower }}
   version: {{ version }}
 
 source:
-  url: https://github.com/KGerhardt/TIR-Learner/archive/refs/tags/{{ version }}.tar.gz
+  url: https://github.com/KGerhardt/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:
   number: 0
   noarch: generic
   run_exports:
-    - {{ pin_subpackage('tir-learner4', max_pin='x') }}
+    - {{ pin_subpackage(name | lower, max_pin='x') }}
 
 requirements:
   run:
@@ -34,10 +34,10 @@ test:
     - tirlearner4 --help
 
 about:
-  home: https://github.com/KGerhardt/TIR-Learner
+  home: https://github.com/KGerhardt/{{ name }}
   summary: "Accelerated tool for identifying TIR transposable elements"
   license: GPL-3.0-or-later
   license_family: GPL3
   license_file: LICENSE
-  dev_url: https://github.com/KGerhardt/TIR-Learner
-  doc_url: https://github.com/KGerhardt/TIR-Learner/blob/main/README.md
+  dev_url: https://github.com/KGerhardt/{{ name }}
+  doc_url: https://github.com/KGerhardt/{{ name }}/blob/main/README.md


### PR DESCRIPTION
Bioconda package try number 2 for TIR-Learner v4. Incorporated fixes suggested from pull 63598 as well as some code improvements. I've closed the old pull.

The code publishes a new TIR-Learner package separately from TIR-Learner v3. The v3 program is still in review for publication and we don't want to overwrite or interrupt it, but do want to switch to this version of TIR-Learner for our own use.

@thanhleviet

@oushujun 

@Juke34 