### PR TITLE
Update iobrpy to 0.1.8

### DIFF
--- a/recipes/iobrpy/meta.yaml
+++ b/recipes/iobrpy/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 60046891042a276d7bc6426c608920db44be9e1dc1df8f5fd4f3f28faca51104
 
 build:
-  number: 0
+  number: 1
   skip: true  # [not linux64 or py<311 or py>=314]
   run_exports:
     - {{ pin_subpackage(name|lower, max_pin="x.x") }}
@@ -48,6 +48,7 @@ requirements:
     - salmon
     - gzip
     - trust4
+    - samtools ==1.21
 
 test:
   commands:


### PR DESCRIPTION
Update the iobrpy 0.1.8 recipe with a revised build.

Changes:
- bump build number from 0 to 1
- add samtools 1.21 as a runtime dependency

The source tarball and sha256 are unchanged because this is a recipe-only rebuild for the existing 0.1.8 release.

