### PR TITLE
Add bacprune v0.9.0

### DIFF
--- a/recipes/bacprune/meta.yaml
+++ b/recipes/bacprune/meta.yaml
@@ -17,9 +17,7 @@ build:
 requirements:
   build:
     - {{ compiler('rust') }}
-    - {{ compiler('c') }}
-    - {{ stdlib('c') }}
-
+    
 test:
   commands:
     - bacprune --help

--- a/recipes/bacprune/meta.yaml
+++ b/recipes/bacprune/meta.yaml
@@ -17,7 +17,8 @@ build:
 requirements:
   build:
     - {{ compiler('rust') }}
-    - {{ compiler('c') }}       # needed by some Rust crates on Linux
+    - {{ compiler('c') }}
+    - {{ stdlib('c') }}
 
 test:
   commands:

--- a/recipes/bacprune/meta.yaml
+++ b/recipes/bacprune/meta.yaml
@@ -17,6 +17,7 @@ build:
 requirements:
   build:
     - {{ compiler('rust') }}
+    - {{ stdlib('c') }}
     
 test:
   commands:

--- a/recipes/bacprune/meta.yaml
+++ b/recipes/bacprune/meta.yaml
@@ -1,0 +1,47 @@
+{% set version = "0.9.0" %}
+
+package:
+  name: bacprune
+  version: {{ version }}
+
+source:
+  url: https://github.com/bacpop/BacPrune-Rust/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: f81039b4e666cf8e8787490b55031ba73a5d9a4192af58fdb4c7da74a6a7dab8
+
+build:
+  number: 0
+  script: cargo install --locked --root "${PREFIX}" --path .
+  run_exports:
+    - {{ pin_subpackage('bacprune', max_pin="x.x") }}
+
+requirements:
+  build:
+    - {{ compiler('rust') }}
+    - {{ compiler('c') }}       # needed by some Rust crates on Linux
+
+test:
+  commands:
+    - bacprune --help
+    - bacprune --version | grep -q "{{ version }}"
+
+about:
+  home: https://github.com/bacpop/BacPrune-Rust
+  license: MIT
+  license_file: LICENSE
+  summary: Fast LD pruning of haploid genotype matrices
+  description: |
+    BacPrune-Rust prunes a haploid genotype matrix by linkage disequilibrium
+    (LD) threshold. Three modes are available:
+
+      --r       Greedy pruning by r² (Pearson r-squared) threshold (default).
+      --dprime  Greedy pruning by |D'| threshold.
+      --dedup   Hash-based exact-duplicate removal only (O(n·v), no pairwise
+                LD calculation).
+
+    All modes first remove exact duplicate variant columns via hashing before
+    any threshold-based pruning.  Output includes the pruned genotype matrix,
+    a pruning summary, and a per-variant correlation-direction file.
+
+extra:
+  recipe-maintainers:
+    - qtoussaint

--- a/recipes/bacprune/meta.yaml
+++ b/recipes/bacprune/meta.yaml
@@ -10,14 +10,13 @@ source:
 
 build:
   number: 0
-  script: cargo install --locked --root "${PREFIX}" --path .
+  script: cargo install --locked --root "${PREFIX}" --path . --no-track
   run_exports:
     - {{ pin_subpackage('bacprune', max_pin="x.x") }}
 
 requirements:
   build:
     - {{ compiler('rust') }}
-    - {{ stdlib('c') }}
     
 test:
   commands:
@@ -45,3 +44,8 @@ about:
 extra:
   recipe-maintainers:
     - qtoussaint
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64
+  skip-lints:
+    - compiler_needs_stdlib_c


### PR DESCRIPTION
Add bacprune v0.9.0 to bioconda

BacPrune-Rust prunes a haploid genotype matrix by linkage disequilibrium (LD) threshold. v0.9.0 supports pruning by recombination as measured by D' score, r^2 (default), and pruning only identical variants (by hash). 