### PR TITLE
Update ipcr to 5.0.0

### DIFF
--- a/recipes/ipcr/meta.yaml
+++ b/recipes/ipcr/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "ipcr" %}
-{% set version = "4.1.1" %}
+{% set version = "5.0.0" %}
 
 package:
   name: {{ name }}
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://github.com/KPU-AGC/ipcr/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: bb03d6d4bea510f13655d6d10bd9b952aaa4d8a95754c51927c147f0ea435e54
+  sha256: c7966f4ee8ce6840dfbf7ca5370aa1ea18dc67da9b352ef9ff75d40cdf409954
 
 build:
-  number: 2
+  number: 0
   run_exports:
     - {{ pin_subpackage(name, max_pin="x") }}
 

--- a/recipes/ipcr/meta.yaml
+++ b/recipes/ipcr/meta.yaml
@@ -16,6 +16,8 @@ build:
 
 requirements:
   build:
+    - {{ compiler('c') }}
+    - {{ stdlib('c') }}
     - {{ compiler('go') }}
     - go-licenses
     - make


### PR DESCRIPTION
Updates ipcr to 5.0.0 and fixes the Bioconda lint error by adding stdlib('c') for the C compiler requirement.