### PR TITLE
Fix TEsmall 2.0.9 recipe: add missing wget dependency

### DIFF
--- a/recipes/tesmall/meta.yaml
+++ b/recipes/tesmall/meta.yaml
@@ -1,0 +1,63 @@
+{% set name = "tesmall" %}
+{% set version = "2.0.9" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/mhammell-laboratory/TEsmall/archive/refs/tags/{{ version }}.tar.gz
+  sha256: 457af1b1c3ddbd75e61ecd0921a36b351beef89f7bb1847e46c8e966a5a36e38
+
+build:
+  noarch: python
+  number: 0
+  entry_points:
+    - TEsmall = TEsmall.command_line:main
+  script:
+    - {{ PYTHON }} -m pip install . -vvv --no-deps --no-build-isolation --no-cache-dir
+  run_exports:
+    - {{ pin_subpackage('tesmall', max_pin="x.x") }}
+
+requirements:
+  host:
+    - python >=3.9
+    - pip
+    - setuptools
+  run:
+    - python >=3.9
+    - numpy >=1.11.3,<2.0
+    - scipy >=0.18.0
+    - pandas >=0.18.1
+    - matplotlib-base >=1.5.1
+    - seaborn >=0.7.1
+    - bokeh >=1.0.0,<3.0.0
+    - pysam >=0.9.1
+    - pybedtools >=0.7.8
+    - cutadapt >=1.10
+    - samtools
+    - bedtools
+    - bowtie
+
+test:
+  commands:
+    - TEsmall --help
+    - TEsmall --version
+  imports:
+    - TEsmall
+    - TEsmall.command_line
+
+about:
+  home: https://github.com/mhammell-laboratory/TEsmall
+  summary: A pipeline for profiling small RNAs
+  description: |
+    TEsmall is a tool that allows for the simultaneous processing and analysis of a  variety of small RNAs in a single integrated workflow.
+  license: GPL-3.0-only
+  license_family: GPL3
+  license_file: LICENSE
+  dev_url: https://github.com/mhammell-laboratory/TEsmall
+  doc_url: https://www.mghlab.org/software/tesmall
+
+extra:
+  recipe-maintainers:
+    - niekwit

--- a/recipes/tesmall/meta.yaml
+++ b/recipes/tesmall/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   entry_points:
     - TEsmall = TEsmall.command_line:main
   script:
@@ -38,6 +38,7 @@ requirements:
     - samtools
     - bedtools
     - bowtie
+    - wget
 
 test:
   commands:
@@ -51,7 +52,7 @@ about:
   home: https://github.com/mhammell-laboratory/TEsmall
   summary: A pipeline for profiling small RNAs
   description: |
-    TEsmall is a tool that allows for the simultaneous processing and analysis of a  variety of small RNAs in a single integrated workflow.
+    TEsmall is a tool that allows for the simultaneous processing and analysis of a variety of small RNAs in a single integrated workflow.
   license: GPL-3.0-only
   license_family: GPL3
   license_file: LICENSE


### PR DESCRIPTION
`wget` is required at runtime for downloading reference genome and annotation files but was missing from the original recipe.