### PR TITLE
Add molamola v0.1.0

### DIFF
--- a/recipes/molamola/meta.yaml
+++ b/recipes/molamola/meta.yaml
@@ -1,0 +1,64 @@
+{% set name = "molamola" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 0318335cd45fb56bdb4bcd1d915af00b427ef58f84a2434afaf60ac91d9310c8
+
+build:
+  number: 0
+  noarch: python
+  run_exports:
+    - {{ pin_subpackage("molamola", max_pin="x.x") }}
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  entry_points:
+    - molamola = molamola:main
+
+requirements:
+  host:
+    - python >=3.10
+    - pip
+    - setuptools >=68
+    - wheel
+  run:
+    - python >=3.10
+    - matplotlib-base >=3.6
+    - numpy >=1.23
+    - pandas >=1.5
+    - biopython >=1.80
+    - pycirclize >=1.10
+
+test:
+  imports:
+    - molamola
+  commands:
+    - molamola --help
+  requires:
+    - pip
+  source_files:
+    - tests/
+
+about:
+  home: https://github.com/martinandclaude/molamola
+  summary: Plot Oxford Nanopore variation as self-contained HTML reports.
+  description: |
+    A Python plotting tool for Oxford Nanopore variation data.
+    One VCF in, one self-contained HTML report out. molamola
+    inspects the VCF header and dispatches to the right plot type:
+    a circos + linear cytoband SV report for long-read SV VCFs
+    (Sniffles2 / cuteSV / SVIM / pbsv / NanoVar), or per-gene
+    phased-haplotype panels for compound-het workup from phased
+    + VEP-annotated small-variant VCFs.
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  doc_url: https://github.com/martinandclaude/molamola
+  dev_url: https://github.com/martinandclaude/molamola
+
+extra:
+  recipe-maintainers:
+    - martinandclaude


### PR DESCRIPTION
## Summary

- Adds molamola v0.1.0 — a plotting tool for Oxford Nanopore
  variation data.
- Single VCF in, one self-contained HTML report out. Auto-detects
  the plot type from the VCF header (SV vs phased+VEP small variant).
- Pure-Python noarch.
- PyPI sdist: https://pypi.org/project/molamola/0.1.0/

## Notes for reviewers

- `pycirclize` is on conda-forge (verified before submitting).
- `matplotlib-base` chosen over `matplotlib` for the noarch build —
  molamola never opens a GUI.
- `pyliftover` is an optional script-time dep (only used by
  `scripts/derive_canonical_exons.py --lift-to <chain>`); not in
  `requirements.run`.
- ~13 MB of bundled ClinVar TSV inside `molamola/data/` is
  intentional: molamola is a closed-system tool with deterministic
  output. The `--clinvar PATH` flag accepts a fresher copy, but the
  bundled snapshot keeps the package useful out of the box.
- `run_exports` set to `pin_subpackage("molamola", max_pin="x.x")`
  per the 0.x.x semver guidance in the PR template.