### PR TITLE
tecap: 0.3.0

### DIFF
--- a/recipes/tecap/meta.yaml
+++ b/recipes/tecap/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "tecap" %}
-{% set version = "0.2.0" %}
+{% set version = "0.3.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/FullLengthFanatic/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 1adf28f1a85e4be09e4badf36eda7ef18b060d566c27cac0341cb253aa8c42b1
+  sha256: ccc43c03c27e5b748094cfa37c4d87fecdc5de3496e0fe49bfae24b456fd4ff7
 
 build:
   number: 0
@@ -48,8 +48,9 @@ about:
     capture failures into nine mechanism buckets and measures reference base
     composition downstream of each cleavage site to distinguish classic
     A-tract internal priming from moderate-A priming characteristic of
-    saturating in-solution oligo-dT. Designed for PacBio Iso-Seq / Kinnex
-    and Oxford Nanopore cDNA BAMs. Direct-RNA sequencing is unsupported.
+    saturating-local-concentration oligo-dT chemistries (10x GEM droplets,
+    BD Rhapsody capture beads). Designed for PacBio Iso-Seq / Kinnex and
+    Oxford Nanopore cDNA BAMs. Direct-RNA sequencing is unsupported.
   license: MIT
   license_family: MIT
   license_file: LICENSE


### PR DESCRIPTION
Routine version bump from 0.2.0 to 0.3.0.                                                                                                                                          
                                                                                                                                                                                     
  Changes in v0.3.0 (per upstream CHANGELOG): readability/reporting                                                                                                                  
  improvements (HTML report, `tecap explain`, `tecap report`),                                                                                                                       
  improved cross-sample comparison plots, and corrected attribution                                                                                                                  
  of the moderate-A priming signature based on a 4-sample chemistry                                                                                                                  
  comparison. JSON output schema unchanged from v0.2.0.                                                                                                                              
                                                                                                                                                                                     
  No new runtime dependencies. No build/test changes. `run_exports`                                                                                                                  
  already present from the v0.2.0 recipe.                                                                                                                                            
                                                                                                                                                                                     
  - Tarball SHA256 verified against                                                                                                                                                  
    https://github.com/FullLengthFanatic/tecap/archive/refs/tags/v0.3.0.tar.gz                                                                                                       
  - `description` text updated to match the corrected v0.3                                                                                                                           
    attribution in the upstream CITATION.cff and README.     