### PR TITLE
Add metastrand

### DIFF
--- a/recipes/metastrand/build.sh
+++ b/recipes/metastrand/build.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install entrypoints
+install -d "${PREFIX}/bin"
+install -m 0755 "bin/metastrand" "${PREFIX}/bin/metastrand"
+
+# Install package data (scripts, templates, README)
+install -d "${PREFIX}/share/metastrand"
+install -d "${PREFIX}/share/metastrand/scripts"
+
+cp -R "scripts/." "${PREFIX}/share/metastrand/scripts/"
+
+# Optional: template config
+if [[ -f "config.template.txt" ]]; then
+  install -m 0644 "config.template.txt" "${PREFIX}/share/metastrand/config.template.txt"
+fi
+if [[ -f "config.test.txt" ]]; then
+  install -m 0644 "config.test.txt" "${PREFIX}/share/metastrand/config.test.txt"
+fi

--- a/recipes/metastrand/meta.yaml
+++ b/recipes/metastrand/meta.yaml
@@ -1,0 +1,42 @@
+package:
+  name: metastrand
+  version: "0.1.1"
+
+source:
+  url: https://gitlab.com/mpust/metastrand/-/archive/v0.1.1/metastrand-v0.1.1.tar.gz
+  sha256: edb49260149298c4f6a64d6a003bb5d506b7844c797af459cbcfebbe6d7aa29c
+
+build:
+  number: 0
+
+requirements:
+  run:
+    - python
+    - pandas
+    - pysam
+    - numpy
+    - scipy
+    - bwa
+    - samtools=1.23
+    - subread=2.1.1
+    - htslib=1.23
+    - bedtools=2.31.1
+    - sambamba=1.0.1
+    - bbmap=39.52
+
+about:
+  home: "https://gitlab.com/mpust/metastrand"
+  license: MIT
+  license_file: LICENSE
+  summary: "Metastrand: Making sense of antisense"
+
+extra:
+  recipe-maintainers:
+    - mpust
+
+test:
+  commands:
+    - which metastrand
+    - metastrand --help
+    - test -f "$CONDA_PREFIX/share/metastrand/config.template.txt"
+    - test -f "$CONDA_PREFIX/share/metastrand/config.test.txt"

--- a/recipes/metastrand/meta.yaml
+++ b/recipes/metastrand/meta.yaml
@@ -8,6 +8,9 @@ source:
 
 build:
   number: 0
+  noarch: generic
+  run_exports:
+    - {{ pin_subpackage('metastrand', max_pin="x.x") }}
 
 requirements:
   run:
@@ -17,12 +20,12 @@ requirements:
     - numpy
     - scipy
     - bwa
-    - samtools=1.23
-    - subread=2.1.1
-    - htslib=1.23
-    - bedtools=2.31.1
-    - sambamba=1.0.1
-    - bbmap=39.52
+    - samtools =1.23
+    - subread =2.1.1
+    - htslib =1.23
+    - bedtools =2.31.1
+    - sambamba =1.0.1
+    - bbmap =39.52
 
 about:
   home: "https://gitlab.com/mpust/metastrand"
@@ -38,5 +41,5 @@ test:
   commands:
     - which metastrand
     - metastrand --help
-    - test -f "$CONDA_PREFIX/share/metastrand/config.template.txt"
-    - test -f "$CONDA_PREFIX/share/metastrand/config.test.txt"
+    - test -f "$PREFIX/share/metastrand/config.template.txt"
+    - test -f "$PREFIX/share/metastrand/config.test.txt"

--- a/recipes/metastrand/meta.yaml
+++ b/recipes/metastrand/meta.yaml
@@ -14,18 +14,18 @@ build:
 
 requirements:
   run:
-    - python
+    - python >=3.9
     - pandas
     - pysam
     - numpy
     - scipy
     - bwa
-    - samtools =1.23
-    - subread =2.1.1
-    - htslib =1.23
-    - bedtools =2.31.1
-    - sambamba =1.0.1
-    - bbmap =39.52
+    - samtools >=1.23
+    - subread >=2.1.1
+    - htslib >=1.23
+    - bedtools >=2.31.1
+    - sambamba >=1.0.1
+    - bbmap >=39.52
 
 about:
   home: "https://gitlab.com/mpust/metastrand"


### PR DESCRIPTION
### Add metastrand

This PR adds a new Bioconda recipe for **metastrand**, a pipeline for analyzing sense (sMTX) and antisense (asMTX) transcriptional signals in metagenomic/metatranscriptomic data.

- Source: https://gitlab.com/mpust/metastrand
- License: MIT
- Language: Python + shell scripts

### Functionality
Metastrand provides a workflow for:
- mapping MTX/MGX reads
- generating count matrices
- analyzing antisense transcription patterns

### Notes
- This is a wrapper-style package (no compilation required)
- Tested via `metastrand --help` and bundled config templates
- Dependencies are available on conda-forge/bioconda

### Checklist
- [x] Recipe builds locally
- [x] Tests pass locally
- [x] Source tarball is versioned and reproducible