### PR TITLE
Update trim-galore to 2.2.0

### DIFF
--- a/recipes/trim-galore/meta.yaml
+++ b/recipes/trim-galore/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "trim-galore" %}
-{% set version = "2.1.0" %}
+{% set version = "2.2.0" %}
 
 package:
   name: {{ name }}
@@ -7,11 +7,11 @@ package:
 
 source:
   - url: https://github.com/FelixKrueger/TrimGalore/releases/download/v{{ version }}/trim_galore-linux-x86_64.tar.gz  # [linux and x86_64]
-    sha256: d408c9d30b5302fa4acbda3df10ab810eafad5644e3c9eb6bc62e6ed5df5a4e1  # [linux and x86_64]
+    sha256: 7ed9de04632ef4b8430aa03ee9a8d0872822299279dfda4d637ff73cde7a6474  # [linux and x86_64]
   - url: https://github.com/FelixKrueger/TrimGalore/releases/download/v{{ version }}/trim_galore-linux-aarch64.tar.gz  # [linux and aarch64]
-    sha256: 4e073581269b92da490641f67ae6cd5417962c033416f25fe355d01e36ed9c8c  # [linux and aarch64]
+    sha256: 507c203ae72374a7a1ffa84ea20560707908fb720741d64dfb81984bfda22118  # [linux and aarch64]
   - url: https://github.com/FelixKrueger/TrimGalore/releases/download/v{{ version }}/trim_galore-macos-aarch64.tar.gz  # [osx and arm64]
-    sha256: 3cccb8d3193d3d54525c9ae85be110e2da6634f38deda8c64e98ea4ecca50934  # [osx and arm64]
+    sha256: cac32ddcd2ecd6837e770d097892002af2564781c9b3843ca70d75dda862d15b  # [osx and arm64]
 
 build:
   number: 0


### PR DESCRIPTION
Bumps the prebuilt-binary recipe from v2.1.0 to v2.2.0 — released today (2026-05-07): https://github.com/FelixKrueger/TrimGalore/releases/tag/v2.2.0

\`\`\`yaml
{% set version = \"2.1.0\" %}  →  {% set version = \"2.2.0\" %}
\`\`\`

Plus three new sha256s for the v2.2.0 tarballs:

| Arch | sha256 |
|---|---|
| linux-x86_64 | \`7ed9de04632ef4b8430aa03ee9a8d0872822299279dfda4d637ff73cde7a6474\` |
| linux-aarch64 | \`507c203ae72374a7a1ffa84ea20560707908fb720741d64dfb81984bfda22118\` |
| macos-aarch64 | \`cac32ddcd2ecd6837e770d097892002af2564781c9b3843ca70d75dda862d15b\` |

## What's new in v2.2.0 (vs v2.1.0)

- **\`--clumpify\` opt-in compression mode** — reorders reads by canonical 16-mer minimizer so similar reads share gzip dictionary windows; shrinks output 15–55% on fragment-clustered data (ATAC, Ribo, RRBS, RNA-seq, MiSeq amplicons). Coverage-diverse data (WGBS PE, scRNA-seq R2) regress, with per-data-type guidance in [the docs](https://www.trimgalore.com/performance/clumpy/).
- **\`--compression <N>\`** (1–9, default 1) — replaces \`--high_compression\` (which is removed in this release).
- **\`--memory <SIZE>\`** — tool-wide memory budget, used by clumpify for bin sizing.
- **Integer-arithmetic max_errors** in adapter alignment (~0.2% wall, byte-identical).
- **Memory & I/O reference data** added to the [Threading model docs](https://www.trimgalore.com/performance/threading/).

## Compatibility

- **\`--high_compression\` flag removed.** Users who previously passed \`--high_compression\` should switch to \`--compression 6\`. This is a real CLI removal of a v2.1.0 GA flag — not a pre-release shim.
- Everything else CLI-compatible. Same output filenames, same report format. Drop-in replacement.

## Build

No change to \`build.sh\` — same prebuilt-binary install pattern (conda_build hoists the single top-level dir from each tarball; \`install -m 0755 trim_galore \$PREFIX/bin/\`). \`build.number: 0\` for the version bump. \`skip: True  # [osx and x86_64]\` retained (no Intel-Mac binary in the v2.2.0 release; users should \`cargo install trim-galore\` for that platform).