### PR TITLE
Add ecolityper v1.1.0 and data packages (CHTyper, MLST, Serotypefinder)

### DIFF
--- a/recipes/ecolityper-chtyper-data/build.sh
+++ b/recipes/ecolityper-chtyper-data/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+cd "$SRC_DIR"
+DEST="$SP_DIR/ecoliTyper/modules/CHTyper_module"
+mkdir -p "$DEST"
+cp -r ./* "$DEST/"

--- a/recipes/ecolityper-chtyper-data/meta.yaml
+++ b/recipes/ecolityper-chtyper-data/meta.yaml
@@ -1,0 +1,28 @@
+{% set version = "1.1.0" %}
+
+package:
+  name: ecolityper-chtyper-data
+  version: {{ version }}
+
+source:
+  url: https://github.com/bbeckley-hub/EcoliTyper/releases/download/v{{ version }}/ecolityper-chtyper-data-v{{ version }}.tar.gz
+  sha256: a28f8484d0da5c0d3854c2f5391ce7c5c35093107d0836b33a844cbf6010b47c
+
+build:
+  noarch: python
+  number: 0
+  run_exports:
+    - {{ pin_subpackage('ecolityper-chtyper-data', max_pin="x") }}
+
+requirements:
+  run:
+    - python
+
+test:
+  commands:
+    - test -f $SP_DIR/ecoliTyper/modules/CHTyper_module/blaster.py
+
+about:
+  home: https://github.com/bbeckley-hub/EcoliTyper
+  license: MIT
+  summary: 'CHTyper database and scripts for ecoliTyper'

--- a/recipes/ecolityper-chtyper-data/meta.yaml
+++ b/recipes/ecolityper-chtyper-data/meta.yaml
@@ -21,6 +21,8 @@ requirements:
 test:
   commands:
     - test -n "$(find $PREFIX -name blaster.py -print -quit)"
+
+about:
   home: https://github.com/bbeckley-hub/EcoliTyper
   license: MIT
   summary: 'CHTyper database and scripts for ecoliTyper'

--- a/recipes/ecolityper-chtyper-data/meta.yaml
+++ b/recipes/ecolityper-chtyper-data/meta.yaml
@@ -20,9 +20,7 @@ requirements:
 
 test:
   commands:
-    - test -f $SP_DIR/ecoliTyper/modules/CHTyper_module/blaster.py
-
-about:
+    - test -n "$(find $PREFIX -name blaster.py -print -quit)"
   home: https://github.com/bbeckley-hub/EcoliTyper
   license: MIT
   summary: 'CHTyper database and scripts for ecoliTyper'

--- a/recipes/ecolityper-mlst-data/build.sh
+++ b/recipes/ecolityper-mlst-data/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+cd "$SRC_DIR"
+DEST="$SP_DIR/ecoliTyper/modules/mlst_module"
+mkdir -p "$DEST"
+cp -r bin db perl5 scripts "$DEST/"

--- a/recipes/ecolityper-mlst-data/meta.yaml
+++ b/recipes/ecolityper-mlst-data/meta.yaml
@@ -20,9 +20,7 @@ requirements:
 
 test:
   commands:
-    - test -f $SP_DIR/ecoliTyper/modules/mlst_module/db/scheme_species_map.tab
-
-about:
+    - test -n "$(find $PREFIX -name scheme_species_map.tab -print -quit)"
   home: https://github.com/bbeckley-hub/EcoliTyper
   license: MIT
   summary: 'MLST database for ecoliTyper (E. coli)'

--- a/recipes/ecolityper-mlst-data/meta.yaml
+++ b/recipes/ecolityper-mlst-data/meta.yaml
@@ -1,0 +1,28 @@
+{% set version = "1.1.0" %}
+
+package:
+  name: ecolityper-mlst-data
+  version: {{ version }}
+
+source:
+  url: https://github.com/bbeckley-hub/EcoliTyper/releases/download/v{{ version }}/ecolityper-mlst-data-v{{ version }}.tar.gz
+  sha256: 17c8c75c58ddd5499bfb164b54087c57e29d4643acb3bf340d9df40945589ac2
+
+build:
+  noarch: python
+  number: 0
+  run_exports:
+    - {{ pin_subpackage('ecolityper-mlst-data', max_pin="x") }}
+
+requirements:
+  run:
+    - python
+
+test:
+  commands:
+    - test -f $SP_DIR/ecoliTyper/modules/mlst_module/db/scheme_species_map.tab
+
+about:
+  home: https://github.com/bbeckley-hub/EcoliTyper
+  license: MIT
+  summary: 'MLST database for ecoliTyper (E. coli)'

--- a/recipes/ecolityper-mlst-data/meta.yaml
+++ b/recipes/ecolityper-mlst-data/meta.yaml
@@ -21,6 +21,8 @@ requirements:
 test:
   commands:
     - test -n "$(find $PREFIX -name scheme_species_map.tab -print -quit)"
+
+about:
   home: https://github.com/bbeckley-hub/EcoliTyper
   license: MIT
   summary: 'MLST database for ecoliTyper (E. coli)'

--- a/recipes/ecolityper-serotype-data/build.sh
+++ b/recipes/ecolityper-serotype-data/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+cd "$SRC_DIR"
+DEST="$SP_DIR/ecoliTyper/modules/serotypefinder_module"
+mkdir -p "$DEST"
+cp -r ./* "$DEST/"

--- a/recipes/ecolityper-serotype-data/meta.yaml
+++ b/recipes/ecolityper-serotype-data/meta.yaml
@@ -20,9 +20,7 @@ requirements:
 
 test:
   commands:
-    - test -f $SP_DIR/ecoliTyper/modules/serotypefinder_module/serotypefinder.py
-
-about:
+    - test -n "$(find $PREFIX -name serotypefinder.py -print -quit)"
   home: https://github.com/bbeckley-hub/EcoliTyper
   license: MIT
   summary: 'Serotypefinder database and scripts for ecoliTyper'

--- a/recipes/ecolityper-serotype-data/meta.yaml
+++ b/recipes/ecolityper-serotype-data/meta.yaml
@@ -21,6 +21,8 @@ requirements:
 test:
   commands:
     - test -n "$(find $PREFIX -name serotypefinder.py -print -quit)"
+
+about:
   home: https://github.com/bbeckley-hub/EcoliTyper
   license: MIT
   summary: 'Serotypefinder database and scripts for ecoliTyper'

--- a/recipes/ecolityper-serotype-data/meta.yaml
+++ b/recipes/ecolityper-serotype-data/meta.yaml
@@ -1,0 +1,28 @@
+{% set version = "1.1.0" %}
+
+package:
+  name: ecolityper-serotype-data
+  version: {{ version }}
+
+source:
+  url: https://github.com/bbeckley-hub/EcoliTyper/releases/download/v{{ version }}/ecolityper-serotype-data-v{{ version }}.tar.gz
+  sha256: 062d8319b9edc4ab831edf8ff4bd5181e842c292bf36dc1fd97653de3a58256f
+
+build:
+  noarch: python
+  number: 0
+  run_exports:
+    - {{ pin_subpackage('ecolityper-serotype-data', max_pin="x") }}
+
+requirements:
+  run:
+    - python
+
+test:
+  commands:
+    - test -f $SP_DIR/ecoliTyper/modules/serotypefinder_module/serotypefinder.py
+
+about:
+  home: https://github.com/bbeckley-hub/EcoliTyper
+  license: MIT
+  summary: 'Serotypefinder database and scripts for ecoliTyper'

--- a/recipes/ecolityper/meta.yaml
+++ b/recipes/ecolityper/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - tabulate >=0.9.0
     - beautifulsoup4 >=4.11.0
     - lxml >=4.9.0
-    - matplotlib >=3.5.0
+    - matplotlib-base >=3.5.0
     - seaborn >=0.12.0
     - scipy >=1.10.1
     - plotly >=5.10.0

--- a/recipes/ecolityper/meta.yaml
+++ b/recipes/ecolityper/meta.yaml
@@ -1,0 +1,76 @@
+{% set version = "1.1.0" %}
+
+package:
+  name: ecolityper
+  version: {{ version }}
+
+source:
+  url: https://github.com/bbeckley-hub/EcoliTyper/archive/v{{ version }}.tar.gz
+  sha256: 006e1562003f3ffcd64ad01efbf2e8e22732798cd4ca5d31f6a602b60f4ef540
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vvv"
+  run_exports:
+    - {{ pin_subpackage('ecolityper', max_pin="x") }}
+
+requirements:
+  host:
+    - python >=3.8
+    - pip
+    - setuptools
+  run:
+    - python >=3.8
+    - pandas >=1.5.0
+    - biopython >=1.80
+    - psutil >=5.9.0
+    - requests >=2.28.0
+    - tqdm >=4.64.0
+    - click >=8.0.0
+    - tabulate >=0.9.0
+    - beautifulsoup4 >=4.11.0
+    - lxml >=4.9.0
+    - matplotlib >=3.5.0
+    - seaborn >=0.12.0
+    - scipy >=1.10.1
+    - plotly >=5.10.0
+    - abricate >=1.2.0
+    - ezclermont >=0.7.0
+    - perl
+    - any2fasta
+    - cgecore >=1.5.6
+    - blast >=2.13.0
+    - perl-moo
+    - perl-list-moreutils
+    - perl-json
+    - perl-lwp-protocol-https
+    - perl-path-tiny
+    - perl-data-dumper
+    - perl-getopt-long
+    - perl-file-which
+    # Data packages
+    - ecolityper-chtyper-data ==1.1.0
+    - ecolityper-mlst-data ==1.1.0
+    - ecolityper-serotype-data ==1.1.0
+
+test:
+  commands:
+    - ecolityper --help
+
+about:
+  home: https://github.com/bbeckley-hub/EcoliTyper
+  license: MIT
+  license_file: LICENSE
+  summary: 'Comprehensive E. coli typing pipeline: MLST, Serotyping, CH Typing, Phylogrouping, AMR, and Virulence'
+  description: |
+    EcoliTyper is a comprehensive bioinformatics pipeline for complete Escherichia coli
+    genomic characterization. It integrates multiple typing schemes including MLST,
+    serotyping (O and H antigens), CH typing (FumC and FimH), ezClermont phylogrouping,
+    antibiotic resistance detection (AMRfinderPlus), and virulence/plasmid screening (ABRicate).
+  doc_url: https://github.com/bbeckley-hub/EcoliTyper
+  dev_url: https://github.com/bbeckley-hub/EcoliTyper
+
+extra:
+  recipe-maintainers:
+    - bbeckley-hub


### PR DESCRIPTION
Add ecolityper v1.1.0 with CHTyper, MLST, and serotype data packages. Dependencies from conda-forge/bioconda; data packages install scripts and databases to site-packages. Ready for review.