### PR TITLE
Update r-cobrar

### DIFF
--- a/recipes/r-cobrar/meta.yaml
+++ b/recipes/r-cobrar/meta.yaml
@@ -24,6 +24,7 @@ build:
 requirements:
   build:
     - {{ compiler('cxx') }}
+    - {{ stdlib('c') }}
     - make
   host:
     - glpk >=4.65

--- a/recipes/r-cobrar/meta.yaml
+++ b/recipes/r-cobrar/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "cobrar" %}
-{% set version = '0.2.4' %}
+{% set version = '0.2.5' %}
 {% set github = "https://github.com/Waschina/cobrar" %}
-{% set sha256 = 'faf043346b20a0b96eefea3654adee1b3b91664ed7e7482b823f20b1ee659576' %}
+{% set sha256 = 'fc35893c253212016f746cef407e872e86b8b12d24238232ae0964743324fb04' %}
 
 package:
   name: r-{{ name }}


### PR DESCRIPTION
This PR fixes the lint error from the autobump PR in the `r-cobrar` recipe by adding the missing `stdlib('c') ` requirement.

Update [`r-cobrar`](https://bioconda.github.io/recipes/r-cobrar/README.html): **0.2.4** &rarr; **0.2.5**

[![install with bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg?style=flat)](http://bioconda.github.io/recipes/r-cobrar/README.html) [![Conda](https://img.shields.io/conda/dn/bioconda/r-cobrar.svg)](https://anaconda.org/bioconda/r-cobrar/files)

Info | Link or Description
-----|--------------------
Recipe | [`recipes/r-cobrar`](https://github.com//bioconda/bioconda-recipes/tree/bump/r_cobrar/recipes/r-cobrar) (click to view/edit other files)
Summary | COnstraint-based Reconstruction and Analysis (COBRA) of metabolic networks in R
Home | [https://github.com/Waschina/cobrar](https://github.com/Waschina/cobrar)
Releases |[https://github.com/Waschina/cobrar/tags](https://github.com/Waschina/cobrar/tags)
Recipe Maintainer(s) | @Waschina
Author | `@Waschina`

The autobump PR (#65144 ) failed Bioconda linting with:
```
compiler_needs_stdlib_c: The recipe requests a compiler in the build section, but does not have stdlib.
```

This PR adds:
```
- {{ stdlib('c') }}
```
to the requirements: build: section of recipes/r-cobrar/meta.yaml