### PR TITLE
Update rigel to 0.4.0

### DIFF
--- a/recipes/rigel/meta.yaml
+++ b/recipes/rigel/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "rigel" %}
-{% set version = "0.3.3" %}
+{% set version = "0.4.0" %}
 
 package:
   name: {{ name }}
@@ -7,12 +7,11 @@ package:
 
 source:
   url: https://pypi.org/packages/source/r/rigel-rnaseq/rigel_rnaseq-{{ version }}.tar.gz
-  sha256: f744b31b775b1d97050a20a1f1b2e4f0904c0afd2ab214527b467aba1900dd41
+  sha256: ccc96add5b65e0b600aaf167bc7112c104bede20440b5f7d1094fbea017eb83f
 
 build:
   number: 0
   skip: true  # [py < 312]
-  # script: build.sh
   run_exports:
     - {{ pin_subpackage(name, max_pin="x.x") }}
 
@@ -20,6 +19,7 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - {{ stdlib('c') }}
     - cmake >=3.15
     - make
     - pkg-config
@@ -44,7 +44,6 @@ requirements:
     - pysam >=0.22
     - pyyaml >=6.0
     - scipy >=1.11
-    - htslib
 
 test:
   imports:
@@ -56,20 +55,9 @@ about:
   home: https://github.com/mkiyer/rigel
   license: GPL-3.0-or-later
   license_family: GPL3
-  license_file: LICENSE
-  summary: Bayesian RNA-seq transcript quantification with joint mRNA, nRNA, and gDNA deconvolution
-  description: |
-    Rigel is a Bayesian transcript quantification method for RNA-seq data
-    that jointly models three nucleic acid species: mature mRNA, nascent
-    pre-mRNA (nRNA), and genomic DNA contamination (gDNA). It uses a linked
-    kinetic model coupling mRNA and nRNA through shared per-transcript
-    parameters, and a hierarchical empirical Bayes framework for initialization.
+  summary: Bayesian RNA-seq transcript quantification tool
   dev_url: https://github.com/mkiyer/rigel
-  doc_url: https://github.com/mkiyer/rigel/blob/main/docs/MANUAL.md
 
 extra:
-  additional-platforms:
-    - linux-aarch64
-    - osx-arm64
   recipe-maintainers:
     - mkiyer


### PR DESCRIPTION
Updates rigel to 0.4.0. Also adds `{{ stdlib('c') }}` as required by the
current bioconda lint rules.

Supersedes the failed auto-bump PR(s).