### PR TITLE
Add fg-sra

### DIFF
--- a/recipes/fg-sra/build.sh
+++ b/recipes/fg-sra/build.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Point fg-sra-vdb-sys at the conda-installed ncbi-vdb.
+export VDB_INCDIR="${PREFIX}/include"
+export VDB_LIBDIR="${PREFIX}/lib"
+
+# Build the fg-sra binary with default features disabled so the
+# `vendored` code path (which would try to build ncbi-vdb from a
+# bundled submodule via cmake) is skipped. fg-sra-vdb-sys will
+# bindgen against $VDB_INCDIR and static-link $VDB_LIBDIR/libncbi-vdb.a.
+cargo install \
+    --locked \
+    --no-track \
+    --no-default-features \
+    --root "${PREFIX}" \
+    --path crates/fg-sra

--- a/recipes/fg-sra/meta.yaml
+++ b/recipes/fg-sra/meta.yaml
@@ -1,0 +1,58 @@
+{% set name = "fg-sra" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/fg-labs/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 8a3700e5ffbddc712d0e398ca4d44ec4e8b7f745b0ccfbad375adfedbf6877f6
+
+build:
+  number: 0
+  skip: True  # [win]
+  script_env:
+    - VDB_INCDIR
+    - VDB_LIBDIR
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - {{ compiler('rust') }}
+    - make
+    - pkg-config
+  host:
+    - ncbi-vdb
+    - libxml2
+    - zlib
+    - bzip2
+  run:
+    - libxml2
+    - zlib
+    - bzip2
+
+test:
+  commands:
+    - fg-sra --help
+    - fg-sra --version
+
+about:
+  home: https://github.com/fg-labs/fg-sra
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: "High-performance SRA-to-SAM/BAM converter replacing NCBI sam-dump"
+  description: |
+    fg-sra is a fast, parallel converter from NCBI SRA format to SAM/BAM,
+    designed as a drop-in replacement for sam-dump with significantly
+    higher throughput on modern multi-core systems.
+  dev_url: https://github.com/fg-labs/fg-sra
+  doc_url: https://github.com/fg-labs/fg-sra
+
+extra:
+  recipe-maintainers:
+    - nh13
+  skip-lints:
+    - compiler_needs_stdlib_c  # until https://github.com/bioconda/bioconda-utils/issues/1095 is resolved

--- a/recipes/fg-sra/meta.yaml
+++ b/recipes/fg-sra/meta.yaml
@@ -19,6 +19,7 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
+    - {{ stdlib('c') }}
     - {{ compiler('cxx') }}
     - {{ compiler('rust') }}
     - make
@@ -54,5 +55,3 @@ about:
 extra:
   recipe-maintainers:
     - nh13
-  skip-lints:
-    - compiler_needs_stdlib_c  # until https://github.com/bioconda/bioconda-utils/issues/1095 is resolved


### PR DESCRIPTION
Adds a recipe for [fg-sra](https://github.com/fg-labs/fg-sra), a high-performance SRA-to-SAM/BAM converter replacing NCBI sam-dump. Builds against the existing bioconda `ncbi-vdb` package; no source patches needed.

`fg-sra-vdb-sys` is pointed at the conda-installed ncbi-vdb via `VDB_INCDIR=$PREFIX/include` and `VDB_LIBDIR=$PREFIX/lib`, and the `--no-default-features` flag disables fg-sra's vendored ncbi-vdb submodule build path so cargo links against `$PREFIX/lib/libncbi-vdb.a` directly.

A `skip-lints: compiler_needs_stdlib_c` directive is included as a workaround for bioconda/bioconda-utils#1095 (adding `stdlib("c")` currently breaks the upload stage). Will be removed once that issue is resolved.

Maintainer: @nh13