### PR TITLE
Update linezolid-amr to 0.1.2

### DIFF
--- a/recipes/linezolid-amr/meta.yaml
+++ b/recipes/linezolid-amr/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "linezolid-amr" %}
-{% set version = "0.1.1" %}
+{% set version = "0.1.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/iowa69/linezolid-amr/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 38ed406269c00324cf98633bbee8c6e329b801edb25619e96e5a4ada832dba3a
+  sha256: 8910a3ffc5b2a9e0e30716690494cbe6d005de91560c8f63922f6bdd260a8109
 
 build:
   number: 0
@@ -32,14 +32,17 @@ requirements:
     - minimap2 >=2.24
     - samtools >=1.18
     - bcftools >=1.18
+    - mlst >=2.19
 
 test:
   imports:
     - linezolid_amr
     - linezolid_amr.cli
     - linezolid_amr.amrfinder
+    - linezolid_amr.mlst
     - linezolid_amr.rrna23s
     - linezolid_amr.references
+    - linezolid_amr.summary
   commands:
     - linezolid-amr --version
     - linezolid-amr --help
@@ -50,16 +53,19 @@ about:
   license: MIT
   license_family: MIT
   license_file: LICENSE
-  summary: Integrated AMR profiling (AMRFinderPlus) + 23S rRNA linezolid-resistance frequency analysis
+  summary: Integrated AMR profiling (AMRFinderPlus + MLST) + 23S rRNA linezolid-resistance frequency analysis
   description: |
-    linezolid-amr combines NCBI AMRFinderPlus gene/mutation detection on an
-    assembly with species-aware mapping of raw reads to 23S rRNA references to
-    detect heteroresistant linezolid-resistance mutations (e.g. G2576T, G2505A)
-    in Staphylococcus aureus, Enterococcus faecalis/faecium, Streptococcus
-    pneumoniae, and Mycobacterium tuberculosis. The same --organism flag drives
-    both AMRFinderPlus species mode and 23S reference selection. Mutations are
-    reported in E. coli K-12 23S numbering (the clinical-literature convention)
-    via a pairwise-alignment-derived position map computed at fetch time.
+    linezolid-amr combines NCBI AMRFinderPlus gene/mutation detection and
+    Seemann's MLST on an assembly with species-aware mapping of raw reads to
+    23S rRNA references to detect heteroresistant linezolid-resistance
+    mutations (e.g. G2576T, G2505A) in Staphylococcus aureus, Enterococcus
+    faecalis/faecium, and Streptococcus pneumoniae. MLST runs first to infer
+    the organism and Sequence Type; the same organism drives both
+    AMRFinderPlus species mode and 23S reference selection. Mutations are
+    reported in E. coli K-12 23S numbering (clinical literature convention)
+    via a pairwise-alignment-derived position map. Outputs include
+    per-sample and cohort-level wide (Kleborate-style) and long CSV summaries
+    plus a full 23S VCF.
   dev_url: https://github.com/iowa69/linezolid-amr
   doc_url: https://github.com/iowa69/linezolid-amr#readme
 


### PR DESCRIPTION
Bumps **linezolid-amr** from 0.1.1 (just merged in #65400, thank you @bgruening!) to **0.1.2**.

### What's new in 0.1.2

- 🆕 **MLST integration** (Seemann's `mlst`) — auto-infers AMRFinderPlus organism + Sequence Type. `--organism` becomes an optional override with mismatch warning.
- 🆕 **🗂️ Folder mode**: `linezolid-amr folder -i input/ -o results/` auto-pairs assemblies with FASTQs (R1_001 / R1 / _1 variants × `.fastq[.gz]` / `.fq[.gz]`) and emits cohort-level wide+long CSVs.
- 🆕 **AMRFinderPlus `--plus`** pass-through (stress/virulence/biocide search).
- 🆕 **Kleborate-style wide CSV** + long-format CSV per sample, plus cohort-level summaries.
- 🆕 **Short CLI flags** (`-a/-1/-2/-i/-o/-s/-O/-t`), default threads = all CPUs.
- 🆕 **Verified PMIDs** for every canonical 23S LZD position in `loci.json`; new `CITATION.cff`.
- 🗑️ Dropped *M. tuberculosis* support (domain-specific TB tools cover it better).
- ✅ 35 unit tests passing locally.

### Recipe changes

| Field | Change |
|---|---|
| `version` | 0.1.1 → 0.1.2 |
| `source.sha256` | `8910a3ff...60a8109` (verified) |
| `requirements.run` | adds `mlst >=2.19` |
| `test.imports` | adds `linezolid_amr.mlst`, `linezolid_amr.summary` |

⚠️ Heads-up: `mlst 2.33` transitively depends on `perl-bio-samtools 1.43` which pins `samtools 0.1.x`. The Python code degrades gracefully if `mlst` isn't on PATH, so if CI hits a solver conflict I'm happy to drop `mlst` to recommended-only.

### Upstream

- Source: https://github.com/iowa69/linezolid-amr
- Release: https://github.com/iowa69/linezolid-amr/releases/tag/v0.1.2
- Changelog: see release notes above
- Maintainer: @iowa69