### PR TITLE
update: bgen-cpp to 1.2.0, with s3 support and cmake and dynamic dependencies.

### DIFF
--- a/recipes/bgen-cpp/build.sh
+++ b/recipes/bgen-cpp/build.sh
@@ -1,50 +1,18 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-mkdir -p "${PREFIX}/bin"
+cmake ${CMAKE_ARGS} \
+    -S . -B build \
+    -G Ninja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+    -DBGEN_BUILD_TESTS=ON \
+    -DBGEN_WITH_S3=ON
 
-export CFLAGS="${CFLAGS:-} -I${PREFIX}/include"
-export CXXFLAGS="${CXXFLAGS:-} -I${PREFIX}/include"
-export LDFLAGS="${LDFLAGS:-} -L${PREFIX}/lib"
+cmake --build build --parallel "${CPU_COUNT}"
 
-case "$(uname)"  in
-    Linux)
-        echo "Patching Linux build script"
-        # patch waf script on Linux
-        # force gcc to use C11 plus GNU extensions
-        sed -i "15s/\(\s*cfg\.env\.CXXFLAGS *= *\[\)/\1'-std=gnu++11', /" wscript
-        sed -i "16s/\(\s*cfg\.env\.CFLAGS *= *\[\)/\1'-std=gnu11', /" wscript
+# Run unit tests; skip S3 integration test (requires live MinIO/S3)
+ctest --test-dir build -E test_s3_bgen --output-on-failure
 
-        ./waf configure \
-            --check-c-compiler=gcc \
-            --check-cxx-compiler=g++ \
-            --prefix=${PREFIX} \
-            --bindir=${PREFIX}/bin \
-            --libdir=${PREFIX}/lib \
-            --jobs=${CPU_COUNT}
-        ;;
-    Darwin)
-        echo "Patching macOS build script"
-        # patch waf script on macOS (remember: different sed version)
-        # force clang to use C11 standard
-        sed -i '' "15s/\(\s*cfg\.env\.CXXFLAGS *= *\[\)/\1'-stdlib=libc++', '-std=c++11', /" wscript
-        sed -i '' "16s/\(\s*cfg\.env\.CFLAGS *= *\[\)/\1'-std=c11', /" wscript
+cmake --install build
 
-        ./waf configure \
-            --check-c-compiler=clang \
-            --check-cxx-compiler=clang++ \
-            --prefix=${PREFIX} \
-            --bindir=${PREFIX}/bin \
-            --libdir=${PREFIX}/lib \
-            --jobs=${CPU_COUNT}
-        ;;
-esac
-
-./waf build --mode=release install
-
-# run unit tests after building
-if ./build/test/unit/test_bgen | grep -q "All tests passed"; then
-  exit 0
-else
-  exit 1
-fi

--- a/recipes/bgen-cpp/meta.yaml
+++ b/recipes/bgen-cpp/meta.yaml
@@ -1,30 +1,32 @@
 {% set name = "bgen-cpp" %}
-{% set version = "1.1.7" %}
-{% set sha256 = "69703c3f5d6d8c22bd933d2550caf4496f9c8b9876299b162e0b9a2ab2cfa605" %}
+{% set version = "1.2.0" %}
+{% set sha256 = "6935a8c9694caaa195b1ea361b566526ca6f263e39a6b2dc841188a374017719" %}
 
 package:
   name: "{{ name|lower }}"
   version: "{{ version }}"
 
 source:
-  # bgen is distributed via a fossil repo, so I created a git mirror by importing fossil's history
-  # (the repo hasn't been updated for a few years)
-  url: https://github.com/nebfield/bgen-git-mirror/archive/refs/tags/v{{version}}.tar.gz
+  url: https://github.com/jpfeuffer/bgen/archive/refs/tags/v{{version}}.tar.gz
   sha256: {{ sha256 }}
 
 build:
   number: 0
   run_exports:
     - {{ pin_subpackage('bgen-cpp', max_pin="x") }}
-  # clang builds fail on osx x86_64 which I can't reproduce
-  skip: True  # [osx and x86_64]
 
 requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - cmake
+    - ninja
   host:
     - zlib
+    - boost-cpp
+    - zstd
+    - sqlite
+    - aws-sdk-cpp
 
 test:
   commands:

--- a/recipes/bgen-cpp/meta.yaml
+++ b/recipes/bgen-cpp/meta.yaml
@@ -28,6 +28,8 @@ requirements:
     - zstd
     - sqlite
     - aws-sdk-cpp
+  run:
+    - boost-cpp
 
 test:
   commands:

--- a/recipes/bgen-cpp/meta.yaml
+++ b/recipes/bgen-cpp/meta.yaml
@@ -19,6 +19,7 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - {{ stdlib('c') }}
     - cmake
     - ninja
   host:


### PR DESCRIPTION
Updates bgen-cpp to a community maintained 1.2.0 version with a modern build system and s3 support.
Also should work on osx and arm

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
