### PR TITLE
Add fastq-dupaway

### DIFF
--- a/recipes/fastq-dupaway/build.sh
+++ b/recipes/fastq-dupaway/build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+mkdir -p build
+cd build
+
+cmake ${CMAKE_ARGS} \
+    -DCMAKE_INSTALL_PREFIX=$PREFIX \
+    -DCMAKE_BUILD_TYPE=Release \
+    ..
+
+make -j${CPU_COUNT}
+
+mkdir -p $PREFIX/bin
+mv fastq-dupaway $PREFIX/bin/

--- a/recipes/fastq-dupaway/meta.yaml
+++ b/recipes/fastq-dupaway/meta.yaml
@@ -13,7 +13,8 @@ build:
   number: 0
   detect_binary_files_with_prefix: true
   run_exports:
-    - {{ pin_subpackage('fastq-dupaway', max_pin="x") }}
+    weak:
+      - {{ pin_subpackage(name, max_pin="x.x") }}
 
 requirements:
   build:
@@ -23,7 +24,7 @@ requirements:
   host:
     - boost-cpp
   run:
-    - boost-cpp
+    - libboost
 
 test:
   commands:
@@ -33,3 +34,8 @@ about:
   home: https://github.com/AndrewSigorskih/fastq-dupaway
   license: MIT
   summary: "Bioinformatics tool for memory-efficient deduplication of single-end and paired-end FASTQ and FASTA files"
+extra:
+  identifiers:
+    - doi:10.1038/s41598-025-28948-w
+  skip-lints:
+    - compiler_needs_stdlib_c

--- a/recipes/fastq-dupaway/meta.yaml
+++ b/recipes/fastq-dupaway/meta.yaml
@@ -25,7 +25,7 @@ requirements:
 
 test:
   commands:
-    - fastq-dupaway --help
+    - fastq-dupaway --help || true
 
 about:
   home: https://github.com/AndrewSigorskih/fastq-dupaway

--- a/recipes/fastq-dupaway/meta.yaml
+++ b/recipes/fastq-dupaway/meta.yaml
@@ -2,7 +2,7 @@
 {% set version = "1.5.0" %}
 
 package:
-  name: mytool
+  name: {{ name }}
   version: "{{ version }}"
 
 source:

--- a/recipes/fastq-dupaway/meta.yaml
+++ b/recipes/fastq-dupaway/meta.yaml
@@ -12,6 +12,8 @@ source:
 build:
   number: 0
   detect_binary_files_with_prefix: true
+  run_exports:
+    - {{ pin_subpackage('fastq-dupaway', max_pin="x") }}
 
 requirements:
   build:

--- a/recipes/fastq-dupaway/meta.yaml
+++ b/recipes/fastq-dupaway/meta.yaml
@@ -6,8 +6,8 @@ package:
   version: "{{ version }}"
 
 source:
-  url: https://github.com/AndrewSigorskih/fastq-dupaway/archive/refs/tags/1.5.tar.gz
-  sha256: 6737142203b74de3656209bad64df94852573133d3fdf16d8507cb29d74b2bdf
+  url: https://github.com/AndrewSigorskih/fastq-dupaway/archive/refs/tags/{{ version }}.tar.gz
+  sha256: 5d970a15548d1e4e27c8440e73241246e3ec1206d7dad1696af9c29b2b2a0a73
 
 build:
   number: 0

--- a/recipes/fastq-dupaway/meta.yaml
+++ b/recipes/fastq-dupaway/meta.yaml
@@ -1,0 +1,33 @@
+{% set name = "fastq-dupaway" %}
+{% set version = "1.5.0" %}
+
+package:
+  name: mytool
+  version: "{{ version }}"
+
+source:
+  url: https://github.com/AndrewSigorskih/fastq-dupaway/archive/refs/tags/1.5.tar.gz
+  sha256: 6737142203b74de3656209bad64df94852573133d3fdf16d8507cb29d74b2bdf
+
+build:
+  number: 0
+  detect_binary_files_with_prefix: true
+
+requirements:
+  build:
+    - {{ compiler('cxx') }}
+    - make
+    - cmake
+  host:
+    - boost-cpp
+  run:
+    - boost-cpp
+
+test:
+  commands:
+    - fastq-dupaway --help
+
+about:
+  home: https://github.com/AndrewSigorskih/fastq-dupaway
+  license: MIT
+  summary: "Bioinformatics tool for memory-efficient deduplication of single-end and paired-end FASTQ and FASTA files"

--- a/recipes/fastq-dupaway/meta.yaml
+++ b/recipes/fastq-dupaway/meta.yaml
@@ -24,11 +24,12 @@ requirements:
   host:
     - boost-cpp
   run:
-    - libboost
+    - boost-cpp
 
 test:
   commands:
-    - fastq-dupaway --help || true
+    - fastq-dupaway --help >stdout.txt 2>stderr.txt || true
+    - grep -E "^fastq-dupaway V" stderr.txt
 
 about:
   home: https://github.com/AndrewSigorskih/fastq-dupaway


### PR DESCRIPTION
## New recipe: fastq-dupaway

A tool for memory-efficient deduplication of single-end and paired-end FASTQ and FASTA files.
https://doi.org/10.1038/s41598-025-28948-w

Source: https://github.com/AndrewSigorskih/fastq-dupaway

-----


- [x] I have read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
- [x] Local tests passing. 
 

