### PR TITLE
Add bioconductor-dotseq

### DIFF
--- a/recipes/bioconductor-dotseq/build.sh
+++ b/recipes/bioconductor-dotseq/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+mv DESCRIPTION DESCRIPTION.old
+grep -v '^Priority: ' DESCRIPTION.old > DESCRIPTION
+mkdir -p ~/.R
+echo -e "CC=$CC
+FC=$FC
+CXX=$CXX
+CXX98=$CXX
+CXX11=$CXX
+CXX14=$CXX" > ~/.R/Makevars
+$R CMD INSTALL --build .

--- a/recipes/bioconductor-dotseq/meta.yaml
+++ b/recipes/bioconductor-dotseq/meta.yaml
@@ -26,6 +26,7 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - {{ stdlib('c') }}
     - make
   host:
     - bioconductor-annotationdbi >=1.72.0,<1.73.0

--- a/recipes/bioconductor-dotseq/meta.yaml
+++ b/recipes/bioconductor-dotseq/meta.yaml
@@ -1,0 +1,94 @@
+{% set version = "1.0.0" %}
+{% set name = "DOTSeq" %}
+{% set bioc = "3.23" %}
+
+package:
+  name: bioconductor-{{ name|lower }}
+  version: '{{ version }}'
+
+source:
+  url:
+    - https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/{{ name }}_{{ version }}.tar.gz
+    - https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/Archive/{{ name }}/{{ name }}_{{ version }}.tar.gz
+    - https://bioarchive.galaxyproject.org/{{ name }}_{{ version }}.tar.gz
+    - https://depot.galaxyproject.org/software/bioconductor-{{ name|lower }}/bioconductor-{{ name|lower }}_{{ version }}_src_all.tar.gz
+  md5: 4f0cb85f1c5972184ae8e9f04c5b5fe1
+
+build:
+  number: 0
+  rpaths:
+    - lib/R/lib/
+    - lib/
+  run_exports: '{{ pin_subpackage("bioconductor-dotseq", max_pin="x.x") }}'
+
+# Suggests: BSgenome.Hsapiens.UCSC.hg38, TxDb.Hsapiens.UCSC.hg38.knownGene, TxDb.Dmelanogaster.UCSC.dm3.ensGene, org.Hs.eg.db, curl, pasillaBamSubset, BiocStyle, biomaRt, DHARMa, eulerr, ggplot2, ggsignif, knitr, rmarkdown, testthat, withr, magick
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - make
+  host:
+    - bioconductor-annotationdbi >=1.72.0,<1.73.0
+    - bioconductor-biocgenerics >=0.56.0,<0.57.0
+    - bioconductor-biocparallel >=1.44.0,<1.45.0
+    - bioconductor-biostrings >=2.78.0,<2.79.0
+    - bioconductor-bsgenome >=1.78.0,<1.79.0
+    - bioconductor-deseq2 >=1.50.0,<1.51.0
+    - bioconductor-genomicalignments >=1.46.0,<1.47.0
+    - bioconductor-genomicfeatures >=1.62.0,<1.63.0
+    - bioconductor-genomeinfodb >=1.46.0,<1.47.0
+    - bioconductor-genomeinfodbdata >=1.2.15,<1.3.0
+    - bioconductor-genomicranges >=1.62.0,<1.63.0
+    - bioconductor-iranges >=2.44.0,<2.45.0
+    - bioconductor-rsamtools >=2.26.0,<2.27.0
+    - bioconductor-rtracklayer >=1.70.0,<1.71.0
+    - bioconductor-s4vectors >=0.48.0,<0.49.0
+    - bioconductor-summarizedexperiment >=1.40.0,<1.41.0
+    - bioconductor-txdbmaker >=1.6.0,<1.7.0
+    - r-ashr
+    - r-base
+    - r-boot
+    - r-data.table
+    - r-emmeans
+    - r-glmmtmb
+    - r-matrix
+    - r-pbapply
+    - r-rcpp
+  run:
+    - bioconductor-annotationdbi >=1.72.0,<1.73.0
+    - bioconductor-biocgenerics >=0.56.0,<0.57.0
+    - bioconductor-biocparallel >=1.44.0,<1.45.0
+    - bioconductor-biostrings >=2.78.0,<2.79.0
+    - bioconductor-bsgenome >=1.78.0,<1.79.0
+    - bioconductor-deseq2 >=1.50.0,<1.51.0
+    - bioconductor-genomicalignments >=1.46.0,<1.47.0
+    - bioconductor-genomicfeatures >=1.62.0,<1.63.0
+    - bioconductor-genomeinfodb >=1.46.0,<1.47.0
+    - bioconductor-genomeinfodbdata >=1.2.15,<1.3.0
+    - bioconductor-genomicranges >=1.62.0,<1.63.0
+    - bioconductor-iranges >=2.44.0,<2.45.0
+    - bioconductor-rsamtools >=2.26.0,<2.27.0
+    - bioconductor-rtracklayer >=1.70.0,<1.71.0
+    - bioconductor-s4vectors >=0.48.0,<0.49.0
+    - bioconductor-summarizedexperiment >=1.40.0,<1.41.0
+    - bioconductor-txdbmaker >=1.6.0,<1.7.0
+    - r-ashr
+    - r-base
+    - r-boot
+    - r-data.table
+    - r-emmeans
+    - r-glmmtmb
+    - r-matrix
+    - r-pbapply
+    - r-rcpp
+
+test:
+  commands:
+    - $R -e "library('{{ name }}')"
+
+about:
+  home: https://bioconductor.org/packages/{{ bioc }}/bioc/html/{{ name }}.html
+  license: MIT + file LICENSE
+  summary: Genome-wide Detection of Differential ORF Usage
+  description: Differential open reading frame (ORF) translation analysis framework for ribosome profiling (Ribo-seq) with matched RNA-seq. Implements (i) Differential ORF Usage (DOU), a beta-binomial generalized linear model that models the expected proportion of Ribo-seq versus RNA-seq reads mapping to each ORF within a gene, and (ii) ORF-level Differential Translation Efficiency (DTE), a negative binomial GLM that capture changes in translation efficiency of individual ORFs across experimental conditions. Supports ORF-level read summarization for bulk and single-cell Ribo-seq.
+  license_file: LICENSE


### PR DESCRIPTION
Add a recipe for [DOTSeq](https://bioconductor.org/packages/release/bioc/html/DOTSeq.html), a Bioconductor package for genome-wide detection of differential ORF usage (DOU) and ORF-level differential translation efficiency (DTE) from Ribo-seq with matched RNA-seq.

- Bioconductor: 3.23 (initial release)
- Version: 1.0.0
- Source: https://github.com/compgenom/DOTSeq
- License: MIT + file LICENSE

The package uses Rcpp (C++) so the recipe pulls in C/C++ compilers in `build`, following the bioconductor-deseq2 pattern. Bioconductor dependency pins are aligned with the currently-merged Bioc 3.22 versions; they'll bump on the Bioc 3.23 migration. CRAN dependencies (`ashr`, `boot`, `data.table`, `emmeans`, `glmmTMB`, `Matrix`, `Rcpp`, `pbapply`) are pulled from conda-forge.

##### Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/) before opening a pull request (PR).

* [x] Read the [guidelines](https://bioconda.github.io/contributor/) and follow the recipe naming conventions.
* [x] Existing tests pass on bioconda's CI.