### PR TITLE
Fix covsnap description and add html_report import test

### DIFF
--- a/recipes/covsnap/meta.yaml
+++ b/recipes/covsnap/meta.yaml
@@ -38,6 +38,7 @@ test:
     - covsnap.cli
     - covsnap.engines
     - covsnap.annotation
+    - covsnap.html_report
   commands:
     - covsnap --version
     - covsnap --help
@@ -50,8 +51,8 @@ about:
   summary: Coverage inspector for targeted sequencing QC (hg38)
   description: |
     covsnap computes per-target and per-exon depth metrics from
-    BAM/CRAM files, producing a machine-readable raw TSV and a
-    human-readable interpreted report with PASS/FAIL classifications.
+    BAM/CRAM files, producing an interactive HTML report with
+    PASS/FAIL classifications and visual coverage summaries.
     Supports gene symbols, genomic regions, and BED files as input.
     Ships with a bundled GENCODE v44 hg38 gene index — no internet
     or GTF files required at runtime.


### PR DESCRIPTION
## Summary
- Update package description: TSV/Markdown → interactive HTML report (v0.2.0 switched to HTML-only output)
- Add `covsnap.html_report` to import tests