### PR TITLE
Add fracsim recipe v1.0.2

### DIFF
--- a/recipes/fracsim/meta.yaml
+++ b/recipes/fracsim/meta.yaml
@@ -1,0 +1,47 @@
+{% set name = "fracsim" %}
+{% set version = "1.0.2" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/fracsim-{{ version }}.tar.gz
+  sha256: 9b44d02819095e6e5cf781072b8915f9f373a2d495412d7f57dfe83e4636ba85
+
+build:
+  entry_points:
+    - fracsim = fracsim.main:main
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+  run_exports:
+    - {{ pin_subpackage('fracsim', max_pin='x.x') }}
+
+requirements:
+  host:
+    - python >=3.8,<3.13
+    - pip
+    - setuptools
+    - mmh3 >=4.0.0
+  run:
+    - python >=3.8,<3.13
+    - mmh3 >=4.0.0
+
+test:
+  imports:
+    - fracsim
+  commands:
+    - fracsim --help
+  requires:
+    - pip
+
+about:
+  home: https://github.com/zhuyu534/FracSim
+  summary: a FracMinHash-based genome similarity estimator for bacteria
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - zhuyu534


### PR DESCRIPTION
fracsim is a lightweight, FracMinHash‑based command‑line tool for estimating genome similarity in bacteria. It computes Jaccard indices and ANI directly from FASTA/FASTQ files (including compressed ones) without external alignment tools.

PyPI page: https://pypi.org/project/FracSim/

GitHub repository: https://github.com/zhuyu534/FracSim

License: MIT

Author: Yu Zhu (@zhuyu534)

Recipe details:

Pure Python, noarch

Runtime dependencies: python >=3.8,<3.13 and mmh3 >=4.0.0 only (no extra heavy libraries)

Added run_exports with max_pin="x.x" (semantic versioning)

Tested locally: conda build succeeds, fracsim --help works

Checklist:

Recipe uses noarch: python

All dependencies are correctly listed in host and run

run_exports is present to avoid ABI/CLI breakage

License file is included (LICENSE)

Commands are tested (fracsim --help)

I confirm that I will maintain this recipe in the future.

@BiocondaBot please add label