### PR TITLE
Update linezolid-amr to 0.1.3

### DIFF
--- a/recipes/linezolid-amr/meta.yaml
+++ b/recipes/linezolid-amr/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "linezolid-amr" %}
-{% set version = "0.1.1" %}
+{% set version = "0.1.3" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/iowa69/linezolid-amr/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 38ed406269c00324cf98633bbee8c6e329b801edb25619e96e5a4ada832dba3a
+  sha256: bd503ee45ef4fab0842653d3634eab14f4a3c6cced3a19b7c8164161e14dc804
 
 build:
   number: 0
@@ -32,14 +32,23 @@ requirements:
     - minimap2 >=2.24
     - samtools >=1.18
     - bcftools >=1.18
+    # NOTE: `mlst` (Seemann) is an optional companion for organism auto-inference
+    # and MLST sequence typing. It is NOT listed as a hard dep because
+    # `mlst >=2.19` transitively pulls `perl-bio-samtools 1.43`, which pins
+    # samtools 0.1.x and conflicts with our samtools >=1.18 constraint. Users
+    # who want MLST inference can install it in a separate env or via
+    # `mamba install --no-deps mlst`. The Python code degrades gracefully when
+    # `mlst` is not on PATH — users just pass --organism explicitly.
 
 test:
   imports:
     - linezolid_amr
     - linezolid_amr.cli
     - linezolid_amr.amrfinder
+    - linezolid_amr.mlst
     - linezolid_amr.rrna23s
     - linezolid_amr.references
+    - linezolid_amr.summary
   commands:
     - linezolid-amr --version
     - linezolid-amr --help
@@ -53,13 +62,19 @@ about:
   summary: Integrated AMR profiling (AMRFinderPlus) + 23S rRNA linezolid-resistance frequency analysis
   description: |
     linezolid-amr combines NCBI AMRFinderPlus gene/mutation detection on an
-    assembly with species-aware mapping of raw reads to 23S rRNA references to
-    detect heteroresistant linezolid-resistance mutations (e.g. G2576T, G2505A)
-    in Staphylococcus aureus, Enterococcus faecalis/faecium, Streptococcus
-    pneumoniae, and Mycobacterium tuberculosis. The same --organism flag drives
-    both AMRFinderPlus species mode and 23S reference selection. Mutations are
-    reported in E. coli K-12 23S numbering (the clinical-literature convention)
-    via a pairwise-alignment-derived position map computed at fetch time.
+    assembly with species-aware mapping of raw reads to bundled 23S rRNA
+    references to detect heteroresistant linezolid-resistance mutations
+    (e.g. G2576T, G2505A) in Staphylococcus aureus, Enterococcus
+    faecalis/faecium, and Streptococcus pneumoniae. Per-organism 23S FASTA
+    and E. coli K-12 position maps are shipped inside the package so the
+    tool works fully offline. AMRFinderPlus species mode and 23S reference
+    selection share the same --organism flag (optionally inferred via
+    Seemann's mlst when installed separately). Mutations are reported in
+    E. coli K-12 23S numbering (clinical literature convention) via a
+    pairwise-alignment-derived position map. Outputs include a per-sample
+    wide CSV (Kleborate-style), a long CSV (one row per gene/mutation),
+    a sorted indexed BAM, and a full 23S VCF. A `folder` subcommand
+    processes an entire input directory in a single command.
   dev_url: https://github.com/iowa69/linezolid-amr
   doc_url: https://github.com/iowa69/linezolid-amr#readme
 


### PR DESCRIPTION
Bumps **linezolid-amr** from 0.1.1 (merged in #65400, thank you @bgruening!) to **0.1.3**, skipping the 0.1.2 attempts (#65423 closed, #65425 from autobump) because of a real dependency conflict that 0.1.3 resolves.

## What's new since 0.1.1

- 💾 **Bundled offline 23S references** — per-organism FASTA + LZD-position BED + E. coli K-12 position map ship inside the package (~200 KB). No internet needed at install or runtime.
- 🆕 **🗂️ Folder mode**: `linezolid-amr folder -i input/ -o results/` auto-pairs assemblies with FASTQs (R1_001/R1/_1 × .fastq[.gz]/.fq[.gz]), emits cohort-level wide+long CSVs.
- 🆕 **AMRFinderPlus `--plus`** pass-through (stress/virulence/biocide).
- 🆕 **Kleborate-style wide CSV** + long-format CSV per sample, plus cohort summaries.
- 🆕 **Short CLI flags** (`-a/-1/-2/-i/-o/-s/-O/-t`), default threads = all CPUs.
- 🆕 **MLST integration** (Seemann's `mlst`) — auto-infers organism + Sequence Type when `mlst` is on PATH.
- 🆕 **Verified PMIDs** for every canonical 23S LZD position in `loci.json`; new `CITATION.cff`.
- 🗑️ Dropped *M. tuberculosis* support (covered by domain-specific TB tools).
- ✅ 31 unit tests pass locally; new tests verify bundled references for each supported organism.

## Why `mlst` isn't a hard dep

The previous v0.1.2 attempt added `mlst >=2.19` to `requirements.run`. The bioconda Linux solver rejected it:

```
Unsatisfiable dependencies for platform linux-64:
  MatchSpec("mlst==2.19.0=0"), MatchSpec("zlib")
  → mlst's perl-bio-samtools 1.43 → libzlib >=1.2.13,<1.3.0a0
  → conflicts with our samtools >=1.18 → libzlib >=1.3.1
```

mlst transitively requires `perl-bio-samtools 1.43`, which pins `samtools 0.1.x` and is incompatible with modern `zlib` 1.3.x — same conflict regardless of mlst version 2.19→2.33.

The Python code degrades gracefully when `mlst` is missing on PATH (it raises a clear ClickException prompting the user to pass `--organism` manually). Users who want MLST inference can install it via a separate env:

```bash
conda create -n mlst-tool -c bioconda mlst
# then either:  conda activate mlst-tool; linezolid-amr run ...
# or:           PATH=/opt/mlst-env/bin:$PATH linezolid-amr run ...
```

## Recipe changes vs. 0.1.1

| Field | Change |
|---|---|
| `version` | 0.1.1 → 0.1.3 |
| `source.sha256` | `bd503ee4…dc804` |
| `test.imports` | + `linezolid_amr.mlst`, `linezolid_amr.summary` |
| `description` | refreshed (offline references, folder mode, Kleborate-style outputs) |

## Upstream

- Source: https://github.com/iowa69/linezolid-amr
- Release: https://github.com/iowa69/linezolid-amr/releases/tag/v0.1.3
- Maintainer: @iowa69