### PR TITLE
Add kleboscope v1.0.0 and MLST data package

### DIFF
--- a/recipes/kleboscope-mlst-data/build.sh
+++ b/recipes/kleboscope-mlst-data/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+DEST="$SP_DIR/kleboscope/modules/kleb_mlst_module"
+mkdir -p "$DEST"
+cp -r $SRC_DIR/kleb_mlst_data/* "$DEST/"

--- a/recipes/kleboscope-mlst-data/meta.yaml
+++ b/recipes/kleboscope-mlst-data/meta.yaml
@@ -1,0 +1,28 @@
+{% set version = "1.0.0" %}
+
+package:
+  name: kleboscope-mlst-data
+  version: {{ version }}
+
+source:
+  url: https://github.com/bbeckley-hub/Kleboscope/releases/download/v{{ version }}-data/kleb_mlst_data-v{{ version }}.tar.gz
+  sha256: 069603c1d5cbd09f4307abf0184b861ed5b5583b1e499b3291cfd3381a888113
+
+build:
+  noarch: python
+  number: 0
+  run_exports:
+    - {{ pin_subpackage('kleboscope-mlst-data', max_pin="x") }}
+
+requirements:
+  run:
+    - python
+
+test:
+  commands:
+    - test -f $SP_DIR/kleboscope/modules/kleb_mlst_module/db/scheme_species_map.tab
+
+about:
+  home: https://github.com/bbeckley-hub/Kleboscope
+  license: MIT
+  summary: 'MLST typing database for Kleboscope (K. pneumoniae)'

--- a/recipes/kleboscope/meta.yaml
+++ b/recipes/kleboscope/meta.yaml
@@ -12,6 +12,8 @@ build:
   noarch: python
   number: 0
   script: "{{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vvv"
+  run_exports:
+    - {{ pin_subpackage('kleboscope', max_pin="x") }}
 
 requirements:
   host:

--- a/recipes/kleboscope/meta.yaml
+++ b/recipes/kleboscope/meta.yaml
@@ -1,0 +1,68 @@
+{% set version = "1.0.0" %}
+
+package:
+  name: kleboscope
+  version: {{ version }}
+
+source:
+  url: https://github.com/bbeckley-hub/Kleboscope/archive/v{{ version }}.tar.gz
+  sha256: 944f4e33a463b56876b063e225db94ca5ffa240d39dca89704663e574414213f
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vvv"
+
+requirements:
+  host:
+    - python >=3.9
+    - pip
+    - setuptools
+  run:
+    - python >=3.9
+    - pandas >=1.5.0
+    - biopython >=1.85
+    - psutil >=5.9.0
+    - requests >=2.28.0
+    - tqdm >=4.64.0
+    - click >=8.0.0
+    - kaptive >=3.1.0
+    - beautifulsoup4 >=4.11.0
+    - lxml >=4.9.0
+    - matplotlib-base >=3.5.0
+    - seaborn >=0.12.0
+    - scipy >=1.10.1
+    - plotly >=5.10.0
+    - abricate >=1.2.0
+    - perl
+    - any2fasta
+    - blast >=2.13.0
+    - perl-moo
+    - perl-list-moreutils
+    - perl-json
+    - perl-lwp-protocol-https
+    - perl-path-tiny
+    - perl-data-dumper
+    - perl-getopt-long
+    - perl-file-which
+    # Data package
+    - kleboscope-mlst-data ==1.0.0
+
+test:
+  commands:
+    - kleboscope --help
+
+about:
+  home: https://github.com/bbeckley-hub/Kleboscope
+  license: MIT
+  license_file: LICENSE
+  summary: 'Kleboscope: Comprehensive K. pneumoniae genomic typing pipeline'
+  description: |
+    Kleboscope is a complete, automated genomic analysis pipeline for Klebsiella pneumoniae,
+    featuring parallel execution for rapid processing of bacterial genomes...
+  doc_url: https://github.com/bbeckley-hub/Kleboscope
+  dev_url: https://github.com/bbeckley-hub/Kleboscope
+
+extra:
+  recipe-maintainers:
+    - bbeckley-hub

--- a/recipes/staphscope-mlst-data/build.sh
+++ b/recipes/staphscope-mlst-data/build.sh
@@ -1,9 +1,20 @@
 #!/bin/bash
 set -e
 
-# Destination directory for mlst_module
-DEST="$PREFIX/share/staphscope/modules/mlst_module"
-mkdir -p "$DEST"
+echo "=== Debug: SRC_DIR = $SRC_DIR"
+ls -la $SRC_DIR
 
-# Copy all contents from SRC_DIR (these are the mlst_module files) into DEST
-cp -r $SRC_DIR/* "$DEST/"
+DEST="$SP_DIR/staphscope/modules/mlst_module"
+mkdir -p "$DEST"
+echo "=== Debug: DEST = $DEST"
+
+if [ -d "$SRC_DIR/mlst_module" ]; then
+    echo "=== Found mlst_module directory, copying its contents"
+    cp -rv "$SRC_DIR/mlst_module/." "$DEST/"
+else
+    echo "=== No mlst_module directory, copying all contents"
+    cp -rv "$SRC_DIR/." "$DEST/"
+fi
+
+echo "=== Debug: Final contents of $DEST"
+ls -la "$DEST"

--- a/recipes/staphscope-mlst-data/meta.yaml
+++ b/recipes/staphscope-mlst-data/meta.yaml
@@ -10,13 +10,13 @@ source:
 
 build:
   noarch: generic
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage('staphscope-mlst-data', max_pin="x") }}
 
 test:
   commands:
-    - test -f $PREFIX/share/staphscope/modules/mlst_module/mlst_module.py
+    - test -n "$(find $PREFIX -name mlst_module.py -print -quit)"
 
 about:
   home: https://github.com/bbeckley-hub/staphscope-typing-tool

--- a/recipes/staphscope-sccmec-data/build.sh
+++ b/recipes/staphscope-sccmec-data/build.sh
@@ -1,10 +1,20 @@
 #!/bin/bash
 set -e
 
-# Create the destination database folder (tool expects a 'database' subdirectory)
-DEST="$PREFIX/share/staphscope/modules/sccmec_module/database"
-mkdir -p "$DEST"
+echo "=== Debug: SRC_DIR = $SRC_DIR"
+ls -la $SRC_DIR
 
-# Copy all contents from SRC_DIR into DEST
-# (The tarball contains the database files directly)
-cp -r $SRC_DIR/* "$DEST/"
+DEST="$SP_DIR/staphscope/modules/sccmec_module/database"
+mkdir -p "$DEST"
+echo "=== Debug: DEST = $DEST"
+
+if [ -d "$SRC_DIR/database" ]; then
+    echo "=== Found database directory, copying its contents"
+    cp -rv "$SRC_DIR/database/." "$DEST/"
+else
+    echo "=== No database directory, copying all contents"
+    cp -rv "$SRC_DIR/." "$DEST/"
+fi
+
+echo "=== Debug: Final contents of $DEST"
+ls -la "$DEST"

--- a/recipes/staphscope-sccmec-data/meta.yaml
+++ b/recipes/staphscope-sccmec-data/meta.yaml
@@ -10,13 +10,13 @@ source:
 
 build:
   noarch: generic
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage('staphscope-sccmec-data', max_pin="x") }}
 
 test:
   commands:
-    - test -f $PREFIX/share/staphscope/modules/sccmec_module/database/mec_database_20171117.fasta
+    - test -n "$(find $PREFIX -name mec_database_20171117.fasta -print -quit)"
 
 about:
   home: https://github.com/bbeckley-hub/staphscope-typing-tool

--- a/recipes/staphscope/meta.yaml
+++ b/recipes/staphscope/meta.yaml
@@ -11,10 +11,8 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: "{{ PYTHON }} -m pip install . --no-deps --no-build-isolation --no-cache-dir -vvv"
-  entry_points:
-    - staphscope = staphscope.staphscope:main
   run_exports:
     - {{ pin_subpackage(name, max_pin="x") }}
 


### PR DESCRIPTION
This PR adds kleboscope (v1.0.0), a complete genomic analysis pipeline for Klebsiella pneumoniae, along with its required MLST database package.

    kleboscope: Python‑based pipeline integrating MLST, K/O locus typing (Kaptive), AMR (AMRfinderPlus + ABRicate), virulence, plasmid profiling, quality control, and interactive HTML reports.

    kleboscope-mlst-data: MLST typing database (Pasteur scheme) versioned with the tool.

Recipe details:

    Main package uses noarch: python and installs via pip.

    Data package uses noarch: python and includes python as a run dependency to ensure $SP_DIR resolves correctly at install time.

    Database files are bundled as a separate Conda package.

    Tests: kleboscope --help for the main tool, and a file existence check for the MLST database.

All dependencies are from conda‑forge or bioconda. Local builds and tests pass on Linux.

Please review and merge.