### PR TITLE
Update smashpp recipe to 26.04

### DIFF
--- a/recipes/smashpp/build.sh
+++ b/recipes/smashpp/build.sh
@@ -1,24 +1,7 @@
-#! /bin/bash
+#!/bin/bash
+set -euxo pipefail
 
-# Export
-export C_INCLUDE_PATH=$C_INCLUDE_PATH:${PREFIX}/include
-#export CPLUS_INCLUDE_PATH=$CPLUS_INCLUDE_PATH:${PREFIX}/include
-export LIBRARY_PATH=$LIBRARY_PATH:${PREFIX}/lib
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="${PREFIX}"
 
-# Parameters
-BUILD_TYPE=Release
-BUILD=${PREFIX}/build
-PARALLEL=8
-BIN=${PREFIX}/bin
-
-# Configure CMake
-cmake -B $BUILD -DCMAKE_BUILD_TYPE=$BUILD_TYPE
-
-# Build
-cmake --build $BUILD --parallel $PARALLEL --config $BUILD_TYPE
-
-# Copy executables to the bin directory
-mkdir -p $BIN
-cp $BUILD/smashpp $BIN
-cp $BUILD/smashpp-inv-rep $BIN
-cp $BUILD/exclude_N $BIN
+cmake --build build --parallel "${CPU_COUNT:-1}" --config Release
+cmake --install build --config Release

--- a/recipes/smashpp/meta.yaml
+++ b/recipes/smashpp/meta.yaml
@@ -1,29 +1,28 @@
-{% set version = "23.09" %}
+{% set version = "26.04" %}
 
 package:
   name: smashpp
   version: {{ version }}
 
 build:
-  # Passes some invalid flags for clang
-  skip: True  # [osx]
-  number: 1
+  number: 0
   run_exports:
     - {{ pin_subpackage('smashpp', max_pin="x") }}
 
 source:
-  url: https://github.com/smortezah/smashpp/archive/refs/tags/{{ version }}.tar.gz
-  sha256: fefb51add6bcefb62d0e4c70a5566746eee94790eae5b72b5ced655a5174b0ed
+  url: https://github.com/smortezah/smashpp/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: fc9b29e25b00fff7eb6a77b99d2392ac7d841e4ed1734b4f63e923d38820021f
 
 requirements:
   build:
     - make
-    - cmake
+    - cmake >=4,<5
     - {{ compiler('cxx') }}
+    - {{ stdlib('c') }}
 
 test:
   commands:
-    - smashpp --version 2>&1 | grep {{ version }}
+    - smashpp -V 2>&1 | grep {{ version }}
 
 about:
   home: https://github.com/smortezah/smashpp
@@ -31,3 +30,8 @@ about:
   license_file: LICENSE
   license_family: GPL3
   summary: A fast tool to find and visualize rearrangements in DNA sequences
+
+extra:
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64


### PR DESCRIPTION
This pull request updates the build and packaging process for the `smashpp` recipe, primarily to support a new upstream version and improve compatibility and maintainability. The main changes include updating to version 26.04, simplifying and standardizing the build script, and expanding platform support.

**Version and Packaging Updates:**

* Updated the `smashpp` version from 23.09 to 26.04, along with the corresponding source URL and SHA256 checksum in `meta.yaml`.
* Reset the build number to 0 and removed the OSX build skip, reflecting a fresh release and improved cross-platform compatibility.

**Build Process Improvements:**

* Refactored `build.sh` to use a more standard and concise CMake build and install workflow, eliminating manual copying of binaries and unnecessary environment variable exports.
* Updated CMake dependency specification to require version >=4,<5 and added an explicit C standard library dependency for improved build reliability.

**Platform and Testing Enhancements:**

* Added support for additional platforms (`linux-aarch64`, `osx-arm64`) in the `extra` section, increasing the portability of the package.
* Updated the test command to use `smashpp -V` for version checking, aligning with the upstream tool's latest interface.