### PR TITLE
Add fracsim recipe v1.0.2

### DIFF
--- a/recipes/fracsim/meta.yaml
+++ b/recipes/fracsim/meta.yaml
@@ -13,10 +13,12 @@ build:
   noarch: python
   entry_points:
     - fracsim = fracsim.main:main
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-          f [ -f $SP_DIR/fracsim-*.dist-info/requires.txt ]; then
-            sed -i '/pytest/d' $SP_DIR/fracsim-*.dist-info/requires.txt
-          fi
+  script: |
+    {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+    # 移除上游错误声明的 pytest 和 pytest-cov 运行时依赖
+    if [ -f $SP_DIR/fracsim-*.dist-info/requires.txt ]; then
+        sed -i '/pytest/d' $SP_DIR/fracsim-*.dist-info/requires.txt
+    fi
   number: 0
   run_exports:
     - {{ pin_subpackage('fracsim', max_pin='x.x') }}

--- a/recipes/fracsim/meta.yaml
+++ b/recipes/fracsim/meta.yaml
@@ -10,23 +10,24 @@ source:
   sha256: 9b44d02819095e6e5cf781072b8915f9f373a2d495412d7f57dfe83e4636ba85
 
 build:
-  noarch: python                     # 关键：使包不绑定具体 Python 子版本
+  noarch: python
   entry_points:
     - fracsim = fracsim.main:main
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
+  run_exports:
+    - {{ pin_subpackage('fracsim', max_pin='x.x') }}
 
 requirements:
   host:
     - python >=3.8
     - pip
-    - setuptools                     # 构建 sdist 必需
-    - wheel                          # 构建 wheel 元数据推荐
-    # 注意：mmh3 不需要在 host 中，它会在 run 时自动安装
+    - setuptools
+    - wheel
   run:
     - python >=3.8
     - mmh3 >=4.0.0
-    - numpy >=1.21.0                 # 根据原始 PyPI 依赖补充
+    - numpy >=1.21.0
 
 test:
   imports:

--- a/recipes/fracsim/meta.yaml
+++ b/recipes/fracsim/meta.yaml
@@ -14,6 +14,9 @@ build:
   entry_points:
     - fracsim = fracsim.main:main
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+          f [ -f $SP_DIR/fracsim-*.dist-info/requires.txt ]; then
+            sed -i '/pytest/d' $SP_DIR/fracsim-*.dist-info/requires.txt
+          fi
   number: 0
   run_exports:
     - {{ pin_subpackage('fracsim', max_pin='x.x') }}

--- a/recipes/fracsim/meta.yaml
+++ b/recipes/fracsim/meta.yaml
@@ -1,0 +1,50 @@
+{% set name = "fracsim" %}
+{% set version = "1.0.2" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/fracsim-{{ version }}.tar.gz
+  sha256: 9b44d02819095e6e5cf781072b8915f9f373a2d495412d7f57dfe83e4636ba85
+
+build:
+  noarch: python                     # 关键：使包不绑定具体 Python 子版本
+  entry_points:
+    - fracsim = fracsim.main:main
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python >=3.8
+    - pip
+    - setuptools                     # 构建 sdist 必需
+    - wheel                          # 构建 wheel 元数据推荐
+    # 注意：mmh3 不需要在 host 中，它会在 run 时自动安装
+  run:
+    - python >=3.8
+    - mmh3 >=4.0.0
+    - numpy >=1.21.0                 # 根据原始 PyPI 依赖补充
+
+test:
+  imports:
+    - fracsim
+  commands:
+    - pip check
+    - fracsim --help
+  requires:
+    - pip
+    - pytest >=7.0.0
+    - pytest-cov >=4.0.0
+
+about:
+  home: https://github.com/zhuyu534/FracSim
+  summary: a FracMinHash-based genome similarity estimator for bacteria
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - zhuyu534


### PR DESCRIPTION
This PR adds the recipe for fracsim (v1.0.2), a FracMinHash-based genome similarity estimator for bacteria.

PyPI page: https://pypi.org/project/FracSim/

GitHub repository: https://github.com/zhuyu534/FracSim

License: MIT

Author: Yu Zhu (@zhuyu534)

The package is a pure‑Python command‑line tool, depends on mmh3 only, and is already available on PyPI. The recipe was generated with grayskull pypi fracsim --strict-conda-forge and manually adjusted to remove optional/test dependencies from run and to correct the entry point.

Checks performed locally:

conda build recipes/fracsim succeeds

conda install --use-local fracsim works

fracsim --help runs without error

I confirm that I will maintain this recipe in the future.