### PR TITLE
fix: handle current "packages.conda" top-level key alongside legacy "packages" key for patches

### DIFF
--- a/recipes/bioconda-repodata-patches/gen_patch_json.py
+++ b/recipes/bioconda-repodata-patches/gen_patch_json.py
@@ -50,30 +50,24 @@ def _add_removals(instructions, subdir):
     instructions["remove"].extend(tuple(set(currvals)))
 
 
-def _gen_patch_instructions(index, new_index, subdir):
-    instructions = {
-        "patch_instructions_version": 1,
-        "packages": defaultdict(dict),
-        "revoke": [],
-        "remove": [],
-    }
-
+def _gen_patch_instructions_per_key(index_per_key, new_index, subdir):
     #_add_removals(instructions, subdir)
+    instructions = defaultdict(dict)
 
     # diff all items in the index and put any differences in the instructions
-    for fn in index:
+    for fn in index_per_key:
         assert fn in new_index
 
         # replace any old keys
-        for key in index[fn]:
-            assert key in new_index[fn], (key, index[fn], new_index[fn])
-            if index[fn][key] != new_index[fn][key]:
-                instructions['packages'][fn][key] = new_index[fn][key]
+        for key in index_per_key[fn]:
+            assert key in new_index[fn], (key, index_per_key[fn], new_index[fn])
+            if index_per_key[fn][key] != new_index[fn][key]:
+                instructions[fn][key] = new_index[fn][key]
 
         # add any new keys
         for key in new_index[fn]:
-            if key not in index[fn]:
-                instructions['packages'][fn][key] = new_index[fn][key]
+            if key not in index_per_key[fn]:
+                instructions[fn][key] = new_index[fn][key]
 
     return instructions
 
@@ -91,14 +85,14 @@ def parse_version(version):
 changes = set([])
 
 
-def _gen_new_index(repodata, subdir):
+def _gen_new_index_per_key(repodata, packages_key, subdir):
     """Make any changes to the index by adjusting the values directly.
 
     This function returns the new index with the adjustments.
     Finally, the new and old indices are then diff'ed to produce the repo
     data patches.
     """
-    index = copy.deepcopy(repodata["packages"])
+    index = copy.deepcopy(repodata[packages_key])
 
     for fn, record in index.items():
         record_name = record["name"]
@@ -370,12 +364,24 @@ def main():
         if not isdir(prefix_subdir):
             os.makedirs(prefix_subdir)
 
-        # Step 2a. Generate a new index.
-        new_index = _gen_new_index(repodatas[subdir], subdir)
+        # basic structure of the patch instructions file
+        instructions = {
+            "patch_instructions_version": 1,
+            "packages": defaultdict(dict),
+            "packages.conda": defaultdict(dict),
+            "revoke": [],
+            "remove": [],
+        }
 
-        # Step 2b. Generate the instructions by diff'ing the indices.
-        instructions = _gen_patch_instructions(
-            repodatas[subdir]['packages'], new_index, subdir)
+        # iterate over legacy ("packages") and current ("packages.conda")
+        # top-level key in the repodata.json structure
+        for packages_key in ["packages", "packages.conda"]:
+            # Step 2a. Generate a new index.
+            new_index = _gen_new_index_per_key(repodatas[subdir], packages_key, subdir)
+
+            # Step 2b. Generate the instructions by diff'ing the indices.
+            instructions[packages_key] = _gen_patch_instructions_per_key(
+                repodatas[subdir][packages_key], new_index, subdir)
 
         # Step 2c. Output this to $PREFIX so that we bundle the JSON files.
         patch_instructions_path = join(

--- a/recipes/bioconda-repodata-patches/show_diff.py
+++ b/recipes/bioconda-repodata-patches/show_diff.py
@@ -5,8 +5,9 @@ import difflib
 import json
 import os
 import urllib
+from collections import defaultdict
 
-from gen_patch_json import _gen_new_index, _gen_patch_instructions, SUBDIRS
+from gen_patch_json import _gen_new_index_per_key, _gen_patch_instructions_per_key, SUBDIRS
 
 from conda_index.index import _apply_instructions
 
@@ -17,15 +18,15 @@ CACHE_DIR = os.environ.get(
 BASE_URL = "https://conda.anaconda.org/bioconda"
 
 
-def show_record_diffs(subdir, ref_repodata, new_repodata):
-    for name, ref_pkg in ref_repodata["packages"].items():
-        new_pkg = new_repodata["packages"][name]
+def show_record_diffs_per_key(packages_key, subdir, ref_repodata, new_repodata):
+    for name, ref_pkg in ref_repodata[packages_key].items():
+        new_pkg = new_repodata[packages_key][name]
         # license_family gets added for new packages, ignore it in the diff
         ref_pkg.pop("license_family", None)
         new_pkg.pop("license_family", None)
         if ref_pkg == new_pkg:
             continue
-        print(f"{subdir}::{name}")
+        print(f'new_repodata["{packages_key}"] diff for {subdir}::{name} entry')
         ref_lines = json.dumps(ref_pkg, indent=2).splitlines()
         new_lines = json.dumps(new_pkg, indent=2).splitlines()
         for ln in difflib.unified_diff(ref_lines, new_lines, n=0, lineterm=''):
@@ -39,10 +40,20 @@ def do_subdir(subdir, raw_repodata_path, ref_repodata_path):
         raw_repodata = json.load(fh)
     with bz2.open(ref_repodata_path) as fh:
         ref_repodata = json.load(fh)
-    new_index = _gen_new_index(raw_repodata, subdir)
-    instructions = _gen_patch_instructions(raw_repodata['packages'], new_index, subdir)
+    # basic structure of the patch instructions file
+    instructions = {
+        "patch_instructions_version": 1,
+        "packages": defaultdict(dict),
+        "packages.conda": defaultdict(dict),
+        "revoke": [],
+        "remove": [],
+    }
+    for packages_key in ["packages", "packages.conda"]:
+        new_index = _gen_new_index_per_key(raw_repodata, packages_key, subdir)
+        instructions[packages_key] = _gen_patch_instructions_per_key(raw_repodata[packages_key], new_index, subdir)
     new_repodata = _apply_instructions(subdir, raw_repodata, instructions)
-    show_record_diffs(subdir, ref_repodata, new_repodata)
+    for packages_key in ["packages", "packages.conda"]:
+        show_record_diffs_per_key(packages_key, subdir, ref_repodata, new_repodata)
 
 
 def download_subdir(subdir, raw_repodata_path, ref_repodata_path):


### PR DESCRIPTION
This brings bioconda up to date with these patching updates in conda-forge:
https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/215

This came up when [trying to patch the `snakemake-minimal` repodata](https://github.com/bioconda/bioconda-recipes/pull/64539#issuecomment-4266796176). This goes back to a new format for the repodata, which introduced the `repodata["packages.conda"]` key to be used for newer repodata:
https://github.com/conda/conda-build/blob/26ac2051ddd2d9f0cb232ec3d19cb8c0f72fa56c/CHANGELOG.md?plain=1#L2388

This became the new standard (with the `repodata["packages"]` key staying around for legacy packages) in 2024:
https://github.com/conda/conda-build/issues/5183

And, as mentioned above, [`conda-forge` handled this much earlier](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/215). So maybe the repodata patching code should eventually be harmonized with `conda-forge` in some way? Maybe even just re-use the code from conda-forge, as patching (done on the anaconda servers) will be handled identically, and the conda-forge code for example has tests...

But this PR here should at least fix the repodata patching for now...

Describe your pull request here

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
