### PR TITLE
Update cagecleaner to 1.5.0

### DIFF
--- a/recipes/cagecleaner/meta.yaml
+++ b/recipes/cagecleaner/meta.yaml
@@ -33,6 +33,7 @@ requirements:
     - skder >=1.3.4
     - any2fasta >=0.8.1
     - mmseqs2
+    - networkx
 
 test:
   commands:

--- a/recipes/cagecleaner/meta.yaml
+++ b/recipes/cagecleaner/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "cagecleaner" %}
-{% set version = "1.4.5" %}
+{% set version = "1.5.0" %}
 
 package:
   name: "{{ name|lower }}"
@@ -7,7 +7,7 @@ package:
 
 source:
   url: "https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
-  sha256: e6a824e16d5783cfdcab3ff00939da9955ab266d62a9295ae3e82d41ab8a3bc5
+  sha256: 0474489d1b2bdfbd98a38d9f305d3adbfb69b453cc10521625c43e2dcc28f72f
 
 build:
   number: 0
@@ -27,12 +27,12 @@ requirements:
     - python >=3.12
     - biopython
     - cblaster >=1.3.20
-    - pandas
+    - pandas <3.0.0
     - scipy <=1.14.1
     - ncbi-datasets-cli
-    - entrez-direct
     - skder >=1.3.4
-    - any2fasta
+    - any2fasta >=0.8.1
+    - mmseqs2
 
 test:
   commands:
@@ -43,7 +43,7 @@ about:
   license: MIT
   license_family: MIT
   license_file: LICENSE
-  summary: "Genomic redundancy removal tool for cblaster hit sets."
+  summary: "Redundancy removal for gene cluster mining hit sets"
   doc_url: "https://github.com/LucoDevro/CAGEcleaner/wiki"
   dev_url: "https://github.com/LucoDevro/CAGEcleaner"
 


### PR DESCRIPTION
This PR updates cagecleaner to v1.5.0, and updates dependency pins.

Please ignore autobump PR #64689 in favour of this PR.