### PR TITLE
Add palmscan

### DIFF
--- a/recipes/palmscan/0001-drop-static-linking.patch
+++ b/recipes/palmscan/0001-drop-static-linking.patch
@@ -1,0 +1,22 @@
+From: Shoichi Sakaguchi <peace.apple@gmail.com>
+Date: 2026-05-17
+Subject: Drop -static link flag on Linux
+
+Bioconda disallows fully-static binaries; conda's libgomp/libstdc++ must
+be linked dynamically so version pinning via run_exports remains effective.
+This patch removes the `LDFLAGS += -static` branch from the Linux build.
+The resulting binary depends on libgomp.so.1 / libstdc++.so.6, both of
+which conda-forge ships.
+
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -9,9 +9,6 @@ CXXFLAGS := $(CXXFLAGS) -O3 -fopenmp -ffast-math -msse -mfpmath=sse
+
+ UNAME_S := $(shell uname -s)
+ LDFLAGS := $(LDFLAGS) -O3 -fopenmp -pthread -lpthread
+-ifeq ($(UNAME_S),Linux)
+-    LDFLAGS += -static
+-endif
+
+ HDRS = \
+   abcxyz.h \

--- a/recipes/palmscan/build.sh
+++ b/recipes/palmscan/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -euo pipefail
+
+cd src
+make -j "${CPU_COUNT}"
+
+mkdir -p "${PREFIX}/bin"
+install -m 0755 ../bin/palmscan2 "${PREFIX}/bin/palmscan2"

--- a/recipes/palmscan/build.sh
+++ b/recipes/palmscan/build.sh
@@ -2,7 +2,12 @@
 set -euo pipefail
 
 cd src
-make -j "${CPU_COUNT}"
+# Override CXX on the make command line: the upstream Makefile hard-codes
+# `CXX = g++`, which shadows the $CXX env var that conda's compiler
+# activation script sets. On bioconda CI there is no bare `g++` on PATH,
+# only $BUILD_PREFIX/bin/x86_64-conda-linux-gnu-c++, so the build fails
+# without this override.
+make -j "${CPU_COUNT}" CXX="${CXX}"
 
 mkdir -p "${PREFIX}/bin"
 install -m 0755 ../bin/palmscan2 "${PREFIX}/bin/palmscan2"

--- a/recipes/palmscan/meta.yaml
+++ b/recipes/palmscan/meta.yaml
@@ -1,14 +1,13 @@
 {% set name = "palmscan" %}
-{% set version = "2.0" %}
-{% set commit = "954a5642a3651879455ff701d9d35d059e01afab" %}
-{% set sha256 = "d4b0326ace8e9a0a7a92ca2144446ea83ad88c849d434a8764ff87fa462b75fc" %}
+{% set version = "2.0.0" %}
+{% set sha256 = "7d37378f82aaf5295fbbe77cfeec43dc83a8eea1c1ed379c50c72491f69ac8c3" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://github.com/rcedgar/palmscan/archive/{{ commit }}.tar.gz
+  url: https://github.com/rcedgar/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
   sha256: {{ sha256 }}
   patches:
     - 0001-drop-static-linking.patch

--- a/recipes/palmscan/meta.yaml
+++ b/recipes/palmscan/meta.yaml
@@ -1,0 +1,50 @@
+{% set name = "palmscan" %}
+{% set version = "2.0" %}
+{% set commit = "954a5642a3651879455ff701d9d35d059e01afab" %}
+{% set sha256 = "d4b0326ace8e9a0a7a92ca2144446ea83ad88c849d434a8764ff87fa462b75fc" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/rcedgar/palmscan/archive/{{ commit }}.tar.gz
+  sha256: {{ sha256 }}
+  patches:
+    - 0001-drop-static-linking.patch
+
+build:
+  number: 0
+  skip: True  # [not linux64]
+  run_exports:
+    - {{ pin_subpackage(name|lower, max_pin="x") }}
+
+requirements:
+  build:
+    - {{ compiler('cxx') }}
+    - {{ stdlib('c') }}
+    - make
+  host:
+    - libgomp  # [linux]
+  run:
+    - libgomp  # [linux]
+
+test:
+  commands:
+    - palmscan2 -version 2>&1 | grep "^palmscan2 v"
+
+about:
+  home: https://github.com/rcedgar/palmscan
+  license: AGPL-3.0-only
+  license_family: AGPL
+  license_file: LICENSE
+  summary: "Detect viral polymerase palmprint barcode sequences via PSSMs"
+  description: |
+    Palmscan2 finds palmprint regions in nucleotide and protein sequences
+    using position-specific scoring matrices. It is used for RNA virus
+    classification and is a runtime dependency of palm_annot.
+  dev_url: https://github.com/rcedgar/palmscan
+
+extra:
+  recipe-maintainers:
+    - shoichisakaguchi


### PR DESCRIPTION
Adds a recipe for [palmscan](https://github.com/rcedgar/palmscan) (palmscan2 binary),
a PSSM-based detector of viral RdRp palmprint regions used for RNA virus classification.

Submitted as part of the ViBioM 2026 Hackathon (2026-05-17).

### Notes
- Source: pinned to upstream release tag **`v2.0.0`** (cut by upstream in response to
  rcedgar/palmscan#4 — thanks!). Tag points to the same commit (954a5642) the recipe
  initially used, so build content is identical.
- License: AGPL-3.0-only
- linux-64 only for this initial PR. The Makefile uses `-msse -mfpmath=sse` which is
  x86_64-only; aarch64 / osx-arm64 can be added in follow-ups.
- A small in-recipe patch removes `LDFLAGS += -static` on Linux so that conda's
  libgomp / libstdc++ are linked dynamically per the bioconda policy. Verified that
  the resulting binary links against `libgomp.so.1` and `libstdc++.so.6` shipped
  by conda-forge.
- Local verification: built and ran `palmscan2 -version` inside the bioconda build
  container (a companion PR for a downstream wrapper, `palm_annot`, is ready locally
  and will be opened after this one merges).

Please confirm: I followed the existing `muscle` recipe (same author) as a
structural reference; happy to adjust naming or split if reviewers prefer.
