### PR TITLE
Add mako: fast SAM/BAM sorter

### DIFF
--- a/recipes/fg-mako/build.sh
+++ b/recipes/fg-mako/build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+
+export RUST_BACKTRACE=1
+
+export CPPFLAGS="${CPPFLAGS} -I${PREFIX}/include"
+export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib"
+export CFLAGS="${CFLAGS} -O3"
+export LD_LIBRARY_PATH="${PREFIX}/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+export DYLD_FALLBACK_LIBRARY_PATH="${PREFIX}/lib${DYLD_FALLBACK_LIBRARY_PATH:+:${DYLD_FALLBACK_LIBRARY_PATH}}"
+
+cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
+
+cargo install --no-track --locked --verbose --root "${PREFIX}" --path .

--- a/recipes/fg-mako/meta.yaml
+++ b/recipes/fg-mako/meta.yaml
@@ -1,0 +1,54 @@
+{% set name = "fg-mako" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/fg-labs/mako/archive/v{{ version }}.tar.gz
+  sha256: 78903f301343718d262c7b39c77bdee0727ed6039dfe512d9cb8dd5f3565c114
+
+build:
+  number: 0
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x.x") }}
+  ignore_run_exports_from:
+    - libdeflate
+    - libgit2
+    - zlib
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ stdlib('c') }}
+    - {{ compiler('rust') }}
+    - cargo-bundle-licenses
+    - pkg-config
+    - make
+  host:
+    - libdeflate
+    - libgit2
+    - zlib
+
+test:
+  commands:
+    - mako --version
+
+about:
+  home: https://github.com/fg-labs/mako
+  license: MIT
+  license_family: MIT
+  license_file:
+    - LICENSE
+    - THIRDPARTY.yml
+  summary: Fast SAM/BAM sorter (installs the `mako` binary).
+  dev_url: https://github.com/fg-labs/mako
+  doc_url: https://docs.rs/fg-mako
+
+extra:
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64
+  recipe-maintainers:
+    - nh13


### PR DESCRIPTION
## Add new recipe: `mako`

[`mako`](https://github.com/fg-labs/mako) is a fast SAM/BAM sorter, packaging the sort engine from [fgumi](https://github.com/fulcrumgenomics/fgumi) as a focused single-purpose CLI.

- Source: GitHub release archive `v0.1.0`
- Binary installed: `mako`
- License: MIT
- Locally built and tested with `conda-build` against bioconda + conda-forge channels with `conda-forge-pinning` variant config (osx-arm64). `mako --version` runs cleanly in the test environment.

Recipe generated with [redskull](https://github.com/fg-labs/redskull).

Please direct issues with this recipe to @nh13.