### PR TITLE
Update psQTL to v1.3.9

### DIFF
--- a/recipes/psqtl/build.sh
+++ b/recipes/psqtl/build.sh
@@ -3,11 +3,11 @@
 mkdir -p $PREFIX/bin
 
 cp psQTL_prep.py $PREFIX/bin/psQTL_prep.py
-cp psQTL_prep.py $PREFIX/bin/psQTL_prep
+ln -s $PREFIX/bin/psQTL_prep.py $PREFIX/bin/psQTL_prep
 cp psQTL_proc.py $PREFIX/bin/psQTL_proc.py
-cp psQTL_proc.py $PREFIX/bin/psQTL_proc
+ln -s $PREFIX/bin/psQTL_proc.py $PREFIX/bin/psQTL_proc
 cp psQTL_post.py $PREFIX/bin/psQTL_post.py
-cp psQTL_post.py $PREFIX/bin/psQTL_post
+ln -s $PREFIX/bin/psQTL_post.py $PREFIX/bin/psQTL_post
 cp _version.py $PREFIX/bin/_version.py
 
 mkdir -p $PREFIX/bin/modules

--- a/recipes/psqtl/meta.yaml
+++ b/recipes/psqtl/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "psqtl" %}
-{% set version = "1.3.7" %}
+{% set version = "1.3.9" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/zkstewart/psQTL/archive/v{{ version }}.tar.gz
-  sha256: 262ee79aaf746afb3e05987d7c1f4dfd32272e37150dba0a9e9b909a5f9e0ca6
+  sha256: c058f493a09838fc1eeebbe93d23be910e2a5e0d6a9c6c5a10e475c1ffe75eb3
 
 build:
   number: 0
@@ -48,7 +48,7 @@ about:
   home: https://github.com/zkstewart/psQTL
   dev_url: https://github.com/zkstewart/psQTL
   doc_url: https://github.com/zkstewart/psQTL/wiki
-  license: GPL-3
+  license: GPL-3.0-only
   license_file: LICENSE
   summary: A collection of Python scripts to predict QTLs using per-sample sequencing.
   license_family: GPL


### PR DESCRIPTION
- Clarify GPL licence.
- Make executables via symlink rather than copying the entire file.
