### PR TITLE
Update ecolityper: build number 1, fix serotyping, allow pip install …

### DIFF
--- a/recipes/ecolityper/meta.yaml
+++ b/recipes/ecolityper/meta.yaml
@@ -7,12 +7,12 @@ package:
 
 source:
   url: https://github.com/bbeckley-hub/EcoliTyper/archive/v{{ version }}.tar.gz
-  sha256: c52d46f5ac7bcbc4404a622f90978d9e493a788576dcba66c261cd2e8b5d89d8
+  sha256: af602f8181f1dddbc8231d971ebaf86633e16bdcd2bc5ace84c43982f3f17f3f
 
 build:
   noarch: python
-  number: 0
-  script: "{{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vvv"
+  number: 1
+  script: "{{ PYTHON }} -m pip install . --no-build-isolation -vvv"
   run_exports:
     - {{ pin_subpackage(name, max_pin="x") }}
 


### PR DESCRIPTION
Fix serotyping (distutils → shutil) and allow pip to install ezclermont. No version change, build number 1.