### PR TITLE
Add tricord

### DIFF
--- a/recipes/tricord/build.sh
+++ b/recipes/tricord/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euo pipefail
+
+export RUST_BACKTRACE=1
+
+export BINDGEN_EXTRA_CLANG_ARGS="${CFLAGS} ${CPPFLAGS}"
+
+cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
+
+cargo install --no-track --locked --verbose --root "${PREFIX}" --path .

--- a/recipes/tricord/meta.yaml
+++ b/recipes/tricord/meta.yaml
@@ -1,0 +1,45 @@
+{% set name = "tricord" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/fg-labs/{{ name }}/archive/v{{ version }}.tar.gz
+  sha256: cc2a0cc0e9bbe35fbd911429895152ed0e7579a82a99b45ab3968a087dddeac6
+
+build:
+  number: 0
+  run_exports:
+    - {{ pin_subpackage("tricord", max_pin="x") }}
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ stdlib('c') }}
+    - {{ compiler('rust') }}
+    - cargo-bundle-licenses
+    - clangdev
+
+test:
+  commands:
+    - tricorder --help
+
+about:
+  home: https://github.com/fg-labs/tricord
+  license: MIT
+  license_family: MIT
+  license_file:
+    - LICENSE
+    - THIRDPARTY.yml
+  summary: Run a command and report its process tree's CPU, memory, and I/O usage
+  dev_url: https://github.com/fg-labs/tricord
+  doc_url: https://github.com/fg-labs/tricord/blob/v{{ version }}/README.md
+
+extra:
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64
+  recipe-maintainers:
+    - nh13


### PR DESCRIPTION
Adds a new recipe for [tricord](https://github.com/fg-labs/tricord) v0.1.0.

`tricord` runs a command, watches its entire process tree, and reports CPU, memory, and disk I/O usage. The companion binary is `tricorder`. Compared to Snakemake's built-in benchmark sampler, it counts I/O of exited children and is a single self-contained Rust binary.

Notes:

- Pure-Rust binary (`cargo install`-style recipe via `cargo-bundle-licenses` + `cargo install --no-track --locked`).
- Recipe was generated with [redskull](https://github.com/fg-labs/redskull) and verified locally:
  - `bioconda-utils lint --packages tricord` → "All checks OK".
  - `build.sh` runs end-to-end (`tricorder` installs, `tricorder --help` exits 0).
  - SHA256 verified against the GitHub archive of `v0.1.0`.
- `additional-platforms`: `linux-aarch64` and `osx-arm64` — the Linux back-end uses `procfs` and the macOS back-end uses `libproc` (both pure-Rust over libc). `clangdev` is in the build deps because `libproc`'s build script uses bindgen.
- `run_exports` uses `max_pin="x"` since the project is pre-1.0 (per the bioconda PR template's semantic-versioning-0.x.x guidance).

Recipe maintainer: @nh13.