### PR TITLE
Add kegg_pull 3.2.2

### DIFF
--- a/recipes/kegg_pull/meta.yaml
+++ b/recipes/kegg_pull/meta.yaml
@@ -1,0 +1,48 @@
+{% set name = "kegg_pull" %}
+{% set version = "3.2.2" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: "https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  sha256: ce948881378e5d6d44a8d3a6b85f46c10dd07dcc7000195d71a77fe3082f85f6
+
+build:
+  number: 0
+  noarch: python
+  entry_points:
+    - kegg_pull = kegg_pull.__main__:main
+  script: "{{ PYTHON }} -m pip install . -vvv --no-deps --no-build-isolation --no-cache-dir"
+  run_exports:
+    - {{ pin_subpackage('kegg_pull', max_pin="x") }}
+
+requirements:
+  host:
+    - python >=3.10
+    - pip
+    - setuptools
+  run:
+    - python >=3.10
+    - docopt
+    - requests
+    - tqdm
+    - jsonschema
+
+test:
+  commands:
+    - kegg_pull -h
+
+about:
+  home: "https://github.com/MoseleyBioinformaticsLab/kegg_pull"
+  license: Clear BSD License with Extra Clause
+  license_family: BSD
+  license_file: LICENSE
+  summary: "Package that facilitates pulling database entries from KEGG via its REST API "
+  doc_url: "https://moseleybioinformaticslab.github.io/kegg_pull/index.html"
+  dev_url: "https://github.com/MoseleyBioinformaticsLab/kegg_pull"
+
+extra:
+  recipe-maintainers:
+    - LucoDevro


### PR DESCRIPTION
This PR brings the PyPi package kegg_pull to Bioconda, enabling its use as a dependency in other Bioconda packages.