### PR TITLE
Add primer demux v0.0.2

### DIFF
--- a/recipes/primer_demux/build.sh
+++ b/recipes/primer_demux/build.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+export CARGO_HOME="${BUILD_PREFIX}/cargo"
+mkdir -p "${CARGO_HOME}"
+
+cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
+
+cargo install -v --locked --no-track --root "${PREFIX}" --path .
+
+rm -f "${PREFIX}/.crates.toml" "${PREFIX}/.crates2.json"

--- a/recipes/primer_demux/meta.yaml
+++ b/recipes/primer_demux/meta.yaml
@@ -11,6 +11,8 @@ source:
 
 build:
   number: 0
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x.x") }}
 
 requirements:
   build:

--- a/recipes/primer_demux/meta.yaml
+++ b/recipes/primer_demux/meta.yaml
@@ -17,20 +17,25 @@ requirements:
     - {{ compiler('rust') }}
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - {{ stdlib('c') }}
     - cargo-bundle-licenses
+    - make
     - pkg-config
+    - cargo-bundle-licenses
 
   host:
     - openssl
     - zlib
     - bzip2
     - xz
+    - libcurl
 
   run:
     - openssl
     - zlib
     - bzip2
     - xz
+    - libcurl
 
 test:
   commands:

--- a/recipes/primer_demux/meta.yaml
+++ b/recipes/primer_demux/meta.yaml
@@ -32,13 +32,6 @@ requirements:
     - xz
     - libcurl
 
-  run:
-    - openssl
-    - zlib
-    - bzip2
-    - xz
-    - libcurl
-
 test:
   commands:
     - primer_demux --help > /dev/null

--- a/recipes/primer_demux/meta.yaml
+++ b/recipes/primer_demux/meta.yaml
@@ -1,0 +1,53 @@
+{% set name = "primer_demux" %}
+{% set version = "0.0.2" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/huiN95/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: d73ba50b09b0e7184b7995e4cfb553a08ab414a92084e116d2f790bf912aa17c
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - {{ compiler('rust') }}
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - cargo-bundle-licenses
+    - pkg-config
+
+  host:
+    - openssl
+    - zlib
+    - bzip2
+    - xz
+
+  run:
+    - openssl
+    - zlib
+    - bzip2
+    - xz
+
+test:
+  commands:
+    - primer_demux --help > /dev/null
+
+about:
+  home: https://github.com/huiN95/primer_demux
+  license: MIT
+  license_file:
+    - LICENSE
+    - THIRDPARTY.yml
+  summary: Primer demultiplexing tool for sequencing data
+  description: |
+    primer_demux is a command-line tool for demultiplexing sequencing reads
+    by primer or barcode-like sequence patterns.
+  dev_url: https://github.com/huiN95/primer_demux
+
+extra:
+  recipe-maintainers:
+    - huiN95


### PR DESCRIPTION
add a new recipe `primer_demux` for demultiplexing sequencing reads based on primer sequences (including connected reads). 