### PR TITLE
openstructure - relax py3.10 pin, scipy 2.13 is incompatible with py 3.13

### DIFF
--- a/recipes/openstructure/conda_build_config.yaml
+++ b/recipes/openstructure/conda_build_config.yaml
@@ -3,6 +3,3 @@ c_compiler_version: # [osx]
 
 cxx_compiler_version: # [osx]
   - 20 # [osx]
-
-python:
-  - "3.10.* *_cpython"

--- a/recipes/openstructure/meta.yaml
+++ b/recipes/openstructure/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 3
-  skip: True  # [(py < 312 and aarch64) or (py < 311 and arm64)]
+  skip: True  # [(py < 312 and aarch64) or (py < 311 and arm64) or (py > 312)]
   run_exports:
     - {{ pin_subpackage(name|lower, max_pin="x.x") }}
 

--- a/recipes/openstructure/meta.yaml
+++ b/recipes/openstructure/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 9ac12e1ce8ec879ec900b69bdbcc71632ed05d8cf8c09d3e847a57814d8a7e7b
 
 build:
-  number: 2
+  number: 3
   skip: True  # [(py < 312 and aarch64) or (py < 311 and arm64)]
   run_exports:
     - {{ pin_subpackage(name|lower, max_pin="x.x") }}


### PR DESCRIPTION
py pin workaround was introduced in https://github.com/bioconda/bioconda-recipes/commit/a7cde3373308ebdb21b2633ca8d4a491e1e71e82 and it marked the problem as numpy related, but the real issue is that scipy 1.13.x doesn't have a py 3.13 build and the resolver gets confused.