### PR TITLE
Add ba3

### DIFF
--- a/recipes/ba3/build.sh
+++ b/recipes/ba3/build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euo pipefail
+
+# The upstream Makefile hardcodes /usr/local for include and lib paths and
+# pins CC=g++. Override those to use the conda-provided toolchain and the
+# host environment's headers/libs under $PREFIX.
+
+make \
+    CC="${CXX} -std=c++11" \
+    CFLAGS="${CXXFLAGS:-} -O3 ${CPPFLAGS:-}" \
+    INCLFLAGS="-I${PREFIX}/include" \
+    LIBFLAGS="${LDFLAGS:-} -L${PREFIX}/lib"
+
+install -d "${PREFIX}/bin"
+install -m 0755 BA3 "${PREFIX}/bin/BA3"

--- a/recipes/ba3/meta.yaml
+++ b/recipes/ba3/meta.yaml
@@ -18,6 +18,7 @@ build:
 requirements:
   build:
     - {{ compiler('cxx') }}
+    - {{ stdlib('c') }}
     - make
   host:
     - gsl

--- a/recipes/ba3/meta.yaml
+++ b/recipes/ba3/meta.yaml
@@ -23,9 +23,6 @@ requirements:
   host:
     - gsl
     - htslib
-  run:
-    - gsl
-    - htslib
 
 test:
   commands:

--- a/recipes/ba3/meta.yaml
+++ b/recipes/ba3/meta.yaml
@@ -1,0 +1,51 @@
+{% set name = "ba3" %}
+{% set version = "3.4.4" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/brannala/BA3/releases/download/v{{ version }}/BA3-{{ version }}.tar.gz
+  sha256: 2ef42af31610cfcd1c0c1b6511427a145c1ef83c96d113cfb5d9e97c22285f4e
+
+build:
+  number: 0
+  skip: true  # [win]
+  run_exports:
+    - {{ pin_subpackage("ba3", max_pin="x") }}
+
+requirements:
+  build:
+    - {{ compiler('cxx') }}
+    - make
+  host:
+    - gsl
+    - htslib
+  run:
+    - gsl
+    - htslib
+
+test:
+  commands:
+    - BA3 -h
+
+about:
+  home: https://github.com/brannala/BA3
+  license: AGPL-3.0-or-later
+  license_family: AGPL
+  license_file: LICENSE
+  summary: Bayesian inference of recent migration rates from multilocus genotypes
+  description: |
+    BA3 (BayesAss Edition 3) is a Bayesian MCMC program that estimates
+    recent migration rates between populations from multilocus genotype
+    data (SNPs or microsatellites). In addition to migration rates, it
+    infers first- and second-generation migrant individuals, population
+    allele frequencies, and inbreeding coefficients. Supports both the
+    native BA3 text format and VCF input.
+  doc_url: https://github.com/brannala/BA3/wiki
+  dev_url: https://github.com/brannala/BA3
+
+extra:
+  recipe-maintainers:
+    - brannala


### PR DESCRIPTION
This PR adds a new recipe for **BA3 (BayesAss Edition 3)** — a Bayesian MCMC program that estimates recent migration rates between populations from multilocus genotype data (SNPs or microsatellites).

- **Homepage:** https://github.com/brannala/BA3
- **Manual:** https://github.com/brannala/BA3/wiki
- **License:** AGPL-3.0-or-later
- **Dependencies:** `gsl`, `htslib`

BA3 is widely used in conservation genetics and population biology to infer recent migration rates, identify first- and second-generation migrants, and estimate population allele frequencies and inbreeding coefficients. As of v3.4.0 it also supports VCF input (hence the `htslib` dependency) and reports a Savage-Dickey density-ratio Bayes factor with a KL-divergence column for each migration-rate parameter.

### Testing

Built and tested locally on `osx-arm64` via `conda build`:

- Recipe builds cleanly (1m 18s, no warnings)
- The `BA3 -h` test in `meta.yaml` passes
- End-to-end smoke test: installed the built package into a fresh env and ran a 5K-iteration MCMC on the upstream `examples/uninformative.txt`; output produced correctly (migration matrix, Savage-Dickey block, inbreeding coefficients).

### Notes for reviewers

- `run_exports` uses `max_pin="x"` because the project follows semantic versioning and the 3.x line has had a stable CLI/output format.
- The upstream Makefile hardcodes `/usr/local` for include/lib paths and pins `g++`; `build.sh` overrides `CC`, `INCLFLAGS`, and `LIBFLAGS` to use the conda toolchain and `$PREFIX`.
- Skipped on Windows (upstream does not currently support a portable Windows build via this Makefile).

I'm the upstream author and listed myself as the recipe maintainer.