### PR TITLE
Update requirements in meta.yaml

### DIFF
--- a/recipes/sniffles/meta.yaml
+++ b/recipes/sniffles/meta.yaml
@@ -28,6 +28,7 @@ requirements:
     - python-edlib >=1.3.9
     - psutil >=5.9.4
     - numpy >=2.2.0
+    - pyspoa >=0.2.1
 
 test:
   commands:


### PR DESCRIPTION
Added missing requirement `pyspoa >=0.2.1` to `meta.yaml`
