### PR TITLE
Add patch_stringmlst.sh and update meta.yml to fix stringMLST.py for k-mer based methods.

### DIFF
--- a/recipes/seqsero2s/meta.yaml
+++ b/recipes/seqsero2s/meta.yaml
@@ -31,6 +31,7 @@ requirements:
   run:
     - python >=3
     - blast >=2.2
+    - zstd         # libzstd.so.1 required by blastn binary
     - samtools
     - bedtools >=2.17
     - sra-tools >=2.8

--- a/recipes/seqsero2s/meta.yaml
+++ b/recipes/seqsero2s/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "SeqSero2S" %}
 {% set version = "1.1.4" %}
-{% set release = "7498388efeaf66c4eb0513e793f18dbfee62842f" %}
+{% set release = "89f1f5aca7a8819ee96239592fedd2e737036ada" %}
 {% set sha256 = "995f1815cc6cee7b8e37604b068bbec673e2ee8880e41adf6df0350966fe4c65" %}
 
 package:
@@ -12,9 +12,13 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 2
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vvv --no-deps --no-build-isolation --no-cache-dir
+  script:
+    - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation --no-cache-dir
+    # patch stringMLST.py log path: replace dbPrefix reference with cwd to avoid
+    # patches ALL occurrences (at line 1464 and predict section at line 1478).
+    - bash $RECIPE_DIR/patch_stringmlst.sh
   run_exports:
     - {{ pin_subpackage(name|lower, max_pin="x.x") }}
 
@@ -23,6 +27,7 @@ requirements:
     - python >=3
     - pip
     - setuptools
+    - stringmlst >=0.6
   run:
     - python >=3
     - blast >=2.2
@@ -55,5 +60,6 @@ extra:
   recipe-maintainers:
     - LSTUGA
     - crashfrog
+    - biocoder
   identifiers:
     - doi:10.1128/aem.02600-24

--- a/recipes/seqsero2s/patch_stringmlst.sh
+++ b/recipes/seqsero2s/patch_stringmlst.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+# patch stringMLST.py log path: replace dbPrefix reference with cwd.
+# patches all occurrences (at line 1464 and predict section at line 1478).
+
+set -euo pipefail
+
+STRINGMLST="$PREFIX/bin/stringMLST.py"
+
+if [ ! -f "$STRINGMLST" ]; then
+    echo "SKIP: $STRINGMLST not found"
+    exit 0
+fi
+
+python3 << 'PATCH_WITH_PY'
+import os
+
+p = os.path.join(os.environ["PREFIX"], "bin", "stringMLST.py")
+with open(p) as f:
+    lines = f.readlines()
+
+original = "            log = dbPrefix+'.log'\n"
+commented = "            # log = dbPrefix+'.log'\n"
+replacement = '            log = os.path.join(os.getcwd(), "kmer.log")\n'
+
+# Count occurrences BEFORE modifying
+occurrences = lines.count(original)
+
+if occurrences == 0:
+    print("SKIP: stringMLST.py has 0 occurrences, expected at least 1")
+    exit(0)
+
+out = []
+for line in lines:
+    if line.rstrip("\n") == original.rstrip("\n"):
+        out.append(commented)
+        out.append(replacement)
+    else:
+        out.append(line)
+
+with open(p, "w") as f:
+    f.writelines(out)
+
+print("PATCHED: stringMLST.py log path fixed (%d occurrences)" % occurrences)
+PATCH_WITH_PY


### PR DESCRIPTION
The stringMLST.py dependency issue. 

log path: replace dbPrefix reference with cwd to avoid
 patches ALL occurrences (at line 1464 and predict section at line 1478) with `log = os.path.join(os.getcwd(), "kmer.log")\n'`

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
