### PR TITLE
Add coreutils runtime dependency to kraken2

### DIFF
--- a/recipes/kraken2/meta.yaml
+++ b/recipes/kraken2/meta.yaml
@@ -20,6 +20,7 @@ build:
 requirements:
   build:
     - {{ compiler('cxx') }}
+    - {{ stdlib("c") }}
     - make
   host:
     - perl

--- a/recipes/kraken2/meta.yaml
+++ b/recipes/kraken2/meta.yaml
@@ -13,7 +13,7 @@ source:
     - 0001-src-Makefile.patch
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage(name, max_pin="x") }}
 
@@ -31,6 +31,7 @@ requirements:
     - rsync
     - zlib
   run:
+    - coreutils
     - python
     - libgomp      # [linux]
     - llvm-openmp  # [osx]


### PR DESCRIPTION
I plan to introduce the following as a process in our nextflow pipeline:
```
#!/bin/env bash

dbdir="/path/to/dbs"
db="k2_standard_20240904"
target="/dev/shm/$db"

# --- Cleanup Function ---
cleanup() {
    echo -e "\n[CLEANUP] Removing $target from RAM..."
    rm -rf "$target"
}

# Trap signals: EXIT (normal), SIGINT (Ctrl+C), SIGTERM (kill) Ignore EXIT for testing of db copy
trap cleanup EXIT SIGINT SIGTERM
# trap cleanup SIGINT SIGTERM

if [[ ! -d "$target" ]] ; then
    mkdir -p "$target"
else
    echo "Error: $target already exists. Clean up first."
    # We exit here, but since the trap is active, it would delete the OLD dir.
    # To avoid that, we disable the trap before exiting:
    trap - EXIT
    exit 1
fi

echo "Starting copy to RAM..."

for file in "$dbdir/$db"/* ; do
    echo "Copying ${file##*/}..."
    if ! dd if="$file" of="$target/${file##*/}" \
         bs=4M conv=fdatasync iflag=nocache oflag=nocache \
         status=progress; then
        echo "ERROR: Copy failed!"
        exit 1 # This triggers the 'cleanup' function via the trap
    fi
done

echo "Database successfully loaded into RAM."

while IFS=$'\t' read -r sample_id fastq1 fastq2; do
    reads_arg="${fastq1}${fastq2:+ ${fastq2}}"
    kraken2 \
    --gzip-compressed --memory-mapping \
    --memory-mapping \
    --threads 16 \
    --db ${SHM_DB} \
    --output ${sample_id}_kraken.out \
    --report ${sample_id}_kraken.report \
    ${reads_arg}
done < kraken_batch_input.list

# When the script finishes here, 'cleanup' runs automatically.
```
The problem is that copying the krakendb securely to a RAM disk requires `coreutils`. It adds very little space to the overall image size and I think it will be a functionality that will be used given kraken2's `--memory-mapping` functionality.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
