### PR TITLE
Fix GECCO dependency

### DIFF
--- a/recipes/gecco/meta.yaml
+++ b/recipes/gecco/meta.yaml
@@ -32,7 +32,7 @@ requirements:
     - importlib_resources >=5.7  #[py37, py38, py39, py310]
     - numpy >=1.0,<3.0
     - polars >=1.0,<2.0
-    - pyhmmer >=0.11.0,<0.12.0
+    - pyhmmer >=0.12.0
     - pyrodigal >=3.0,<4.0
     - rich >=12.4.0
     - rich-argparse >=1.0,<2.0

--- a/recipes/gecco/meta.yaml
+++ b/recipes/gecco/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 9edcec2c5bd419b75e5035ef4c650365bdc2a53769793447df41688091137e97
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv "
   run_exports:


### PR DESCRIPTION
GECCO depends on pyhmmer 0.12.0 since version 0.10.2. See [GECCO's changelog](https://github.com/zellerlab/GECCO/blob/e837e629e1264b17ce800acc4595f468c8fae1b9/CHANGELOG.md?plain=1#L25).