### PR TITLE
Add fastaguard 0.1.1

### DIFF
--- a/recipes/fastaguard/build.sh
+++ b/recipes/fastaguard/build.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
+cargo install -v --locked --no-track --root "${PREFIX}" --path .
+rm -f "${PREFIX}/.crates.toml" "${PREFIX}/.crates2.json"
+
+mkdir -p "${PREFIX}/share/${PKG_NAME}/schema"
+install -m644 schema/fastaguard.schema.json \
+  "${PREFIX}/share/${PKG_NAME}/schema/fastaguard.schema.json"
+install -m644 schema/finding-catalog.json \
+  "${PREFIX}/share/${PKG_NAME}/schema/finding-catalog.json"

--- a/recipes/fastaguard/meta.yaml
+++ b/recipes/fastaguard/meta.yaml
@@ -1,0 +1,50 @@
+{% set name = "fastaguard" %}
+{% set version = "0.1.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/ehsanestaji/FastaGuard/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 10a5520e54d7e7884aa4cdfec5108cd7183c6033053e7839f969b9dcd9d73a17
+
+build:
+  number: 0
+  run_exports:
+    - {{ pin_subpackage('fastaguard', max_pin="x.x") }}
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('rust') }}
+    - {{ stdlib('c') }}
+    - cargo-bundle-licenses
+
+test:
+  commands:
+    - fastaguard --help
+    - fastaguard --schema
+    - fastaguard --finding-catalog
+
+about:
+  home: https://github.com/ehsanestaji/FastaGuard
+  license: MIT
+  license_family: MIT
+  license_file:
+    - LICENSE
+    - THIRDPARTY.yml
+  summary: FASTA preflight QC for assembly pipelines
+  description: |
+    FastaGuard validates assembly FASTA files, detects structural and
+    composition red flags, and emits pipeline-ready JSON, TSV, HTML, and
+    MultiQC outputs before downstream analysis.
+  dev_url: https://github.com/ehsanestaji/FastaGuard
+  doc_url: https://github.com/ehsanestaji/FastaGuard/blob/v{{ version }}/README.md
+
+extra:
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64
+  recipe-maintainers:
+    - ehsanestaji


### PR DESCRIPTION
Add FastaGuard 0.1.1.

FastaGuard is a Rust CLI for FASTA preflight QC before heavier downstream assembly checks. It validates assembly FASTA files, detects structural and composition red flags, and emits pipeline-ready JSON, TSV, HTML, and MultiQC-compatible outputs.

Recipe notes:

- Source release: https://github.com/ehsanestaji/FastaGuard/releases/tag/v0.1.1
- License: MIT
- Third-party Rust license bundle generated with `cargo-bundle-licenses`
- Build: `cargo install --locked --no-track`
- Test commands: `fastaguard --help`, `fastaguard --schema`, `fastaguard --finding-catalog`
- Requested additional platforms: `linux-aarch64`, `osx-arm64`

Local checks performed:

- Rendered recipe YAML with substituted Jinja variables and parsed it successfully
- `bash -n recipes/fastaguard/build.sh`
- `git diff --check --cached`
- Source archive SHA256 verified against the recipe
