### PR TITLE
Add cerberus-mg

### DIFF
--- a/recipes/cerberus-mg/meta.yaml
+++ b/recipes/cerberus-mg/meta.yaml
@@ -1,0 +1,73 @@
+{% set name = "cerberus-mg" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/iowa69/cerberus/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 2728b50ef145fe564fbd9c94b968a4afd1e0d39e97e9b2a6a566afc22c687c07
+
+build:
+  number: 0
+  noarch: python
+  entry_points:
+    - cerberus = cerberus.cli:main
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x.x") }}
+
+requirements:
+  host:
+    - python >=3.10
+    - pip
+    - setuptools >=68
+  run:
+    - python >=3.10
+    - tqdm >=4.66
+    - pyyaml >=6.0
+    - fastp >=0.24
+    - minimap2 >=2.28
+    - bowtie2 >=2.5
+    - bbmap >=39.0
+    - kraken2 >=2.1.3
+    - samtools >=1.20
+    - seqkit >=2.8
+    - pigz
+    - aria2
+    - multiqc >=1.25
+    - chopper >=0.9
+    - winnowmap >=2.03
+    - bedtools >=2.31
+    - zstd >=1.5
+
+test:
+  imports:
+    - cerberus
+  commands:
+    - cerberus --version
+    - cerberus --help
+
+about:
+  home: https://github.com/iowa69/cerberus
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: "Three-headed host-removal pipeline for metagenomics: assembly, profiling, and GDPR-compliant outputs from one run."
+  description: |
+    Cerberus is an opinionated all-in-one host-decontamination pipeline that
+    produces three publication-ready outputs from a single run: a paired-end
+    assembly-ready FASTQ pair (conservative), a single merged FASTQ for
+    taxonomic profiling (aggressive), and a GDPR-compliant zero-host scrubbed
+    output (via two orthogonal mechanisms: Kraken2 + minimap2). Works on
+    Illumina short reads, ONT long reads, and PacBio HiFi/CLR. Autotunes its
+    parameters from fastp QC.
+  doc_url: https://github.com/iowa69/cerberus
+  dev_url: https://github.com/iowa69/cerberus
+
+extra:
+  recipe-maintainers:
+    - iowa69
+  identifiers:
+    - doi:10.5281/zenodo.20258069

--- a/recipes/cerberus-mg/meta.yaml
+++ b/recipes/cerberus-mg/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "cerberus-mg" %}
-{% set version = "0.1.0" %}
+{% set version = "0.1.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/iowa69/cerberus/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 2728b50ef145fe564fbd9c94b968a4afd1e0d39e97e9b2a6a566afc22c687c07
+  sha256: c17944783acded3876b5d49a572ac77371b8e1737646b05f8b4c87f5d8d149bf
 
 build:
   number: 0


### PR DESCRIPTION
## Adds new recipe: cerberus-mg

[Cerberus](https://github.com/iowa69/cerberus) is a three-headed host-removal pipeline for metagenomic data that produces three publication-ready outputs from a single run:

- **`--meta`** — Paired-end output for assembly (SPAdes, MEGAHIT). Conservative.
- **`--profiling`** — Single merged FASTQ for taxonomic profiling (Kraken2, Bracken). Aggressive.
- **`--gdpr`** — Zero-host scrubbed output for publication. Two orthogonal mechanisms (Kraken2 + minimap2).

Works on Illumina short reads, ONT long reads, and PacBio HiFi/CLR. Autotunes parameters from fastp QC.

- Source: https://github.com/iowa69/cerberus
- Release: https://github.com/iowa69/cerberus/releases/tag/v0.1.0
- Reference data: [Zenodo DOI 10.5281/zenodo.20258069](https://doi.org/10.5281/zenodo.20258069)

### Notes for review
- Pure-Python `noarch: python` package; CLI entry point `cerberus`.
- All runtime dependencies already in bioconda / conda-forge.
- License: MIT. Maintainer: @iowa69.

Please describe your pull request:
- [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
- [x] This PR adds a new recipe.
- [x] The recipe builds and tests successfully (`cerberus --version`, `cerberus --help`).
- [x] The package is for a tool I maintain.