### PR TITLE
Add redskull 0.1.0

### DIFF
--- a/recipes/redskull/build.sh
+++ b/recipes/redskull/build.sh
@@ -3,6 +3,12 @@ set -euo pipefail
 
 export RUST_BACKTRACE=1
 
+export CPPFLAGS="${CPPFLAGS} -I${PREFIX}/include"
+export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib"
+export CFLAGS="${CFLAGS} -O3"
+export LD_LIBRARY_PATH="${PREFIX}/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+export DYLD_FALLBACK_LIBRARY_PATH="${PREFIX}/lib${DYLD_FALLBACK_LIBRARY_PATH:+:${DYLD_FALLBACK_LIBRARY_PATH}}"
+
 cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
 
 cargo install --no-track --locked --verbose --root "${PREFIX}" --path .

--- a/recipes/redskull/build.sh
+++ b/recipes/redskull/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -euo pipefail
+
+export RUST_BACKTRACE=1
+
+cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
+
+cargo install --no-track --locked --verbose --root "${PREFIX}" --path .

--- a/recipes/redskull/conda_build_config.yaml
+++ b/recipes/redskull/conda_build_config.yaml
@@ -1,0 +1,6 @@
+libgit2:
+  - 1.9
+openssl:
+  - 3.5
+zlib:
+  - 1

--- a/recipes/redskull/conda_build_config.yaml
+++ b/recipes/redskull/conda_build_config.yaml
@@ -1,6 +1,0 @@
-libgit2:
-  - 1.9
-openssl:
-  - 3.5
-zlib:
-  - 1

--- a/recipes/redskull/meta.yaml
+++ b/recipes/redskull/meta.yaml
@@ -1,0 +1,44 @@
+{% set name = "redskull" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/fg-labs/redskull/archive/v{{ version }}.tar.gz
+  sha256: 528ea51a3e24558b0d308f18130daf9f8e0c295162a330bc946407e316361707
+
+build:
+  number: 0
+  run_exports:
+    - {{ pin_subpackage("redskull", max_pin="x.x") }}
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ stdlib('c') }}
+    - {{ compiler('rust') }}
+    - cargo-bundle-licenses
+
+test:
+  commands:
+    - redskull --help
+
+about:
+  home: https://github.com/fg-labs/redskull
+  license: MIT
+  license_family: MIT
+  license_file:
+    - LICENSE
+    - THIRDPARTY.yml
+  summary: A conda recipe generator for Rust crates.
+  dev_url: https://github.com/fg-labs/redskull
+  doc_url: https://github.com/fg-labs/redskull/blob/v{{ version }}/README.md
+
+extra:
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64
+  recipe-maintainers:
+    - nh13

--- a/recipes/redskull/meta.yaml
+++ b/recipes/redskull/meta.yaml
@@ -17,7 +17,6 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
-    - {{ stdlib('c') }}
     - {{ compiler('rust') }}
     - cargo-bundle-licenses
     - pkg-config

--- a/recipes/redskull/meta.yaml
+++ b/recipes/redskull/meta.yaml
@@ -17,9 +17,21 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
     - {{ stdlib('c') }}
     - {{ compiler('rust') }}
     - cargo-bundle-licenses
+    - pkg-config
+    - make
+    - cmake
+  host:
+    - libgit2
+    - openssl  # [not osx]
+    - zlib
+  run:
+    - libgit2
+    - openssl  # [not osx]
+    - zlib
 
 test:
   commands:

--- a/recipes/redskull/meta.yaml
+++ b/recipes/redskull/meta.yaml
@@ -17,13 +17,11 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
-    - {{ compiler('cxx') }}
     - {{ stdlib('c') }}
     - {{ compiler('rust') }}
     - cargo-bundle-licenses
     - pkg-config
     - make
-    - cmake
   host:
     - libgit2
     - openssl  # [not osx]

--- a/recipes/redskull/meta.yaml
+++ b/recipes/redskull/meta.yaml
@@ -17,7 +17,7 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
-    - {{ stdlib('c') }}
+    # stdlib('c') intentionally omitted — see skip-lints below.
     - {{ compiler('rust') }}
     - cargo-bundle-licenses
     - pkg-config
@@ -52,3 +52,5 @@ extra:
     - osx-arm64
   recipe-maintainers:
     - nh13
+  skip-lints:
+    - compiler_needs_stdlib_c  # until https://github.com/bioconda/bioconda-utils/issues/1095 is resolved

--- a/recipes/redskull/meta.yaml
+++ b/recipes/redskull/meta.yaml
@@ -17,17 +17,18 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
+    - {{ stdlib('c') }}
     - {{ compiler('rust') }}
     - cargo-bundle-licenses
     - pkg-config
     - make
   host:
     - libgit2
-    - openssl  # [not osx]
+    - openssl
     - zlib
   run:
     - libgit2
-    - openssl  # [not osx]
+    - openssl
     - zlib
 
 test:


### PR DESCRIPTION
Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

- [x] If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
- [x] New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge](https://conda-forge.org/) channel instead of Bioconda.
- [x] PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
- [x] Please post questions on [Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues

Currently, Bioconda is not able to automatically rebuild packages when one of their dependencies is updated in a way that breaks the build. To avoid such issues, please:

- [x] Follow [guidelines for specifying `run_exports`](https://bioconda.github.io/contributor/linting.html#missing-run-exports) when adding or updating recipes.
- [x] If your PR adds or updates the `run_exports` of a recipe, please assess what other recipes might be affected by the change. Affected recipes are those that list the current recipe as one of their `host` dependencies (direct dependency), plus those that depend on them further down the line (indirect dependencies). The easiest way to detect this is to search GitHub for recipes mentioning the changed recipe.

### Instructions for backporting bug fixes

- [x] Backports in bioconda are managed by adding a new version at the end of the `meta.yaml` file while keeping the old one. See [#38066](https://github.com/bioconda/bioconda-recipes/pull/38066) for an example.

---

Adds a recipe for [`redskull`](https://github.com/fg-labs/redskull) v0.1.0 — a conda recipe generator for Rust crates ("grayskull for Rust").

Fun detail: the recipe in this PR was itself generated by running `redskull --bioconda --maintainers nh13 redskull` — i.e. redskull bootstrapped its own bioconda recipe.

- crates.io: https://crates.io/crates/redskull
- repository: https://github.com/fg-labs/redskull
- license: MIT