### PR TITLE
Update gfaffix version to 0.2.2

### DIFF
--- a/recipes/gfaffix/meta.yaml
+++ b/recipes/gfaffix/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "GFAffix" %}
-{% set version = "0.2.1" %}
-{% set sha256 = "19435b111b6da680f43278301c5ec340263312556a906dd22ade35dbdae4bd78 " %}
+{% set version = "0.2.2" %}
+{% set sha256 = "c92769443999780cca9ed1b9a9b4f6444a97200aef2178c335c4d7623abd4708" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://github.com/marschall-lab/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
+  url: https://github.com/codialab/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:
@@ -27,12 +27,12 @@ test:
     - gfaffix --help
 
 about:
-  home: https://github.com/marschall-lab/{{ name }}
+  home: https://github.com/codialab/{{ name }}
   license: MIT
   license_family: MIT
   license_file: LICENSE.md
   summary: "GFAffix identifies and collapses walk-preserving shared affixes in variation graphs" 
-  dev_url: https://github.com/marschall-lab/{{ name|lower }}
+  dev_url: https://github.com/codialab/{{ name|lower }}
 
 
 extra:

--- a/recipes/gfaffix/meta.yaml
+++ b/recipes/gfaffix/meta.yaml
@@ -17,6 +17,7 @@ build:
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - {{ compiler('rust') }}
     - cmake


### PR DESCRIPTION
Bumps the version of GFAffix to 0.2.2 (fixes a previous bug)

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
