### PR TITLE
Update metagraph to 0.5.2

### DIFF
--- a/recipes/metagraph/conda_build_config.yaml
+++ b/recipes/metagraph/conda_build_config.yaml
@@ -3,3 +3,6 @@ cxx_compiler_version:
   - 18  # [osx]
 c_compiler_version:
   - 18  # [osx]
+# Folly requires std::filesystem, which needs macOS >= 10.15
+c_stdlib_version:  # [osx and x86_64]
+  - "10.15"        # [osx and x86_64]

--- a/recipes/metagraph/conda_build_config.yaml
+++ b/recipes/metagraph/conda_build_config.yaml
@@ -3,6 +3,6 @@ cxx_compiler_version:
   - 18  # [osx]
 c_compiler_version:
   - 18  # [osx]
-# Folly requires std::filesystem, which needs macOS >= 10.15
+# metagraph requires std::filesystem, which needs macOS >= 10.15
 c_stdlib_version:  # [osx and x86_64]
   - "10.15"        # [osx and x86_64]

--- a/recipes/metagraph/meta.yaml
+++ b/recipes/metagraph/meta.yaml
@@ -18,6 +18,7 @@ build:
 requirements:
   build:
     - {{ compiler('cxx') }}
+    - {{ stdlib('c') }}
     - make
     - cmake
     - autoconf

--- a/recipes/metagraph/meta.yaml
+++ b/recipes/metagraph/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "metagraph" %}
-{% set version = "0.5.1" %}
+{% set version = "0.5.2" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/ratschlab/metagraph/releases/download/v{{ version }}/v{{ version }}-sources-with-submodules.tar.gz
-  sha256: 3a9a5f3757d173169580731f8ce9d1e177b97525f51c446350d7b1dee217d156
+  sha256: 7e663295893679e956f8daf414599305628dea11f2ab3a8f349144987f12ffb8
 
 build:
   number: 0


### PR DESCRIPTION
## Summary

Supersedes #65142 by bundling the autobump (v0.5.1 → v0.5.2 + stdlib('c')) together with the osx-64 deployment-target fix needed to make it actually build.

- **v0.5.1 → v0.5.2** (source URL, sha256, `{{ stdlib('c') }}` build req — same as in #65142)
- **Bump `c_stdlib_version` to 10.15 on osx-64**: metagraph's CMakeLists.txt requires `std::filesystem` and fatal-errors if the `CPPNOFS` / `CPPFS` / `STDCPPFS` probes all fail. libc++ ships `std::filesystem` only for macOS >= 10.15, but the default osx-64 stdlib in conda-forge is `darwin13` (10.9). Adding `{{ stdlib('c') }}` (as #65142 does) enforces this pin and exposes the mismatch; bumping the deployment target fixes it. osx-arm64 (always >= 11) and Linux are unaffected.

Closes #65142.

## Test plan

- [x] OSX-64 build passes CI
- [x] Linux build still passes
- [x] osx-arm64 build still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
