### PR TITLE
Update molamola to v0.3.0

### DIFF
--- a/recipes/molamola/meta.yaml
+++ b/recipes/molamola/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "molamola" %}
-{% set version = "0.2.0" %}
+{% set version = "0.3.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 6653ec0f5dd1719111491442f3b9b17a40ad1ad4adcb4df36be783e9cdbcd37e
+  sha256: 1dec3cb110fd507e53632e28e2272031ceea1f2248307a4079ad93d22f2c0b28
 
 build:
   number: 0
@@ -47,12 +47,19 @@ about:
   summary: Plot Oxford Nanopore variation as self-contained HTML reports.
   description: |
     A Python plotting tool for Oxford Nanopore variation data.
-    One VCF in, one self-contained HTML report out. molamola
-    inspects the VCF header and dispatches to the right plot type:
-    a circos + linear cytoband SV report for long-read SV VCFs
-    (Sniffles2 / cuteSV / SVIM / pbsv / NanoVar), or per-gene
-    phased-haplotype panels for compound-het workup from phased
-    + VEP-annotated small-variant VCFs.
+    One input in, one self-contained HTML report out. molamola
+    picks the visualiser from its input:
+
+    * VCF with ``##INFO=<ID=SVTYPE,...>``: a circos + linear
+      cytoband SV report (Sniffles2 / cuteSV / SVIM / pbsv /
+      NanoVar).
+    * VCF with ``##INFO=<ID=CSQ,...>`` + ``##FORMAT=<ID=PS,...>``:
+      per-gene phased-haplotype panels for compound-het workup
+      from phased + VEP-annotated small-variant VCFs.
+    * Mosdepth ``regions.bed.gz`` (via ``--mosdepth``): a
+      karyotype coverage report -- genome-wide CN scatter +
+      rolling-median smooth, with an optional BAF panel beneath
+      when paired with a small-variant VCF.
   license: MIT
   license_family: MIT
   license_file: LICENSE


### PR DESCRIPTION
## Summary

- Bumps molamola from v0.2.0 to v0.3.0.
- PyPI sdist: <https://pypi.org/project/molamola/0.3.0/>.
- sha256: `1dec3cb110fd507e53632e28e2272031ceea1f2248307a4079ad93d22f2c0b28`.
- No new runtime dependencies vs. v0.2.0 -- everything new is stdlib + the
  existing matplotlib / numpy / pandas stack.
- Bundled-data total grows from ~14 MB to ~28 MB (the new exclusion
  masks + 10 kb GC tables that drive karyotype mode). Still well below
  the GB-scale annotation-cache tools on the channel; the
  "closed-system tool, refs are part of the contract" framing the
  v0.1 / v0.2 reviewers accepted continues to apply.
- `about.description` rewritten to surface all three modes (SV /
  compound-het / karyotype) instead of the v0.2-era two.

## What's new in v0.3.0

- **Karyotype coverage mode** -- new third plot type, dispatched by
  `--mosdepth PATH`. Genome-wide CN scatter + rolling-median smooth,
  with an optional BAF panel beneath when paired with a small-variant
  VCF.
- **Bundled exclusion masks** + **10 kb GC tables** for hg38 and
  T2T-CHM13v2.0 to drive the karyotype mode's normalisation.
- **Adaptive-sampling detection** from the depth distribution (an
  "AS suspected" chip lands in the run metadata when the autosomal
  depth profile looks bimodal).
- **BAF QC**: PASS + biallelic het GT + SNV-only + FORMAT/DP >=
  --min-baf-dp + FORMAT/GQ >= --min-baf-gq (default 20, applied only
  when GQ is present in the VCF). Hard-refuses upfront when the VCF
  header carries `##INFO=<ID=SVTYPE,...>`.
- **`--out` is now required** (every mode); molamola exits 2 with a
  usage error rather than silently writing the report next to the
  input.

Full CHANGELOG: <https://github.com/martinandclaude/molamola/blob/main/CHANGELOG.md>.