### PR TITLE
Add ohe-rs: ultra-fast one-hot encoding for bioinformatics

### DIFF
--- a/recipes/ohe-rs/meta.yaml
+++ b/recipes/ohe-rs/meta.yaml
@@ -1,0 +1,58 @@
+{% set name = "ohe-rs" %}
+{% set version = "0.0.1" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/genpat-it/ohe-rs/archive/v{{ version }}.tar.gz
+  sha256: 9e06ab483d636a69dbc99f4def3cb22d0b0bc36f430499339e85275aff0f2a48
+
+build:
+  number: 0
+  script: |
+    maturin build --release --interpreter ${PYTHON}
+    ${PYTHON} -m pip install target/wheels/*.whl --no-deps --no-build-isolation -vv
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x.x") }}
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('rust') }}
+    - cargo-bundle-licenses
+  host:
+    - python
+    - pip
+    - maturin >=1.0,<2.0
+    - numpy
+  run:
+    - python
+    - numpy >=1.20
+    - scipy >=1.7
+
+test:
+  imports:
+    - ohe_rs
+  commands:
+    - python -c "from ohe_rs import encode_sparse; import numpy as np; v,i,p,k = encode_sparse(np.array([0,1,2,0], dtype=np.int64)); assert k == 3"
+
+about:
+  home: https://github.com/genpat-it/ohe-rs
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: Ultra-fast one-hot encoding for bioinformatics and ML, powered by Rust
+  description: |
+    ohe-rs is an ultra-fast one-hot encoding library with Python bindings,
+    built in Rust for maximum performance. Designed for cgMLST allele profiles
+    and large-scale categorical data in bioinformatics pipelines.
+    Features parallel encoding (rayon), sparse CSR output, multi-column
+    encoding, and optional CUDA GPU acceleration.
+  dev_url: https://github.com/genpat-it/ohe-rs
+  doc_url: https://github.com/genpat-it/ohe-rs
+
+extra:
+  recipe-maintainers:
+    - andreadlm

--- a/recipes/ohe-rs/meta.yaml
+++ b/recipes/ohe-rs/meta.yaml
@@ -20,6 +20,7 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
+    - {{ stdlib('c') }}
     - {{ compiler('rust') }}
     - cargo-bundle-licenses
   host:

--- a/recipes/ohe-rs/meta.yaml
+++ b/recipes/ohe-rs/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "ohe-rs" %}
-{% set version = "0.0.2" %}
+{% set version = "0.1.0" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/genpat-it/ohe-rs/archive/v{{ version }}.tar.gz
-  sha256: 0edc01a8a588501b1afeeb68bc6a18a1ef18abf58719b1069d75ce6c6b6346d5
+  sha256: 9f145cacc4f937cfc334736867a51c439708099065961be5ba13649d086d5496
 
 build:
   number: 0

--- a/recipes/ohe-rs/meta.yaml
+++ b/recipes/ohe-rs/meta.yaml
@@ -11,7 +11,9 @@ source:
 
 build:
   number: 0
-  script: ${PYTHON} -m pip install . --no-deps --no-build-isolation -vv
+  script:
+    - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --disable-pip-version-check -vv
+    - cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
   run_exports:
     - {{ pin_subpackage(name, max_pin="x.x") }}
 
@@ -20,6 +22,10 @@ requirements:
     - {{ compiler('c') }}
     - {{ stdlib('c') }}
     - {{ compiler('rust') }}
+    - python                              # [build_platform != target_platform]
+    - cross-python_{{ target_platform }}  # [build_platform != target_platform]
+    - crossenv                            # [build_platform != target_platform]
+    - maturin >=1.0,<2.0
     - cargo-bundle-licenses
   host:
     - python
@@ -41,17 +47,20 @@ about:
   home: https://github.com/genpat-it/ohe-rs
   license: MIT
   license_family: MIT
-  license_file: LICENSE
+  license_file:
+    - LICENSE
+    - THIRDPARTY.yml
   summary: Ultra-fast one-hot encoding for bioinformatics and ML, powered by Rust
   description: |
     ohe-rs is an ultra-fast one-hot encoding library with Python bindings,
     built in Rust for maximum performance. Designed for cgMLST allele profiles
     and large-scale categorical data in bioinformatics pipelines.
-    Features parallel encoding (rayon), sparse CSR output, multi-column
-    encoding, and optional CUDA GPU acceleration.
   dev_url: https://github.com/genpat-it/ohe-rs
   doc_url: https://github.com/genpat-it/ohe-rs
 
 extra:
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64
   recipe-maintainers:
     - andreadlm

--- a/recipes/ohe-rs/meta.yaml
+++ b/recipes/ohe-rs/meta.yaml
@@ -15,16 +15,18 @@ build:
     - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --disable-pip-version-check -vv
     - cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
   run_exports:
-    - {{ pin_subpackage(name, max_pin="x.x") }}
+    - {{ pin_subpackage(name, max_pin="x") }}
 
 requirements:
   build:
+    - {{ compiler('c') }}
+    - {{ stdlib('c') }}
     - {{ compiler('rust') }}
+    - cargo-bundle-licenses
     - python                              # [build_platform != target_platform]
     - cross-python_{{ target_platform }}  # [build_platform != target_platform]
     - crossenv                            # [build_platform != target_platform]
-    - maturin >=1.0,<2.0
-    - cargo-bundle-licenses
+    - maturin >=1.0,<2.0                  # [build_platform != target_platform]
   host:
     - python
     - pip

--- a/recipes/ohe-rs/meta.yaml
+++ b/recipes/ohe-rs/meta.yaml
@@ -14,8 +14,6 @@ build:
   script:
     - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --disable-pip-version-check -vv
     - cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
-  run_exports:
-    - {{ pin_subpackage(name, max_pin="x.x") }}
 
 requirements:
   build:

--- a/recipes/ohe-rs/meta.yaml
+++ b/recipes/ohe-rs/meta.yaml
@@ -19,8 +19,6 @@ build:
 
 requirements:
   build:
-    - {{ compiler('c') }}
-    - {{ stdlib('c') }}
     - {{ compiler('rust') }}
     - python                              # [build_platform != target_platform]
     - cross-python_{{ target_platform }}  # [build_platform != target_platform]

--- a/recipes/ohe-rs/meta.yaml
+++ b/recipes/ohe-rs/meta.yaml
@@ -11,9 +11,7 @@ source:
 
 build:
   number: 0
-  script: |
-    maturin build --release --interpreter ${PYTHON}
-    ${PYTHON} -m pip install target/wheels/*.whl --no-deps --no-build-isolation -vv
+  script: ${PYTHON} -m pip install . --no-deps --no-build-isolation -vv
   run_exports:
     - {{ pin_subpackage(name, max_pin="x.x") }}
 

--- a/recipes/ohe-rs/meta.yaml
+++ b/recipes/ohe-rs/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/genpat-it/ohe-rs/archive/v{{ version }}.tar.gz
-  sha256: a072e725dcddcfe63e4a541984371a833f616d34b4604fe9d4960f28d9e5e38d
+  sha256: 0edc01a8a588501b1afeeb68bc6a18a1ef18abf58719b1069d75ce6c6b6346d5
 
 build:
   number: 0

--- a/recipes/ohe-rs/meta.yaml
+++ b/recipes/ohe-rs/meta.yaml
@@ -14,6 +14,8 @@ build:
   script:
     - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --disable-pip-version-check -vv
     - cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x.x") }}
 
 requirements:
   build:
@@ -29,7 +31,6 @@ requirements:
     - python
     - pip
     - maturin >=1.0,<2.0
-    - numpy
   run:
     - python
     - numpy >=1.20

--- a/recipes/ohe-rs/meta.yaml
+++ b/recipes/ohe-rs/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "ohe-rs" %}
-{% set version = "0.0.1" %}
+{% set version = "0.0.2" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/genpat-it/ohe-rs/archive/v{{ version }}.tar.gz
-  sha256: 9e06ab483d636a69dbc99f4def3cb22d0b0bc36f430499339e85275aff0f2a48
+  sha256: a072e725dcddcfe63e4a541984371a833f616d34b4604fe9d4960f28d9e5e38d
 
 build:
   number: 0

--- a/recipes/ohe-rs/meta.yaml
+++ b/recipes/ohe-rs/meta.yaml
@@ -20,7 +20,6 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
-    - {{ stdlib('c') }}
     - {{ compiler('rust') }}
     - cargo-bundle-licenses
     - python                              # [build_platform != target_platform]
@@ -49,7 +48,7 @@ about:
   license_file:
     - LICENSE
     - THIRDPARTY.yml
-  summary: Ultra-fast one-hot encoding for bioinformatics and ML, powered by Rust
+  summary: "Ultra-fast one-hot encoding for bioinformatics and ML, powered by Rust."
   description: |
     ohe-rs is an ultra-fast one-hot encoding library with Python bindings,
     built in Rust for maximum performance. Designed for cgMLST allele profiles
@@ -63,3 +62,5 @@ extra:
     - osx-arm64
   recipe-maintainers:
     - andreadlm
+  skip-lints:
+    - compiler_needs_stdlib_c


### PR DESCRIPTION
## Summary

Add [ohe-rs](https://github.com/genpat-it/ohe-rs), an ultra-fast one-hot encoding library for bioinformatics and ML.

- **Language:** Rust core with Python bindings (PyO3/maturin)
- **Performance:** 15-35x faster than scikit-learn OneHotEncoder
- **Use case:** cgMLST allele profiles, large-scale categorical data
- **Features:** parallel encoding (rayon), sparse CSR output, multi-column encoding, optional CUDA GPU support

## Tests

```python
from ohe_rs import encode_sparse
import numpy as np
v, i, p, k = encode_sparse(np.array([0, 1, 2, 0], dtype=np.int64))
assert k == 3
```