### PR TITLE
Update GTDB-Tk data downloader to use correct release.

### DIFF
--- a/recipes/gtdbtk/download-db.sh
+++ b/recipes/gtdbtk/download-db.sh
@@ -1,7 +1,7 @@
 set -e
 
 # Configuration
-N_FILES_IN_TAR=307538
+N_FILES_IN_TAR=263
 DB_URL="https://data.gtdb.aau.ecogenomic.org/releases/release232/232.0/auxillary_files/gtdbtk_package/full_package/gtdbtk_r232_data.tar.gz"
 TARGET_TAR_NAME="gtdbtk_r232_data.tar.gz"
 

--- a/recipes/gtdbtk/download-db.sh
+++ b/recipes/gtdbtk/download-db.sh
@@ -2,8 +2,8 @@ set -e
 
 # Configuration
 N_FILES_IN_TAR=307538
-DB_URL="https://data.gtdb.aau.ecogenomic.org/releases/release226/226.0/auxillary_files/gtdbtk_package/full_package/gtdbtk_r226_data.tar.gz"
-TARGET_TAR_NAME="gtdbtk_r226_data.tar.gz"
+DB_URL="https://data.gtdb.aau.ecogenomic.org/releases/release232/232.0/auxillary_files/gtdbtk_package/full_package/gtdbtk_r232_data.tar.gz"
+TARGET_TAR_NAME="gtdbtk_r232_data.tar.gz"
 
 # Script variables (no need to configure)
 TARGET_DIR=${1:-$GTDBTK_DATA_PATH}

--- a/recipes/gtdbtk/meta.yaml
+++ b/recipes/gtdbtk/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 657c6b63b7d2fa7e875acbc075ff8d0b20e2a0d761125f527cded90c0c957c0a
 
 build:
-  number: 0
+  number: 1
   noarch: python
   entry_points:
     - gtdbtk = gtdbtk.__main__:main

--- a/recipes/gtdbtk/post-link.sh
+++ b/recipes/gtdbtk/post-link.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 echo "
-    GTDB-Tk v${PKG_VERSION} requires ~140G of external data which needs to be downloaded
+    GTDB-Tk v${PKG_VERSION} requires ~56GB of external data which needs to be downloaded
     and extracted. This can be done automatically, or manually.
 
     Automatic:
@@ -12,11 +12,11 @@ echo "
     Manual:
 
         1. Manually download the latest reference data:
-            wget https://data.gtdb.aau.ecogenomic.org//releases/release226/226.0/auxillary_files/gtdbtk_package/full_package/gtdbtk_r226_data.tar.gz
+            wget https://data.gtdb.aau.ecogenomic.org/releases/release232/232.0/auxillary_files/gtdbtk_package/full_package/gtdbtk_r232_data.tar.gz
 
         2. Extract the archive to a target directory:
-            tar -xvzf gtdbtk_r226_data.tar.gz -C \"/path/to/target/db\" --strip 1 > /dev/null
-            rm gtdbtk_r226_data.tar.gz
+            tar -xvzf gtdbtk_r232_data.tar.gz -C \"/path/to/target/db\" --strip 1 > /dev/null
+            rm gtdbtk_r232_data.tar.gz
 
         3. Set the GTDBTK_DATA_PATH environment variable by running:
             conda env config vars set GTDBTK_DATA_PATH=\"/path/to/target/db\"


### PR DESCRIPTION
This updates GTDB-Tk to use the R232 package (the one that should have been used for 2.7+).