### PR TITLE
Bump r-shinyngs to 2.4.0

### DIFF
--- a/recipes/r-shinyngs/meta.yaml
+++ b/recipes/r-shinyngs/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = '2.3.0' %}
+{% set version = '2.4.0' %}
 {% set d3heatmap_version = '0.6.1.2' %}
 
 package:
@@ -7,7 +7,7 @@ package:
 
 source:
   - url: https://github.com/pinin4fjords/shinyngs/archive/refs/tags/v{{ version }}.tar.gz
-    sha256: "768a7d60240b42e24e705d5b5ced019176d69728cf208ffe0dbc5767984087f8"
+    sha256: "333ef7b9f60a5afa294baf235ce246d2f116e71a73f680d028a7b0966a8a40e3"
     folder: shinyngs
   - url: https://github.com/cran/d3heatmap/archive/refs/tags/{{ d3heatmap_version }}.tar.gz 
     sha256: "bda213c4d335b199c38a48cb8e60027c929a8ba8ef6e14dc7de692967777c25a"
@@ -54,6 +54,7 @@ requirements:
     - r-plotly  >=4.3.4
     - r-plyr
     - r-rcolorbrewer
+    - r-reformulas
     - r-reshape2
     - r-png
     - r-rsconnect
@@ -91,6 +92,7 @@ requirements:
     - r-plyr
     - r-png
     - r-rcolorbrewer
+    - r-reformulas
     - r-reshape2
     - r-rsconnect
     - r-scales >=0.2.5


### PR DESCRIPTION
## Summary
- Bump r-shinyngs from 2.3.0 to 2.4.0
- Add `r-reformulas` dependency (new in this release)

Upstream release: https://github.com/pinin4fjords/shinyngs/releases/tag/v2.4.0