### PR TITLE
Update rnaframework PERL5LIB in conda activate/deactivate hooks

### DIFF
--- a/recipes/rnaframework/build.sh
+++ b/recipes/rnaframework/build.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 mkdir -p "${PREFIX}/share/rnaframework/lib"
 mkdir -p "${PREFIX}/bin"
+mkdir -p "${PREFIX}/etc/conda/activate.d"
+mkdir -p "${PREFIX}/etc/conda/deactivate.d"
 
 export DATAPATH="${PREFIX}/share/rnastructure/data_tables/"
 
@@ -22,5 +24,26 @@ for script in rf-*; do
         echo "WARNING: expected script '${script}' not found in source tree" >&2
     fi
 done
+
+cat > "${PREFIX}/etc/conda/activate.d/${PKG_NAME}_perl5lib.sh" <<'EOF'
+if [ "${PERL5LIB+x}" = x ]; then
+    export _RF_OLD_PERL5LIB="${PERL5LIB}"
+    export _RF_HAD_PERL5LIB=1
+else
+    unset _RF_OLD_PERL5LIB
+    export _RF_HAD_PERL5LIB=0
+fi
+export PERL5LIB="${CONDA_PREFIX}/share/rnaframework/lib${PERL5LIB:+:${PERL5LIB}}"
+EOF
+
+cat > "${PREFIX}/etc/conda/deactivate.d/${PKG_NAME}_perl5lib.sh" <<'EOF'
+if [ "${_RF_HAD_PERL5LIB:-0}" = 1 ]; then
+    export PERL5LIB="${_RF_OLD_PERL5LIB}"
+else
+    unset PERL5LIB
+fi
+unset _RF_OLD_PERL5LIB
+unset _RF_HAD_PERL5LIB
+EOF
 
 echo "RNAFramework ${PKG_VERSION} installed successfully."

--- a/recipes/rnaframework/build.sh
+++ b/recipes/rnaframework/build.sh
@@ -26,24 +26,21 @@ for script in rf-*; do
 done
 
 cat > "${PREFIX}/etc/conda/activate.d/${PKG_NAME}_perl5lib.sh" <<'EOF'
-if [ "${PERL5LIB+x}" = x ]; then
-    export _RF_OLD_PERL5LIB="${PERL5LIB}"
-    export _RF_HAD_PERL5LIB=1
-else
-    unset _RF_OLD_PERL5LIB
-    export _RF_HAD_PERL5LIB=0
-fi
+# The `use lib` injected into rf-* scripts only sets @INC for the top-level process.
+# PERL5LIB is needed so child Perl processes (system/backticks) can also find rnaframework modules.
 export PERL5LIB="${CONDA_PREFIX}/share/rnaframework/lib${PERL5LIB:+:${PERL5LIB}}"
 EOF
 
 cat > "${PREFIX}/etc/conda/deactivate.d/${PKG_NAME}_perl5lib.sh" <<'EOF'
-if [ "${_RF_HAD_PERL5LIB:-0}" = 1 ]; then
-    export PERL5LIB="${_RF_OLD_PERL5LIB}"
-else
-    unset PERL5LIB
+_rf_lib="${CONDA_PREFIX}/share/rnaframework/lib"
+if [ -n "${PERL5LIB:-}" ]; then
+    PERL5LIB=":${PERL5LIB}:"
+    PERL5LIB="${PERL5LIB//:${_rf_lib}:/:}"
+    PERL5LIB="${PERL5LIB#:}"
+    PERL5LIB="${PERL5LIB%:}"
+    [ -z "${PERL5LIB}" ] && unset PERL5LIB || export PERL5LIB
 fi
-unset _RF_OLD_PERL5LIB
-unset _RF_HAD_PERL5LIB
+unset _rf_lib
 EOF
 
 echo "RNAFramework ${PKG_VERSION} installed successfully."

--- a/recipes/rnaframework/meta.yaml
+++ b/recipes/rnaframework/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 81f89568fe34ae50cd9986afcda590bb2ca02e19d031d683c265dc8cbd7a86a1
 
 build:
-  number: 1
+  number: 2
   noarch: generic
   run_exports:
     - {{ pin_subpackage('rnaframework', max_pin="x") }}
@@ -35,6 +35,9 @@ requirements:
 test:
   commands:
     - grep -Fq "use lib \"${PREFIX}/share/rnaframework/lib\";" ${PREFIX}/share/rnaframework/rf-count
+    - grep -Fq 'export PERL5LIB="${CONDA_PREFIX}/share/rnaframework/lib${PERL5LIB:+:${PERL5LIB}}"' ${PREFIX}/etc/conda/activate.d/rnaframework_perl5lib.sh
+    - bash -c 'unset PERL5LIB; source "${PREFIX}/etc/conda/activate.d/rnaframework_perl5lib.sh"; [[ "${PERL5LIB}" == "${PREFIX}/share/rnaframework/lib" ]]; source "${PREFIX}/etc/conda/deactivate.d/rnaframework_perl5lib.sh"; [[ -z "${PERL5LIB+x}" ]]'
+    - bash -c 'export PERL5LIB="existing"; source "${PREFIX}/etc/conda/activate.d/rnaframework_perl5lib.sh"; [[ "${PERL5LIB}" == "${PREFIX}/share/rnaframework/lib:existing" ]]; source "${PREFIX}/etc/conda/deactivate.d/rnaframework_perl5lib.sh"; [[ "${PERL5LIB}" == "existing" ]]'
     - PERL5LIB= rf-map -h 2>&1 | grep -qi "usage\|rf-map\|options"
     - PERL5LIB= rf-count -h 2>&1 | grep -qi "usage\|rf-count\|options"
     - PERL5LIB= rf-norm -h 2>&1 | grep -qi "usage\|rf-norm\|options"


### PR DESCRIPTION
Adds activate.d/deactivate.d scripts to set PERL5LIB on conda activation, fixing deployment in Galaxy and Snakemake environments where the environment may not be fully activated interactively. Bumps build number to 2.