### PR TITLE
Update covsnap to 0.4.0

### DIFF
--- a/recipes/covsnap/meta.yaml
+++ b/recipes/covsnap/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "covsnap" %}
-{% set version = "0.3.0" %}
+{% set version = "0.4.0" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/enes-ak/covsnap/archive/v{{ version }}.tar.gz
-  sha256: f8cd4c37aedb42bf82143323f23982a2fb1ff03756f4cbdb4b8d3a8f5363ba12
+  sha256: 95233c74278b408b5f52d9ee58f5af2cd5fc88674056ea8a876c2a4b915ef305
 
 build:
   number: 0


### PR DESCRIPTION
Bumps `covsnap` from 0.3.0 to 0.4.0.

## Release highlights
- New **pysam** depth engine (~92x faster than samtools for typical targets)
- Parallel exon analysis; full-gene depth pass skipped in exon-only mode
- HTML report: exon bars now show mean depth instead of %≥20x
- New `--exon-only` flag
- GUI surfaces actual underlying error messages

## Links
- Release: https://github.com/enes-ak/covsnap/releases/tag/v0.4.0
- PyPI: https://pypi.org/project/covsnap/0.4.0/
- Source sha256: `95233c74278b408b5f52d9ee58f5af2cd5fc88674056ea8a876c2a4b915ef305`

No dependency changes vs 0.3.0.