### PR TITLE
Add bwa-mem3 0.2.0

### DIFF
--- a/recipes/bwa-mem3/build.sh
+++ b/recipes/bwa-mem3/build.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+set -ex
+
+export CXXFLAGS="${CXXFLAGS} -O3"
+
+# Use conda-forge's htslib (host/run dep) instead of building the bundled
+# submodule. ext/htslib stays in place because the Makefile has explicit
+# dependency rules listing ext/htslib/htslib/*.h as prereqs of bwa-mem3's
+# object files; deleting the dir breaks those rules. Instead the bundled
+# 1.21 headers stay on the include path for compilation, while linking
+# resolves -lhts via conda's -L${PREFIX}/lib (which precedes the bundled
+# -Lext/htslib in the link line). The Makefile's $(HTS_LIB): rule has no
+# prerequisites, so when HTS_LIB points at an already-existing file make
+# treats it as up-to-date and skips the autoreconf+configure+make chain.
+# The 1.21->1.23 ABI drift across bwa-mem3's small htslib API surface
+# (hts_open/close, sam_hdr_init/add_line/add_lines/destroy/write,
+# bam_aux_append) is zero -- all stable since htslib 1.0.
+
+MAKE_ARGS=(
+  -j${CPU_COUNT}
+  CC="${CC}"
+  CXX="${CXX}"
+  # safestringlib's safeclib_private.h calls abort()/memcpy() via macros
+  # without including <stdlib.h>/<string.h>. bwa-mem3's Makefile force-
+  # includes them for clang/Darwin only; modern conda gcc on Linux also
+  # promotes -Wimplicit-function-declaration to an error.
+  SAFE_EXTRA_CFLAGS="-include stdlib.h -include ctype.h"
+  # bwa-mem3's Makefile derives VERSION_STRING from `git describe`; the
+  # source tarball has no .git, so set the version explicitly.
+  VERSION_STRING="${PKG_VERSION}"
+  # Compile-time SIMD floor for non-kernel TUs (x86_64 only; the Makefile
+  # ignores this on aarch64/arm64). The runtime dispatcher in
+  # src/simd_dispatch.cpp (PR #83) selects the right kernel tier per host
+  # from all five compiled kernel tiers. avx2 is upstream's distribution
+  # default; per docs/src/whats-different/avx512-baseline.md the cold-path
+  # delta to a host-locked avx512bw build is ~2-4% on Zen 4 and <1% on
+  # Sapphire Rapids -- not worth a multi-binary split. Pre-AVX2 hosts
+  # (Sandy/Ivy Bridge, Bulldozer/Piledriver, older Atom) are not
+  # supported by this build.
+  BASELINE_ARCH=avx2
+)
+
+if [ "$(uname)" = "Darwin" ]; then
+  # The Makefile's macOS branch expects LIBOMP_PREFIX to point at a directory
+  # containing include/ and lib/libomp.dylib. The conda llvm-openmp package
+  # installs both under ${PREFIX}.
+  MAKE_ARGS+=( LIBOMP_PREFIX="${PREFIX}" )
+  # Use conda-forge's mimalloc and htslib instead of building bundled
+  # submodules. The Makefile's $(MIMALLOC_LIB): and $(HTS_LIB): rules have
+  # no prerequisites, so pointing them at already-existing files makes
+  # make treat them as up-to-date.
+  MAKE_ARGS+=(
+    MIMALLOC_LIB="${PREFIX}/lib/libmimalloc.dylib"
+    MIMALLOC_LDFLAGS="-L${PREFIX}/lib -lmimalloc -Wl,-rpath,${PREFIX}/lib"
+    HTS_LIB="${PREFIX}/lib/libhts.dylib"
+  )
+else
+  # bwa-mem3 calls shm_open/shm_unlink, which on conda's CentOS-7 sysroot
+  # (glibc 2.17) live in librt. Newer Linux glibc (>= 2.34) folds them
+  # into libc, so upstream CI on ubuntu-latest doesn't need this.
+  MAKE_ARGS+=( LIBS_EXTRA="-lrt" )
+  # Use conda-forge's mimalloc and htslib. conda-forge ships only the
+  # shared library form on Linux (no .a), so switch from the upstream
+  # Makefile's `-Wl,--whole-archive libmimalloc.a -Wl,--no-whole-archive`
+  # static linking to dynamic linking. mimalloc's docs note that placing
+  # `-lmimalloc` before `-lc` in link order is sufficient for malloc
+  # interposition via ELF symbol resolution order; the upstream LIBS
+  # variable already places $(MIMALLOC_LDFLAGS) before the implicit -lc.
+  MAKE_ARGS+=(
+    MIMALLOC_LIB="${PREFIX}/lib/libmimalloc.so"
+    MIMALLOC_LDFLAGS="-L${PREFIX}/lib -lmimalloc -Wl,-rpath,${PREFIX}/lib"
+    HTS_LIB="${PREFIX}/lib/libhts.so"
+  )
+fi
+
+make "${MAKE_ARGS[@]}"
+
+mkdir -p "${PREFIX}/bin"
+install -v -m 0755 bwa-mem3 "${PREFIX}/bin/"

--- a/recipes/bwa-mem3/meta.yaml
+++ b/recipes/bwa-mem3/meta.yaml
@@ -1,0 +1,59 @@
+{% set name = "bwa-mem3" %}
+{% set version = "0.2.0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/fg-labs/{{ name }}/releases/download/v{{ version }}/Source_code_including_submodules.tar.gz
+  sha256: ed74c191d6dde30e5f943867a9c73f1a6717c31215e91490504da69f3726d7b3
+
+build:
+  number: 0
+  run_exports:
+    - {{ pin_subpackage('bwa-mem3', max_pin="x") }}
+
+requirements:
+  build:
+    - make
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - {{ stdlib('c') }}
+  host:
+    - zlib
+    - mimalloc >=3.3,<4
+    - htslib >=1.21,<2
+    - llvm-openmp  # [osx]
+    - libgomp      # [linux]
+  run:
+    - mimalloc >=3.3,<4
+    - htslib >=1.21,<2
+    - llvm-openmp  # [osx]
+    - libgomp      # [linux]
+
+test:
+  commands:
+    - bwa-mem3 version
+
+about:
+  home: "https://github.com/fg-labs/bwa-mem3"
+  license: "MIT AND Apache-2.0"
+  license_family: MIT
+  license_file:
+    - LICENSE
+    - ext/safestringlib/LICENSE
+    - ext/libsais/LICENSE
+    - ext/sse2neon/LICENSE
+  summary: "Short-read aligner derived from bwa-mem2 with correctness fixes, performance improvements, and methylation alignment."
+  dev_url: "https://github.com/fg-labs/bwa-mem3"
+  doc_url: "https://bwa-mem3.readthedocs.io"
+
+extra:
+  recipe-maintainers:
+    - nh13
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64
+  identifiers:
+    - doi:10.1109/IPDPS.2019.00041


### PR DESCRIPTION
Adds a new recipe for [bwa-mem3](https://github.com/fg-labs/bwa-mem3) v0.2.0, a short-read aligner derived from bwa-mem2 with correctness fixes, performance improvements, and methylation alignment support.

### Source distribution

The recipe pulls a `Source_code_including_submodules.tar.gz` release asset attached to the v0.2.0 tag. bwa-mem3 vendors five git submodules (`safestringlib`, `htslib`, `libsais`, `mimalloc`, `sse2neon`) that are required at build time; bundling them in the release asset keeps the bioconda build host network-free, matching the pattern used by [recipes/bwa-mem2](https://github.com/bioconda/bioconda-recipes/tree/master/recipes/bwa-mem2).

### Build

- **linux-64 / x86_64**: single binary with in-process SIMD dispatch across `sse41`/`sse42`/`avx`/`avx2`/`avx512bw` kernels selected at startup via `__builtin_cpu_supports`. No `.<tier>` companion binaries.
- **linux-aarch64 / osx-arm64**: NEON build via the bundled `sse2neon` shim.

### Checklist (from CONTRIBUTING.md)

- [x] Recipe lives under `recipes/bwa-mem3/`
- [x] `meta.yaml` includes `run_exports` with pinned major version
- [x] `additional-platforms` set for `linux-aarch64` and `osx-arm64`
- [x] License (`MIT`) declared and `license_file: LICENSE` set
- [x] Test command (`bwa-mem3 version`)

Opening as **draft** to verify the bioconda CI build before requesting review.