### PR TITLE
Add refseq2cds

### DIFF
--- a/recipes/refseq2cds/meta.yaml
+++ b/recipes/refseq2cds/meta.yaml
@@ -1,0 +1,58 @@
+{% set name = "refseq2cds" %}
+{% set version = "0.1.2" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/chulbioinfo/refseq2cds/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 945b7876eb314c5809357bb4067d3934a706641b9d24987b2026a6d7600dd474
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps
+  number: 0
+  run_exports:
+    - {{ pin_subpackage(name|lower, max_pin="x.x") }}
+
+requirements:
+  host:
+    - python >=3.9
+    - pip
+    - setuptools >=68
+    - wheel
+  run:
+    - python >=3.9
+    - biopython >=1.85
+    - dendropy >=5
+    - jinja2 >=3
+    - networkx >=3
+    - pandas >=2
+    - pyarrow >=15
+    - ncbi-datasets-cli
+    - mafft
+    - pal2nal
+
+test:
+  imports:
+    - refseq2cds
+  commands:
+    - refseq2cds --help
+    - refseq2cds test --example mini
+
+about:
+  home: https://github.com/chulbioinfo/refseq2cds
+  license: MIT
+  license_file: LICENSE
+  summary: Build RefSeq singleton ortholog CDS FASTA files and human coordinate matrices.
+  description: |
+    refseq2cds builds strict N-way singleton ortholog CDS FASTA files from
+    locked RefSeq GCF assembly annotation packages and NCBI Gene orthology
+    edges. It also generates human CDS-to-genome coordinate matrices and
+    optional MAFFT+PAL2NAL codon alignments.
+  dev_url: https://github.com/chulbioinfo/refseq2cds
+
+extra:
+  recipe-maintainers:
+    - chulbioinfo

--- a/recipes/refseq2cds/meta.yaml
+++ b/recipes/refseq2cds/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "refseq2cds" %}
-{% set version = "0.1.2" %}
+{% set version = "0.1.4" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/chulbioinfo/refseq2cds/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 945b7876eb314c5809357bb4067d3934a706641b9d24987b2026a6d7600dd474
+  sha256: 60c3f187dbbd7a6143049dc6ef9e8d4845ee8ef9e14a5941a23933eb1dfde9a1
 
 build:
   noarch: python
@@ -45,12 +45,13 @@ about:
   home: https://github.com/chulbioinfo/refseq2cds
   license: MIT
   license_file: LICENSE
-  summary: Build RefSeq singleton ortholog CDS FASTA files and human coordinate matrices.
+  summary: Build RefSeq ortholog CDS FASTA, alignments, and coordinate matrices.
   description: |
-    refseq2cds builds strict N-way singleton ortholog CDS FASTA files from
-    locked RefSeq GCF assembly annotation packages and NCBI Gene orthology
-    edges. It also generates human CDS-to-genome coordinate matrices and
-    optional MAFFT+PAL2NAL codon alignments.
+    refseq2cds builds assembly-exact RefSeq ortholog CDS FASTA files from
+    locked GCF annotation packages and NCBI Gene orthology edges. It supports
+    strict N-way singleton parsing, reference-gene present-species queries,
+    human CDS-to-genome coordinate matrices, MAFFT+PAL2NAL codon alignments,
+    and target-specific coding event BED outputs.
   dev_url: https://github.com/chulbioinfo/refseq2cds
 
 extra:


### PR DESCRIPTION
This PR adds refseq2cds, a Python noarch package for building assembly-exact RefSeq singleton ortholog CDS FASTA files, human CDS-to-genome coordinate matrices, and optional MAFFT+PAL2NAL codon alignments.

Local checks performed:
- bioconda-utils lint recipes config.yml --packages refseq2cds --full-report: passed
- conda-build conda-recipe -c conda-forge -c bioconda --no-anaconda-upload: passed
- refseq2cds test --example mini: passed in conda test env