### PR TITLE
Update openstructure to use the bioconda numpy version

### DIFF
--- a/recipes/openstructure/meta.yaml
+++ b/recipes/openstructure/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 9ac12e1ce8ec879ec900b69bdbcc71632ed05d8cf8c09d3e847a57814d8a7e7b
 
 build:
-  number: 1
+  number: 2
   skip: True  # [(py < 312 and aarch64) or (py < 311 and arm64)]
   run_exports:
     - {{ pin_subpackage(name|lower, max_pin="x.x") }}

--- a/recipes/openstructure/meta.yaml
+++ b/recipes/openstructure/meta.yaml
@@ -33,7 +33,7 @@ requirements:
     - libpng
     - libtiff
     - parasail
-    - numpy >=1,<2
+    - numpy
     - pandas >=1
     - scipy >=1,<1.14
     - networkx >=2


### PR DESCRIPTION
There is no C linkage with numpy anymore due to https://git.scicore.unibas.ch/schwede/openstructure/-/commit/728ad1c9334ece304c0796c904ab650b3c59855c

So the python dependencies can be less restrictive for an env.
