### PR TITLE
Updated beast_pype's dependencies in it's meta.yaml & post-link.sh files.

### DIFF
--- a/recipes/beast-pype/meta.yaml
+++ b/recipes/beast-pype/meta.yaml
@@ -14,7 +14,7 @@ build:
   entry_points:
     - beast_pype = beast_pype.cli:beast_pype
   noarch: python
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage(name, max_pin="x") }}
 
@@ -30,7 +30,7 @@ requirements:
     - pytest-xdist >=3.8.0
     - psutil >=7.2.2
     # BEAST itself
-    - beast2 >=2.6.0
+    - beast2 >=2.6.3
     # Python
     - python >=3.10
     # Bioinformatics
@@ -38,7 +38,7 @@ requirements:
     - nextclade >=3.18.1
     - iqtree >=3.0.1
     - treetime >=0.11.4
-    - beast2-xml >=1.5.0
+    - beast2-xml >=1.6.2
     - dark-matter >=5.1.2
     - seqkit >=2.12.0
     - ete3 >=3.1.1

--- a/recipes/beast-pype/post-link.sh
+++ b/recipes/beast-pype/post-link.sh
@@ -8,4 +8,5 @@ Rscript -e 'IRkernel::installspec(name="beast_pype_R", displayname = "beast_pype
 echo "Adding BDSKY and BEASTLabs to BEAST 2's package manager"
 packagemanager -add BDSKY
 packagemanager -add BEASTLabs
+packagemanager -add CCD
 echo "Post-link script for beast-pype completed successfully"


### PR DESCRIPTION
I have updated beast_pype's dependencies in it's meta.yaml & post-link.sh files. Some dependencies are installed post build via BEAST 2's packamanger, hence the post-link.sh update.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
