### PR TITLE
Add price2 1.0.0

### DIFF
--- a/recipes/price2/meta.yaml
+++ b/recipes/price2/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/kilian-m/PRICE2/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 79f246c73d46d681db3d5e536a6cff2e387655fb53aefe3b3df8774fb33795e3
+  sha256: 9eb96e66a867889f6adba576137aeb6d75f4f36b096c82fd01630010f4e005c6
 
 build:
   number: 0
@@ -50,7 +50,7 @@ about:
   summary: "Detect actively translated ORFs from multiple Ribo-seq datasets using group-LASSO penalized Poisson regression."
   description: |
     PRICE 2 detects actively translated open reading frames based on multiple
-    Ribo-seq or TI-seq datasets. It builds on ideas from PRICE and a generative
+    Ribo-seq or QTI-seq datasets. It builds on ideas from PRICE and a generative
     model for isoform deconvolution, using group-LASSO penalized Poisson
     regression over read equivalence groups.
   license: GPL-3.0-or-later

--- a/recipes/price2/meta.yaml
+++ b/recipes/price2/meta.yaml
@@ -1,0 +1,64 @@
+{% set name = "price2" %}
+{% set version = "1.0.0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/kilian-m/PRICE2/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 79f246c73d46d681db3d5e536a6cff2e387655fb53aefe3b3df8774fb33795e3
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x") }}
+  entry_points:
+    - price2 = price2.price:main
+
+requirements:
+  host:
+    - python >=3.10
+    - pip
+    - setuptools >=61
+  run:
+    - python >=3.10
+    - numpy
+    - scipy
+    - pandas
+    - numba
+    - htseq
+    - pysam
+    - pyfaidx
+    - pebble
+    - filelock
+    - psutil
+    - tqdm
+    - matplotlib-base
+    - samtools
+
+test:
+  imports:
+    - price2
+  commands:
+    - price2 --help
+
+about:
+  home: https://github.com/kilian-m/PRICE2
+  summary: "Detect actively translated ORFs from multiple Ribo-seq datasets using group-LASSO penalized Poisson regression."
+  description: |
+    PRICE 2 detects actively translated open reading frames based on multiple
+    Ribo-seq or TI-seq datasets. It builds on ideas from PRICE and a generative
+    model for isoform deconvolution, using group-LASSO penalized Poisson
+    regression over read equivalence groups.
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  license_file: LICENSE
+  doc_url: https://github.com/kilian-m/PRICE2/blob/main/README.md
+  dev_url: https://github.com/kilian-m/PRICE2
+
+extra:
+  recipe-maintainers:
+    - kilian-m


### PR DESCRIPTION
Adds a recipe for **price2** v1.0.0.

PRICE 2 detects actively translated ORFs from multiple Ribo-seq / QTI-seq datasets using group-LASSO penalized Poisson regression. Upstream: https://github.com/kilian-m/PRICE2 (GPL-3.0-or-later).

Pure-Python, packaged as `noarch: python`. `samtools` is included as a runtime dependency (invoked via subprocess for BAM downsampling).

---

- [x] I have read the [guidelines](https://bioconda.github.io/contributor/guidelines.html) for bioconda recipes.
- [x] This PR adds a new recipe (new package, no existing package affected).
- [x] Recipe builds `noarch: python` with pinned-free run deps and `run_exports`.
- [x] `about` includes `license`, `license_family`, and `license_file`.
- [x] Tests cover import of the package and the `price2 --help` CLI entry point.