### PR TITLE
Update kleboscope v1.0.1 (build 1) with bundled MLST bin

### DIFF
--- a/recipes/kleboscope/meta.yaml
+++ b/recipes/kleboscope/meta.yaml
@@ -7,11 +7,11 @@ package:
 
 source:
   url: https://github.com/bbeckley-hub/Kleboscope/archive/v{{ version }}.tar.gz
-  sha256: b5836cf57a0131dd9b91b3b42fcc47999d88efc7181d0073e517fb5a20c5f46d
+  sha256: db7fbfbfd2f3aac9c6504a33490d69adffdeadc047a91e046097aab339fbc756
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: "{{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vvv"
   run_exports:
     - {{ pin_subpackage(name, max_pin="x") }}


### PR DESCRIPTION
This PR updates kleboscope v1.0.1, which finally includes the missing bin/mlst executable. The previous v1.0.0 had the database files but forgot the binary – so MLST always returned "UNKNOWN". Now it actually works. 😅

Bundled everything in one package, no separate data packages. Uses matplotlib-base and a simple --help test. Ready for review.