### PR TITLE
Update molamola to 0.2.0

### DIFF
--- a/recipes/molamola/meta.yaml
+++ b/recipes/molamola/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "molamola" %}
-{% set version = "0.1.0" %}
+{% set version = "0.2.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 0318335cd45fb56bdb4bcd1d915af00b427ef58f84a2434afaf60ac91d9310c8
+  sha256: 6653ec0f5dd1719111491442f3b9b17a40ad1ad4adcb4df36be783e9cdbcd37e
 
 build:
   number: 0


### PR DESCRIPTION
## Summary

- Bumps `molamola` recipe from 0.1.0 → 0.2.0.
- Source: https://pypi.org/project/molamola/0.2.0/
- sha256 of the new sdist: `6653ec0f5dd1719111491442f3b9b17a40ad1ad4adcb4df36be783e9cdbcd37e`

## What's new in 0.2.0

- Adds an opt-in `--png` flag that writes each embedded figure as a standalone PNG alongside the HTML report. Default behaviour unchanged. Closes upstream issue [martinandclaude/molamola#1](https://github.com/martinandclaude/molamola/issues/1) — useful for embedding molamola figures in MultiQC and similar pipeline reports.

No dependency or run_exports changes from 0.1.0.