### PR TITLE
Update MetagenomeScope to 1.3.0, and update dependencies

### DIFF
--- a/recipes/metagenomescope/meta.yaml
+++ b/recipes/metagenomescope/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "metagenomescope" %}
-{% set version = "1.2.0" %}
-{% set sha256 = "12b4fcfa8f690e0b086d67987d08580545282650ce0dde695c56e4524a4dd316" %}
+{% set version = "1.3.0" %}
+{% set sha256 = "e041797d72be6841404317f42b0381e61025589324d533c162239c2a9e71e0bb" %}
 
 package:
   name: "{{ name }}"
@@ -30,7 +30,6 @@ requirements:
     - pygraphviz
     - click
     - networkx
-    - gfapy
     - pyfastg >=0.2.0
     - pandas
     - dash-bootstrap-components


### PR DESCRIPTION
It looks like I don't have permission to edit #65453 - this is intended to replace that.

Version 1.3.0 of [MetagenomeScope](https://github.com/marbl/MetagenomeScope/) removes the dependency on Gfapy, so this PR just applies the changes from #65453 and removes the `gfapy` line from the list of `run` requirements. Thanks!