### PR TITLE
Update Python version requirements to 3.10-3.14

### DIFF
--- a/recipes/suvtk/meta.yaml
+++ b/recipes/suvtk/meta.yaml
@@ -20,11 +20,11 @@ build:
 
 requirements:
   host:
-    - python >=3.9
+    - python >=3.10,<3.14
     - uv-build >=0.8.0,<0.9.0
     - pip
   run:
-    - python >=3.9
+    - python >=3.10,<3.14
     - biopython >=1.83
     - click
     - numpy >1.24.4


### PR DESCRIPTION
Restrict python to >=3.10,<3.14 to fix conda build (some dependencies had issues before with python 3.14)