### PR TITLE
Update mmcif to 1.1.1

### DIFF
--- a/recipes/mmcif/build.sh
+++ b/recipes/mmcif/build.sh
@@ -16,8 +16,5 @@ sed -i.bak -E \
 sed -i.bak -E \
     's|cmake_minimum_required\(VERSION .*\)|cmake_minimum_required(VERSION 3.5)|' \
     modules/pybind11/CMakeLists.txt
-sed -i.bak -E \
-    's|cmake_minimum_required\(VERSION .*\)|cmake_minimum_required(VERSION 3.5)|' \
-    modules/pybind11_2_12_1/CMakeLists.txt
 
 ${PYTHON} -m pip install . -vvv --no-deps --no-build-isolation --no-cache-dir

--- a/recipes/mmcif/conda_build_config.yaml
+++ b/recipes/mmcif/conda_build_config.yaml
@@ -1,0 +1,3 @@
+c_stdlib_version:  # [osx and x86_64]
+  - 10.15          # [osx and x86_64]
+

--- a/recipes/mmcif/meta.yaml
+++ b/recipes/mmcif/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "mmcif" %}
-{% set version = "1.1.0" %}
+{% set version = "1.1.1" %}
 
 package:
   name: {{ name }}
@@ -7,12 +7,10 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/mmcif-{{ version }}.tar.gz
-  sha256: ad33f85b581218c3df0e231b2b034244e9f2380d2c8d05244a262a24d30b2f91
+  sha256: 00f7075a824a90f9148f209e5dd1907cdb9e4329357b3ae55e664e6d37dadafd
 
 build:
   number: 0
-  script_env:
-    - MACOSX_DEPLOYMENT_TARGET=10.15  # [osx and x86_64]
   entry_points:
     - build_dict_cli = mmcif.io.BuildDictionaryExec:main
   run_exports:
@@ -22,6 +20,7 @@ requirements:
   build:
     - {{ compiler("c") }}
     - {{ compiler("cxx") }}
+    - {{ stdlib("c") }}
     - bison
     - cmake
     - flex

--- a/recipes/mmcif/meta.yaml
+++ b/recipes/mmcif/meta.yaml
@@ -55,7 +55,6 @@ about:
   license_file:
     - LICENSE
     - modules/pybind11/LICENSE
-    - modules/pybind11_2_12_1/LICENSE
 
 extra:
   additional-platforms:


### PR DESCRIPTION
This pull request updates the `mmcif` recipe to version 1.1.1 and improves compatibility with macOS by adjusting the C standard library configuration. The main changes focus on updating the package version and hash, as well as ensuring the correct C standard library is used during builds on macOS.

**Version and dependency updates:**

* Bumped the `mmcif` package version from 1.1.0 to 1.1.1 and updated the corresponding source URL and SHA256 hash in `meta.yaml`.

**Build configuration improvements (macOS compatibility):**

* Added `c_stdlib_version` (set to 10.15) in `conda_build_config.yaml` to specify the C standard library version for macOS x86_64 builds.
* Added `{{ stdlib("c") }}` to the build requirements in `meta.yaml` to ensure the appropriate C standard library is used.
* Removed the explicit `MACOSX_DEPLOYMENT_TARGET=10.15` environment variable from the build script environment, as the new configuration makes it redundant.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
