### PR TITLE
Update hicstuff to 3.2.5

### DIFF
--- a/recipes/hicstuff/meta.yaml
+++ b/recipes/hicstuff/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.2.4" %}
+{% set version = "3.2.5" %}
 
 package:
   name: hicstuff
@@ -6,26 +6,27 @@ package:
 
 source:
   url: https://pypi.io/packages/source/h/hicstuff/hicstuff-{{ version }}.tar.gz
-  sha256: 7d74bcbddaff40029a07ed18283701110b338617fbbda13b9b6ec6e3cc107d02
+  sha256: 8db7b39fee781bdbbe81add343e2ff49d43ee5b41d21cd3e023962e62b1149b6
 
 build:
   number: 0
   noarch: python
   entry_points:
-    - hicstuff=hicstuff.main:main
+    - hicstuff=hicstuff.cli:cli
   run_exports:
     - {{ pin_subpackage('hicstuff', max_pin='x') }}
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --no-cache-dir -vvv
 
 requirements:
   host:
-    - python >=3.6
+    - python >=3.8
     - pip
     - setuptools
+    - wheel
   run:
-    - python >=3.6
+    - python >=3.8
     - biopython
-    - docopt
+    - rich-click >=1.7
     - matplotlib-base
     - numpy
     - pandas

--- a/recipes/hicstuff/meta.yaml
+++ b/recipes/hicstuff/meta.yaml
@@ -11,8 +11,6 @@ source:
 build:
   number: 0
   noarch: python
-  entry_points:
-    - hicstuff=hicstuff.cli:cli
   run_exports:
     - {{ pin_subpackage('hicstuff', max_pin='x') }}
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --no-cache-dir -vvv


### PR DESCRIPTION
- Version bump 3.2.4 → 3.2.5
- Update entry point: `hicstuff.main:main` → `hicstuff.cli:cli`
- Require Python ≥3.8
- Replace `docopt` with `rich-click >=1.7`
- Add `wheel` to host requirements