### PR TITLE
Update latch lytekit pin to 0.15.35 for py3.12 support

### DIFF
--- a/recipes/latch/meta.yaml
+++ b/recipes/latch/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: bfb23bd05efd0ffcc4bf585ffbef1be721e3d354c001c6fc4055d728f9a26ac4
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps  --no-build-isolation --no-cache-dir -vvv
   entry_points:
@@ -37,7 +37,7 @@ requirements:
     - gql ==3.5.0
     - graphql-core ==3.2.3
     - latch-persistence >=0.1.5
-    - lytekit ==0.15.28
+    - lytekit ==0.15.35
     - lytekitplugins-pods ==0.7.4
     - orjson >=3.10.12
     - paramiko >=3.4.0


### PR DESCRIPTION
## Summary

Bump the `lytekit` pin on `latch 2.71.2` from `==0.15.28` to `==0.15.35`, matching the upstream `pyproject.toml`. This brings the recipe in line with the regenerated protobuf bindings shipped in `lyteidl 0.3.1` / `lytekit 0.15.35`, which support Python 3.12 under `protobuf >= 4`.

Background: latchbio/latch#589.

**Depends on conda-forge/lyteidl-feedstock#6 and conda-forge/lytekit-feedstock#9** — both need to merge and rebuild on conda-forge before this can resolve.

Build number bumped to 1 (version unchanged).

## Test plan

- Conda build resolves `lytekit 0.15.35` and transitively `lyteidl 0.3.1`, `protobuf 4.x/5.x` on the noarch matrix including py3.12.
- Existing `latch --help` test continues to pass.