### PR TITLE
Add `kb info` test to kb-python: kb is still broken

### DIFF
--- a/recipes/kb-python/meta.yaml
+++ b/recipes/kb-python/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: acddfa039e5092d2ef16f7e01067f45c1d9979c1b6e19da729a732f8f78516e7
 
 build:
-  number: 0
+  number: 1
   noarch: python
   detect_binary_files_with_prefix: False
   ignore_prefix_files: True
@@ -49,6 +49,7 @@ test:
   commands:
     - kb ref --help
     - kb info
+    
   imports:
     - kb_python
 

--- a/recipes/kb-python/meta.yaml
+++ b/recipes/kb-python/meta.yaml
@@ -48,6 +48,7 @@ requirements:
 test:
   commands:
     - kb ref --help
+    - kb info
   imports:
     - kb_python
 


### PR DESCRIPTION
kb has been broken for about a year and a half; perennial issues finding libraries. This will not fix it but it will at least fail some tests.


See here: https://github.com/bioconda/bioconda-recipes/pull/56226#issuecomment-4337743854

`kb ref --help` does not test whether the binaries are present and available. `kb info` does. Lapses in `kb` being able to find binaries have been a perennial issue for a few years. This PR is a starting point to flag and start fixing some of these issues; I am sure other people have stronger and more informed opinions about the right way to address them.

Pinging @Yenaled for any thoughts on the right way to do this.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
