### PR TITLE
Update riker to 0.2.0

### DIFF
--- a/recipes/riker/build.sh
+++ b/recipes/riker/build.sh
@@ -1,5 +1,0 @@
-#!/bin/bash -e
-
-cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
-
-cargo install --no-track --locked --verbose --root "${PREFIX}" --path .

--- a/recipes/riker/meta.yaml
+++ b/recipes/riker/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "riker" %}
-{% set version = "0.1.0" %}
+{% set version = "0.2.0" %}
 
 package:
   name: {{ name }}
@@ -7,15 +7,28 @@ package:
 
 source:
   url: https://github.com/fulcrumgenomics/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: 0e140b02d723713c3648763e9fd3535a4fa6dca6c7371f8ef8ea9b5272801841
+  sha256: fd7ae8267c5b6dd665fedeb73de8346efb264b3cf6caf7c71d121a9600393399
 
 build:
   number: 0
+  script:
+    - cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
+    # x86_64: build a single launcher that embeds x86-64-v1/v2/v4 variants
+    # via cargo-multivers (configured by [package.metadata.multivers.x86_64]
+    # in Cargo.toml).
+    - cargo install --locked cargo-multivers                                       # [x86_64]
+    - cargo multivers --profile dist --out-dir "${PREFIX}/bin"                     # [x86_64]
+    # aarch64: a single portable ARMv8-A binary built with the dist profile.
+    # Do NOT use cargo-multivers here -- on non-x86_64 it would expand to every
+    # rustc-known CPU rather than the v1-v4 microarch levels.
+    - cargo install --no-track --locked --profile dist --root "${PREFIX}" --path . # [not x86_64]
   run_exports:
     - {{ pin_subpackage('riker', max_pin="x.x") }}
 
 requirements:
   build:
+    - {{ compiler('c') }}
+    - {{ stdlib('c') }}
     - {{ compiler('rust') }}
     - cargo-bundle-licenses
 
@@ -38,8 +51,6 @@ extra:
   additional-platforms:
     - linux-aarch64
     - osx-arm64
-  skip-lints:
-    - compiler_needs_stdlib_c  # until https://github.com/bioconda/bioconda-utils/issues/1095 is resolved
   recipe-maintainers:
     - nh13
     - tfenne

--- a/recipes/riker/meta.yaml
+++ b/recipes/riker/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/fulcrumgenomics/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: fd7ae8267c5b6dd665fedeb73de8346efb264b3cf6caf7c71d121a9600393399
+  sha256: e1270cbae29f63ad28ac475ced1710ca76c8c4cf6f62e2ac6cf0811a9fadb466
 
 build:
   number: 0

--- a/recipes/riker/meta.yaml
+++ b/recipes/riker/meta.yaml
@@ -32,6 +32,7 @@ requirements:
     - {{ stdlib('c') }}
     - {{ compiler('rust') }}
     - cargo-bundle-licenses
+    - clangdev <22
     - cmake
     - make
 

--- a/recipes/riker/meta.yaml
+++ b/recipes/riker/meta.yaml
@@ -28,9 +28,12 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
     - {{ stdlib('c') }}
     - {{ compiler('rust') }}
     - cargo-bundle-licenses
+    - cmake
+    - make
 
 test:
   commands:

--- a/recipes/riker/meta.yaml
+++ b/recipes/riker/meta.yaml
@@ -11,6 +11,12 @@ source:
 
 build:
   number: 0
+  # The cargo-multivers launcher is a single statically-linked binary that
+  # embeds zstd-compressed CPU-variant payloads. conda-build's macOS rpath
+  # post-processing runs `llvm-otool -l` on every binary and intermittently
+  # SIGABRTs on the launcher. We have nothing to relocate (no $PREFIX/lib
+  # rpaths -- everything is statically linked), so skip the pass entirely.
+  binary_relocation: false
   script:
     - cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
     # x86_64: build a single launcher that embeds x86-64-v1/v2/v4 variants


### PR DESCRIPTION
This is slightly more than a simple version bump on the recipe.  Riker's build got a little more complicated between v0.1.0 and v0.2.0, in that it now needs a full C toolchain to build, and the x86 build uses the `cargo-multivers` to provide a single-binary with optimizations for different ISAs on x86.  However, since aarch64 has shown no benefit from a multivers build, it still performs a regular release build - and the build script is bifurcated by architecture.

----

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
