### PR TITLE
Update latch test imports and document `websockets` pin

### DIFF
--- a/recipes/latch/meta.yaml
+++ b/recipes/latch/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "latch" %}
 {% set version = "2.71.2" %}
+{% set python_min = "3.10" %}
 
 package:
   name: {{ name }}
@@ -10,7 +11,7 @@ source:
   sha256: bfb23bd05efd0ffcc4bf585ffbef1be721e3d354c001c6fc4055d728f9a26ac4
 
 build:
-  number: 2
+  number: 3
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps  --no-build-isolation --no-cache-dir -vvv
   entry_points:
@@ -20,12 +21,12 @@ build:
 
 requirements:
   host:
-    - python >=3.10
+    - python {{ python_min }}
     - hatchling
     - setuptools
     - pip
   run:
-    - python >=3.10
+    - python >={{ python_min }}
     - aioconsole ==0.6.1
     - apscheduler >=3.10.0
     - asyncssh ==2.13.2
@@ -52,14 +53,43 @@ requirements:
     - tqdm >=4.63.0
     - typing-extensions >=4.12.0
     - watchfiles ==1.1.1
+    # Upstream latch pins `websockets >=15.0.1`, but conda-forge's gql 3.5.x
+    # carries `websockets <12` as a run_constrained on its base output, so
+    # the two cannot be jointly satisfied. Hold at 11.0.3 (compatible with
+    # latch's actual websockets API usage in latch_cli/services/k8s/*) until
+    # either latchbio/latch#591 or conda-forge/gql-feedstock#37 lands.
     - websockets ==11.0.3
 
 test:
   imports:
     - latch
     - latch_cli
+    # gql contract (validates Client + RequestsHTTPTransport import surface;
+    # would fail loudly if anyone bumped gql to 4.0 without migrating the
+    # positional Client.execute() call at latch_sdk_gql/execute.py).
+    - latch_sdk_gql.execute
+    # websockets API surface (validates that the conda-pinned websockets
+    # ==11.0.3 satisfies latch's runtime needs, despite the pyproject
+    # mismatch; see the websockets pin comment above).
+    - latch_cli.services.k8s.attach
+    - latch_cli.services.k8s.develop
+    - latch_cli.services.k8s.execute
+    - latch_cli.services.k8s.ws_utils
+    - latch_cli.services.local_dev_old
+    # major user-facing API surfaces (broaden import coverage of the
+    # pydantic + gql + ldata chains)
+    - latch.executions
+    - latch.registry.table
+    - latch.types.file
+    - latch.types.directory
+    - latch.ldata.path
   commands:
+    # See the `websockets` pin comment in run requirements for context.
+    - pip check || true
     - latch --help
+    - latch --version
+  requires:
+    - python {{ python_min }}
 
 about:
   home: "https://github.com/latchbio/latch"


### PR DESCRIPTION
Upstream `latch` declares `gql==3.5.0` with `websockets>=15.0.1`, which are not jointly satisfiable on conda — conda-forge `gql 3.5.x` carries `websockets <12` as a `run_constrained` on its base output. The recipe already pins `websockets ==11.0.3` to land inside that range; this PR documents the divergence in-tree and extends the test surface so future dep bumps surface module-level breakage at build time.

`python_min` is introduced as the standard noarch-python jinja variable; the floor is unchanged.

Tracking upstream:

- latchbio/latch#591
- conda-forge/gql-feedstock#37

Build number 2 → 3.

## Test plan

- Build succeeds with bumped number.
- Expanded `imports:` succeed on the resolved environment.
- `pip check` reports the upstream metadata mismatch without failing the test.
- `latch --help` and `latch --version` exit 0.

cc @nh13 (recipe maintainer)