### PR TITLE
Add recipe for dist2mst v0.0.2

### DIFF
--- a/recipes/dist2mst/meta.yaml
+++ b/recipes/dist2mst/meta.yaml
@@ -1,0 +1,45 @@
+{% set name = "dist2mst" %}
+{% set version = "0.0.2" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/genpat-it/{{ name }}/archive/v{{ version }}.tar.gz
+  sha256: cccc146e83bf7d38cb332a7591be335df9caed3539bd7a3c32635ad21d7d78e2
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x.x") }}
+
+requirements:
+  host:
+    - python >=3.7
+    - pip
+    - setuptools
+  run:
+    - python >=3.7
+    - numba >=0.56
+    - numpy >=1.23
+    - pandas >=1.5
+    - tqdm >=4.64
+
+test:
+  commands:
+    - dist2mst --help || python -m dist2mst --help
+
+about:
+  home: https://github.com/genpat-it/dist2mst
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: High-performance Minimum Spanning Tree construction from distance matrices with Numba acceleration
+  dev_url: https://github.com/genpat-it/dist2mst
+
+extra:
+  recipe-maintainers:
+    - andreaderuvo

--- a/recipes/dist2mst/meta.yaml
+++ b/recipes/dist2mst/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/genpat-it/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: cccc146e83bf7d38cb332a7591be335df9caed3539bd7a3c32635ad21d7d78e2
+  sha256: f216894004e532626d7ab9a136e173e930d2205d1243d2ce1dcb80e716032811
 
 build:
   number: 0

--- a/recipes/dist2mst/meta.yaml
+++ b/recipes/dist2mst/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/genpat-it/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: f216894004e532626d7ab9a136e173e930d2205d1243d2ce1dcb80e716032811
+  sha256: 82aabc9d4f8c88c05a52519ad060e0a4e93bd569ef25a0ce0202c3b2498bfd6f
 
 build:
   number: 0


### PR DESCRIPTION
## Summary

Add recipe for **dist2mst** — a high-performance tool for constructing Minimum Spanning Trees (MST) from symmetric distance matrices using Numba JIT compilation.

- **Home:** https://github.com/genpat-it/dist2mst
- **License:** MIT
- **Version:** 0.0.2
- **noarch: python**

## Tests

- `dist2mst --help`

## Links

- [GitHub repository](https://github.com/genpat-it/dist2mst)
- [Release v0.0.2](https://github.com/genpat-it/dist2mst/releases/tag/v0.0.2)