### PR TITLE
Update gapseq

### DIFF
--- a/recipes/gapseq/build.sh
+++ b/recipes/gapseq/build.sh
@@ -1,26 +1,11 @@
 #!/usr/bin/env bash
 
-# Installation instructions taken from https://gapseq.readthedocs.io/en/latest/install.html
-
 # Copy contents to conda prefix
 mkdir -p ${PREFIX}/share/gapseq/
 cp ISSUE_TEMPLATE.MD LICENSE README.md gapseq gapseq_env.yml ${PREFIX}/share/gapseq/
 cp -r dat/ docs/ src/ toy/ unit/ ${PREFIX}/share/gapseq/
 
-
-
 # Make binaries available
 mkdir -p ${PREFIX}/bin/
 ln -sr ${PREFIX}/share/gapseq/gapseq ${PREFIX}/bin/
 
-# Download reference sequence data
-# To install the database, we must call the installed file as it uses its own path to place the files correctly.
-bash ${PREFIX}/share/gapseq/src/update_sequences.sh
-
-# --- 
-
-
-# Build at home with (before submitting to azure):
-# conda activate bioconda-utils
-# bioconda-utils lint --git-range master
-# bioconda-utils build --mulled-test --git-range master

--- a/recipes/gapseq/meta.yaml
+++ b/recipes/gapseq/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.4.0" %}
+{% set version = "2.0.1" %}
 
 package:
   name: gapseq
@@ -6,31 +6,26 @@ package:
 
 source:
   url: https://github.com/jotech/gapseq/archive/refs/tags/v{{ version}}.tar.gz
-  sha256: 701770d8ef36e8e086b2be0ff179983e937362819c2c4155a843b8fa661355d0
+  sha256: 2c0b57d3c718b8554d3dc39c7d2bfaa03a3830bd71fa11b547c956f34f2f3f4c
 
 build:
-  number: 1
+  number: 0
+  noarch: generic
   run_exports:
     - {{ pin_subpackage('gapseq', max_pin="x") }}
-  skip: True  # [osx]
-
 
 requirements:
   run:
     - r-base
-    - perl
-    - parallel
+    - diamond >=2.1.9
+    - pyrodigal
     - gawk
     - sed
     - grep
     - bc
-    - git
     - coreutils
     - wget
     - openssl
-    - barrnap
-    - bedtools
-    - exonerate
     - glpk
     - hmmer
     - blast
@@ -40,15 +35,14 @@ requirements:
     - r-stringi
     - r-getopt
     - r-r.utils
-    - r-cobrar
+    - r-cobrar >=0.2.5
     - r-biocmanager
     - bioconductor-biostrings
     - r-jsonlite
     - r-renv
     - r-rcurl
     - r-httr
-  build: 
-    - wget
+
 
 test:
   commands:
@@ -56,13 +50,22 @@ test:
 
 about:
   home: https://github.com/jotech/gapseq
-  summary: Informed prediction and analysis of bacterial metabolic pathways and genome-scale networks 
+  summary: Informed prediction and analysis of bacterial metabolic pathways and genome-scale networks
+  description: |
+    gapseq predicts bacterial metabolic pathways and reconstructs
+    genome-scale metabolic models.
+
+    After installation, initialize the required databases with:
+
+      gapseq update-sequences -t Bacteria
+      gapseq update-sequences -t Archaea
+
   license_family: GPL
   license: AGPL-3.0-only
   license_file: LICENSE
 extra:
-  skip-lints:
-    - should_be_noarch_generic
   recipe-maintainers:
     - cmkobel
+    - jotech
+    - Waschina
 


### PR DESCRIPTION
Dependencies have changed in gapseq>=2.0.0. Here, the recipe is corrected to build the gapseq package via bioconda.

This PR also adds @jotech and me as recipe maintainers. We are also the maintainers of the [gapseq software](https://github.com/jotech/gapseq).

Important change:
The reference sequence database is no longer bundled with the conda package, as it is large and updated independently of the gapseq software itself. Users are now expected to download the required databases after installation using the appropriate gapseq update-sequences commands.

Supersedes previous gapseq update PRs #54075  and #61877 . Please ignore/close the earlier PRs, as this PR replaces them with a cleaned-up and fully tested recipe update.