### PR TITLE
Add recipe for cgmlst-dists-py 0.1.3

### DIFF
--- a/recipes/cgmlst-dists-py/build.sh
+++ b/recipes/cgmlst-dists-py/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+mkdir -p ${PREFIX}/bin
+
+chmod +x cgmlst-dists.py
+cp cgmlst-dists.py ${PREFIX}/bin/cgmlst-dists
+cp cgmlst-dists.py ${PREFIX}/bin/

--- a/recipes/cgmlst-dists-py/meta.yaml
+++ b/recipes/cgmlst-dists-py/meta.yaml
@@ -9,9 +9,9 @@ package:
 
 build:
   number: 0
-  noarch: python
+  noarch: generic
   run_exports:
-    - {{ pin_subpackage("cgmlst-dists-py", max_pin="x.x") }}
+    - {{ pin_subpackage(name, max_pin="x.x") }}
 
 source:
   url: https://github.com/{{ user }}/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
@@ -32,8 +32,12 @@ test:
     - cgmlst-dists.py -h
 
 about:
-  home: https://github.com/{{ user }}/{{ name }}
-  license: GPL-3.0-only
+  home: "https://github.com/{{ user }}/{{ name }}"
+  license: "GPL-3.0-only"
   license_file: LICENSE
-  summary: High-performance pairwise Hamming distance calculator for cgMLST data with GPU acceleration
-  dev_url: https://github.com/{{ user }}/{{ name }}
+  summary: "High-performance pairwise Hamming distance calculator for cgMLST data with GPU acceleration."
+  dev_url: "https://github.com/{{ user }}/{{ name }}"
+
+extra:
+  skip-lints:
+    - should_be_noarch_python

--- a/recipes/cgmlst-dists-py/meta.yaml
+++ b/recipes/cgmlst-dists-py/meta.yaml
@@ -1,0 +1,39 @@
+{% set name = "cgmlst-dists-py" %}
+{% set version = "0.1.3" %}
+{% set sha256 = "7275e6287092d116c575389b6dfed34dfecf02258c595921ec202e895e380a16" %}
+{% set user = "genpat-it" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+build:
+  number: 0
+  noarch: python
+  run_exports:
+    - {{ pin_subpackage("cgmlst-dists-py", max_pin="x.x") }}
+
+source:
+  url: https://github.com/{{ user }}/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+requirements:
+  run:
+    - python >=3.9
+    - numpy
+    - pandas
+    - numba
+    - tqdm
+    - psutil
+
+test:
+  commands:
+    - cgmlst-dists.py --version | grep -F '{{ version }}'
+    - cgmlst-dists.py -h
+
+about:
+  home: https://github.com/{{ user }}/{{ name }}
+  license: GPL-3.0-only
+  license_file: LICENSE
+  summary: High-performance pairwise Hamming distance calculator for cgMLST data with GPU acceleration
+  dev_url: https://github.com/{{ user }}/{{ name }}


### PR DESCRIPTION
## Summary

Add Bioconda recipe for [cgmlst-dists-py](https://github.com/genpat-it/cgmlst-dists-py) v0.1.3.

cgmlst-dists-py is a high-performance Python implementation of cgmlst-dists for calculating pairwise Hamming distances in cgMLST data, with optional GPU (CUDA) acceleration.

This supersedes #63618 which was stalled on a missing LICENSE file (now resolved).

## Changes
- `recipes/cgmlst-dists-py/meta.yaml` - Package metadata, dependencies, and tests
- `recipes/cgmlst-dists-py/build.sh` - Build script