### PR TITLE
Update MultiQC to v1.35

### DIFF
--- a/recipes/multiqc/meta.yaml
+++ b/recipes/multiqc/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "multiqc" %}
-{% set version = "1.34" %}
+{% set version = "1.35" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/MultiQC/MultiQC/archive/v{{ version }}.tar.gz
-  sha256: 5d740e275a9fdecf96efc7b1f2750fc9a139bfe3af2bb33478cc670b94bf30fa
+  sha256: b76fa0562b5720fe338f19dc03a3043f6f1fad310315470dccc7b41ccf54cd1a
 
 build:
   number: 0
@@ -21,11 +21,11 @@ build:
 requirements:
   host:
     # Python 3.14.1 breaks upstream deps, see https://github.com/MultiQC/MultiQC/issues/3412
-    - python >=3.8,!=3.14.1
+    - python >=3.9,!=3.14.1
     - pip
     - setuptools
   run:
-    - python >=3.8,!=3.14.1
+    - python >=3.9,!=3.14.1
     - click
     - coloredlogs
     - humanize
@@ -48,9 +48,9 @@ requirements:
     - rich-click
     - spectra >=0.0.10
     - tqdm
-    - typeguard
+    - typeguard >=4
     - tiktoken
-    - polars-lts-cpu
+    - polars >=1.34.0
 
 test:
   # Python imports


### PR DESCRIPTION
Updated MultiQC to v1.35

Also:

* Bumped minimum Python version to 3.9
* Set a minimum version for typeguard
* Removed `polars-lts-cpu` and left just `polars` - see https://github.com/MultiQC/MultiQC/issues/3510

I might have to add in `polars-runtime-compat >=1.34.0`, I'm not sure yet.

<details>
----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>

</details>