### PR TITLE
Add new recipe for holodeck - rusty NGS read simulator.

### DIFF
--- a/recipes/holodeck/build.sh
+++ b/recipes/holodeck/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -euo pipefail
+
+export RUST_BACKTRACE=1
+
+cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
+
+cargo install --no-track --locked --verbose --root "${PREFIX}" --path .

--- a/recipes/holodeck/meta.yaml
+++ b/recipes/holodeck/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "holodeck" %}
-{% set version = "0.1.0" %}
+{% set version = "0.2.0" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/fg-labs/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: 397b9b0107bb607ced30745483bd3a6a84221301518c375837cf31cefbb197b0
+  sha256: 5d16e1947363d41456d7f7cf374c19477eddb202beff91e622a0c3728f3474ed
 
 build:
   number: 0

--- a/recipes/holodeck/meta.yaml
+++ b/recipes/holodeck/meta.yaml
@@ -16,6 +16,7 @@ build:
 
 requirements:
   build:
+    - {{ compiler('cxx') }}
     - {{ compiler('rust') }}
     - cargo-bundle-licenses
 

--- a/recipes/holodeck/meta.yaml
+++ b/recipes/holodeck/meta.yaml
@@ -18,6 +18,7 @@ requirements:
   build:
     - {{ compiler('cxx') }}
     - {{ compiler('rust') }}
+    - {{ stdlib('c') }}
     - cargo-bundle-licenses
 
 test:

--- a/recipes/holodeck/meta.yaml
+++ b/recipes/holodeck/meta.yaml
@@ -1,0 +1,42 @@
+{% set name = "holodeck" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://crates.io/api/v1/crates/holodeck/0.1.0/download
+  sha256: b941f6d6047fadbd86f2f9da2e4b2f3afdbbe3b6efac7355fc108653da4df8d5
+
+build:
+  number: 0
+  run_exports:
+    - {{ pin_subpackage("holodeck", max_pin="x.x") }}
+
+requirements:
+  build:
+    - {{ compiler('cxx') }}
+    - {{ compiler('rust') }}
+    - cargo-bundle-licenses
+
+test:
+  commands:
+    - holodeck --help
+
+about:
+  home: https://github.com/fg-labs/holodeck
+  license: MIT
+  license_file:
+    - LICENSE
+    - THIRDPARTY.yml
+  summary: Modern NGS read simulator
+  dev_url: https://github.com/fg-labs/holodeck
+
+extra:
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64
+  recipe-maintainers:
+    - tfenne
+

--- a/recipes/holodeck/meta.yaml
+++ b/recipes/holodeck/meta.yaml
@@ -6,8 +6,8 @@ package:
   version: {{ version }}
 
 source:
-  url: https://crates.io/api/v1/crates/holodeck/0.1.0/download
-  sha256: b941f6d6047fadbd86f2f9da2e4b2f3afdbbe3b6efac7355fc108653da4df8d5
+  url: https://github.com/fg-labs/{{ name }}/archive/v{{ version }}.tar.gz
+  sha256: 397b9b0107bb607ced30745483bd3a6a84221301518c375837cf31cefbb197b0
 
 build:
   number: 0
@@ -16,9 +16,7 @@ build:
 
 requirements:
   build:
-    - {{ compiler('cxx') }}
     - {{ compiler('rust') }}
-    - {{ stdlib('c') }}
     - cargo-bundle-licenses
 
 test:
@@ -38,6 +36,7 @@ extra:
   additional-platforms:
     - linux-aarch64
     - osx-arm64
+  skip-lints:
+    - compiler_needs_stdlib_c  # until https://github.com/bioconda/bioconda-utils/issues/1095 is resolved
   recipe-maintainers:
     - tfenne
-

--- a/recipes/holodeck/meta.yaml
+++ b/recipes/holodeck/meta.yaml
@@ -19,6 +19,8 @@ requirements:
     - {{ compiler('cxx') }}
     - {{ compiler('rust') }}
     - cargo-bundle-licenses
+    - cmake
+    - make
 
 test:
   commands:


### PR DESCRIPTION
Adds a new recipe for [holodeck](https://github.com/fg-labs/holodeck) a new NGS read simulator.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
