### PR TITLE
fix(qpx): add scipy, mudata, anndata to run dependencies

### DIFF
--- a/recipes/qpx/meta.yaml
+++ b/recipes/qpx/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 80afef9d60e395126d3eac5e7bddfd2b04178a7540ddba40b9af7cf45dc5923e
 
 build:
-  number: 0
+  number: 1
   noarch: python
   run_exports:
     - {{ pin_subpackage(name, max_pin="x.x") }}
@@ -33,6 +33,9 @@ requirements:
     - numpy >=1.24
     - duckdb >=1.1.3
     - pyyaml >=6.0
+    - scipy
+    - mudata >=0.2.4
+    - anndata >=0.9.0
 
 test:
   imports:


### PR DESCRIPTION
This pull request updates the `qpx` recipe to add new dependencies and increment the build number. The most important changes are the addition of several required Python packages to the runtime dependencies, which will ensure better compatibility and functionality for users.

**Dependency updates:**

* Added `scipy`, `mudata >=0.2.4`, and `anndata >=0.9.0` to the `run` requirements in `recipes/qpx/meta.yaml`.

**Build metadata:**

* Incremented the build `number` from 0 to 1 in `recipes/qpx/meta.yaml`.