### PR TITLE
fix: update civicpy

### DIFF
--- a/recipes/civicpy/meta.yaml
+++ b/recipes/civicpy/meta.yaml
@@ -1,47 +1,42 @@
 {% set name = "civicpy" %}
 {% set version = "5.4.0" %}
-
 package:
   name: {{ name|lower }}
   version: {{ version }}
-
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 48991a1ddd7f0f6cc9246070a0b7f486bdc08f4b47dbd6738bdd9abfbce43fad
-
 build:
-  number: 0
+  number: 2
   noarch: python
+  run_exports:
+    - {{ pin_subpackage('civicpy', max_pin="x") }}
   entry_points:
     - civicpy = civicpy.cli:cli
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --no-cache-dir --use-pep517 -vvv
-  run_exports:
-    - {{ pin_subpackage('civicpy', max_pin="x") }}
-
 requirements:
-  host: 
+  host:
     - pip
     - python >=3.10
     - setuptools
   run:
     - python >=3.10
-    - backports
-    - backports-datetime-fromisoformat
     - click
     - deprecation
+    - ga4gh.vrs
+    - ga4gh.cat_vrs
+    - ga4gh.va_spec >=0.4.1,<0.5
     - networkx
     - obonet
-    - pandas
+    - pandas <=2.3.3
     - pysam
     - requests
-    - vcfpy
-
+    - vcfpy >=0.13.8,<0.14
 test:
   imports:
     - civicpy
-  #commands:
-    #- civicpy --help
-
+  commands:
+    - civicpy --help
 about:
   home: "https://civicpy.org"
   license: MIT

--- a/recipes/civicpy/meta.yaml
+++ b/recipes/civicpy/meta.yaml
@@ -7,7 +7,7 @@ source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 48991a1ddd7f0f6cc9246070a0b7f486bdc08f4b47dbd6738bdd9abfbce43fad
 build:
-  number: 2
+  number: 1
   noarch: python
   run_exports:
     - {{ pin_subpackage('civicpy', max_pin="x") }}


### PR DESCRIPTION
We need to update some of the dependencies of civicpy given some recent changes in the package upstream

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
