### PR TITLE
Add snakemake-logger-plugin-panoptes 0.1.1

### DIFF
--- a/recipes/snakemake-logger-plugin-panoptes/meta.yaml
+++ b/recipes/snakemake-logger-plugin-panoptes/meta.yaml
@@ -1,0 +1,43 @@
+{% set name = "snakemake-logger-plugin-panoptes" %}
+{% set version = "0.1.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/snakemake_logger_plugin_panoptes-{{ version }}.tar.gz
+  sha256: ec4593d064c07e66cf49d0ec56f896d8be834da329a1cc10733b45101fcef729
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vvv --no-deps --no-build-isolation --no-cache-dir
+  number: 0
+  run_exports:
+    - {{ pin_subpackage(name, max_pin='x') }}
+
+requirements:
+  host:
+    - python >=3.11,<4.0
+    - hatchling
+    - pip
+  run:
+    - python >=3.11,<4.0
+    - snakemake-interface-logger-plugins >=2.0.0,<3.0.0
+    - requests >=2.22.0
+
+test:
+  imports:
+    - snakemake_logger_plugin_panoptes
+
+about:
+  home: "https://github.com/panoptes-organization/snakemake-logger-plugin-panoptes"
+  summary: "Snakemake 9 logger plugin that forwards workflow events to a panoptes server."
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  dev_url: "https://github.com/panoptes-organization/snakemake-logger-plugin-panoptes"
+
+extra:
+  recipe-maintainers:
+    - fgypas


### PR DESCRIPTION
Snakemake 9 logger plugin that forwards workflow events to a panoptes server, replacing the legacy `--wms-monitor` flag removed in Snakemake 9.

- Upstream: https://github.com/panoptes-organization/snakemake-logger-plugin-panoptes
- PyPI: https://pypi.org/project/snakemake-logger-plugin-panoptes/0.1.1/
- License: MIT
- `noarch: python`, pure-Python wheel
- `run_exports`: `{{ pin_subpackage(name, max_pin='x') }}` (semantic versioning; matches the sibling `snakemake-logger-plugin-*` recipes)