### PR TITLE
Add egt

### DIFF
--- a/recipes/egt/meta.yaml
+++ b/recipes/egt/meta.yaml
@@ -49,9 +49,6 @@ test:
     - egt
   commands:
     - egt --help
-    - pip check
-  requires:
-    - pip
 
 about:
   home: https://github.com/conchoecia/egt

--- a/recipes/egt/meta.yaml
+++ b/recipes/egt/meta.yaml
@@ -1,0 +1,69 @@
+{% set name = "egt" %}
+{% set version = "0.2.3" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://files.pythonhosted.org/packages/00/fa/0b1688ed2e1eacdbd3990ee5c064eacb515647d349781dd8334286db811a/egt-{{ version }}.tar.gz
+  sha256: fd9f85888630bf875b7125822c09fc576d8253ae202f8cc16dc174449057fd15
+
+build:
+  number: 0
+  noarch: python
+  script: "{{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation"
+  entry_points:
+    - egt = egt.cli:main
+  run_exports:
+    - {{ pin_subpackage('egt', max_pin="x") }}
+
+requirements:
+  host:
+    - python >=3.10
+    - pip
+    - setuptools >=64
+    - wheel
+  run:
+    - python >=3.10
+    - numpy
+    - pandas
+    - scipy
+    - scikit-learn
+    - matplotlib-base
+    - networkx
+    - pillow
+    - umap-learn
+    # umap-learn[plot] extras (datashader, holoviews, scikit-image, colorcet)
+    - datashader
+    - holoviews
+    - scikit-image
+    - colorcet
+    - bokeh
+    - ete4
+    - snakemake-minimal >=7,<9
+    - pyyaml
+
+test:
+  imports:
+    - egt
+  commands:
+    - egt --help
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/conchoecia/egt
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: "Evolutionary Genome Topology: chromosome-evolution analysis toolkit for metazoan genomes using reciprocal-best-hits data."
+  dev_url: https://github.com/conchoecia/egt
+  doc_url: https://github.com/conchoecia/egt
+
+extra:
+  identifiers:
+    - pypi:egt
+  recipe-maintainers:
+    - conchoecia


### PR DESCRIPTION
Adds a recipe for [egt](https://github.com/conchoecia/egt), an Evolutionary Genome Topology analysis toolkit for chromosome evolution across metazoan genomes.

- Source: PyPI sdist (`egt-0.2.3.tar.gz`)
- Pure-Python, `noarch: python`
- All runtime deps available in conda-forge / bioconda (`umap-learn[plot]` extras inlined as datashader, holoviews, scikit-image, colorcet)
- Entry point: `egt` CLI (`egt.cli:main`)

### Citations

The methods implemented in `egt` are described in:

- Schultz, D. T., Blümel, A., Destanović, D., Sarigol, F., & Simakov, O. (2024).
  *Topological mixing and irreversibility in animal chromosome evolution.*
    bioRxiv. https://doi.org/10.1101/2024.07.29.605683

- Schultz, D. T., Simakov, O. (2026). Topological Approaches in Animal Comparative Genomics. Annual Review of Animal Biosciences 14(1), 17–48. 
    https://doi.org/10.1146/annurev-animal-030424-084541

### Please read the [guidelines for contributing](https://bioconda.github.io/contributor/index.html) and remember the following:

* [x] Tests pass locally where applicable
* [x] noarch: python set, no compiled components
* [x] Includes `run_exports`
* [x] Maintainer added (@conchoecia)