### PR TITLE
Update get_mnv to 1.1.2

### DIFF
--- a/recipes/get_mnv/meta.yaml
+++ b/recipes/get_mnv/meta.yaml
@@ -23,6 +23,7 @@ build:
 
 requirements:
   build:
+    - {{ compiler('c') }}
     - {{ compiler('rust') }}
     - {{ stdlib('c') }}
     - pkg-config

--- a/recipes/get_mnv/meta.yaml
+++ b/recipes/get_mnv/meta.yaml
@@ -17,9 +17,7 @@ build:
     export LANG=C.UTF-8
     export LC_ALL=C.UTF-8
     export RUST_BACKTRACE=1
-    # Remove src-tauri from workspace (needs system GUI libs not available in conda)
-    sed -i 's/members = \[".", "src-tauri"\]/members = ["."]/' Cargo.toml
-    cargo install --no-track --verbose --root "${PREFIX}" --path .
+    cargo install --no-track --locked --verbose --root "${PREFIX}" --path . --bin get_mnv
   run_exports:
     - {{ pin_subpackage(name, max_pin="x") }}
 
@@ -52,8 +50,6 @@ extra:
   recipe-maintainers:
     - paururo
     - PathoGenOmics-Lab
-  skip-lints:
-    - compiler_needs_stdlib_c
   categories:
     - Genomics
     - Variant Analysis

--- a/recipes/get_mnv/meta.yaml
+++ b/recipes/get_mnv/meta.yaml
@@ -24,6 +24,7 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
+    - {{ stdlib('c') }}
     - {{ compiler('rust') }}
     - pkg-config
 

--- a/recipes/get_mnv/meta.yaml
+++ b/recipes/get_mnv/meta.yaml
@@ -27,7 +27,6 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('rust') }}
-    - {{ stdlib('c') }}
     - pkg-config
 
 test:
@@ -53,6 +52,8 @@ extra:
   recipe-maintainers:
     - paururo
     - PathoGenOmics-Lab
+  skip-lints:
+    - compiler_needs_stdlib_c
   categories:
     - Genomics
     - Variant Analysis

--- a/recipes/get_mnv/meta.yaml
+++ b/recipes/get_mnv/meta.yaml
@@ -17,7 +17,9 @@ build:
     export LANG=C.UTF-8
     export LC_ALL=C.UTF-8
     export RUST_BACKTRACE=1
-    cargo install --no-track --locked --verbose --root "${PREFIX}" --path .
+    # Remove src-tauri from workspace (needs system GUI libs not available in conda)
+    sed -i 's/members = \[".", "src-tauri"\]/members = ["."]/' Cargo.toml
+    cargo install --no-track --verbose --root "${PREFIX}" --path .
   run_exports:
     - {{ pin_subpackage(name, max_pin="x") }}
 

--- a/recipes/get_mnv/meta.yaml
+++ b/recipes/get_mnv/meta.yaml
@@ -24,6 +24,7 @@ build:
 requirements:
   build:
     - {{ compiler('rust') }}
+    - {{ stdlib('c') }}
     - pkg-config
 
 test:

--- a/recipes/get_mnv/meta.yaml
+++ b/recipes/get_mnv/meta.yaml
@@ -23,7 +23,6 @@ build:
 
 requirements:
   build:
-    - {{ compiler('c') }}
     - {{ compiler('rust') }}
     - pkg-config
 

--- a/recipes/get_mnv/meta.yaml
+++ b/recipes/get_mnv/meta.yaml
@@ -24,7 +24,6 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
-    - {{ stdlib('c') }}
     - {{ compiler('rust') }}
     - pkg-config
 
@@ -51,6 +50,8 @@ extra:
   recipe-maintainers:
     - paururo
     - PathoGenOmics-Lab
+  skip-lints:
+    - compiler_needs_stdlib_c
   categories:
     - Genomics
     - Variant Analysis

--- a/recipes/get_mnv/meta.yaml
+++ b/recipes/get_mnv/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "get_mnv" %}
-{% set version = "1.1.1" %}
-{% set sha256 = "4f20a5f169a4eae3c7eb934e2621b21d4464c9f24ae99f770f70b4edc1b40d6a" %}
+{% set version = "1.1.2" %}
+{% set sha256 = "dd64b4c54434e3ed17f220c95e0e16014a92d2868ffbb38a6152264a9b9283a0" %}
 
 package:
   name: "{{ name|lower }}"
@@ -48,6 +48,7 @@ extra:
     - linux-aarch64
     - osx-arm64
   recipe-maintainers:
+    - paururo
     - PathoGenOmics-Lab
   categories:
     - Genomics


### PR DESCRIPTION
## Changes

- Version: 1.1.1 → 1.1.2
- Added `paururo` to recipe-maintainers

### What's new in 1.1.2

- Honor GFF phase (column 8) for CDS features — fixes eukaryotic codon grouping ([#12](https://github.com/PathoGenOmics-Lab/get_MNV/issues/12))
- Transcript-aware amino acid numbering for multi-exon CDS
- Fix gene name extraction for eukaryotic GFF/GTF files (now shows `GNAQ` instead of `agat-cds-37838`)
- Support optional phase column in TSV gene annotation file
- Fix three latent bugs around CDS handling
- Documentation: note about multiple transcripts per gene producing multiple output lines

Full changelog: [PathoGenOmics-Lab/get_MNV@1.1.1...1.1.2](https://github.com/PathoGenOmics-Lab/get_MNV/compare/1.1.1...1.1.2)