### PR TITLE
Add baysor-v0.7.1

### DIFF
--- a/recipes/baysor/build.sh
+++ b/recipes/baysor/build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+mkdir -p "${PREFIX}/bin"
+mkdir -p "${PREFIX}/lib/baysor"
+
+# copy the entire bundled runtime
+cp -r bin/baysor/* "${PREFIX}/lib/baysor/"
+
+# make all files writable so conda-build can patch rpaths
+chmod -R u+w "${PREFIX}/lib/baysor/"
+
+# create a wrapper script that sets library path before running
+cat > "${PREFIX}/bin/baysor" << 'EOF'
+#!/bin/bash
+export LD_LIBRARY_PATH="${CONDA_PREFIX}/lib/baysor/lib:${LD_LIBRARY_PATH}"
+exec "${CONDA_PREFIX}/lib/baysor/bin/baysor" "$@"
+EOF
+
+chmod +x "${PREFIX}/bin/baysor"

--- a/recipes/baysor/meta.yaml
+++ b/recipes/baysor/meta.yaml
@@ -9,6 +9,9 @@ source:
   sha256: f37f02695a068fd360ade7abd0f91b07c5199a3cce6e91ded550689459fbe5c0
 
 build:
+  noarch: generic
+  run_exports:
+    - {{ pin_subpackage('baysor', max_pin='x.x')}}
   number: 0
   skip: True
   binary_relocation: false

--- a/recipes/baysor/meta.yaml
+++ b/recipes/baysor/meta.yaml
@@ -9,11 +9,8 @@ source:
   sha256: f37f02695a068fd360ade7abd0f91b07c5199a3cce6e91ded550689459fbe5c0
 
 build:
-  noarch: generic
-  run_exports:
-    - {{ pin_subpackage('baysor', max_pin='x.x')}}
   number: 0
-  skip: True
+  skip: True  # [not linux]
   binary_relocation: false
 
 test:

--- a/recipes/baysor/meta.yaml
+++ b/recipes/baysor/meta.yaml
@@ -18,6 +18,7 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
+    - {{ stdlib('c') }}
 
 test:
   commands:

--- a/recipes/baysor/meta.yaml
+++ b/recipes/baysor/meta.yaml
@@ -1,0 +1,31 @@
+{% set version = "0.7.1" %}
+
+package:
+  name: baysor
+  version: "{{ version }}"
+
+source:
+  url: https://github.com/kharchenkolab/Baysor/releases/download/v{{ version }}/baysor-x86_x64-linux-v{{ version }}_build.zip
+  sha256: f37f02695a068fd360ade7abd0f91b07c5199a3cce6e91ded550689459fbe5c0
+
+build:
+  number: 0
+  skip: True
+  binary_relocation: false
+
+test:
+  commands:
+    - baysor --help
+
+about:
+  home: https://github.com/kharchenkolab/Baysor
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: Bayesian segmentation of imaging-based spatial transcriptomics data
+  doc_url: https://kharchenkolab.github.io/Baysor/dev/
+  dev_url: https://github.com/kharchenkolab/Baysor
+
+extra:
+  recipe-maintainers:
+    - khersameesh24

--- a/recipes/baysor/meta.yaml
+++ b/recipes/baysor/meta.yaml
@@ -12,6 +12,8 @@ build:
   number: 0
   skip: True  # [not linux]
   binary_relocation: false
+  run_exports:
+    - {{ pin_subpackage('baysor', max_pin='x.x') }}
 
 test:
   commands:

--- a/recipes/baysor/meta.yaml
+++ b/recipes/baysor/meta.yaml
@@ -15,6 +15,10 @@ build:
   run_exports:
     - {{ pin_subpackage('baysor', max_pin='x.x') }}
 
+requirements:
+  build:
+    - {{ compiler('c') }}
+
 test:
   commands:
     - baysor --help


### PR DESCRIPTION
Added new recipe for Baysor v0.7.1
- baysor is a segmentation method and it used in nf-core pipelines
- pre-compiled binary used to build recipe
- recommended installation method by the developers of the package
- compilation takes a long time (too many dependencies) and usually fails with a timeout, hence the use of binaries

Closes #48883 
Closes #64488 