### PR TITLE
Update dotmatch to 0.1.4

### DIFF
--- a/recipes/dotmatch/build.sh
+++ b/recipes/dotmatch/build.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 make \
+  DOTMATCH_VERSION="${PKG_VERSION}" \
   CC="${CC}" \
   CFLAGS="${CFLAGS:-} ${CPPFLAGS:-} -std=c11 -Wall -Wextra -Wpedantic -Iinclude" \
   LDFLAGS="${LDFLAGS:-}" \

--- a/recipes/dotmatch/build.sh
+++ b/recipes/dotmatch/build.sh
@@ -6,14 +6,15 @@ make \
   CC="${CC}" \
   CFLAGS="${CFLAGS:-} ${CPPFLAGS:-} -std=c11 -Wall -Wextra -Wpedantic -Iinclude" \
   LDFLAGS="${LDFLAGS:-}" \
-  dotmatch libdotmatch.a shared
+  libdotmatch.a shared
 
 mkdir -p "${PREFIX}/bin" \
          "${PREFIX}/include" \
          "${PREFIX}/lib" \
          "${PREFIX}/share/${PKG_NAME}"
 
-install -m 755 dotmatch "${PREFIX}/bin/dotmatch"
+${PYTHON} -m pip install . -vv --no-deps --no-build-isolation
+
 install -m 644 include/qdalign.h "${PREFIX}/include/qdalign.h"
 install -m 644 libdotmatch.a "${PREFIX}/lib/libdotmatch.a"
 install -m 644 LICENSE "${PREFIX}/share/${PKG_NAME}/LICENSE"

--- a/recipes/dotmatch/meta.yaml
+++ b/recipes/dotmatch/meta.yaml
@@ -38,7 +38,7 @@ test:
     - dotmatch --version | grep '^dotmatch {{ version }}$'
     - dotmatch dist ACGT AGGT | grep '^1$'
     - dotmatch leq 1 ACGT AGGT | grep '^true$'
-    - dotmatch --help | grep 'Workflow namespaces:'
+    - dotmatch --help | grep 'Workflow namespaces'
     - dotmatch assay --help | grep 'dotmatch assay'
     - dotmatch barcode --help | grep 'dotmatch barcode'
     - dotmatch panel --help | grep 'dotmatch panel'

--- a/recipes/dotmatch/meta.yaml
+++ b/recipes/dotmatch/meta.yaml
@@ -58,6 +58,7 @@ test:
     - dotmatch panel design --n 2 --length 4 --candidate-pool-size 100 --restarts 1 --min-hamming-distance 2 --min-levenshtein-distance 2 --out-dir panel_out
     - test -f panel_out/barcodes.tsv
     - test -f panel_out/design_report.json
+    - chmod -R a+rwX panel_out
 
 about:
   home: https://github.com/dnncha/dotmatch

--- a/recipes/dotmatch/meta.yaml
+++ b/recipes/dotmatch/meta.yaml
@@ -54,7 +54,7 @@ test:
     - printf 'barcode_id\tbarcode_seq\ns1\tACGT\ns2\tTTTT\n' > barcodes.tsv
     - printf '@r1\nNACGTAAAA\n+\nIIIIIIIII\n@r2\nNTTTTAAAA\n+\nIIIIIIIII\n' > barcode_reads.fastq
     - dotmatch barcode infer --barcodes barcodes.tsv --reads barcode_reads.fastq --scan-starts 0:2 --barcode-length 4 --sample-reads 10 --out offset_scan.tsv --summary barcode_summary.json
-    - grep '"recommended_start": 1' barcode_summary.json
+    - "grep '\"recommended_start\": 1' barcode_summary.json"
     - dotmatch panel design --n 2 --length 4 --candidate-pool-size 100 --restarts 1 --min-hamming-distance 2 --min-levenshtein-distance 2 --out-dir panel_out
     - test -f panel_out/barcodes.tsv
     - test -f panel_out/design_report.json

--- a/recipes/dotmatch/meta.yaml
+++ b/recipes/dotmatch/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "dotmatch" %}
-{% set version = "0.1.3" %}
-{% set sha256 = "a33ed2f546d51fb04e3370f0ed6df115106a24ab2497d40f8bf1f6abd5a490da" %}
+{% set version = "0.1.4" %}
+{% set sha256 = "909279eed208f5fa70707400f7f4bc7e2168c1c7b0edf3aa1ce3b4f4c605ad50" %}
 
 package:
   name: {{ name|lower }}
@@ -14,7 +14,7 @@ build:
   number: 0
   run_exports:
     - {{ pin_subpackage("dotmatch", max_pin="x.x") }}
-  skip: true  # [win]
+  skip: true  # [win or py<39]
 
 requirements:
   build:
@@ -22,20 +22,42 @@ requirements:
     - {{ stdlib('c') }}
     - make
   host:
+    - python >=3.9
+    - pip
+    - setuptools >=77
+    - wheel
     - zlib
+  run:
+    - python >=3.9
+    - tomli  # [py<311]
 
 test:
   commands:
+    - python -c "import dotmatch; assert dotmatch.distance('ACGT', 'AGGT') == 1"
+    - python -c "from dotmatch.native import find_native_cli; p=find_native_cli(); assert p.name == 'dotmatch-native' and p.exists()"
     - dotmatch --version | grep '^dotmatch {{ version }}$'
     - dotmatch dist ACGT AGGT | grep '^1$'
     - dotmatch leq 1 ACGT AGGT | grep '^true$'
+    - dotmatch --help | grep 'Workflow namespaces:'
+    - dotmatch assay --help | grep 'dotmatch assay'
+    - dotmatch barcode --help | grep 'dotmatch barcode'
+    - dotmatch panel --help | grep 'dotmatch panel'
     - test -f "${PREFIX}/include/qdalign.h"
     - test -f "${PREFIX}/lib/libdotmatch.a"
     - test -f "${PREFIX}/lib/libdotmatch.so" || test -f "${PREFIX}/lib/libdotmatch.dylib"
+    - dotmatch assay init --template crispr --out assay.toml
+    - grep 'assay_type = "crispr"' assay.toml
     - printf 'target_id\ttarget_seq\nbc0\tACGT\n' > targets.tsv
     - printf '@r0\nACGT\n+\nIIII\n' > reads.fastq
     - dotmatch count --targets targets.tsv --reads reads.fastq --sample-label sample --target-start 0 --target-length 4 --k 0 --metric hamming --out counts.tsv
     - awk -F '\t' 'NR==2 { exit !($1=="bc0" && $2=="ACGT" && $3=="" && $4=="0" && $5=="1" && $10=="1") }' counts.tsv
+    - printf 'barcode_id\tbarcode_seq\ns1\tACGT\ns2\tTTTT\n' > barcodes.tsv
+    - printf '@r1\nNACGTAAAA\n+\nIIIIIIIII\n@r2\nNTTTTAAAA\n+\nIIIIIIIII\n' > barcode_reads.fastq
+    - dotmatch barcode infer --barcodes barcodes.tsv --reads barcode_reads.fastq --scan-starts 0:2 --barcode-length 4 --sample-reads 10 --out offset_scan.tsv --summary barcode_summary.json
+    - grep '"recommended_start": 1' barcode_summary.json
+    - dotmatch panel design --n 2 --length 4 --candidate-pool-size 100 --restarts 1 --min-hamming-distance 2 --min-levenshtein-distance 2 --out-dir panel_out
+    - test -f panel_out/barcodes.tsv
+    - test -f panel_out/design_report.json
 
 about:
   home: https://github.com/dnncha/dotmatch

--- a/recipes/dotmatch/meta.yaml
+++ b/recipes/dotmatch/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "dotmatch" %}
-{% set version = "0.1.2" %}
+{% set version = "0.1.3" %}
+{% set sha256 = "a33ed2f546d51fb04e3370f0ed6df115106a24ab2497d40f8bf1f6abd5a490da" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +8,7 @@ package:
 
 source:
   url: https://github.com/dnncha/dotmatch/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 7bec094be490d631ea2d5822bcc9891ce3c426a61f172c7a5b7f4bb1e710f5e7
+  sha256: {{ sha256 }}
 
 build:
   number: 0
@@ -28,6 +29,13 @@ test:
     - dotmatch --version | grep '^dotmatch {{ version }}$'
     - dotmatch dist ACGT AGGT | grep '^1$'
     - dotmatch leq 1 ACGT AGGT | grep '^true$'
+    - test -f "${PREFIX}/include/qdalign.h"
+    - test -f "${PREFIX}/lib/libdotmatch.a"
+    - test -f "${PREFIX}/lib/libdotmatch.so" || test -f "${PREFIX}/lib/libdotmatch.dylib"
+    - printf 'target_id\ttarget_seq\nbc0\tACGT\n' > targets.tsv
+    - printf '@r0\nACGT\n+\nIIII\n' > reads.fastq
+    - dotmatch count --targets targets.tsv --reads reads.fastq --sample-label sample --target-start 0 --target-length 4 --k 0 --metric hamming --out counts.tsv
+    - awk -F '\t' 'NR==2 { exit !($1=="bc0" && $2=="ACGT" && $3=="" && $4=="0" && $5=="1" && $10=="1") }' counts.tsv
 
 about:
   home: https://github.com/dnncha/dotmatch


### PR DESCRIPTION
Updates dotmatch to 0.1.4.

This release switches the recipe to install the Python `dotmatch` console script, while still installing the public C header plus static/shared library artifacts. That makes the installed CLI expose the workflow namespaces (`dotmatch assay`, `dotmatch barcode`, and `dotmatch panel`) as well as the native assignment commands.

The recipe keeps the existing native smoke tests and adds small installed-package checks for the Python package, bundled `dotmatch-native`, namespace help, `assay init`, `barcode infer`, and `panel design`.

Source tarball:
https://github.com/dnncha/dotmatch/archive/refs/tags/v0.1.4.tar.gz

SHA256:
`909279eed208f5fa70707400f7f4bc7e2168c1c7b0edf3aa1ce3b4f4c605ad50`