### PR TITLE
Update mlstudio to 1.4.0

### DIFF
--- a/recipes/mlstudio/meta.yaml
+++ b/recipes/mlstudio/meta.yaml
@@ -15,6 +15,8 @@ build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
     - mlstudio = mlstudio.cli:app
+  run_exports:
+    - {{ pin_subpackage('mlstudio', max_pin="x") }}
 
 requirements:
   host:

--- a/recipes/mlstudio/meta.yaml
+++ b/recipes/mlstudio/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "mlstudio" %}
-{% set version = "1.3.0" %}
+{% set version = "1.3.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/iowa69/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 14dbdaa4feabc921a3be87e3a92c8b7cdecbf50829ff950afad5e77fbd7e1504
+  sha256: 5bb6172e5c127eef056b6a86c6221bee72f5415069fa0ec9601273a40ff11486
 
 build:
   number: 0

--- a/recipes/mlstudio/meta.yaml
+++ b/recipes/mlstudio/meta.yaml
@@ -1,0 +1,81 @@
+{% set name = "mlstudio" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/iowa69/mlstudio/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 0790835d0b8f68c23b05250c0e89d4f89c75313af1194eb1885af1cc84b6c2c2
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  entry_points:
+    - mlstudio = mlstudio.cli:app
+
+requirements:
+  host:
+    - python >=3.11
+    - pip
+    - hatchling >=1.21
+  run:
+    - python >=3.11
+    - typer >=0.12
+    - rich >=13.7
+    - httpx >=0.27
+    - fastapi >=0.111
+    - uvicorn-standard >=0.30
+    - websockets >=12
+    - python-multipart >=0.0.9
+    - pydantic >=2.7
+    - numpy >=1.26
+    - pandas >=2.2
+    - pyarrow >=16
+    - biopython >=1.83
+    - pysam >=0.22
+    - networkx >=3.3
+    - platformdirs >=4.2
+    # External tools used at runtime
+    - blast >=2.15
+    - bowtie2 >=2.5
+    - samtools >=1.20
+    - fastp >=0.23
+    - seqkit >=2.8
+    - prodigal >=2.6
+
+test:
+  imports:
+    - mlstudio
+    - mlstudio.api
+    - mlstudio.calling
+    - mlstudio.schemes
+  commands:
+    - mlstudio --version
+    - mlstudio --help
+    - mlstudio schemes --help
+    - mlstudio call --help
+
+about:
+  home: https://github.com/iowa69/mlstudio
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: 'MLST and cgMLST typing with an interactive minimum spanning tree, for Linux.'
+  description: |
+    MLSTudio takes a folder of assembled bacterial genomes (and optionally
+    paired-end Illumina reads), pulls the appropriate typing scheme from
+    PubMLST.org or BIGSdb-Pasteur, calls alleles with BLAST across all
+    available cores, computes pairwise allele distances, and renders an
+    interactive minimum spanning tree in the browser. Cluster halos with
+    user-set thresholds, metadata-driven coloring, identical-genotype
+    pie collapsing, multiple missing-data policies, ad-hoc cgMLST scheme
+    building from a single reference genome, incremental analysis caching.
+  dev_url: https://github.com/iowa69/mlstudio
+  doc_url: https://github.com/iowa69/mlstudio#readme
+
+extra:
+  recipe-maintainers:
+    - iowa69

--- a/recipes/mlstudio/meta.yaml
+++ b/recipes/mlstudio/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "mlstudio" %}
-{% set version = "1.3.1" %}
+{% set version = "1.4.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/iowa69/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 5bb6172e5c127eef056b6a86c6221bee72f5415069fa0ec9601273a40ff11486
+  sha256: e99bc4bae8472c1d7e536b5caf4e52c68f4369b983c0c8d39501958616befc53
 
 build:
   number: 0

--- a/recipes/mlstudio/meta.yaml
+++ b/recipes/mlstudio/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "mlstudio" %}
-{% set version = "0.1.0" %}
+{% set version = "1.3.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://github.com/iowa69/mlstudio/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 0790835d0b8f68c23b05250c0e89d4f89c75313af1194eb1885af1cc84b6c2c2
+  url: https://github.com/iowa69/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 14dbdaa4feabc921a3be87e3a92c8b7cdecbf50829ff950afad5e77fbd7e1504
 
 build:
   number: 0
@@ -23,6 +23,7 @@ requirements:
     - hatchling >=1.21
   run:
     - python >=3.11
+    # Python deps (mirror of pyproject.toml [project.dependencies])
     - typer >=0.12
     - rich >=13.7
     - httpx >=0.27
@@ -38,43 +39,45 @@ requirements:
     - pysam >=0.22
     - networkx >=3.3
     - platformdirs >=4.2
-    # External tools used at runtime
-    - blast >=2.15
-    - bowtie2 >=2.5
-    - samtools >=1.20
-    - fastp >=0.23
-    - seqkit >=2.8
-    - prodigal >=2.6
+    # External CLI binaries invoked via subprocess
+    - blast >=2.14         # blastn, makeblastdb
+    - prodigal >=2.6.3     # ad-hoc scheme CDS prediction
+    - fastp >=0.23         # paired-read QC + platform autodetect
+    - ncbi-amrfinderplus >=3.12   # AMR scanning alongside typing
 
 test:
   imports:
     - mlstudio
-    - mlstudio.api
-    - mlstudio.calling
-    - mlstudio.schemes
+    - mlstudio.api.server
+    - mlstudio.calling.cgmlst
+    - mlstudio.calling.mlst
+    - mlstudio.profiles.distance
+    - mlstudio.profiles.mst
   commands:
     - mlstudio --version
     - mlstudio --help
-    - mlstudio schemes --help
-    - mlstudio call --help
+    # Confirm the required external binaries are co-installed
+    - blastn -version
+    - makeblastdb -version
+    - prodigal -v 2>&1 | grep -i prodigal
+    - fastp --version 2>&1 | grep -i fastp
+    - amrfinder --version
 
 about:
   home: https://github.com/iowa69/mlstudio
   license: MIT
   license_family: MIT
   license_file: LICENSE
-  summary: 'MLST and cgMLST typing with an interactive minimum spanning tree, for Linux.'
+  summary: Free, open-source MLST/cgMLST typing with an interactive minimum-spanning-tree GUI for Linux.
   description: |
-    MLSTudio takes a folder of assembled bacterial genomes (and optionally
-    paired-end Illumina reads), pulls the appropriate typing scheme from
-    PubMLST.org or BIGSdb-Pasteur, calls alleles with BLAST across all
-    available cores, computes pairwise allele distances, and renders an
-    interactive minimum spanning tree in the browser. Cluster halos with
-    user-set thresholds, metadata-driven coloring, identical-genotype
-    pie collapsing, multiple missing-data policies, ad-hoc cgMLST scheme
-    building from a single reference genome, incremental analysis caching.
+    MLSTudio is an integrated MLST and cgMLST typing tool for bacterial isolates,
+    bundling scheme management (PubMLST, BIGSdb-Pasteur, cgMLST.org, ad-hoc),
+    BLAST-based allele calling, AMRFinderPlus integration, and a local web UI
+    with a Cytoscape.js minimum-spanning-tree viewer. Aimed at filling the gap
+    between calling-only tools (chewBBACA) and visualization-only tools
+    (GrapeTree) without a SeqSphere-style licence cost.
+  doc_url: https://github.com/iowa69/mlstudio
   dev_url: https://github.com/iowa69/mlstudio
-  doc_url: https://github.com/iowa69/mlstudio#readme
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Adds [mlstudio](https://github.com/iowa69/mlstudio) — a free, open-source MLST/cgMLST typing tool with an interactive Cytoscape.js minimum-spanning-tree GUI for Linux. Aimed at filling the gap between calling-only tools (chewBBACA) and visualization-only tools (GrapeTree), with a workflow modelled on the SeqSphere clinical-micro experience.

### What 1.3.0 includes
- BLAST-based MLST + cgMLST allele calling (RAM-bounded batched BLAST DBs)
- One-command ESKAPEE cgMLST bulk pull (`mlstudio schemes pull-eskapee`)
- AMRFinderPlus integration alongside typing (results never affect the allele-distance MST)
- Local web UI: cluster halos, pie-collapsed identical genotypes, non-tree close-pair edges, configurable fcose / radial / cose / circle layout, exported PNG/SVG
- Project save/load (`.mlsproj`)
- Ad-hoc cgMLST schemes from any reference assembly via prodigal + self-BLAST
- Source release: <https://github.com/iowa69/mlstudio/releases/tag/v1.3.0>

### Description

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/) before opening a pull request (PR).

**General instructions**

- [x] If this PR adds a new recipe or updates an existing recipe, please use "Add" or "Update" appropriately as the first word in its title.
- [x] New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge](https://conda-forge.org/) channel instead of Bioconda.
- [x] PRs require reviews from one or more members of the Bioconda core or @bioconda/<package-team> teams. These will be requested automatically.
- [x] When updating a recipe, please make sure to bump the version number when needed and reset the build number to 0 when bumping the version.

**Instructions for avoiding API, ABI, and CLI breakage issues**

- [x] Where possible, pin exact build dependencies, e.g. `compatible_pinnings`.

**Tests pass locally**
- [x] `mlstudio --version` → `mlstudio 1.3.0  ·  Developed by Giovanni Lorenzin`
- [x] `mlstudio --help`
- [x] All five external CLI binaries from `requirements/run` are exercised in the recipe's `test/commands` section.

Recipe maintainer: @iowa69 (Giovanni Lorenzin)