### PR TITLE
Update linezolid-amr to 0.1.5

### DIFF
--- a/recipes/linezolid-amr/meta.yaml
+++ b/recipes/linezolid-amr/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "linezolid-amr" %}
-{% set version = "0.1.1" %}
+{% set version = "0.1.5" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/iowa69/linezolid-amr/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 38ed406269c00324cf98633bbee8c6e329b801edb25619e96e5a4ada832dba3a
+  sha256: 94cf070b7fcda3f0cc27b091635a137d5e01afd4e6021f08ba7646fa8b998f40
 
 build:
   number: 0
@@ -32,14 +32,18 @@ requirements:
     - minimap2 >=2.24
     - samtools >=1.18
     - bcftools >=1.18
+    - blast >=2.12
 
 test:
   imports:
     - linezolid_amr
     - linezolid_amr.cli
     - linezolid_amr.amrfinder
+    - linezolid_amr.internal_mlst
+    - linezolid_amr.mlst
     - linezolid_amr.rrna23s
     - linezolid_amr.references
+    - linezolid_amr.summary
   commands:
     - linezolid-amr --version
     - linezolid-amr --help
@@ -50,16 +54,23 @@ about:
   license: MIT
   license_family: MIT
   license_file: LICENSE
-  summary: Integrated AMR profiling (AMRFinderPlus) + 23S rRNA linezolid-resistance frequency analysis
+  summary: Integrated AMR profiling + 23S rRNA linezolid heteroresistance + in-house MLST (S. aureus, E. faecalis, E. faecium, S. pneumoniae)
   description: |
-    linezolid-amr combines NCBI AMRFinderPlus gene/mutation detection on an
-    assembly with species-aware mapping of raw reads to 23S rRNA references to
-    detect heteroresistant linezolid-resistance mutations (e.g. G2576T, G2505A)
-    in Staphylococcus aureus, Enterococcus faecalis/faecium, Streptococcus
-    pneumoniae, and Mycobacterium tuberculosis. The same --organism flag drives
-    both AMRFinderPlus species mode and 23S reference selection. Mutations are
-    reported in E. coli K-12 23S numbering (the clinical-literature convention)
-    via a pairwise-alignment-derived position map computed at fetch time.
+    linezolid-amr combines NCBI AMRFinderPlus gene/mutation detection, an
+    in-house BLAST-based MLST caller (no external mlst dependency), and
+    species-aware read mapping to bundled 23S rRNA references to detect
+    heteroresistant linezolid-resistance mutations (e.g. G2576T, G2505A)
+    in Staphylococcus aureus, Enterococcus faecalis, Enterococcus faecium,
+    and Streptococcus pneumoniae. PubMLST schemes are shipped inside the
+    package so MLST works fully offline; per-organism 23S FASTA and
+    E. coli K-12 position maps are also bundled. MLST runs first and
+    infers the organism + Sequence Type; the same organism drives both
+    AMRFinderPlus species mode and 23S reference selection. Mutations are
+    reported in E. coli K-12 23S numbering (clinical literature convention).
+    Outputs include per-sample wide CSV (Kleborate-style), long CSV, sorted
+    indexed BAM, full 23S VCF, JSON report, and human-readable text summary.
+    A `folder` subcommand processes an entire input directory in a single
+    command and emits cohort-level aggregated CSVs.
   dev_url: https://github.com/iowa69/linezolid-amr
   doc_url: https://github.com/iowa69/linezolid-amr#readme
 


### PR DESCRIPTION
Updates **linezolid-amr** from 0.1.1 (currently published, merged in #65400) to **0.1.5**, consolidating four months of development into a single bump. The 0.1.2 / 0.1.3 PR attempts (#65423, #65425, #65426) were closed because they listed `mlst` (Seemann) as a hard run-dep, which transitively pinned `samtools 0.1.x` via `perl-bio-samtools 1.43` — unsatisfiable against our `samtools >=1.18`. 0.1.5 resolves this cleanly by shipping our own MLST.

## Highlights

- 🧬 **In-house MLST** — Python module backed by PubMLST schemes (saureus, efaecalis, efaecium, spneumoniae) bundled in the package. Uses `blastn` (no zlib/perl conflict). Thresholds and BLAST options are 1:1 with `tseemann/mlst`; per-locus notation (`n` / `~n` / `n?` / `n,m` / `-`) and ST assignment behave identically. Cross-checked on a 67-sample real-world cohort: STs and alleles match Seemann's output exactly.
- 💾 **Bundled offline 23S references** — per-organism FASTA + LZD position map + E. coli K-12 position map ship inside the package (~200 KB). Works fully offline.
- 🗂️ **Folder mode** — `linezolid-amr folder -i dir/ -o results/` auto-pairs assemblies with FASTQs (R1_001/R1/_1 × .fastq[.gz]/.fq[.gz]), batch-runs, and emits cohort-level wide+long CSVs.
- 📊 **Statistics-friendly CSV** — wide CSV is a sample × gene matrix: one column per detected gene/mutation, grouped by class prefix (`LZD__`, `LZD_23S_AF__`, `AMR_<class>__`, `VIRULENCE__`, `STRESS_<class>__`). Cells = identity % (AMR) or AF (23S). Long CSV reports every resistance alt at any AF with a `passes_threshold` column.
- 🎯 **Min-AF = 0.15 by default** — positive linezolid call requires ≥1 full operon mutated (worst case S. aureus with 5 operons). Sub-threshold AFs still reported in the output ("always show the proportion").
- 🔧 AMRFinderPlus `--plus` pass-through, AMRFinder DB auto-download on first run, short flags, default threads = all CPUs.
- 📚 Verified PMIDs for each canonical 23S LZD position; new `CITATION.cff`.
- 🗑️ Dropped *M. tuberculosis* (covered by TB-specific tools).
- ✅ 33 unit tests + `scripts/validate_mlst_vs_seemann.py` for ongoing MLST validation.

## Recipe diff vs 0.1.1

| Field | Change |
|---|---|
| `version` | 0.1.1 → 0.1.5 |
| `source.sha256` | real digest of v0.1.5 tarball |
| `requirements.run` | **+ `blast >=2.12`** (`mlst` is NOT added — replaced by our in-house implementation) |
| `test.imports` | + `linezolid_amr.internal_mlst`, `linezolid_amr.mlst`, `linezolid_amr.summary` |

## Upstream

- Source: https://github.com/iowa69/linezolid-amr
- Release: https://github.com/iowa69/linezolid-amr/releases/tag/v0.1.5
- Maintainer: @iowa69