### PR TITLE
Add recipe for gtdb-gtranslate version 0.0.3

### DIFF
--- a/recipes/gtdb-gtranslate/meta.yaml
+++ b/recipes/gtdb-gtranslate/meta.yaml
@@ -1,0 +1,60 @@
+{% set name = "gtdb-gtranslate" %}
+{% set version = "0.0.3" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/g/gtdb-gtranslate/gtdb_gtranslate-{{ version }}.tar.gz
+  sha256: 0b5f8168d76f1ee31ddc81561180270f2a942658465a8a808b674504bfb678ed
+
+build:
+  entry_points:
+    - gtranslate = gtranslate.__main__:main
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python >=3.12
+    - setuptools >=61.0
+    - wheel
+    - pip
+  run:
+    - python >=3.12
+    - joblib >=1.3,<2.dev0
+    - numpy >=1.26.4,<2.0.0
+    - pandas >=2.2,<3.dev0
+    - scikit-learn ==1.6.1
+    - scipy >=1.12,<2.dev0
+    - tqdm >=4.67,<5.dev0
+    - mlxtend >=0.23,<0.24.0
+    - plotly >=5.15,<6.dev0
+    - xgboost ==2.1.4
+    - lightgbm ==4.6.0
+    - requests >=2.32.3
+
+test:
+  imports:
+    - gtranslate
+  commands:
+    - pip check
+    - gtranslate --help
+  requires:
+    - pip
+    - python
+
+about:
+  home: https://pypi.org/project/gtdb-gtranslate/
+  summary: software tool designed to accurately identify the genetic translation table (GTT) used in prokaryotic organisms.
+  license: GPL-3.0-only
+  license_file: LICENSE
+  doc_url: "https://cmc-aau.github.io/gTranslate"
+
+extra:
+  recipe-maintainers:
+    - pchaumeil
+    - donovan-h-parks
+

--- a/recipes/gtdb-gtranslate/meta.yaml
+++ b/recipes/gtdb-gtranslate/meta.yaml
@@ -15,6 +15,8 @@ build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
+  run_exports:
+    - { { pin_subpackage(name, max_pin="x.x") } }
 
 requirements:
   host:

--- a/recipes/gtdb-gtranslate/meta.yaml
+++ b/recipes/gtdb-gtranslate/meta.yaml
@@ -16,7 +16,7 @@ build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
   run_exports:
-    - { { pin_subpackage(name, max_pin="x.x") } }
+    - {{ pin_subpackage(name, max_pin="x.x") }}
 
 requirements:
   host:


### PR DESCRIPTION
This pull request adds a new Conda recipe for the `gtdb-gtranslate` package, enabling its installation and management via Conda. The recipe specifies package metadata, dependencies, build instructions, and test commands to ensure proper integration into the Conda ecosystem.

**New package addition:**

* Added a new Conda recipe for `gtdb-gtranslate` version 0.0.3, including package metadata, source URL, dependencies, build instructions, and test commands in `recipes/gtdb-gtranslate/meta.yaml`.Describe your pull request here

gTranslate is a machine learning-based command-line tool for predicting the translation table (TT) used by prokaryotic genomes. By analyzing specific sequence features — such as coding density differences, Trp ratios, and Gly ratios — gTranslate can accurately distinguish between the genetic codes associated with reassignment of the UGA stop codon, i.e. translation tables 11 (standard prokaryotic code), 4 (UGA=Trp), and 25 (UGA=Gly).

----


