### PR TITLE
Rebuild r-bpcells with current R pinning

### DIFF
--- a/recipes/r-bpcells/conda_build_config.yaml
+++ b/recipes/r-bpcells/conda_build_config.yaml
@@ -1,0 +1,2 @@
+c_stdlib_version:  # [osx and x86_64]
+  - 10.15          # [osx and x86_64]

--- a/recipes/r-bpcells/conda_build_config.yaml
+++ b/recipes/r-bpcells/conda_build_config.yaml
@@ -1,2 +1,0 @@
-c_stdlib_version:  # [osx and x86_64]
-  - 10.15          # [osx and x86_64]

--- a/recipes/r-bpcells/meta.yaml
+++ b/recipes/r-bpcells/meta.yaml
@@ -25,6 +25,7 @@ requirements:
     - cross-r-base {{ r_base }}  # [build_platform != target_platform]
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - {{ stdlib('c') }}
     - make
     - pkg-config
   host:

--- a/recipes/r-bpcells/meta.yaml
+++ b/recipes/r-bpcells/meta.yaml
@@ -13,7 +13,7 @@ source:
     - patches/0001-fix-libhwy-config.patch
 
 build:
-  number: 0
+  number: 1
   rpaths:
     - lib/R/lib/
     - lib/
@@ -28,7 +28,7 @@ requirements:
     - make
     - pkg-config
   host:
-    - r-base
+    - r-base >=4.5.0
     - r-dplyr >=1.0.0
     - r-ggplot2 >=3.4.0
     - r-ggrepel
@@ -52,7 +52,7 @@ requirements:
     - libhwy
     - zlib
   run:
-    - r-base
+    - r-base >=4.5.0
     - r-dplyr >=1.0.0
     - r-ggplot2 >=3.4.0
     - r-ggrepel

--- a/recipes/r-bpcells/meta.yaml
+++ b/recipes/r-bpcells/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - make
     - pkg-config
   host:
-    - r-base >=4.5.0
+    - r-base
     - r-dplyr >=1.0.0
     - r-ggplot2 >=3.4.0
     - r-ggrepel
@@ -53,7 +53,7 @@ requirements:
     - libhwy
     - zlib
   run:
-    - r-base >=4.5.0
+    - r-base
     - r-dplyr >=1.0.0
     - r-ggplot2 >=3.4.0
     - r-ggrepel

--- a/recipes/r-bpcells/patches/0001-fix-libhwy-config.patch
+++ b/recipes/r-bpcells/patches/0001-fix-libhwy-config.patch
@@ -10,7 +10,7 @@ index d6af517..da143e2 100755
      exec 3>/dev/null
  else
      exec 3>&1
-@@ -12,7 +12,7 @@ fi
+@@ -12,7 +12,7 @@
  # No identifiable information or IP addresses are saved, and server logs are
  # deleted every 14 days. More information on data privacy policy: https://plausible.io/data-policy
  
@@ -19,7 +19,20 @@ index d6af517..da143e2 100755
  # or set the CI or ENABLE_INSTALL_COUNTING environment variables ahead of installation.
  if [ -z "$CI" ]; then ENABLE_INSTALL_COUNTING=${ENABLE_INSTALL_COUNTING:-yes}; fi
  
-@@ -166,8 +166,8 @@ sed \
+@@ -29,9 +29,10 @@
+ CXX=$("${R_HOME}/bin/R" CMD config CXX)
+ 
+ ENV_CFLAGS="${CFLAGS-}"
++ENV_CPPFLAGS="${CPPFLAGS-}"
+ ENV_LDFLAGS="${LDFLAGS-}"
+-CFLAGS="$("${R_HOME}/bin/R" CMD config CFLAGS) $ENV_CFLAGS"
+-CXXFLAGS="$("${R_HOME}/bin/R" CMD config CXXFLAGS) $ENV_CFLAGS"
++CFLAGS="$("${R_HOME}/bin/R" CMD config CFLAGS) $ENV_CPPFLAGS $ENV_CFLAGS"
++CXXFLAGS="$("${R_HOME}/bin/R" CMD config CXXFLAGS) $ENV_CPPFLAGS $ENV_CFLAGS"
+ LDFLAGS="$("${R_HOME}/bin/R" CMD config LDFLAGS) $ENV_LDFLAGS"
+ ############################
+ # HDF5 compatibility check
+@@ -166,8 +167,8 @@
    -e "s/@HWY_MIN_VERSION@/$HWY_MIN_VERSION/g" \
    tools/hwy-test.cpp.in > tools/hwy-test.cpp
  


### PR DESCRIPTION
This rebuilds `r-bpcells` against Bioconda's current R pinning by bumping the build number.

The current uploaded `r-bpcells` build was produced for R 4.4, which prevents installation into environments using the current R 4.5 pinning. The recipe remains generic (`r-base`) so existing R 4.4 builds remain available while Bioconda can publish a new build for the current R stack.

This also adds the now-required `{{ stdlib('c') }}` build requirement for recipes using C/C++ compilers.