### PR TITLE
Add raaqa 0.2.0

### DIFF
--- a/recipes/raaqa/meta.yaml
+++ b/recipes/raaqa/meta.yaml
@@ -8,7 +8,7 @@ source:
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -y
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation
   run_exports:
     - {{ pin_subpackage('raaqa', max_pin="x.x") }}
 
@@ -39,5 +39,3 @@ about:
 extra:
   recipe-maintainers:
     - kuzsam
-  skip-lints:
-    - should_be_noarch_generic

--- a/recipes/raaqa/meta.yaml
+++ b/recipes/raaqa/meta.yaml
@@ -14,11 +14,11 @@ build:
 
 requirements:
   host:
-    - python >=3.10
+    - python >=3.10,<3.14
     - pip
     - setuptools
   run:
-    - python >=3.10
+    - python >=3.10,<3.14
     - pysam >=0.22.0
     - matplotlib-base >=3.8
     - pandas >=2.0

--- a/recipes/raaqa/meta.yaml
+++ b/recipes/raaqa/meta.yaml
@@ -26,7 +26,6 @@ requirements:
 
 test:
   commands:
-    - hese --help
     - visualise --help
     - mapq_softclip --help
 

--- a/recipes/raaqa/meta.yaml
+++ b/recipes/raaqa/meta.yaml
@@ -39,3 +39,5 @@ about:
 extra:
   recipe-maintainers:
     - kuzsam
+  skip-lints:
+    - should_be_noarch_generic

--- a/recipes/raaqa/meta.yaml
+++ b/recipes/raaqa/meta.yaml
@@ -1,9 +1,12 @@
+{% set name = "raaqa" %}
+{% set version = "0.2.0" %}
+
 package:
-  name: raaqa
-  version: "0.2.0"
+  name: {{ name }}
+  version: {{ version }}
 
 source:
-  url: https://github.com/kuzsam/raaqa/archive/refs/tags/v0.2.0.tar.gz
+  url: https://github.com/kuzsam/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
   sha256: 0cdea6139d765cc7368ee8a3dc6c227472f81cc16a29852e09d96e9786af2a30
 
 build:
@@ -11,7 +14,7 @@ build:
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation
   run_exports:
-    - {{ pin_subpackage('raaqa', max_pin="x.x") }}
+    - {{ pin_subpackage(name, max_pin="x.x") }}
 
 requirements:
   host:

--- a/recipes/raaqa/meta.yaml
+++ b/recipes/raaqa/meta.yaml
@@ -8,6 +8,7 @@ source:
 
 build:
   number: 0
+  noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation
   run_exports:
     - {{ pin_subpackage('raaqa', max_pin="x.x") }}
@@ -38,5 +39,3 @@ about:
 extra:
   recipe-maintainers:
     - kuzsam
-  skip-lints:
-    - should_be_noarch_generic

--- a/recipes/raaqa/meta.yaml
+++ b/recipes/raaqa/meta.yaml
@@ -1,0 +1,39 @@
+package:
+  name: raaqa
+  version: "0.2.0"
+
+source:
+  url: https://github.com/kuzsam/raaqa/archive/refs/tags/v0.2.0.tar.gz
+  sha256: 0cdea6139d765cc7368ee8a3dc6c227472f81cc16a29852e09d96e9786af2a30
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -y
+
+requirements:
+  host:
+    - python >=3.10
+    - pip
+    - setuptools
+  run:
+    - python >=3.10
+    - pysam >=0.22.0
+    - matplotlib >=3.8
+    - pandas >=2.0
+    - numpy >=1.26
+
+test:
+  commands:
+    - hese --help
+    - visualise --help
+    - mapq_softclip --help
+
+about:
+  home: https://github.com/kuzsam/raaqa
+  license: MIT
+  license_file: LICENSE
+  summary: "Read Alignment-based Assembly Quality Assessment"
+
+extra:
+  recipe-maintainers:
+    - kuzsam

--- a/recipes/raaqa/meta.yaml
+++ b/recipes/raaqa/meta.yaml
@@ -8,7 +8,10 @@ source:
 
 build:
   number: 0
+  noarch: generic
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -y
+  run_exports:
+    - {{ pin_subpackage('raaqa', max_pin="x.x") }}
 
 requirements:
   host:
@@ -18,7 +21,7 @@ requirements:
   run:
     - python >=3.10
     - pysam >=0.22.0
-    - matplotlib >=3.8
+    - matplotlib-base >=3.8
     - pandas >=2.0
     - numpy >=1.26
 

--- a/recipes/raaqa/meta.yaml
+++ b/recipes/raaqa/meta.yaml
@@ -8,7 +8,6 @@ source:
 
 build:
   number: 0
-  noarch: generic
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -y
   run_exports:
     - {{ pin_subpackage('raaqa', max_pin="x.x") }}
@@ -40,3 +39,5 @@ about:
 extra:
   recipe-maintainers:
     - kuzsam
+  skip-lints:
+    - should_be_noarch_generic


### PR DESCRIPTION
Add raaqa 0.2.0 - Read Alignment-based Assembly Quality Assessment tool.
Python CLI package

Raaqa provides quantitative metrics and their visualisation for evaluating genome assembly quality.

Entry points in this release: mapq_softclip, visualise. A parental read-based phasing quality assessment module (hese) is coming in the next release.
