### PR TITLE
splicecraft: add v0.9.0 (first submission)

### DIFF
--- a/recipes/splicecraft/meta.yaml
+++ b/recipes/splicecraft/meta.yaml
@@ -1,0 +1,89 @@
+{% set name = "splicecraft" %}
+{% set version = "0.9.0" %}
+
+# Conda-forge / bioconda recipe for SpliceCraft.
+#
+# This recipe lives in the SpliceCraft repo as a reference; the canonical
+# copy belongs at:
+#   https://github.com/bioconda/bioconda-recipes/tree/master/recipes/splicecraft/
+#
+# After a new PyPI release, bump `version` above and regenerate `source.sha256`:
+#
+#   curl -sL https://pypi.io/packages/source/s/splicecraft/splicecraft-X.Y.Z.tar.gz | sha256sum
+#
+# …then open a PR against bioconda-recipes. Bot feedback arrives within minutes.
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  # Regenerate this on every version bump (see comment above).
+  sha256: 405172d09d40696761860635f0c3398f5dc1b6e883ac4553341595667e8a9fd1
+
+build:
+  noarch: python
+  number: 0
+  # `max_pin="x.x"` because SpliceCraft is on 0.x.y — semver permits
+  # breaking changes between 0.minor releases, so downstreams must
+  # pin to the same minor to stay compatible. Bumps to >=1.0.0 should
+  # relax this to `max_pin="x"`.
+  run_exports:
+    - {{ pin_subpackage('splicecraft', max_pin="x.x") }}
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  entry_points:
+    - splicecraft     = splicecraft:main
+    - splicecraft-cli = splicecraft_cli:main
+
+requirements:
+  host:
+    - python >=3.10
+    - pip
+    - hatchling >=1.24
+  run:
+    - python >=3.10
+    - textual >=8.2.6
+    - biopython >=1.87
+    - primer3-py >=2.3.0
+    - platformdirs >=4.9.6
+    - pyhmmer >=0.12.1
+
+test:
+  imports:
+    - splicecraft
+  commands:
+    - splicecraft --version
+    - splicecraft-cli --help
+  requires:
+    - pip
+
+about:
+  home: https://github.com/Binomica-Labs/SpliceCraft
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: Terminal plasmid workbench (map viewer, sequence editor, cloning)
+  description: |
+    SpliceCraft is a terminal-native plasmid workbench built for daily
+    lab work. Renders circular and linear maps via Unicode braille
+    graphics, edits sequence with full undo / redo, designs primers
+    (detection, cloning, Golden Braid L0, generic) via Primer3, runs
+    SOE-PCR site-directed mutagenesis on any CDS.
+
+    Manages a collection-driven plasmid library with atomic writes and
+    on-disk backups (four-tier safety net: legacy `.bak`, timestamped
+    rotation, daily snapshots, shrink-guard spillover). Provides
+    in-process similarity search (BLASTN / BLASTP / HMMscan) via
+    pyhmmer against the user's plasmid collections — no external
+    blast+ install required.
+
+    Local `.gb` / `.gbk` and `.dna` files (popular commercial plasmid
+    editor format) load directly; bulk-import an archive into a new
+    collection from the panel.
+  dev_url: https://github.com/Binomica-Labs/SpliceCraft
+  doc_url: https://github.com/Binomica-Labs/SpliceCraft
+
+extra:
+  recipe-maintainers:
+    - ATinyGreenCell


### PR DESCRIPTION
Updates the SpliceCraft recipe to v0.9.0.

- PyPI: https://pypi.org/project/splicecraft/0.9.0/
- Upstream: https://github.com/Binomica-Labs/SpliceCraft
- Tag: https://github.com/Binomica-Labs/SpliceCraft/releases/tag/v0.9.0

Recipe synced from the in-repo `conda-recipe/meta.yaml` via `release.py`: version + sha256 (regenerated from the live sdist) + runtime deps (rewritten from `pyproject.toml`'s `[project] dependencies`).

_This is the first bioconda submission for splicecraft._ Recipe maintainer: @ATinyGreenCell. Happy to address any bot feedback.