### PR TITLE
Update latch watchfiles pin and python floor for py3.12 support

### DIFF
--- a/recipes/latch/meta.yaml
+++ b/recipes/latch/meta.yaml
@@ -46,7 +46,7 @@ requirements:
     - python-kubernetes >=24.2.0
     - pyxattr >=0.8.1
     - requests >=2.28.1
-    - requests-toolbelt >=1.0.0,<2
+    - requests-toolbelt ==1.0.0
     - scp >=0.14.0
     - setuptools <78
     - tqdm >=4.63.0

--- a/recipes/latch/meta.yaml
+++ b/recipes/latch/meta.yaml
@@ -20,12 +20,12 @@ build:
 
 requirements:
   host:
-    - python >=3.9
+    - python >=3.10
     - hatchling
     - setuptools
     - pip
   run:
-    - python >=3.9
+    - python >=3.10
     - aioconsole ==0.6.1
     - apscheduler >=3.10.0
     - asyncssh ==2.13.2
@@ -52,7 +52,7 @@ requirements:
     - tqdm >=4.63.0
     - typing-extensions >=4.12.0
     - watchfiles ==1.1.1
-    - websockets >=15.0.1
+    - websockets ==11.0.3
 
 test:
   imports:

--- a/recipes/latch/meta.yaml
+++ b/recipes/latch/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: bfb23bd05efd0ffcc4bf585ffbef1be721e3d354c001c6fc4055d728f9a26ac4
 
 build:
-  number: 1
+  number: 2
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps  --no-build-isolation --no-cache-dir -vvv
   entry_points:
@@ -51,8 +51,8 @@ requirements:
     - setuptools <78
     - tqdm >=4.63.0
     - typing-extensions >=4.12.0
-    - watchfiles ==0.19.0
-    - websockets ==11.0.3
+    - watchfiles ==1.1.1
+    - websockets >=15.0.1
 
 test:
   imports:


### PR DESCRIPTION
## Summary

Update `latch 2.71.2` to resolve under Python 3.12:

- `watchfiles ==0.19.0` → `==1.1.1` (matches upstream `pyproject.toml`)
- `requests-toolbelt >=1.0.0,<2` → `==1.0.0` (matches upstream `pyproject.toml`)
- `python >=3.9` → `>=3.10` on both host and run

`watchfiles` cp312 wheels start at `0.20.0`, so updating the pin allows `latch` to resolve under Python 3.12. On conda-forge, `watchfiles 1.1.1` ships builds for py3.10 through py3.14 (no py3.9), so the python floor is lifted to 3.10 to reflect the actual support window — Python 3.9 reached end of life in October 2025.

The recipe's existing `websockets ==11.0.3` pin is retained. Upstream `latch` declares `websockets >=15.0.1` alongside `gql ==3.5.0`, but conda-forge's `gql 3.5.0` package bundles the `gql[websockets]` extra as a hard runtime dep and pins `websockets >=10,<12`, which makes `>=15.0.1` unsatisfiable in conda. `websockets 11.0.3` ships a cp312 build, so the existing pin does not affect py3.12 resolution.

Companion to #65195, which aligned the `lytekit` / `protobuf` chain for the same Python 3.12 target.

Build number bumped to 2; version unchanged.

## Test plan

- Conda build resolves under py3.10–py3.13 with the new pins.
- Existing `latch --help` test continues to pass.

## Why this surfaces now

Bioconda's CI builds and tests a `noarch: python` recipe in a single environment whose Python version is chosen by the solver from the recipe's run requirements — not a matrix across Python versions. With `watchfiles ==0.19.0` (cp38–cp311) in the run list, the solver settled on Python 3.11 and the build/test passed cleanly; py3.12 wasn't attempted. The conflict becomes observable only once a downstream recipe pins `python >=3.12`, which is what flagged it here.

This is a general property of `noarch: python` builds: divergence between a recipe's pins and upstream's `pyproject.toml` is undetectable in CI until a consumer forces a newer Python.