### PR TITLE
Update covsnap to 0.3.0

### DIFF
--- a/recipes/covsnap/meta.yaml
+++ b/recipes/covsnap/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "covsnap" %}
-{% set version = "0.2.0" %}
+{% set version = "0.3.0" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/enes-ak/covsnap/archive/v{{ version }}.tar.gz
-  sha256: 9b6cec9a324e4fb40fb09f1c8a897ea9ad18dba1632fb176daff6195cdf90cc7
+  sha256: f8cd4c37aedb42bf82143323f23982a2fb1ff03756f4cbdb4b8d3a8f5363ba12
 
 build:
   number: 0
@@ -38,6 +38,8 @@ test:
     - covsnap.cli
     - covsnap.engines
     - covsnap.annotation
+    - covsnap.html_report
+    - covsnap.gui
   commands:
     - covsnap --version
     - covsnap --help
@@ -50,11 +52,13 @@ about:
   summary: Coverage inspector for targeted sequencing QC (hg38)
   description: |
     covsnap computes per-target and per-exon depth metrics from
-    BAM/CRAM files, producing a machine-readable raw TSV and a
-    human-readable interpreted report with PASS/FAIL classifications.
-    Supports gene symbols, genomic regions, and BED files as input.
-    Ships with a bundled GENCODE v44 hg38 gene index — no internet
-    or GTF files required at runtime.
+    BAM/CRAM files, producing an interactive HTML report with
+    PASS/FAIL classifications and visual coverage summaries.
+    Includes a cross-platform graphical interface (Tkinter) and
+    supports gene symbols (single or comma-separated), genomic
+    regions, and BED files as input. Ships with a bundled GENCODE
+    v44 hg38 gene index — no internet or GTF files required at
+    runtime.
   dev_url: https://github.com/enes-ak/covsnap
   doc_url: https://github.com/enes-ak/covsnap/blob/main/README.md
 


### PR DESCRIPTION
## Summary
- Update covsnap from 0.2.0 to 0.3.0
- New sha256 for v0.3.0 tarball
- Updated description: interactive HTML report, Tkinter GUI, multi-gene support
- Added `covsnap.html_report` and `covsnap.gui` import tests

## Changes in v0.3.0
- Cross-platform Tkinter GUI (run `covsnap` with no arguments)
- Comma-separated multi-gene support (e.g. `BRCA1,TP53,ETFDH`)
- GUI status feedback during analysis
- Removed questionary dependency (replaced with built-in Tkinter)