### PR TITLE
Update fastaguard to 0.2.0

### DIFF
--- a/recipes/fastaguard/meta.yaml
+++ b/recipes/fastaguard/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "fastaguard" %}
-{% set version = "0.1.1" %}
+{% set version = "0.2.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/ehsanestaji/FastaGuard/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 10a5520e54d7e7884aa4cdfec5108cd7183c6033053e7839f969b9dcd9d73a17
+  sha256: ad1c2243a7feeb25622bd139b609de942be8219ad5f62176e8e98f46f0d155cf
 
 build:
   number: 0


### PR DESCRIPTION
Update FastaGuard to v0.2.0.

Changes:
- bump recipe version from 0.1.1 to 0.2.0
- update source archive SHA256 for the published GitHub v0.2.0 tag

Local checks:
- git diff --check
- verified source archive SHA256 locally