### PR TITLE
Update linezolid-amr to 0.1.6

### DIFF
--- a/recipes/linezolid-amr/meta.yaml
+++ b/recipes/linezolid-amr/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "linezolid-amr" %}
-{% set version = "0.1.1" %}
+{% set version = "0.1.6" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/iowa69/linezolid-amr/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 38ed406269c00324cf98633bbee8c6e329b801edb25619e96e5a4ada832dba3a
+  sha256: 3feadd34fc6fd41d1421ce29bcc4879d8f907e4803e1beb21b4e27c209c181b5
 
 build:
   number: 0
@@ -32,14 +32,18 @@ requirements:
     - minimap2 >=2.24
     - samtools >=1.18
     - bcftools >=1.18
+    - blast >=2.12
 
 test:
   imports:
     - linezolid_amr
     - linezolid_amr.cli
     - linezolid_amr.amrfinder
+    - linezolid_amr.internal_mlst
+    - linezolid_amr.mlst
     - linezolid_amr.rrna23s
     - linezolid_amr.references
+    - linezolid_amr.summary
   commands:
     - linezolid-amr --version
     - linezolid-amr --help
@@ -50,16 +54,23 @@ about:
   license: MIT
   license_family: MIT
   license_file: LICENSE
-  summary: Integrated AMR profiling (AMRFinderPlus) + 23S rRNA linezolid-resistance frequency analysis
+  summary: Integrated AMR profiling + 23S rRNA linezolid heteroresistance + in-house MLST (S. aureus, E. faecalis, E. faecium, S. pneumoniae)
   description: |
-    linezolid-amr combines NCBI AMRFinderPlus gene/mutation detection on an
-    assembly with species-aware mapping of raw reads to 23S rRNA references to
-    detect heteroresistant linezolid-resistance mutations (e.g. G2576T, G2505A)
-    in Staphylococcus aureus, Enterococcus faecalis/faecium, Streptococcus
-    pneumoniae, and Mycobacterium tuberculosis. The same --organism flag drives
-    both AMRFinderPlus species mode and 23S reference selection. Mutations are
-    reported in E. coli K-12 23S numbering (the clinical-literature convention)
-    via a pairwise-alignment-derived position map computed at fetch time.
+    linezolid-amr combines NCBI AMRFinderPlus gene/mutation detection, an
+    in-house BLAST-based MLST caller (no external mlst dependency), and
+    species-aware read mapping to bundled 23S rRNA references to detect
+    heteroresistant linezolid-resistance mutations (e.g. G2576T, G2505A)
+    in Staphylococcus aureus, Enterococcus faecalis, Enterococcus faecium,
+    and Streptococcus pneumoniae. PubMLST schemes are shipped inside the
+    package so MLST works fully offline; per-organism 23S FASTA and
+    E. coli K-12 position maps are also bundled. MLST runs first and
+    infers the organism + Sequence Type; the same organism drives both
+    AMRFinderPlus species mode and 23S reference selection. Mutations are
+    reported in E. coli K-12 23S numbering (clinical literature convention).
+    Outputs include per-sample wide CSV (Kleborate-style), long CSV, sorted
+    indexed BAM, full 23S VCF, JSON report, and human-readable text summary.
+    A `folder` subcommand processes an entire input directory in a single
+    command and emits cohort-level aggregated CSVs.
   dev_url: https://github.com/iowa69/linezolid-amr
   doc_url: https://github.com/iowa69/linezolid-amr#readme
 


### PR DESCRIPTION
Bumps **linezolid-amr** to **0.1.6** (current bioconda: 0.1.1; in-flight PR for 0.1.5: #65435). Closing #65435 would be appreciated as 0.1.6 supersedes it with additional fixes.

## What's new since 0.1.5

- **Bare-gene wide CSV**: column headers are now plain gene symbols (e.g. `blaZ`, `cfr(D)`, `vanA`, `G2576T`) instead of `LZD__` / `AMR_<class>__` / `VIRULENCE__` / `STRESS_<class>__` prefixes. Drop-in for pandas/R/Excel cohort tables.
- **23S resistance alleles only when AF ≥ --min-af** in the wide CSV (default 0.15 — ≥1 full operon in worst-case organism). Sub-threshold AFs remain in `summary_long.csv` and per-sample `*.23S_lzd_pileup.tsv` for transparency.
- **Reads-only mode**: `linezolid-amr run` accepts only `-1`/`-2` (no assembly) when `-O`/`--organism` is given. `folder --reads-only` batches every R1/R2 pair in a directory. AMR profiling and MLST are skipped in this mode — the call is made solely from read-level 23S allele frequencies.
- **PubMLST null-allele matching**: locus `-` (no BLAST hit clearing threshold) now matches a profile-table `0` (deleted gene). Fixes *E. faecium* ST1478 / ST1421–25 / ST1477 / ... where `pstS = 0` is part of the defining profile.

## Validation

- Run end-to-end on **500+ clinical Gram-positive isolates** (*S. aureus*, *E. faecalis*, *E. faecium*, *S. pneumoniae*) with full detection of both fixed and heteroresistant linezolid-resistance phenotypes.
- MLST concordance against `tseemann/mlst` on a 67-sample subset: **ST 67/67 (100%)**, alleles 63/67 (94%). The four diverging cases are all novel profiles where both engines call `ST = -` and differ only in the integer chosen for a partial allele.

## Recipe diff vs 0.1.1

| Field | Change |
|---|---|
| `version` | 0.1.1 → 0.1.6 |
| `source.sha256` | real digest of v0.1.6 tarball |
| `requirements.run` | + `blast >=2.12` (no `mlst` — in-house implementation) |
| `test.imports` | + `linezolid_amr.internal_mlst`, `linezolid_amr.mlst`, `linezolid_amr.summary` |

## Upstream

- Source: https://github.com/iowa69/linezolid-amr
- Release: https://github.com/iowa69/linezolid-amr/releases/tag/v0.1.6
- Maintainer: @iowa69