### PR TITLE
Update illumina-utils to 2.14

### DIFF
--- a/recipes/illumina-utils/meta.yaml
+++ b/recipes/illumina-utils/meta.yaml
@@ -1,12 +1,12 @@
-{% set version = "2.13" %}
+{% set version = "2.14" %}
 
 package:
   name: 'illumina-utils'
   version: '{{ version }}'
 
 source:
-  url: https://pypi.io/packages/source/i/illumina-utils/illumina-utils-{{ version }}.tar.gz
-  sha256: 'e688ca221ea6178614073b72205fce7b4a54695237c7aa96713492ecd99bd56e'
+  url: https://pypi.io/packages/source/i/illumina-utils/illumina_utils-{{ version }}.tar.gz
+  sha256: '5536158e97f9264d428fb7666b9f60a9a19568a2dbd77331426e8043f9d55564'
 
 build:
   number: 0
@@ -19,6 +19,8 @@ requirements:
   host:
     - python >=3
     - pip
+    - setuptools >=61
+    - wheel
   run:
     - python >=3
     - matplotlib-base
@@ -41,4 +43,5 @@ about:
   home: https://github.com/meren/illumina-utils
   license: GPL-3.0-or-later
   license_family: GPL3
+  license_file: COPYING
   summary: A library and collection of scripts to work with Illumina paired-end data (for CASAVA 1.8+).


### PR DESCRIPTION
Update `illumina-utils` from 2.13 to 2.14.

Changes:
- Update the PyPI source URL for the 2.14 sdist filename.
- Update the sha256 for the 2.14 source distribution.
- Keep build number at 0 for the new upstream release.
- Add `setuptools >=61` and `wheel` to host requirements for the upstream `pyproject.toml`.
- Add `license_file: COPYING`.

Validation:
- `bioconda-utils lint --loglevel debug --full-report --packages illumina-utils`
- `bioconda-utils build recipes config.yml --packages illumina-utils`

Both passed locally.

`run_exports` was already present and left unchanged:
`{{ pin_subpackage('illumina-utils', max_pin="x") }}`