### PR TITLE
Update seqera to 1.5.0

### DIFF
--- a/recipes/seqera/meta.yaml
+++ b/recipes/seqera/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.2.0" %}
+{% set version = "1.5.0" %}
 {% set name = "seqera" %}
 
 package:
@@ -7,11 +7,11 @@ package:
 
 source:
   - url: https://registry.npmjs.org/@seqera/cli-linux-x64/-/cli-linux-x64-{{ version }}.tgz  # [linux]
-    sha256: 3383423bcd06164c34f987af2d8d680461ee10e250c7f0fc3939140d7c5df071  # [linux]
+    sha256: 2d9fc3bb9f8db7c61f8e891dd4667dfed089c1968a97699e52d494b3cde6dced  # [linux]
   - url: https://registry.npmjs.org/@seqera/cli-darwin-x64/-/cli-darwin-x64-{{ version }}.tgz  # [osx and x86_64]
-    sha256: 21e5db2020859a377760e143cf4d28766435920508bc71b442510b2a653eed5c  # [osx and x86_64]
+    sha256: 6a01933ef20c53a56a032388921a5ba7be566c88cf8717b2a5a56b6103f31b10  # [osx and x86_64]
   - url: https://registry.npmjs.org/@seqera/cli-darwin-arm64/-/cli-darwin-arm64-{{ version }}.tgz  # [osx and arm64]
-    sha256: 99d78236a9c8fb67d955ca1aa632821227c4ec7e9289a27fa0d5998ee0948ae1  # [osx and arm64]
+    sha256: 5c099cb8accb6c031254e990435107963444cf1e83b6eb9d61c0508addb11797  # [osx and arm64]
 
 build:
   number: 0


### PR DESCRIPTION
Update seqera from 1.2.0 to 1.5.0.

- bump recipe version to 1.5.0
- refresh Linux, macOS x86_64, and macOS arm64 SHA256 values
- no recipe structure changes

Testing:
- verified latest upstream npm package version is 1.5.0
- did not run recipe build locally
