### PR TITLE
Add cuteSV-Trio v1.0.0

### DIFF
--- a/recipes/cutesv-trio/meta.yaml
+++ b/recipes/cutesv-trio/meta.yaml
@@ -1,0 +1,47 @@
+{% set version = "1.0.0" %}
+
+package:
+  name: cutesv-trio
+  version: {{ version }}
+
+source:
+  url: https://github.com/XLeeHIT/cuteSV-Trio/archive/refs/tags/v1.0.0.tar.gz
+  sha256: 56acf0b09c6ff3637099ec9a2e3abf2d3a7855ab73054a36c7b47fd325e526da
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install --no-deps --no-build-isolation --no-cache-dir -vvv .
+  run_exports:
+    - {{ pin_subpackage("cutesv-trio", max_pin="x") }}
+
+requirements:
+  host:
+    - pip
+    - python >=3
+    - setuptools
+  run:
+    - biopython
+    - cigar
+    - numpy
+    - pysam >=0.15.0
+    - python >=3
+    - pyvcf
+    - scikit-learn
+    - scipy
+
+test:
+  commands:
+    - cuteSVTrio -h
+
+about:
+  home: 'https://github.com/XLeeHIT/cuteSV-Trio'
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: "cuteSV-Trio: Haplotype-Resolved and De Novo Structural Variant Detection from Low-Coverage Long-Read Family Trios data"
+  dev_url: 'https://github.com/XLeeHIT/cuteSV-Trio'
+
+extra:
+  recipe-maintainers:
+    - XLeeHIT


### PR DESCRIPTION
This PR adds a new recipe for cuteSV-Trio(v1.0.0), a Haplotype-Resolved and De Novo Structural Variant Detection from Low-Coverage Long-Read Family Trios data