### PR TITLE
Update BINge to v1.1.1

### DIFF
--- a/recipes/binge/meta.yaml
+++ b/recipes/binge/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "binge" %}
-{% set version = "1.1.0" %}
+{% set version = "1.1.1" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/zkstewart/BINge/archive/v{{ version }}.tar.gz
-  sha256: 9d9d3fabad6f8dfced0158389f143b4beade86fc56c61356575bbd5eafe6d954
+  sha256: 6f39959179f8e0ed44ef12e2ad24c3aa1103b49657eb0509bc90ca95fae8c988
 
 build:
   number: 0


### PR DESCRIPTION
Update of BINge from v1.1.0 to v1.1.1

Primary changes are minor bug fixes for handling `.gz` files.