### PR TITLE
Update get_mnv to 1.1.3

### DIFF
--- a/recipes/get_mnv/meta.yaml
+++ b/recipes/get_mnv/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "get_mnv" %}
-{% set version = "1.1.2" %}
-{% set sha256 = "dd64b4c54434e3ed17f220c95e0e16014a92d2868ffbb38a6152264a9b9283a0" %}
+{% set version = "1.1.3" %}
+{% set sha256 = "85116fddf639eefdf4244d870391748ccd93ac95de69ad224a3217cedfdb3fc8" %}
 
 package:
   name: "{{ name|lower }}"

--- a/recipes/get_mnv/meta.yaml
+++ b/recipes/get_mnv/meta.yaml
@@ -25,6 +25,7 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('rust') }}
+    - {{ stdlib('c') }}
     - pkg-config
 
 test:
@@ -50,8 +51,6 @@ extra:
   recipe-maintainers:
     - paururo
     - PathoGenOmics-Lab
-  skip-lints:
-    - compiler_needs_stdlib_c
   categories:
     - Genomics
     - Variant Analysis


### PR DESCRIPTION
Update get_mnv to version 1.1.3.

Changes:
- bump version from 1.1.2 to 1.1.3
- update the source sha256 for the 1.1.3 tag

Validation:
- verified source tarball sha256
- ran git diff --check

The existing recipe structure from the previous get_mnv update is unchanged.