### PR TITLE
Add gedi: Java framework with the PRICE ORF caller (1.0.6a)

### DIFF
--- a/recipes/gedi/bamlist2cit.sh
+++ b/recipes/gedi/bamlist2cit.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# bamlist2cit launcher (bioconda wrapper).
+#
+# Mirrors upstream's bamlist2cit script. Calls the installed `gedi`
+# command (on PATH) to drive the conversion / merge pipeline rather than
+# depending on its own location, since `gedi` is exposed as a sibling
+# wrapper in $PREFIX/bin.
+set -eu -o pipefail
+
+export LC_ALL=en_US.UTF-8
+
+p=
+tmpfolder=
+nthreads=6
+add=
+
+while [[ ${1-} == -* ]]; do
+    case $1 in
+        -h)
+            printf "bamlist2cit [-p] [-t tmpfolder] [-n nthreads] xyz.bamlist\n\n"
+            printf " -p\tShow progress\n"
+            printf " -t\tspecify tmp folder\n"
+            printf " -n\tnumber of parallel processes\n\n"
+            exit 0
+            ;;
+        -p) p=" -p";;
+        -n) shift; nthreads="$1";;
+        -t) shift
+            tmpfolder=" -Djava.io.tmpdir=$1"
+            mkdir -p "$1"
+            ;;
+        -*) add="$add $1";;
+    esac
+    shift
+done
+
+if [ -z "${1-}" ]; then
+    echo "Usage: bamlist2cit [-p] [-t tmpfolder] [-n nthreads] xyz.bamlist" >&2
+    exit 2
+fi
+
+proc=0
+PIDS=
+CITS=
+for i in $(grep -v "^#" "$1"); do
+    echo "Converting $i"
+    gedi ${tmpfolder}${add} -e Bam2CIT "${i}.cit" "${i}" &
+    PIDS="$PIDS $!"
+    CITS="$CITS ${i}.cit"
+    proc=$((proc + 1))
+    if [ "${proc}" -eq "${nthreads}" ]; then
+        wait $PIDS
+        PIDS=
+        proc=0
+    fi
+done
+wait $PIDS
+
+proc=0
+PIDS=
+for i in $(grep -v "^#" "$1"); do
+    echo "Correcting ${i}.cit"
+    gedi ${tmpfolder}${add} -e CorrectCIT "${i}.cit" &
+    PIDS="$PIDS $!"
+    proc=$((proc + 1))
+    if [ "${proc}" -eq "${nthreads}" ]; then
+        wait $PIDS
+        PIDS=
+        proc=0
+    fi
+done
+wait $PIDS
+
+echo "Merging"
+gedi ${tmpfolder}${add} -e MergeCIT ${p} -c "$1.cit" ${CITS}
+gedi ${tmpfolder}${add} -e ReadCount ${p} "$1.cit"

--- a/recipes/gedi/build.sh
+++ b/recipes/gedi/build.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -euxo pipefail
+
+# Gedi's pom.xml writes build outputs to ${user.dir} (the current working
+# directory), not to a fixed target/ inside the module. Mirror the layout
+# documented in the upstream README: create a sibling "bin" directory and
+# invoke maven against the Gedi module from inside it.
+mkdir -p build_out
+cd build_out
+mvn -f "${SRC_DIR}/Gedi/pom.xml" package -DskipTests=true -B
+
+# The above produces in build_out/:
+#   Gedi-${version}.jar
+#   gedi.jar               (copy of the versioned jar)
+#   lib/*.jar              (runtime classpath)
+#   gedi                   (upstream wrapper script)
+#   bamlist2cit            (upstream wrapper script)
+
+TGT="${PREFIX}/share/${PKG_NAME}-${PKG_VERSION}-${PKG_BUILDNUM}"
+mkdir -p "${TGT}"
+mkdir -p "${PREFIX}/bin"
+
+# Install the jar(s) and runtime classpath.
+cp -p Gedi-${PKG_VERSION}.jar "${TGT}/"
+cp -p gedi.jar "${TGT}/"
+cp -rp lib "${TGT}/"
+
+# Install our own wrapper (POSIX-portable, uses conda-installed java, no
+# upstream-specific hostname or --add-opens dependence on a specific JDK).
+install -m 0755 "${RECIPE_DIR}/gedi.sh" "${TGT}/gedi"
+install -m 0755 "${RECIPE_DIR}/bamlist2cit.sh" "${TGT}/bamlist2cit"
+
+# Expose the wrappers on PATH.
+ln -s "${TGT}/gedi" "${PREFIX}/bin/gedi"
+ln -s "${TGT}/bamlist2cit" "${PREFIX}/bin/bamlist2cit"

--- a/recipes/gedi/gedi.sh
+++ b/recipes/gedi/gedi.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# Gedi launcher (bioconda wrapper).
+#
+# This wraps the JAR + lib/ that the conda package installs under
+# $PREFIX/share/gedi-$VERSION-$BUILDNUM/. It mirrors the option parsing of
+# upstream's gedi script (https://github.com/erhard-lab/gedi) but uses the
+# conda-installed Java and resolves its install directory without relying
+# on `readlink -f` (which is non-portable on older BSD readlink).
+set -eu -o pipefail
+
+export LC_ALL=en_US.UTF-8
+
+mem=16G
+
+# Resolve the real directory of this script, following symlinks one hop at
+# a time so we work on macOS as well as Linux.
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do
+    DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+    SOURCE="$(readlink "$SOURCE")"
+    [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+
+# Prefer the conda env's java.
+if [ -n "${JAVA_HOME:-}" ] && [ -x "$JAVA_HOME/bin/java" ]; then
+    java="$JAVA_HOME/bin/java"
+elif [ -n "${CONDA_PREFIX:-}" ] && [ -x "$CONDA_PREFIX/bin/java" ]; then
+    java="$CONDA_PREFIX/bin/java"
+else
+    java="java"
+fi
+
+CP="$DIR/gedi.jar:$DIR/lib/*:$DIR/plugins/*:$HOME/.gedi/plugins/*"
+
+d=
+p=
+e=
+add="--add-opens java.base/sun.nio.ch=ALL-UNNAMED \
+--add-opens java.base/sun.reflect.generics.reflectiveObjects=ALL-UNNAMED \
+--add-opens java.xml/com.sun.org.apache.xerces.internal.util=ALL-UNNAMED \
+--add-opens java.base/jdk.internal.reflect=ALL-UNNAMED \
+--add-opens java.base/jdk.internal.ref=ALL-UNNAMED \
+--add-opens java.base/java.lang=ALL-UNNAMED"
+tmpfolder=
+jmx=
+
+while [[ ${1-} == -* ]]; do
+    case $1 in
+        -h)
+            printf "gedi [-jmx] [-d] [-d2] [-p] [-mem <XYZ>G] [-t <tmpfolder>] [-e] [-<java-option>] main-class [param...]\n\n"
+            printf " -d\tStart in debug mode (server on port 8998)\n"
+            printf " -d2\tStart in secondary debug mode (server on port 8999)\n"
+            printf " -p\tStart cpu hprof\n"
+            printf " -t\tspecify tmp folder\n"
+            printf " -e\tprepend executables. before main-class\n"
+            printf " -mem <XYZ>G\tmaximal memory available to gedi\n\n"
+            exit 0
+            ;;
+        -d)  d=" -agentlib:jdwp=transport=dt_socket,address=8998,server=y";;
+        -d2) d=" -agentlib:jdwp=transport=dt_socket,address=8999,server=y";;
+        -p)  p=" -Xrunhprof:cpu=samples";;
+        -n)  exit 10;;
+        -mem) shift; mem="$1";;
+        -jmx) jmx="-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=8991 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false";;
+        -t)  shift
+             tmpfolder=" -Djava.io.tmpdir=$1"
+             mkdir -p "$1"
+             ;;
+        -e)  e=executables.;;
+        -*)  add="$add $1";;
+    esac
+    shift
+done
+
+exec "$java" $d$p$tmpfolder $jmx $add "-Xmx${mem}" -Xms2048m -cp "$CP" "${e}${1:-}" "${@:2}"

--- a/recipes/gedi/meta.yaml
+++ b/recipes/gedi/meta.yaml
@@ -1,0 +1,58 @@
+{% set name = "gedi" %}
+{% set version = "1.0.6a" %}
+{% set tag = "Gedi_" + version %}
+{% set sha256 = "ad45df75997f26ef7c44e6a00509f8dbc9e74e5e3ae3b225cb9a7afea3447c67" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/erhard-lab/gedi/archive/refs/tags/{{ tag }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  noarch: generic
+  number: 0
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x") }}
+
+requirements:
+  host:
+    - openjdk >=11
+    - maven
+  run:
+    - openjdk >=11
+
+test:
+  commands:
+    - gedi -h
+    - gedi -e Version
+    - bamlist2cit -h
+
+about:
+  home: https://github.com/erhard-lab/gedi
+  dev_url: https://github.com/erhard-lab/gedi
+  doc_url: https://github.com/erhard-lab/gedi/wiki
+  license: GPL-3.0-only
+  license_family: GPL
+  license_file: LICENSE
+  summary: "GEDI: a Java framework for genomic data analysis, including the PRICE ORF caller for Ribo-seq."
+  description: |
+    Gedi is a software platform for working with genomic data such as
+    sequencing reads, sequences, per-base numeric values or annotations.
+    It is developed by the erhard-lab and bundles a number of executables
+    invoked via `gedi -e <Name>`. One of these is PRICE (probabilistic
+    inference of codon activities by an EM algorithm), a method for
+    identifying open reading frames from ribosome profiling (Ribo-seq)
+    data described in Erhard et al. (2018) Nature Methods.
+
+extra:
+  identifiers:
+    - doi:10.1038/s41592-018-0023-1
+  recipe-maintainers:
+    - pinin4fjords
+  notes: |
+    Gedi exposes its executables via `gedi -e <Name>`. The PRICE ORF
+    caller (Erhard et al., Nat Methods 2018) is available as
+    `gedi -e Price`. See `gedi -h` and `gedi -e <Name> -h` for usage.


### PR DESCRIPTION
### New recipe: `gedi`

Adds [erhard-lab/gedi](https://github.com/erhard-lab/gedi), a Java framework for genomic data analysis that bundles the **PRICE** Ribo-seq ORF caller as one of its executables (`gedi -e Price`).

- **Upstream:** https://github.com/erhard-lab/gedi
- **Version:** `1.0.6a` (tag `Gedi_1.0.6a`, the only public release)
- **License:** GPL-3.0-only (`LICENSE` redistributed in the package)
- **Citation:** Erhard et al. (2018) *Nature Methods*, [doi:10.1038/s41592-018-0023-1](https://doi.org/10.1038/s41592-018-0023-1) (PRICE)

### Build

`noarch: generic`. `mvn package` (Maven + OpenJDK 11+) following the upstream `README.md` instructions, then installs the produced `gedi.jar`, runtime `lib/`, and POSIX-portable launcher wrappers (`gedi`, `bamlist2cit`) into `$PREFIX/share/gedi-$VERSION-$BUILDNUM/` with symlinks on `$PATH`.

### Tests

- `gedi -h` (wrapper usage)
- `gedi -e Version` (initialises the Gedi runtime, prints version banner, exits 0)
- `bamlist2cit -h` (wrapper usage)

`gedi -e Price` is not exercised in the test block because PRICE requires real Ribo-seq BAM + CIT input. The smoke tests above confirm the JVM can resolve the full classpath and that the framework starts up cleanly.

### Notes for reviewers

- Upstream gedi has only one public release (`Gedi_1.0.6a`, April 2024). The pom.xml on `main` is now at `1.0.6d` but no tag/release exists for it, so we pin to the released tag.
- The version string `1.0.6a` parses as a PEP 440-style alpha in conda's version ordering. There is no prior `1.0.6` release to conflict with; happy to renormalise (e.g. `1.0.6.0a` per the snpeff convention) if reviewers prefer.
- Upstream's `gedi` wrapper uses `readlink -f` and hardcodes a `-Djava.rmi.server.hostname` belonging to the developer's workstation. The bundled wrapper here drops the hardcoded hostname and replaces `readlink -f` with a portable symlink-walk so the package works on both Linux and macOS.
- R + `ggplot2`/`reshape2`/`data.table` and JavaFX are intentionally not pulled in. They are only needed for `gedi -e Price -plot` and `gedi -e RiboView`; users who want those paths should install them alongside.
