### PR TITLE
Update bwa-mem3 to 0.2.1; use libsais and sse2neon from conda-forge

### DIFF
--- a/recipes/bwa-mem3/build.sh
+++ b/recipes/bwa-mem3/build.sh
@@ -3,18 +3,12 @@ set -ex
 
 export CXXFLAGS="${CXXFLAGS} -O3"
 
-# Use conda-forge's htslib (host/run dep) instead of building the bundled
-# submodule. ext/htslib stays in place because the Makefile has explicit
-# dependency rules listing ext/htslib/htslib/*.h as prereqs of bwa-mem3's
-# object files; deleting the dir breaks those rules. Instead the bundled
-# 1.21 headers stay on the include path for compilation, while linking
-# resolves -lhts via conda's -L${PREFIX}/lib (which precedes the bundled
-# -Lext/htslib in the link line). The Makefile's $(HTS_LIB): rule has no
-# prerequisites, so when HTS_LIB points at an already-existing file make
-# treats it as up-to-date and skips the autoreconf+configure+make chain.
-# The 1.21->1.23 ABI drift across bwa-mem3's small htslib API surface
-# (hts_open/close, sam_hdr_init/add_line/add_lines/destroy/write,
-# bam_aux_append) is zero -- all stable since htslib 1.0.
+# Use conda-forge htslib instead of building the bundled submodule.
+# ext/htslib stays on disk because the Makefile has explicit prereqs
+# on ext/htslib/htslib/*.h; pointing HTS_LIB at the conda-forge file
+# makes the bundled $(HTS_LIB): rule a no-op and -lhts resolves via
+# -L${PREFIX}/lib. The meta.yaml htslib pin keeps the bundled headers
+# ABI-compatible with the conda shared library.
 
 MAKE_ARGS=(
   -j${CPU_COUNT}

--- a/recipes/bwa-mem3/build.sh
+++ b/recipes/bwa-mem3/build.sh
@@ -39,13 +39,13 @@ MAKE_ARGS=(
   LIBSAIS_OBJS=""
 )
 
-# Use conda-forge sse2neon on ARM: clearing SSE2NEON_INCLUDES drops
-# the bundled include path, and -I${PREFIX}/include (from conda-build's
-# compiler activation) resolves the header. ARM-only because the
-# Makefile only references sse2neon under its IS_ARM branch.
+# Use conda-forge sse2neon on ARM: overriding SSE2NEON_INCLUDES replaces
+# the bundled -Iext/sse2neon with the conda-forge header location under
+# ${PREFIX}/include. ARM-only because the Makefile only references
+# sse2neon under its IS_ARM branch.
 case "$(uname -m)" in
   aarch64|arm64)
-    MAKE_ARGS+=( SSE2NEON_INCLUDES="" )
+    MAKE_ARGS+=( SSE2NEON_INCLUDES="-I${PREFIX}/include" )
     ;;
 esac
 

--- a/recipes/bwa-mem3/build.sh
+++ b/recipes/bwa-mem3/build.sh
@@ -38,6 +38,19 @@ MAKE_ARGS=(
   # (Sandy/Ivy Bridge, Bulldozer/Piledriver, older Atom) are not
   # supported by this build.
   BASELINE_ARCH=avx2
+  # Use conda-forge's libsais (host/run dep) instead of compiling the
+  # bundled ext/libsais sources. Clearing LIBSAIS_OBJS drops the bundled
+  # libsais.o/libsais64.o from both the link line and the prereq chain
+  # (the Makefile's pattern rule $(LIBSAIS_DIR)/src/%.o is only fired by
+  # demand), and -lsais (appended to LIBS_EXTRA below) resolves the
+  # symbols against ${PREFIX}/lib/libsais.{so,dylib}. The bundled headers
+  # in ext/libsais/include are the exact v2.10.4 sources, so the existing
+  # -Iext/libsais/include in INCLUDES matches the conda-forge libsais
+  # 2.10.4 ABI; -DLIBSAIS_OPENMP (already in CPPFLAGS) keeps the _omp
+  # APIs visible. The conda-forge libsais was built with
+  # LIBSAIS_USE_OPENMP=ON and has a SONAME dep on libgomp/libomp, so
+  # OpenMP-parallel construction continues to work.
+  LIBSAIS_OBJS=""
 )
 
 if [ "$(uname)" = "Darwin" ]; then
@@ -53,12 +66,12 @@ if [ "$(uname)" = "Darwin" ]; then
     MIMALLOC_LIB="${PREFIX}/lib/libmimalloc.dylib"
     MIMALLOC_LDFLAGS="-L${PREFIX}/lib -lmimalloc -Wl,-rpath,${PREFIX}/lib"
     HTS_LIB="${PREFIX}/lib/libhts.dylib"
+    LIBS_EXTRA="-L${PREFIX}/lib -lsais -Wl,-rpath,${PREFIX}/lib"
   )
 else
   # bwa-mem3 calls shm_open/shm_unlink, which on conda's CentOS-7 sysroot
   # (glibc 2.17) live in librt. Newer Linux glibc (>= 2.34) folds them
   # into libc, so upstream CI on ubuntu-latest doesn't need this.
-  MAKE_ARGS+=( LIBS_EXTRA="-lrt" )
   # Use conda-forge's mimalloc and htslib. conda-forge ships only the
   # shared library form on Linux (no .a), so switch from the upstream
   # Makefile's `-Wl,--whole-archive libmimalloc.a -Wl,--no-whole-archive`
@@ -70,6 +83,7 @@ else
     MIMALLOC_LIB="${PREFIX}/lib/libmimalloc.so"
     MIMALLOC_LDFLAGS="-L${PREFIX}/lib -lmimalloc -Wl,-rpath,${PREFIX}/lib"
     HTS_LIB="${PREFIX}/lib/libhts.so"
+    LIBS_EXTRA="-lrt -L${PREFIX}/lib -lsais -Wl,-rpath,${PREFIX}/lib"
   )
 fi
 

--- a/recipes/bwa-mem3/build.sh
+++ b/recipes/bwa-mem3/build.sh
@@ -14,11 +14,6 @@ MAKE_ARGS=(
   -j${CPU_COUNT}
   CC="${CC}"
   CXX="${CXX}"
-  # safestringlib's safeclib_private.h calls abort()/memcpy() via macros
-  # without including <stdlib.h>/<string.h>. bwa-mem3's Makefile force-
-  # includes them for clang/Darwin only; modern conda gcc on Linux also
-  # promotes -Wimplicit-function-declaration to an error.
-  SAFE_EXTRA_CFLAGS="-include stdlib.h -include ctype.h"
   # bwa-mem3's Makefile derives VERSION_STRING from `git describe`; the
   # source tarball has no .git, so set the version explicitly.
   VERSION_STRING="${PKG_VERSION}"

--- a/recipes/bwa-mem3/build.sh
+++ b/recipes/bwa-mem3/build.sh
@@ -40,12 +40,14 @@ MAKE_ARGS=(
 )
 
 # Use conda-forge sse2neon on ARM: overriding SSE2NEON_INCLUDES replaces
-# the bundled -Iext/sse2neon with the conda-forge header location under
-# ${PREFIX}/include. ARM-only because the Makefile only references
-# sse2neon under its IS_ARM branch.
+# the bundled -Iext/sse2neon with the conda-forge header location. The
+# conda-forge package installs the header at ${PREFIX}/include/sse2neon/
+# (subdir), so the include path points one level deeper to let
+# bwa-mem3's `#include "sse2neon.h"` resolve. ARM-only because the
+# Makefile only references sse2neon under its IS_ARM branch.
 case "$(uname -m)" in
   aarch64|arm64)
-    MAKE_ARGS+=( SSE2NEON_INCLUDES="-I${PREFIX}/include" )
+    MAKE_ARGS+=( SSE2NEON_INCLUDES="-I${PREFIX}/include/sse2neon" )
     ;;
 esac
 

--- a/recipes/bwa-mem3/build.sh
+++ b/recipes/bwa-mem3/build.sh
@@ -53,6 +53,23 @@ MAKE_ARGS=(
   LIBSAIS_OBJS=""
 )
 
+# Use conda-forge's sse2neon (header-only build dep) on ARM targets
+# instead of the bundled ext/sse2neon/sse2neon.h. The conda-forge
+# sse2neon 1.9.1 is bit-identical to bwa-mem3's submodule
+# (commit 92f6de1 = v1.9.1 tag), so the resulting binary is unchanged.
+# The Makefile's IS_ARM branch sets SSE2NEON_INCLUDES=-Iext/sse2neon;
+# clearing it drops that include path and lets the conda-forge header
+# at ${PREFIX}/include/sse2neon.h resolve via the -I${PREFIX}/include
+# that conda-build adds to CXXFLAGS via the compiler activation. The
+# Makefile's IS_ARM detection (uname -m in {arm64,aarch64}) matches
+# this case statement, so the override only fires where the bundled
+# include path would otherwise be used.
+case "$(uname -m)" in
+  aarch64|arm64)
+    MAKE_ARGS+=( SSE2NEON_INCLUDES="" )
+    ;;
+esac
+
 if [ "$(uname)" = "Darwin" ]; then
   # The Makefile's macOS branch expects LIBOMP_PREFIX to point at a directory
   # containing include/ and lib/libomp.dylib. The conda llvm-openmp package

--- a/recipes/bwa-mem3/build.sh
+++ b/recipes/bwa-mem3/build.sh
@@ -38,32 +38,17 @@ MAKE_ARGS=(
   # (Sandy/Ivy Bridge, Bulldozer/Piledriver, older Atom) are not
   # supported by this build.
   BASELINE_ARCH=avx2
-  # Use conda-forge's libsais (host/run dep) instead of compiling the
-  # bundled ext/libsais sources. Clearing LIBSAIS_OBJS drops the bundled
-  # libsais.o/libsais64.o from both the link line and the prereq chain
-  # (the Makefile's pattern rule $(LIBSAIS_DIR)/src/%.o is only fired by
-  # demand), and -lsais (appended to LIBS_EXTRA below) resolves the
-  # symbols against ${PREFIX}/lib/libsais.{so,dylib}. The bundled headers
-  # in ext/libsais/include are the exact v2.10.4 sources, so the existing
-  # -Iext/libsais/include in INCLUDES matches the conda-forge libsais
-  # 2.10.4 ABI; -DLIBSAIS_OPENMP (already in CPPFLAGS) keeps the _omp
-  # APIs visible. The conda-forge libsais was built with
-  # LIBSAIS_USE_OPENMP=ON and has a SONAME dep on libgomp/libomp, so
-  # OpenMP-parallel construction continues to work.
+  # Use conda-forge libsais: clearing LIBSAIS_OBJS skips the bundled
+  # compile, and -lsais (in LIBS_EXTRA below) resolves the symbols.
+  # The meta.yaml libsais pin keeps the bundled headers in
+  # ext/libsais/include ABI-compatible with the conda shared library.
   LIBSAIS_OBJS=""
 )
 
-# Use conda-forge's sse2neon (header-only build dep) on ARM targets
-# instead of the bundled ext/sse2neon/sse2neon.h. The conda-forge
-# sse2neon 1.9.1 is bit-identical to bwa-mem3's submodule
-# (commit 92f6de1 = v1.9.1 tag), so the resulting binary is unchanged.
-# The Makefile's IS_ARM branch sets SSE2NEON_INCLUDES=-Iext/sse2neon;
-# clearing it drops that include path and lets the conda-forge header
-# at ${PREFIX}/include/sse2neon.h resolve via the -I${PREFIX}/include
-# that conda-build adds to CXXFLAGS via the compiler activation. The
-# Makefile's IS_ARM detection (uname -m in {arm64,aarch64}) matches
-# this case statement, so the override only fires where the bundled
-# include path would otherwise be used.
+# Use conda-forge sse2neon on ARM: clearing SSE2NEON_INCLUDES drops
+# the bundled include path, and -I${PREFIX}/include (from conda-build's
+# compiler activation) resolves the header. ARM-only because the
+# Makefile only references sse2neon under its IS_ARM branch.
 case "$(uname -m)" in
   aarch64|arm64)
     MAKE_ARGS+=( SSE2NEON_INCLUDES="" )

--- a/recipes/bwa-mem3/meta.yaml
+++ b/recipes/bwa-mem3/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "bwa-mem3" %}
-{% set version = "0.2.0" %}
+{% set version = "0.2.1" %}
 
 package:
   name: {{ name }}
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://github.com/fg-labs/{{ name }}/releases/download/v{{ version }}/Source_code_including_submodules.tar.gz
-  sha256: ed74c191d6dde30e5f943867a9c73f1a6717c31215e91490504da69f3726d7b3
+  sha256: b6fc536a938faa32ddd3e814c5362f5481a3b580435665fe0d0ac0747aa332f3
 
 build:
-  number: 1
+  number: 0
   run_exports:
     - {{ pin_subpackage('bwa-mem3', max_pin="x") }}
 
@@ -45,7 +45,6 @@ about:
   license_family: MIT
   license_file:
     - LICENSE
-    - ext/safestringlib/LICENSE
     - ext/sse2neon/LICENSE
   summary: "Short-read aligner derived from bwa-mem2 with correctness fixes, performance improvements, and methylation alignment."
   dev_url: "https://github.com/fg-labs/bwa-mem3"

--- a/recipes/bwa-mem3/meta.yaml
+++ b/recipes/bwa-mem3/meta.yaml
@@ -20,12 +20,12 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - {{ stdlib('c') }}
-    - sse2neon ==1.9.1  # [aarch64 or arm64]
   host:
     - zlib
     - mimalloc >=3.3,<4
     - htslib >=1.21,<2
     - libsais >=2.10.4,<3
+    - sse2neon ==1.9.1  # [aarch64 or arm64]
     - llvm-openmp  # [osx]
     - libgomp      # [linux]
   run:

--- a/recipes/bwa-mem3/meta.yaml
+++ b/recipes/bwa-mem3/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: ed74c191d6dde30e5f943867a9c73f1a6717c31215e91490504da69f3726d7b3
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage('bwa-mem3', max_pin="x") }}
 
@@ -24,11 +24,13 @@ requirements:
     - zlib
     - mimalloc >=3.3,<4
     - htslib >=1.21,<2
+    - libsais >=2.10.4,<3
     - llvm-openmp  # [osx]
     - libgomp      # [linux]
   run:
     - mimalloc >=3.3,<4
     - htslib >=1.21,<2
+    - libsais >=2.10.4,<3
     - llvm-openmp  # [osx]
     - libgomp      # [linux]
 
@@ -43,7 +45,6 @@ about:
   license_file:
     - LICENSE
     - ext/safestringlib/LICENSE
-    - ext/libsais/LICENSE
     - ext/sse2neon/LICENSE
   summary: "Short-read aligner derived from bwa-mem2 with correctness fixes, performance improvements, and methylation alignment."
   dev_url: "https://github.com/fg-labs/bwa-mem3"

--- a/recipes/bwa-mem3/meta.yaml
+++ b/recipes/bwa-mem3/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - {{ stdlib('c') }}
+    - sse2neon ==1.9.1  # [aarch64 or arm64]
   host:
     - zlib
     - mimalloc >=3.3,<4


### PR DESCRIPTION
Bumps bwa-mem3 from 0.2.0 → 0.2.1 and switches two bundled submodules to conda-forge packages.

### Version bump (0.2.0 → 0.2.1)

Upstream 0.2.1 drops the bundled `intel/safestringlib` submodule ([fg-labs/bwa-mem3#105](https://github.com/fg-labs/bwa-mem3/pull/105): −278 lines, replace `*_s` wrappers with plain C, delete the `memcpy_bwamem` chunking wrapper). Reflected in the recipe by dropping `ext/safestringlib/LICENSE` from `license_file` and removing the `SAFE_EXTRA_CFLAGS` workaround from `build.sh`. 0.2.1 also picks up two bug fixes (mapq propagation in `--supp-rep-hard-cap`, smem `enc_qdb` byte-capacity tracking) and an htslib build improvement.

### libsais (linked dependency)

- conda-forge `libsais` 2.10.4 across `linux-64`, `linux-aarch64`, `osx-64`, `osx-arm64`, `win-64`. The conda-forge build pins the same upstream v2.10.4 commit that the bwa-mem3 submodule pins, so the ABI is identical.
- conda-forge's `libsais` is built with `LIBSAIS_USE_OPENMP=ON` and `LIBSAIS_BUILD_SHARED_LIB=ON`; its `libsais.{so,dylib}` carries a SONAME dependency on `libgomp` / `libomp`. bwa-mem3's Makefile already defines `-DLIBSAIS_OPENMP` and injects OpenMP compile/link flags, so OpenMP-parallel suffix-array construction continues to work unchanged.

### sse2neon (header-only, ARM only)

- conda-forge `sse2neon` 1.9.1 is bit-identical to bwa-mem3's bundled `ext/sse2neon` submodule (commit `92f6de1` = `v1.9.1` tag). The resulting ARM binary is unchanged; this is a packaging-only change for consistency with the libsais swap.
- Header-only with no runtime ABI; gated to ARM via the `# [aarch64 or arm64]` selector.
- conda-forge installs the header at `${PREFIX}/include/sse2neon/sse2neon.h` (subdir), so `SSE2NEON_INCLUDES` points one level deeper to let bwa-mem3's `#include "sse2neon.h"` resolve.
- `ext/sse2neon/LICENSE` stays in `license_file` — the header is still inlined into the binary at compile time, so the MIT attribution remains required.

### Changes

- `meta.yaml`:
  - Bump version to 0.2.1, refresh sha256 (`b6fc536…`).
  - Reset `build.number` to 0.
  - Add `libsais >=2.10.4,<3` to `host` + `run`.
  - Add `sse2neon ==1.9.1` to `host` (ARM only).
  - Drop `ext/safestringlib/LICENSE` from `license_file`.
- `build.sh`:
  - Drop `SAFE_EXTRA_CFLAGS` (safestringlib no longer bundled in 0.2.1).
  - Pass `LIBSAIS_OBJS=""` to skip compiling bundled libsais sources; append `-L${PREFIX}/lib -lsais -Wl,-rpath,${PREFIX}/lib` to `LIBS_EXTRA` on both Darwin and Linux.
  - On `uname -m in {aarch64,arm64}`, set `SSE2NEON_INCLUDES=-I${PREFIX}/include/sse2neon` so the Makefile picks up the conda-forge header.
  - Tighten existing htslib/libsais/sse2neon comments to be version-agnostic.