### PR TITLE
Update btllib to 1.7.8

### DIFF
--- a/recipes/btllib/build.sh
+++ b/recipes/btllib/build.sh
@@ -11,10 +11,8 @@ sed -i.bak 's|VERSION 2.8.11|VERSION 3.5|' subprojects/sdsl-lite/CMakeLists.txt
 rm -rf subprojects/cpptoml/*.bak
 rm -rf subprojects/sdsl-lite/*.bak
 
-if [[ "${target_platform}" == "osx-64" ]]; then
-    sed -i.bak '/find_package(LIBCXX/d' subprojects/cpptoml/CMakeLists.txt
-    sed -i.bak '/set_libcxx_required_flags/d' subprojects/cpptoml/CMakeLists.txt
-fi
+sed -i.bak '/find_package(LIBCXX/d' subprojects/cpptoml/CMakeLists.txt
+sed -i.bak '/set_libcxx_required_flags/d' subprojects/cpptoml/CMakeLists.txt
 
 CXX="${CXX}" CXXFLAGS="${CXXFLAGS}" LDFLAGS="${LDFLAGS}" meson setup --buildtype release \
 	--prefix "${PREFIX}" --strip -Db_coverage=false build/

--- a/recipes/btllib/build.sh
+++ b/recipes/btllib/build.sh
@@ -11,6 +11,11 @@ sed -i.bak 's|VERSION 2.8.11|VERSION 3.5|' subprojects/sdsl-lite/CMakeLists.txt
 rm -rf subprojects/cpptoml/*.bak
 rm -rf subprojects/sdsl-lite/*.bak
 
+if [[ "${target_platform}" == "osx-64" ]]; then
+    sed -i.bak '/find_package(LIBCXX/d' subprojects/cpptoml/CMakeLists.txt
+    sed -i.bak '/set_libcxx_required_flags/d' subprojects/cpptoml/CMakeLists.txt
+fi
+
 CXX="${CXX}" CXXFLAGS="${CXXFLAGS}" LDFLAGS="${LDFLAGS}" meson setup --buildtype release \
 	--prefix "${PREFIX}" --strip -Db_coverage=false build/
 

--- a/recipes/btllib/meta.yaml
+++ b/recipes/btllib/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "btllib" %}
-{% set version = "1.7.7" %}
+{% set version = "1.7.8" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/BirolLab/btllib/releases/download/v{{ version }}/{{ name|lower }}-{{ version }}.tar.gz
-  sha256: 9e81a509f60d5bf7f19d5e5d052248a92425fec5809d0d31368537660336247a
+  sha256: cd213d20a971ae3441551dd61b0e46a08559e3d9da19cb59ee8dc3397807f121
   patches:
     - sdsl-louds-tree-fix.patch
 
@@ -19,6 +19,7 @@ build:
 requirements:
   build:
     - {{ compiler('cxx') }}
+    - {{ stdlib('c') }}
     - python
     - cmake <4
     - meson


### PR DESCRIPTION
- Add `stdlib('c')` for linting
- Needed to add extra `sed` commands to fix osx-64 error
----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
