### PR TITLE
Update seqera to 1.7.0

### DIFF
--- a/recipes/seqera/meta.yaml
+++ b/recipes/seqera/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.5.0" %}
+{% set version = "1.7.0" %}
 {% set name = "seqera" %}
 
 package:
@@ -7,11 +7,11 @@ package:
 
 source:
   - url: https://registry.npmjs.org/@seqera/cli-linux-x64/-/cli-linux-x64-{{ version }}.tgz  # [linux]
-    sha256: 2d9fc3bb9f8db7c61f8e891dd4667dfed089c1968a97699e52d494b3cde6dced  # [linux]
+    sha256: d8f36950f36e377346b6b8c9ac797076f9fac07392fcc738766a5be8f190fac1  # [linux]
   - url: https://registry.npmjs.org/@seqera/cli-darwin-x64/-/cli-darwin-x64-{{ version }}.tgz  # [osx and x86_64]
-    sha256: 6a01933ef20c53a56a032388921a5ba7be566c88cf8717b2a5a56b6103f31b10  # [osx and x86_64]
+    sha256: 067b649817a50779bbaed4c484317b790dcfbee8a7dd5b7229d2fd02f7b55a77  # [osx and x86_64]
   - url: https://registry.npmjs.org/@seqera/cli-darwin-arm64/-/cli-darwin-arm64-{{ version }}.tgz  # [osx and arm64]
-    sha256: 5c099cb8accb6c031254e990435107963444cf1e83b6eb9d61c0508addb11797  # [osx and arm64]
+    sha256: b2467c801912e66ec81de4b25e792e762af454a16846c020afd396ae03c8e9d2  # [osx and arm64]
 
 build:
   number: 0


### PR DESCRIPTION
Update the seqera recipe to the latest CLI release, 1.7.0.

SHA256 values were generated from the npm platform tarballs:
- @seqera/cli-linux-x64@1.7.0
- @seqera/cli-darwin-x64@1.7.0
- @seqera/cli-darwin-arm64@1.7.0