### PR TITLE
Update gedi: pin openjdk to >=11,<18 (Java 25 SIGSEGV)

### DIFF
--- a/recipes/gedi/build.sh
+++ b/recipes/gedi/build.sh
@@ -7,7 +7,9 @@ set -euxo pipefail
 # invoke maven against the Gedi module from inside it.
 mkdir -p build_out
 cd build_out
-mvn -f "${SRC_DIR}/Gedi/pom.xml" package -DskipTests=true -B
+mvn -f "${SRC_DIR}/Gedi/pom.xml" package -DskipTests=true -B \
+    -Dproject.build.sourceEncoding=UTF-8 \
+    -Dfile.encoding=UTF-8
 
 # The above produces in build_out/:
 #   Gedi-${version}.jar

--- a/recipes/gedi/meta.yaml
+++ b/recipes/gedi/meta.yaml
@@ -13,22 +13,23 @@ source:
 
 build:
   noarch: generic
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage(name, max_pin="x") }}
 
 requirements:
   host:
-    - openjdk >=11
+    - openjdk >=11,<18
     - maven
   run:
-    - openjdk >=11
+    - openjdk >=11,<18
 
 test:
   commands:
     - gedi -h
     - gedi -e Version
     - bamlist2cit -h
+    - gedi -e Price -h
 
 about:
   home: https://github.com/erhard-lab/gedi


### PR DESCRIPTION
With the previous `openjdk >=11` pin, conda resolves to `openjdk 25.0.2` from conda-forge HEAD. On Java 25, `gedi -e Price` SIGSEGVs at class-discovery time (`StringLatin1.replace` in `java.base@25.0.2`).

Tested across LTS Java versions via Wave-built containers:

| Java | `gedi -h` | `gedi -e Version` | `bamlist2cit -h` | `gedi -e Price -h` |
|------|-----------|-------------------|------------------|--------------------|
| 11   | pass      | pass              | pass             | pass               |
| 17   | pass      | pass              | pass             | pass               |
| 21   | pass      | pass              | pass             | SIGSEGV (`jdk.internal.jimage.ImageReader`) |
| 25   | pass      | pass              | pass             | SIGSEGV (`java.lang.StringLatin1.replace`) |

Pinning `openjdk >=11,<18` keeps the supported LTS range (11, 17) and excludes both broken versions. Java 21 fails too, so a wider `<22` would still be broken.

Also added `gedi -e Price -h` to `test.commands` so this regression would have been caught on the original recipe.

Bumps `build.number` from 0 to 1.

Follow-up to #65445.