### PR TITLE
Add kleboscope v1.0.0 and MLST data package

### DIFF
--- a/recipes/kleboscope-mlst-data/build.sh
+++ b/recipes/kleboscope-mlst-data/build.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 set -e
 
+cd "$SRC_DIR"
+
+# If there is exactly one subdirectory, step into it
+subdir=$(find . -maxdepth 1 -type d ! -name . | head -1)
+if [ -n "$subdir" ]; then
+    cd "$subdir"
+fi
+
 DEST="$SP_DIR/kleboscope/modules/kleb_mlst_module"
 mkdir -p "$DEST"
-cp -r $SRC_DIR/kleb_mlst_data/* "$DEST/"
+cp -r ./* "$DEST/"

--- a/recipes/kleboscope-mlst-data/build.sh
+++ b/recipes/kleboscope-mlst-data/build.sh
@@ -1,25 +1,13 @@
 #!/bin/bash
 set -e
 
-echo "=== Debug: SRC_DIR = $SRC_DIR"
-ls -la $SRC_DIR
-
 cd "$SRC_DIR"
-
-if [ $(ls -1 | wc -l) -eq 1 ] && [ -d "$(ls -1)" ]; then
-    subdir=$(ls -1)
-    echo "=== Entering subdirectory: $subdir"
-    cd "$subdir"
+DATA_DIR=$(find . -maxdepth 2 -type d -name "db" -exec dirname {} \; | head -1)
+if [ -z "$DATA_DIR" ]; then
+    echo "ERROR: Could not find the data directory (containing db/)"
+    exit 1
 fi
 
-echo "=== Current directory contents:"
-ls -la
-
 DEST="$SP_DIR/kleboscope/modules/kleb_mlst_module"
-echo "=== Destination: $DEST"
 mkdir -p "$DEST"
-
-cp -rv ./* "$DEST/"
-
-echo "=== Final contents of DEST:"
-ls -la "$DEST"
+cp -r "$DATA_DIR"/* "$DEST/"

--- a/recipes/kleboscope-mlst-data/build.sh
+++ b/recipes/kleboscope-mlst-data/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+DEST="$SP_DIR/kleboscope/modules/kleb_mlst_module"
+mkdir -p "$DEST"
+cp -r $SRC_DIR/kleb_mlst_data/* "$DEST/"

--- a/recipes/kleboscope-mlst-data/build.sh
+++ b/recipes/kleboscope-mlst-data/build.sh
@@ -1,14 +1,25 @@
 #!/bin/bash
 set -e
 
+echo "=== Debug: SRC_DIR = $SRC_DIR"
+ls -la $SRC_DIR
+
 cd "$SRC_DIR"
 
-# If there is exactly one subdirectory, step into it
-subdir=$(find . -maxdepth 1 -type d ! -name . | head -1)
-if [ -n "$subdir" ]; then
+if [ $(ls -1 | wc -l) -eq 1 ] && [ -d "$(ls -1)" ]; then
+    subdir=$(ls -1)
+    echo "=== Entering subdirectory: $subdir"
     cd "$subdir"
 fi
 
+echo "=== Current directory contents:"
+ls -la
+
 DEST="$SP_DIR/kleboscope/modules/kleb_mlst_module"
+echo "=== Destination: $DEST"
 mkdir -p "$DEST"
-cp -r ./* "$DEST/"
+
+cp -rv ./* "$DEST/"
+
+echo "=== Final contents of DEST:"
+ls -la "$DEST"

--- a/recipes/kleboscope-mlst-data/meta.yaml
+++ b/recipes/kleboscope-mlst-data/meta.yaml
@@ -1,0 +1,28 @@
+{% set version = "1.0.0" %}
+
+package:
+  name: kleboscope-mlst-data
+  version: {{ version }}
+
+source:
+  url: https://github.com/bbeckley-hub/Kleboscope/releases/download/v{{ version }}-data/kleb_mlst_data-v{{ version }}.tar.gz
+  sha256: 069603c1d5cbd09f4307abf0184b861ed5b5583b1e499b3291cfd3381a888113
+
+build:
+  noarch: python
+  number: 0
+  run_exports:
+    - {{ pin_subpackage('kleboscope-mlst-data', max_pin="x") }}
+
+requirements:
+  run:
+    - python
+
+test:
+  commands:
+    - test -f $SP_DIR/kleboscope/modules/kleb_mlst_module/db/scheme_species_map.tab
+
+about:
+  home: https://github.com/bbeckley-hub/Kleboscope
+  license: MIT
+  summary: 'MLST typing database for Kleboscope (K. pneumoniae)'

--- a/recipes/kleboscope-mlst-data/meta.yaml
+++ b/recipes/kleboscope-mlst-data/meta.yaml
@@ -20,7 +20,7 @@ requirements:
 
 test:
   commands:
-    - test -f $SP_DIR/kleboscope/modules/kleb_mlst_module/db/scheme_species_map.tab
+    - test -n "$(find $PREFIX -name scheme_species_map.tab -print -quit)"
 
 about:
   home: https://github.com/bbeckley-hub/Kleboscope

--- a/recipes/kleboscope-mlst-data/meta.yaml
+++ b/recipes/kleboscope-mlst-data/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/bbeckley-hub/Kleboscope/releases/download/v{{ version }}-data/kleb_mlst_data-v{{ version }}.tar.gz
+  url: https://github.com/bbeckley-hub/Kleboscope/releases/download/{{ version }}/kleb_mlst_data-v{{ version }}.tar.gz
   sha256: 069603c1d5cbd09f4307abf0184b861ed5b5583b1e499b3291cfd3381a888113
 
 build:

--- a/recipes/kleboscope/meta.yaml
+++ b/recipes/kleboscope/meta.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/bbeckley-hub/Kleboscope/archive/v{{ version }}.tar.gz
-  sha256: 944f4e33a463b56876b063e225db94ca5ffa240d39dca89704663e574414213f
+  sha256: b5ee68a124aba4c505adc0dec8188047de77547bd2cfc02bb39d8d5e6f86fbd4
 
 build:
   noarch: python

--- a/recipes/kleboscope/meta.yaml
+++ b/recipes/kleboscope/meta.yaml
@@ -1,0 +1,70 @@
+{% set version = "1.0.0" %}
+
+package:
+  name: kleboscope
+  version: {{ version }}
+
+source:
+  url: https://github.com/bbeckley-hub/Kleboscope/archive/v{{ version }}.tar.gz
+  sha256: 944f4e33a463b56876b063e225db94ca5ffa240d39dca89704663e574414213f
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vvv"
+  run_exports:
+    - {{ pin_subpackage('kleboscope', max_pin="x") }}
+
+requirements:
+  host:
+    - python >=3.9
+    - pip
+    - setuptools
+  run:
+    - python >=3.9
+    - pandas >=1.5.0
+    - biopython >=1.85
+    - psutil >=5.9.0
+    - requests >=2.28.0
+    - tqdm >=4.64.0
+    - click >=8.0.0
+    - kaptive >=3.1.0
+    - beautifulsoup4 >=4.11.0
+    - lxml >=4.9.0
+    - matplotlib-base >=3.5.0
+    - seaborn >=0.12.0
+    - scipy >=1.10.1
+    - plotly >=5.10.0
+    - abricate >=1.2.0
+    - perl
+    - any2fasta
+    - blast >=2.13.0
+    - perl-moo
+    - perl-list-moreutils
+    - perl-json
+    - perl-lwp-protocol-https
+    - perl-path-tiny
+    - perl-data-dumper
+    - perl-getopt-long
+    - perl-file-which
+    # Data package
+    - kleboscope-mlst-data ==1.0.0
+
+test:
+  commands:
+    - kleboscope --help
+
+about:
+  home: https://github.com/bbeckley-hub/Kleboscope
+  license: MIT
+  license_file: LICENSE
+  summary: 'Kleboscope: Comprehensive K. pneumoniae genomic typing pipeline'
+  description: |
+    Kleboscope is a complete, automated genomic analysis pipeline for Klebsiella pneumoniae,
+    featuring parallel execution for rapid processing of bacterial genomes...
+  doc_url: https://github.com/bbeckley-hub/Kleboscope
+  dev_url: https://github.com/bbeckley-hub/Kleboscope
+
+extra:
+  recipe-maintainers:
+    - bbeckley-hub


### PR DESCRIPTION
This PR adds kleboscope (v1.0.0), a complete genomic analysis pipeline for Klebsiella pneumoniae, along with its required MLST database package.

kleboscope: Python‑based pipeline integrating MLST, K/O locus typing (Kaptive), AMR (AMRfinderPlus + ABRicate), virulence, plasmid profiling, quality control, and interactive HTML reports.

kleboscope-mlst-data: MLST typing database (Pasteur scheme) versioned with the tool.

Recipe details:

Main package uses noarch: python and installs via pip.

Data package uses noarch: python and includes python as a run dependency to ensure $SP_DIR resolves correctly at install time.

Database files are bundled as a separate Conda package.

Tests: kleboscope --help for the main tool, and a file existence check for the MLST database.

All dependencies are from conda‑forge or bioconda. Local builds and tests pass on Linux.

Please review and merge.