### PR TITLE
Update tecap: retract unsupported mechanism prose

### DIFF
--- a/recipes/tecap/meta.yaml
+++ b/recipes/tecap/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 9408733a7313ea549966e7deb621c877eec867a7ed8fad620e71c55a28d744c9
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:
@@ -46,10 +46,12 @@ about:
     tecap classifies long-read alignments by where their 3' end lands relative
     to the terminal exon, its UTR, and a polyA site atlas. It decomposes
     capture failures into nine mechanism buckets and measures reference base
-    composition downstream of each cleavage site to distinguish classic
-    A-tract internal priming from moderate-A priming characteristic of
-    saturating in-solution oligo-dT. Designed for PacBio Iso-Seq / Kinnex
-    and Oxford Nanopore cDNA BAMs. Direct-RNA sequencing is unsupported.
+    composition downstream of each cleavage site, separating classical A-tract
+    internal priming (>=60% A) from moderate-A priming (30-50% A). Empirically
+    the two regimes split single-cell preps from bulk Iso-Seq; the biochemical
+    driver of the split is currently uncharacterized. Designed for PacBio
+    Iso-Seq / Kinnex and Oxford Nanopore cDNA BAMs. Direct-RNA sequencing is
+    unsupported.
   license: MIT
   license_family: MIT
   license_file: LICENSE


### PR DESCRIPTION
Description-only fix for tecap (recipe was just bumped to 0.3.2 in                                                                                                    
  #65059 by the auto-update bot). Bumping build number 0 -> 1 because              
  this changes the package metadata visible via `conda search --info`.                                                                                                  
                                                                                   
  The previous about.description attributed the moderate-A vs
  classical-A priming split to "saturating in-solution oligo-dT". That
  mechanistic claim is not supported by available bench data: bulk                                                                                                      
  Iso-Seq final oligo-dT is 1.2 uM, in line with FS-ONT and BD    
  Rhapsody, so bulk oligo-dT concentration cannot be the axis driving                                                                                                   
  the split. The same retraction has shipped upstream in v0.3.2                    
  README, CITATION.cff, and .zenodo.json.                                                                                                                               
                                                                                   
  The replacement description sticks to the empirical observation:                                                                                                      
  single-cell prep datasets cluster in the 30-50% A regime, bulk  
  Iso-Seq datasets cluster past the >=60% A line, and the biochemical                                                                                                   
  driver is currently uncharacterized. 