### PR TITLE
Add acinetoscope v1.1.0 with bundled databases

### DIFF
--- a/recipes/acinetoscope/meta.yaml
+++ b/recipes/acinetoscope/meta.yaml
@@ -1,0 +1,90 @@
+{% set name = "acinetoscope" %}
+{% set version = "1.1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/bbeckley-hub/acinetoscope/archive/v{{ version }}.tar.gz
+  sha256: 5228805a1fca2d2203215bad80b1961fc67dec2e39976c349919f55d2b758bfe
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vvv"
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x") }}
+
+requirements:
+  host:
+    - python >=3.9
+    - pip
+    - setuptools
+  run:
+    - python >=3.9
+    - pandas >=1.5.0
+    - biopython >=1.85
+    - psutil >=5.9.0
+    - requests >=2.28.0
+    - tqdm >=4.64.1
+    - click >=8.0.0
+    - kaptive >=3.1.0
+    - beautifulsoup4 >=4.11.0
+    - lxml >=4.9.0
+    - matplotlib-base >=3.5.0
+    - seaborn >=0.12.0
+    - scipy >=1.10.1
+    - plotly >=5.10.0
+    - abricate >=1.2.0
+    - perl
+    - any2fasta
+    - blast >=2.13.0
+    - perl-moo
+    - perl-list-moreutils
+    - perl-json
+    - perl-lwp-protocol-https
+    - perl-path-tiny
+    - perl-data-dumper
+    - perl-getopt-long
+    - perl-file-which
+
+test:
+  commands:
+    - acinetoscope --help
+
+about:
+  home: https://github.com/bbeckley-hub/acinetoscope
+  license: MIT
+  license_file: LICENSE
+  summary: 'AcinetoScope: Comprehensive A. baumannii genomic typing pipeline with parallel execution'
+  description: |
+    AcinetoScope is a complete, automated genomic analysis pipeline for Acinetobacter baumannii,
+    featuring parallel execution for rapid processing of bacterial genomes. The pipeline integrates
+    multiple analysis modules into a unified workflow:
+
+    • Quality Control (FASTA QC) - Comprehensive sequence validation
+    • Multi-Locus Sequence Typing (MLST) - Oxford & Pasteur schemes
+    • K/O Locus Typing (Kaptive) - Capsule and lipooligosaccharide typing
+    • Antimicrobial Resistance (AMR) - Comprehensive resistance gene detection
+    • Virulence & Plasmid Profiling (ABRicate) - Multi-database screening
+    • Critical Genes Flagging - Priority markers for infection control
+    • Interactive HTML Reports - Gene-centric integrated analysis
+    • Cross-genome pattern discovery
+
+    Key Features:
+    🚀 Parallel Execution - All modules run simultaneously for maximum speed
+    📊 Interactive Reports - HTML summaries with visualization
+    🧬 Multi-Database Integration - CARD, ResFinder, VFDB, NCBI, MEGARes, BacMet
+    ⚡ Easy Deployment - Single command analysis with automatic dependency handling
+    🎯 Critical Gene Tracking - Carbapenemases, ESBLs, colistin/tigecycline resistance
+
+    Designed for clinical microbiology, outbreak investigation, and genomic surveillance,
+    AcinetoScope provides clinical labs and researchers with a complete solution for
+    A. baumannii genomic characterization from raw sequencing data to publication-ready reports.
+  doc_url: https://github.com/bbeckley-hub/acinetoscope
+  dev_url: https://github.com/bbeckley-hub/acinetoscope
+
+extra:
+  recipe-maintainers:
+    - bbeckley-hub

--- a/recipes/acinetoscope/meta.yaml
+++ b/recipes/acinetoscope/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/bbeckley-hub/acinetoscope/archive/v{{ version }}.tar.gz
-  sha256: 5228805a1fca2d2203215bad80b1961fc67dec2e39976c349919f55d2b758bfe
+  sha256: f9ace682414a6b0ba4888992d59a1596ec207991d5ee0a9c4f8fc32850cb90b6
 
 build:
   noarch: python


### PR DESCRIPTION
This PR adds acinetoscope v1.1.0, a complete genomic typing pipeline for Acinetobacter baumannii. The source tarball already contains all the necessary MLST, Kaptive, AMR, and virulence databases – no separate data packages, no post‑install downloads, no “where did my database go?” surprises. 😅

- Bundled everything – MLST schemes, Kaptive reference, ABRicate databases, etc.

- Parallel execution – QC, MLST, Kaptive, AMR, and ABRicate run concurrently (where possible).

- Clean recipe – uses matplotlib-base, run_exports, and a simple --help test.

- Tested locally – all green.

Ready for review and merge. 🙏