### PR TITLE
Update ecolityper to build 1: add fastani and ezclermont dependencies

### DIFF
--- a/recipes/ecolityper/meta.yaml
+++ b/recipes/ecolityper/meta.yaml
@@ -11,8 +11,8 @@ source:
 
 build:
   noarch: python
-  number: 0
-  script: "{{ PYTHON }} -m pip install . --no-build-isolation -vvv"
+  number: 1
+  script: "{{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vvv"
   run_exports:
     - {{ pin_subpackage(name, max_pin="x") }}
 
@@ -37,6 +37,8 @@ requirements:
     - scipy >=1.10.1
     - plotly >=5.10.0
     - abricate >=1.2.0
+    - fastani >=1.34
+    - ezclermont >=0.7.0
     - perl
     - any2fasta
     - cgecore >=1.5.6


### PR DESCRIPTION
This PR updates ecolityper v1.2.0 to build 1 with dependency resolution. Please review & merge.
