### PR TITLE
Add virusdetect 2.0.0a0

### DIFF
--- a/recipes/virusdetect/LICENSE
+++ b/recipes/virusdetect/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 kentnf
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/recipes/virusdetect/meta.yaml
+++ b/recipes/virusdetect/meta.yaml
@@ -1,0 +1,49 @@
+{% set name = "virusdetect" %}
+{% set version = "2.0.0a0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/kentnf/VirusDetect/releases/download/v{{ version }}/virusdetect-{{ version }}.tar.gz
+  sha256: d741cbb5150adae0e61962f5d26c0fbecae11b10a0744c24a9558e22c3b9e4c6
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv
+
+requirements:
+  host:
+    - python >=3.10
+    - pip
+    - setuptools >=68
+    - wheel
+  run:
+    - python >=3.10
+    - bwa
+    - samtools
+    - blast
+    - hisat2
+    - spades
+    - velvet
+
+test:
+  commands:
+    - virusdetect --version
+    - virusdetect db path --target
+    - virusdetect tools check --strict
+    - python -c "import virusdetect; print(virusdetect.__version__)"
+    - python -c "import shutil; required = ['bwa', 'samtools', 'blastn', 'blastx', 'makeblastdb', 'hisat2', 'hisat2-build', 'spades.py', 'velveth', 'velvetg']; missing = [name for name in required if shutil.which(name) is None]; assert not missing, missing"
+
+about:
+  home: https://github.com/kentnf/VirusDetect
+  summary: Python rewrite of the VirusDetect plant virus discovery pipeline
+  license: MIT
+  license_file: LICENSE
+  dev_url: https://github.com/kentnf/VirusDetect
+
+extra:
+  recipe-maintainers:
+    - kentnf

--- a/recipes/virusdetect/meta.yaml
+++ b/recipes/virusdetect/meta.yaml
@@ -12,6 +12,8 @@ source:
 build:
   noarch: python
   number: 0
+  run_exports:
+    - {{ pin_subpackage(name|lower, max_pin="x") }}
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv
 
 requirements:


### PR DESCRIPTION
# Bioconda PR Draft

Title:

```text
Add virusdetect 2.0.0a0
```

Body:

```text
This PR adds a new Bioconda recipe for VirusDetect v2.

Summary:
- package: virusdetect
- version: 2.0.0a0
- source: https://github.com/kentnf/VirusDetect/releases/download/v2.0.0a0/virusdetect-2.0.0a0.tar.gz
- sha256: d741cbb5150adae0e61962f5d26c0fbecae11b10a0744c24a9558e22c3b9e4c6

Runtime dependencies:
- bwa
- samtools
- blast
- hisat2
- spades
- velvet

Notes:
- This is the Python rewrite line of VirusDetect.
- The packaged database is distributed separately from the code package and installed with `virusdetect db download`.
- `velvet` is included because the CLI exposes `--assembler velvet` as a supported alternate assembler backend.

Local validation performed:
- conda render recipes/virusdetect/meta.yaml --override-channels -c conda-forge -c bioconda
- conda build recipes/virusdetect/meta.yaml --override-channels -c conda-forge -c bioconda --no-anaconda-upload
```
