### PR TITLE
Update spotyping3 - Added fix for spacer.fasta file

### DIFF
--- a/recipes/spotyping3/meta.yaml
+++ b/recipes/spotyping3/meta.yaml
@@ -12,6 +12,8 @@ source:
 build:
   number: 1
   noarch: python
+  run_exports:
+    - {{ pin_subpackage(spotyping3, max_pin="x") }}
 
 requirements:
   host:

--- a/recipes/spotyping3/meta.yaml
+++ b/recipes/spotyping3/meta.yaml
@@ -6,6 +6,8 @@ package:
 source:
   url: https://github.com/matnguyen/SpoTyping/archive/v{{ version }}.tar.gz
   sha256: 13e79151733e52fa3eb3bf659d07b4c9d7eeb9bd7c5ab63e734c2480ce1bbdae
+  patches:
+    - fix-reference-path.patch
 
 build:
   number: 0

--- a/recipes/spotyping3/meta.yaml
+++ b/recipes/spotyping3/meta.yaml
@@ -10,7 +10,7 @@ source:
     - fix-reference-path.patch
 
 build:
-  number: 0
+  number: 1
   noarch: python
 
 requirements:

--- a/recipes/spotyping3/meta.yaml
+++ b/recipes/spotyping3/meta.yaml
@@ -13,7 +13,7 @@ build:
   number: 1
   noarch: python
   run_exports:
-    - {{ pin_subpackage(spotyping3, max_pin="x") }}
+    - {{ pin_subpackage("spotyping3", max_pin="x") }}
 
 requirements:
   host:

--- a/recipes/spotyping3/meta.yaml
+++ b/recipes/spotyping3/meta.yaml
@@ -7,7 +7,7 @@ source:
   url: https://github.com/matnguyen/SpoTyping/archive/v{{ version }}.tar.gz
   sha256: 13e79151733e52fa3eb3bf659d07b4c9d7eeb9bd7c5ab63e734c2480ce1bbdae
   patches:
-    - fix-reference-path.patch
+    - patches/fix-reference-path.patch
 
 build:
   number: 1

--- a/recipes/spotyping3/patches/fix-reference-path.patch
+++ b/recipes/spotyping3/patches/fix-reference-path.patch
@@ -1,5 +1,5 @@
---- a/SpoTyping.py
-+++ b/SpoTyping.py
+--- a/SpoTyping-3.0/SpoTyping-v3.0-commandLine/SpoTyping.py
++++ b/SpoTyping-3.0/SpoTyping-v3.0-commandLine/SpoTyping.py
 @@ -29,7 +29,7 @@
  import urllib.request, urllib.parse, urllib.error
 

--- a/recipes/spotyping3/patches/fix-reference-path.patch
+++ b/recipes/spotyping3/patches/fix-reference-path.patch
@@ -1,0 +1,11 @@
+--- a/SpoTyping.py
++++ b/SpoTyping.py
+@@ -29,7 +29,7 @@
+ import urllib.request, urllib.parse, urllib.error
+
+ ## Global variables
+-dir = os.path.split(os.path.realpath(__file__))[0] # script directory
++dir = os.path.join(sys.prefix, 'share', 'SpoTyping')# script directory
+ setlength = 50*5000000                             # base input cut-off for swift mode
+
+ ## Option variables


### PR DESCRIPTION
This fixes an issue where the bundled spacer FASTA file cannot be found inside the conda environment.

The error looked like this:

```text
Command line argument error: Argument "query". File is not accessible: `/.../envs/spotyping3/bin/ref/spacer.fasta`
```

The patch changes the reference directory lookup to use the conda `share/` directory instead of resolving paths relative to the executable location.

Let me know if this looks OK, this is my first time working with patches for a Bioconda recipe.
