### PR TITLE
fix: actually rebuild updated repodata patches package

### DIFF
--- a/recipes/bioconda-repodata-patches/README
+++ b/recipes/bioconda-repodata-patches/README
@@ -1,1 +1,7 @@
-To modify package metadata, edit and then run `gen_patch_json.py`. The resulting differences can then be viewed with `show_diff.py`.
+To patch the package metadata in the `repodata.json` files for the different architectures (for example, the [`noarch` folder has this `repodata.json`](https://conda.anaconda.org/bioconda/noarch/)), the following steps are required (on a dedicated branch):
+
+1. Edit `gen_patch_json.py`, adding or adjusting repodata patches in the `_gen_new_index_per_key()` function.
+2. Run `gen_patch_json.py` locally, to see which patches get generated in the `patches/<architecture>/patch_instructions.json` files.
+3. Compare the newly generated patches to the existing patches with `show_diff.py`, and double-check that the modifications work as intended or update accordingly.
+4. Commit all the changes to `gen_patch_json.py` (do not commit the `patches/` folder).
+5. Also update and commit the `meta.yaml` recipe definition for the `bioconda-repodata-patches` package by updating the `version` to the current date and resetting the build number to `0` (if necessary).

--- a/recipes/bioconda-repodata-patches/meta.yaml
+++ b/recipes/bioconda-repodata-patches/meta.yaml
@@ -43,3 +43,4 @@ extra:
     - bioconda/core
   skip-lints:
     - missing_hash
+    - repodata_patches_no_version_bump # TODO: remove this once this has been patched, hopefully via: https://github.com/bioconda/bioconda-utils/pull/1086/commits/d39d6f1494353e4099a15ad3a1ae352da7d4fa12

--- a/recipes/bioconda-repodata-patches/meta.yaml
+++ b/recipes/bioconda-repodata-patches/meta.yaml
@@ -43,4 +43,3 @@ extra:
     - bioconda/core
   skip-lints:
     - missing_hash
-    - repodata_patches_no_version_bump

--- a/recipes/bioconda-repodata-patches/meta.yaml
+++ b/recipes/bioconda-repodata-patches/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "bioconda-repodata-patches" %}
-{% set version = "20251216" %}  # ensure that this is the "current" date, and always higher than the latest version in master
+{% set version = "20260421" %}  # whenever you add or change patches in `gen_patch_json.py` or adjust any other code, ensure that this is the "current" date, and always higher than the latest version in master
 
 package:
   name: {{ name }}
@@ -9,7 +9,7 @@ source:
   path: .
 
 build:
-  number: 1
+  number: 0
   noarch: python
   run_exports:
     - {{ pin_subpackage(name, max_pin=None) }}


### PR DESCRIPTION
This is a follow-up to pull request #64539 , as I was not aware I need to have the `bioconda-repodata-patches` recipe built as a package.

This also updates the `bioconda-repodata-batches/README.md` to include all steps required for a successful repodata patching update, so that other maintainers hopefully don't trip up in the same way...

And it brings back the `repodata_patches_no_version_bump` lint, which it seems was skipped for some maintenance updates a while back.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
