### PR TITLE
Add recipe for protein-mosaic-q

### DIFF
--- a/recipes/protein-mosaic-q/meta.yaml
+++ b/recipes/protein-mosaic-q/meta.yaml
@@ -4,7 +4,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/p/protein-mosaic-q/protein_mosaic_q-0.3.3.tar.gz
-  sha256: 2c98b6448e04d9d54d56584021ef8ca0e962e5bbe8d05e08cc42488ba9e3ba85 *pmq_download/protein_mosaic_q-0.3.3.tar.gz
+  sha256: 2c98b6448e04d9d54d56584021ef8ca0e962e5bbe8d05e08cc42488ba9e3ba85
 
 build:
   number: 0

--- a/recipes/protein-mosaic-q/meta.yaml
+++ b/recipes/protein-mosaic-q/meta.yaml
@@ -1,0 +1,60 @@
+package:
+  name: protein-mosaic-q
+  version: "0.3.3"
+
+source:
+  url: https://pypi.io/packages/source/p/protein-mosaic-q/protein_mosaic_q-0.3.3.tar.gz
+  sha256: 2c98b6448e04d9d54d56584021ef8ca0e962e5bbe8d05e08cc42488ba9e3ba85 *pmq_download/protein_mosaic_q-0.3.3.tar.gz
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -v
+  noarch: python
+
+requirements:
+  host:
+    - python >=3.8
+    - pip
+  run:
+    - python >=3.8
+    - biopython
+
+test:
+  imports:
+    - mosaicq
+
+about:
+  home: https://proteins-mosaic-q.org
+  license: MIT
+  license_family: MIT
+  summary: Calculate the Mosaic Q descriptor, an amino acid clustering trait in protein structure
+  description: |
+    protein-mosaic-q calculates the Mosaic Q and Q_alt descriptors, which
+    capture a proposed conserved structural trait in protein structure: aside from 
+    the hydrophobic core, amino acids tend to cluster in 3D space according to their chemical
+    family (polar, acidic, basic, special), forming groups of approximately 8 residues. 
+    The evidence for this regularity comes from direct analysis of >160,000 X-ray determined 
+    entries in the PDB (Q descriptor), stochastic simulations, and visual inspection of hundreds
+    of structures in collaboration with independent observers across recognized citizen science
+    platforms.
+
+
+    Resources:
+    - Project website: https://proteins-mosaic-q.org
+    - bio.tools: https://bio.tools/protein-mosaic-q
+    - Updated manuscript: https://github.com/UPO-Sevilla-Fco-Javier-Lobo-Cabrera/clustering_trait_proteins/blob/main/Manuscript_and_Supplementary_Materials_v4.pdf
+    - Preprint: https://www.biorxiv.org/content/10.1101/500025v1.full
+    - FAIRsharing: https://fairsharing.org/8206
+    - SciStarter: https://scistarter.org/proteins-mosaic-q-project
+    - EU Citizen Science: https://citizenscience.eu/project/686
+    - Observatorio Ciencia Ciudadana (Spain): https://ciencia-ciudadana.es/project/392
+    - HuggingFace Space: https://huggingface.co/spaces/ProteinsMosaicQProject/proteins-mosaic-q
+    - Dataset: https://huggingface.co/ProteinsMosaicQ/datasets
+    - Collaborative repository: https://proteins-mosaic-q.org/repository/
+    
+  doc_url: https://proteins-mosaic-q.org
+  dev_url: https://github.com/UPO-Sevilla-Fco-Javier-Lobo-Cabrera/mosaicq
+
+extra:
+  recipe-maintainers:
+    - UPO-Sevilla-Fco-Javier-Lobo-Cabrera

--- a/recipes/protein-mosaic-q/meta.yaml
+++ b/recipes/protein-mosaic-q/meta.yaml
@@ -15,11 +15,13 @@ build:
 
 requirements:
   host:
-    - python >=3.8
+    - python >=3.9
     - pip
+    - setuptools >=68
+    - wheel
   run:
-    - python >=3.8
-    - biopython
+    - python >=3.9
+    - biopython >=1.80
 
 test:
   imports:

--- a/recipes/protein-mosaic-q/meta.yaml
+++ b/recipes/protein-mosaic-q/meta.yaml
@@ -10,6 +10,8 @@ build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -v
   noarch: python
+  run_exports:
+    - {{ pin_subpackage('protein-mosaic-q', max_pin="x.x") }}
 
 requirements:
   host:


### PR DESCRIPTION
Add recipe for protein-mosaic-q, a Python package to calculate
the Mosaic Q and Q_alt structural descriptors for protein structures
(PDB/mmCIF format).

- PyPI: https://pypi.org/project/protein-mosaic-q/
- Source: https://github.com/UPO-Sevilla-Fco-Javier-Lobo-Cabrera/mosaicq
- Preprint: https://www.biorxiv.org/content/10.1101/500025v1.full
- Updated manuscript: https://github.com/UPO-Sevilla-Fco-Javier-Lobo-Cabrera/clustering_trait_proteins/blob/main/Manuscript_and_Supplementary_Materials_v4.pdf
- FAIRsharing: https://fairsharing.org/8206
- EU Citizen Science: https://citizenscience.eu/project/686
- SciStarter: https://scistarter.org/proteins-mosaic-q-project
- HuggingFace Space: https://huggingface.co/spaces/ProteinsMosaicQProject/proteins-mosaic-q
- Project website: https://proteins-mosaic-q.org
- bio.tools: https://bio.tools/protein-mosaic-q
- License: MIT
- noarch: python, single dependency (biopython)