### PR TITLE
Add gzip to spechla runtime deps (provides zless)

### DIFF
--- a/recipes/spechla/meta.yaml
+++ b/recipes/spechla/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: b5d136e5150d90eed593d78ccbd47ac9a05a7c29d5a2e2ab4795c2f5081e5085
 
 build:
-  number: 0
+  number: 1
   skip: true  # [not linux64]
   run_exports:
     - {{ pin_subpackage(name, max_pin="x.x") }}
@@ -33,6 +33,7 @@ requirements:
     - samtools >=1.13
     - bcftools
     - htslib
+    - gzip  # provides zless, used by SpecHLA.sh
     - perl
     - perl-findbin
     - perl-getopt-long


### PR DESCRIPTION
SpecHLA's `script/whole/SpecHLA.sh` invokes `zless file.vcf.gz | grep "#"`, which fails inside the current biocontainer with `zless: command not found`. Adding `gzip` (conda-forge) to runtime requirements provides `zless` and resolves the missing-dep at the packaging level.