### PR TITLE
Update mags-visualization to 0.0.9 + Kaleido

### DIFF
--- a/recipes/mags-visualization/meta.yaml
+++ b/recipes/mags-visualization/meta.yaml
@@ -1,6 +1,6 @@
 
 {% set name = "mags-visualization" %}
-{% set version = "0.0.8" %}
+{% set version = "0.0.9" %}
 
 package:
   name: {{ name }}
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://github.com/usegalaxy-eu/MAGs-visualization/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 7726b87784a6b5c70b3bb04f2ee17f23d6f1613e209a6cff80000e1f1eea1420
+  sha256: fd9400b30d932c86f112a8927be8c9f06d998d2141e510fd84a1d27d32ec4ae7
 
 build:
   noarch: python
@@ -32,7 +32,7 @@ requirements:
     - seaborn
     - plotly
     - networkx
-    - python-kaleido
+    - python-kaleido ==0.2.1
 
 test:
   imports:


### PR DESCRIPTION
- Updated Version to 0.0.9
- Changed kaleido version compatible for galaxy, so no Chrome ist required.