### PR TITLE
Update seqera to 1.8.0

### DIFF
--- a/recipes/seqera/meta.yaml
+++ b/recipes/seqera/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.5.0" %}
+{% set version = "1.8.0" %}
 {% set name = "seqera" %}
 
 package:
@@ -7,11 +7,11 @@ package:
 
 source:
   - url: https://registry.npmjs.org/@seqera/cli-linux-x64/-/cli-linux-x64-{{ version }}.tgz  # [linux]
-    sha256: 2d9fc3bb9f8db7c61f8e891dd4667dfed089c1968a97699e52d494b3cde6dced  # [linux]
+    sha256: 254fe67c6be80aa4ffaf8a9408b18773adc4144d0b86c2fd05f78e9a1d6f00aa  # [linux]
   - url: https://registry.npmjs.org/@seqera/cli-darwin-x64/-/cli-darwin-x64-{{ version }}.tgz  # [osx and x86_64]
-    sha256: 6a01933ef20c53a56a032388921a5ba7be566c88cf8717b2a5a56b6103f31b10  # [osx and x86_64]
+    sha256: 0cb5d96c50cf0d2d9f212087d6969f04302f5de809ab24ae4e51d17d68254193  # [osx and x86_64]
   - url: https://registry.npmjs.org/@seqera/cli-darwin-arm64/-/cli-darwin-arm64-{{ version }}.tgz  # [osx and arm64]
-    sha256: 5c099cb8accb6c031254e990435107963444cf1e83b6eb9d61c0508addb11797  # [osx and arm64]
+    sha256: d96f99ddc911e13e036b7acdcb913e8dfecdea406076052a8f129ddbf51dd307  # [osx and arm64]
 
 build:
   number: 0


### PR DESCRIPTION
## Summary
- Bump the Seqera CLI bioconda recipe from 1.5.0 to 1.8.0
- Updated SHA256 hashes for all three platform tarballs (linux-x64, darwin-x64, darwin-arm64)