### PR TITLE
Bump metabat to latest commit

### DIFF
--- a/recipes/metabat2/cmake.patch
+++ b/recipes/metabat2/cmake.patch
@@ -1,14 +1,14 @@
-diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index 3cf10bc..9b8a50a 100644
+diff --ruN a/src/CMakeLists.txt b/src/CMakeLists.txt
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
-@@ -1,8 +1,12 @@
+@@ -1,9 +1,12 @@
  # find and use Boost
 +set(Boost_NO_SYSTEM_PATHS ON)
 +set(Boost_NO_WARN_NEW_VERSION ON)
  set(Boost_NO_BOOST_CMAKE ON) # for backwards comptibility of cmake and boost >= 1.70
 -set(Boost_USE_STATIC_LIBS   ON)
--find_package(Boost 1.55.0 COMPONENTS program_options filesystem system graph serialization iostreams REQUIRED)
+-#find_package(Boost 1.55.0 COMPONENTS program_options filesystem system graph serialization iostreams REQUIRED) # after boost 1.69 system is header only
+-find_package(Boost 1.69.0 COMPONENTS program_options filesystem graph serialization iostreams REQUIRED)
 +set(Boost_USE_STATIC_LIBS OFF)
 +set(Boost_USE_MULTITHREADED TRUE)
 +find_package(Boost 1.71.0 COMPONENTS program_options filesystem system graph serialization iostreams REQUIRED)

--- a/recipes/metabat2/meta.yaml
+++ b/recipes/metabat2/meta.yaml
@@ -26,6 +26,7 @@ requirements:
   build:
     - {{ compiler('cxx') }}
     - {{ compiler('c') }}
+    - {{ stdlib('c') }}
     - cmake
     - make
     - autoconf

--- a/recipes/metabat2/meta.yaml
+++ b/recipes/metabat2/meta.yaml
@@ -1,9 +1,13 @@
 {% set name = "metabat2" %}
 {% set version = "2.18" %}
+# metabat releases infrequently, but every tested push to the master branch
+# is a new release that gets put up on docker, see https://bitbucket.org/berkeleylab/metabat/issues/184/jgi_summarize_bam_contig_depths-core-dump
+# version sufix is a number + part of the commit hash
+{% set version_suffix = "23-gc869c52" %}
 
 package:
   name: {{ name }}
-  version: {{ version }}
+  version: {{ version }}_{{ version_suffix }}
 
 source:
 - url: https://bitbucket.org/berkeleylab/metabat/get/c869c524d0f1.zip  # [linux]
@@ -11,11 +15,12 @@ source:
   patches:  # [linux]
     - cmake.patch  # [linux]
     - cmake-htslib.patch  # [linux and aarch64]
-- url: https://bitbucket.org/berkeleylab/metabat/get/cdb66e9c2fab2cf11ee156ad2e7d7690fb7c8a26.tar.bz2  # [osx]
-  sha256: 7f09be5dbff4ccf046088e967f68252a521b9c7372eb6cd8566925da6e8d4440  # [osx]
-  patches:  # [osx]
-    - 0004-osx-CMakeLists.patch  # [osx]
-    - 0005-GetGitVersion.patch  # [osx]
+# this source for osx refers to an unreleased branch, we can readd once merged to master (using same source for osx+linux)
+# - url: https://bitbucket.org/berkeleylab/metabat/get/cdb66e9c2fab2cf11ee156ad2e7d7690fb7c8a26.tar.bz2  # [osx]
+#   sha256: 7f09be5dbff4ccf046088e967f68252a521b9c7372eb6cd8566925da6e8d4440  # [osx]
+#   patches:  # [osx]
+#     - 0004-osx-CMakeLists.patch  # [osx]
+#     - 0005-GetGitVersion.patch  # [osx]
 
 build:
   number: 3

--- a/recipes/metabat2/meta.yaml
+++ b/recipes/metabat2/meta.yaml
@@ -6,8 +6,8 @@ package:
   version: {{ version }}
 
 source:
-- url: https://bitbucket.org/berkeleylab/metabat/get/v{{ version }}.tar.bz2  # [linux]
-  sha256: 7decee72535c75c390e8ddfb84e2e4d23bab9a4c2c85438e2270b19a7f3e568a  # [linux]
+- url: https://bitbucket.org/berkeleylab/metabat/get/c869c524d0f1.zip  # [linux]
+  sha256: ab4a4df1a4af3ce315317318a53b242e4f91d03e9ffe356279a69dd5df4d7e3c  # [linux]
   patches:  # [linux]
     - cmake.patch  # [linux]
     - cmake-htslib.patch  # [linux and aarch64]
@@ -18,7 +18,7 @@ source:
     - 0005-GetGitVersion.patch  # [osx]
 
 build:
-  number: 2
+  number: 3
   run_exports:
     - {{ pin_subpackage(name, max_pin="x") }}
 

--- a/recipes/metabat2/meta.yaml
+++ b/recipes/metabat2/meta.yaml
@@ -3,7 +3,7 @@
 # metabat releases infrequently, but every tested push to the master branch
 # is a new release that gets put up on docker, see https://bitbucket.org/berkeleylab/metabat/issues/184/jgi_summarize_bam_contig_depths-core-dump
 # version sufix is a number + part of the commit hash
-{% set version_suffix = "23-gc869c52" %}
+{% set version_suffix = "23_gc869c52" %}
 
 package:
   name: {{ name }}

--- a/recipes/metabat2/meta.yaml
+++ b/recipes/metabat2/meta.yaml
@@ -23,7 +23,7 @@ source:
 #     - 0005-GetGitVersion.patch  # [osx]
 
 build:
-  number: 3
+  number: 0
   run_exports:
     - {{ pin_subpackage(name, max_pin="x") }}
 

--- a/recipes/metabat2/meta.yaml
+++ b/recipes/metabat2/meta.yaml
@@ -24,6 +24,7 @@ source:
 
 build:
   number: 0
+  skip: True # [osx]
   run_exports:
     - {{ pin_subpackage(name, max_pin="x") }}
 


### PR DESCRIPTION
following the release strategy of upstream xref
https://bitbucket.org/berkeleylab/metabat/issues/184/jgi_summarize_bam_contig_depths-core-dump (see last comment)

Describe your pull request here

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
