### PR TITLE
Update covsnap to 0.2.0

### DIFF
--- a/recipes/covsnap/meta.yaml
+++ b/recipes/covsnap/meta.yaml
@@ -1,0 +1,64 @@
+{% set name = "covsnap" %}
+{% set version = "0.2.0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/enes-ak/covsnap/archive/v{{ version }}.tar.gz
+  sha256: bc06be36499d1054c78c2832141ebaa960f622c3aa49dd0efe1692c93af592fe
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --no-cache-dir -vvv
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x.x") }}
+
+requirements:
+  host:
+    - python >=3.9
+    - pip
+    - setuptools >=64
+    - setuptools-scm >=8
+  run:
+    - python >=3.9
+    - pysam >=0.22
+    - numpy >=1.24
+    - samtools >=1.17
+    - htslib >=1.17
+    - tabix
+  run_constrained:
+    - mosdepth >=0.3.4
+
+test:
+  imports:
+    - covsnap
+    - covsnap.cli
+    - covsnap.engines
+    - covsnap.annotation
+    - covsnap.html_report
+  commands:
+    - covsnap --version
+    - covsnap --help
+
+about:
+  home: https://github.com/enes-ak/covsnap
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: Coverage inspector for targeted sequencing QC (hg38)
+  description: |
+    covsnap computes per-target and per-exon depth metrics from
+    BAM/CRAM files, producing an interactive HTML report with
+    PASS/FAIL classifications and visual coverage summaries.
+    Supports gene symbols, genomic regions, and BED files as input.
+    Ships with a bundled GENCODE v44 hg38 gene index — no internet
+    or GTF files required at runtime.
+  dev_url: https://github.com/enes-ak/covsnap
+  doc_url: https://github.com/enes-ak/covsnap/blob/main/README.md
+
+extra:
+  recipe-maintainers:
+    - enes-ak


### PR DESCRIPTION
## Summary
- Update covsnap from 0.1.1 to 0.2.0
- Output format changed from TSV + Markdown to interactive HTML report
- Added `covsnap.html_report` import test
- Updated package description to reflect HTML-only output

## Changes in v0.2.0
- HTML-only interactive report (removed TSV/Markdown output)
- Parallel execution for samtools and region/exon analysis
- Region-to-gene/exon overlay for region mode
- Smooth HSL color gradient for exon coverage bars