### PR TITLE
Update rastair to 2.1.1

### DIFF
--- a/recipes/rastair/meta.yaml
+++ b/recipes/rastair/meta.yaml
@@ -2,7 +2,7 @@
 {% set version = "2.1.1" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:
@@ -19,7 +19,6 @@ requirements:
   build:
     - {{ compiler("c") }}
     - {{ compiler("cxx") }}
-    - {{ stdlib("c") }}
     - {{ compiler("rust") }}
     - make
     - cmake
@@ -57,9 +56,9 @@ test:
     - test -f "${PREFIX}/share/rastair/scripts/QC_report.Rmd"
 
 about:
-  home: https://docs.rastair.com/
+  home: https://docs.rastair.com
   dev_url: https://bitbucket.org/bsblabludwig/rastair
-  summary: Fast and flexible extraction of methylation information from BAM files
+  summary: "Fast and flexible extraction of methylation information from BAM files."
   license: LicenseRef-NonCommercial
   license_file:
     - LICENSE.txt
@@ -71,3 +70,5 @@ extra:
     - osx-arm64
   recipe-maintainers:
     - ze97286
+  skip-lints:
+    - compiler_needs_stdlib_c

--- a/recipes/rastair/meta.yaml
+++ b/recipes/rastair/meta.yaml
@@ -19,7 +19,6 @@ requirements:
   build:
     - {{ compiler("c") }}
     - {{ compiler("cxx") }}
-    - {{ stdlib("c") }}
     - {{ compiler("rust") }}
     - make
     - cmake

--- a/recipes/rastair/meta.yaml
+++ b/recipes/rastair/meta.yaml
@@ -19,6 +19,7 @@ requirements:
   build:
     - {{ compiler("c") }}
     - {{ compiler("cxx") }}
+    - {{ stdlib("c") }}
     - {{ compiler("rust") }}
     - make
     - cmake

--- a/recipes/rastair/meta.yaml
+++ b/recipes/rastair/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "rastair" %}
-{% set version = "2.1.0" %}
+{% set version = "2.1.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://s3.eu-west-2.amazonaws.com/com.rastair.releases/build/release-v{{ version }}/rastair-{{ version }}-vendored.tar.gz
-  sha256: e340de77407ad3d666159925c957ec562bbb1ee9cb75ee32547cc5b4f60e734b
+  sha256: 53e4b154e9fdff21ee684e0717079588b5a818bf399adf7af24998837169a90f
 
 build:
   number: 0


### PR DESCRIPTION
Title: Update rastair to 2.1.1                                                                                                           
                                                                                                                                         
  Body:                                                                                                                                  
  ## Summary
  - Update rastair from 2.1.0 to 2.1.1
  - Bug fix release: fixes M-bias read orientation flipping and parameter parsing in the `mbias` subcommand                                
  - No dependency changes   