### PR TITLE
ba3: build for linux-aarch64 and osx-arm64

### DIFF
--- a/recipes/ba3/meta.yaml
+++ b/recipes/ba3/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 2ef42af31610cfcd1c0c1b6511427a145c1ef83c96d113cfb5d9e97c22285f4e
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
   run_exports:
     - {{ pin_subpackage("ba3", max_pin="x") }}

--- a/recipes/ba3/meta.yaml
+++ b/recipes/ba3/meta.yaml
@@ -47,3 +47,6 @@ about:
 extra:
   recipe-maintainers:
     - brannala
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64


### PR DESCRIPTION
Opt the `ba3` recipe (added in #65465) into native ARM builds by setting
`extra.additional-platforms` to `linux-aarch64` and `osx-arm64`.

The original PR's CircleCI "build and test (ARM)" check passed, so the
recipe builds cleanly on `linux-aarch64`. `osx-arm64` is enabled at the
same time since the build is plain C++11 + gsl/htslib with no
architecture-specific code.

No other changes to the recipe; `build.number` is intentionally left at 0
so the existing `linux-64` and `osx-64` artifacts are not rebuilt.