### PR TITLE
Add TAtouScan v0.2.0

### DIFF
--- a/recipes/tatouscan/meta.yaml
+++ b/recipes/tatouscan/meta.yaml
@@ -39,6 +39,7 @@ test:
     - pip
 
 about:
+  home: https://github.com/JeanMainguy/{{ name|lower }}
   summary: 'A command-line tool for identifying toxin-antitoxin (TA) systems in genomes and metagenomes. '
   license: MIT
   license_file: LICENSE

--- a/recipes/tatouscan/meta.yaml
+++ b/recipes/tatouscan/meta.yaml
@@ -1,0 +1,46 @@
+{% set name = "tatouscan" %}
+{% set version = "0.2.0" %}
+
+package:
+  name: tatouscan
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: fdee30704551bfedbd442cca2ddfa854695ee86ed2bfe7aa4209b625e5f55c32
+
+build:
+  entry_points:
+    - tatouscan = tatouscan.main:app
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python >=3.10
+    - setuptools >=61.0.0
+    - pip
+  run:
+    - python >=3.10
+    - pyfastx >=2.0.0,<3.0.0
+    - typer >=0.15.0,<0.16.0
+    - pyhmmer >=0.11.0,<0.12.0
+
+test:
+  imports:
+    - tatouscan
+  commands:
+    - pip check
+    - tatouscan --help
+  requires:
+    - pip
+
+about:
+  summary: 'A command-line tool for identifying toxin-antitoxin (TA) systems in genomes and metagenomes. '
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - JeanMainguy

--- a/recipes/tatouscan/meta.yaml
+++ b/recipes/tatouscan/meta.yaml
@@ -15,6 +15,8 @@ build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
+  run_exports:
+    - {{ pin_subpackage('tatouscan', max_pin="x.x") }}
 
 requirements:
   host:


### PR DESCRIPTION
This PR adds [TAtouScan](https://github.com/JeanMainguy/TAtouScan) a command-line tool for identifying toxin-antitoxin (TA) systems in genomes and metagenomes. 


### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
