### PR TITLE
Add oddSNP v0.1.1

### DIFF
--- a/recipes/oddsnp/meta.yaml
+++ b/recipes/oddsnp/meta.yaml
@@ -1,0 +1,65 @@
+{% set version = "0.1.1" %}
+{% set name = "oddsnp" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/o/oddsnp/oddsnp-{{ version }}.tar.gz
+  sha256: f9226df4f803f40b9d6c748f4414c1430c5d9d654c83700a93c999d0dfc62d55
+  
+build:
+  entry_points:
+    - oddSNP = oddSNP.__main__:oddSNP
+  noarch: python
+  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  number: 0
+  run_exports:
+    - {{ pin_subpackage("oddsnp", max_pin="x.x") }}
+
+requirements:
+  host:
+    - python >=3.12
+    - pip
+    - setuptools
+
+  run:
+    - python >=3.12
+    - click
+    - pandas
+    - pysam
+    - plotly
+    - nbformat
+    - python-kaleido      # conda-forge name for kaleido
+    - tqdm
+    - more-itertools      # conda-forge name for more_itertools
+    - joblib
+    - requests
+    - ipykernel
+    - threadpoolctl
+    - vireosnp
+    - cellsnp-lite 
+
+test:
+  imports:
+    - oddSNP
+  commands:
+    - oddSNP --help
+  requires:
+    - python
+    - pip
+
+about:
+  home: https://github.com/nemoto-lab/oddSNP
+  summary: A CLI tool for Optimizing demultiplexing pooled experiments based on Single-Nucleotide Polymorphism
+  doc_url: https://nemoto-lab.github.io/oddSNP/
+  license: Apache-2.0
+  license_file: LICENSE
+
+extra:
+  authors:
+    - Rodolfo Allendes <rodolfo.allendes.prime@osaka-u.ac.jp>
+    - Takahiro Nemoto <nemoto.takahiro.prime@osaka-u.ac.jp>
+  recipe-maintainers:
+    - RodolfoAllendes

--- a/recipes/oddsnp/meta.yaml
+++ b/recipes/oddsnp/meta.yaml
@@ -10,10 +10,8 @@ source:
   sha256: f9226df4f803f40b9d6c748f4414c1430c5d9d654c83700a93c999d0dfc62d55
   
 build:
-  entry_points:
-    - oddSNP = oddSNP.__main__:oddSNP
   noarch: python
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   number: 0
   run_exports:
     - {{ pin_subpackage("oddsnp", max_pin="x.x") }}
@@ -58,8 +56,5 @@ about:
   license_file: LICENSE
 
 extra:
-  authors:
-    - Rodolfo Allendes <rodolfo.allendes.prime@osaka-u.ac.jp>
-    - Takahiro Nemoto <nemoto.takahiro.prime@osaka-u.ac.jp>
   recipe-maintainers:
     - RodolfoAllendes


### PR DESCRIPTION
## Description

Add oddSNP, a predictive framework for optimizing multiplexed single-cell RNA-seq 
(scRNAseq) experimental design.

### Tool Information

- **Name:** oddSNP
- **Version:** v0.1.1
- **License:** Apache-2.0
- **Home URL:** https://nemoto-lab.github.io/oddSNP/
- **Development URL:** https://github.com/nemoto-lab/oddSNP

### Purpose

oddSNP enables researchers to compute SNP-Information Content (SNP-IC) and 
cell-paired SNP-Information Content (cpSNP-IC) metrics to predict demultiplexing 
success in donor-multiplexed scRNAseq studies. It supports in-silico titration of 
sequencing depth and donor complexity to optimize experimental design before 
committing to large-scale studies.

### Key Features

- Computation of SNP-IC and cpSNP-IC metrics for demultiplexing predictions
- Command-line interface and Python API
- Genotype calling and cell pairing analysis
- Visualization tools
- Downsampling capabilities for experimental optimization

### Citation

If you use oddSNP in research, please cite:

Allendes Osorio, R.S., Nishimura, T., Shigihara, Y., Kimura, M., Takebe, T. and Nemoto, T. 
OddSNP: a predictive framework for optimizing multiplexed single-cell RNA sequencing. 
bioRxiv. https://www.biorxiv.org/content/10.64898/2025.12.08.692882v1 (2025).

### Checklist

- [ x ] Recipe tests pass locally 
- [ x ] Tool runs successfully after installation
- [ x ] Dependencies are correct and minimal
- [ x ] License is properly declared

----


