### PR TITLE
Update panoptes-ui to 1.0.0

### DIFF
--- a/recipes/panoptes-ui/meta.yaml
+++ b/recipes/panoptes-ui/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "panoptes-ui" %}
-{% set version = "0.2.3" %}
+{% set version = "1.0.0" %}
 
 package:
   name: "{{ name|lower }}"
@@ -7,7 +7,7 @@ package:
 
 source:
   url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
-  sha256: 5fa903711786d68fb014e0015d647dd56b80b844fa2d6520554487663e45635d
+  sha256: 5f539b9f30ea88a3459d7cb647d2b9e52ee83c21e3a965ff2d6592581886f038
 
 build:
   noarch: python
@@ -22,17 +22,14 @@ requirements:
     - humanfriendly >=4.18
     - marshmallow >=3.0.1
     - pip
-    - pytest >=5.3.0
-    - python
-    - requests >=2.22.0
+    - python >=3.11
+    - setuptools
     - sqlalchemy >=1.3.7
   run:
     - flask >=1.1.1
     - humanfriendly >=4.18
     - marshmallow >=3.0.1
-    - pytest >=5.3.0
-    - python
-    - requests >=2.22.0
+    - python >=3.11
     - sqlalchemy >=1.3.7
 
 test:

--- a/recipes/panoptes-ui/meta.yaml
+++ b/recipes/panoptes-ui/meta.yaml
@@ -16,7 +16,7 @@ build:
     - {{ pin_subpackage(name, max_pin='x') }}
   entry_points:
     - panoptes=panoptes:main
-  script: "{{ PYTHON }} -m pip install . -vv"
+  script: "{{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv"
 
 requirements:
   host:
@@ -49,6 +49,7 @@ about:
   home: "https://github.com/panoptes-organization/panoptes"
   license: MIT
   license_family: MIT
+  license_file: LICENSE.md
   summary: "panoptes: monitor computational workflows in real time"
 
 extra:

--- a/recipes/panoptes-ui/meta.yaml
+++ b/recipes/panoptes-ui/meta.yaml
@@ -12,6 +12,8 @@ source:
 build:
   noarch: python
   number: 0
+  run_exports:
+    - {{ pin_subpackage(name, max_pin='x') }}
   entry_points:
     - panoptes=panoptes:main
   script: "{{ PYTHON }} -m pip install . -vv"

--- a/recipes/panoptes-ui/meta.yaml
+++ b/recipes/panoptes-ui/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: "{{ version }}"
 
 source:
-  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name|replace('-', '_') }}-{{ version }}.tar.gz"
   sha256: 5f539b9f30ea88a3459d7cb647d2b9e52ee83c21e3a965ff2d6592581886f038
 
 build:


### PR DESCRIPTION
panoptes 1.0.0 adds Snakemake 9 support and drops Python < 3.11. `pytest` and `requests` are no longer runtime dependencies (they moved to a `[dev]` extra upstream), so they are removed from `host`/`run`; `python` is pinned to `>=3.11` and `setuptools` is added to `host`. A `run_exports` (`pin_subpackage`, `max_pin='x'`) is added per the recipe guidelines.

This is the human-curated version of the bump (dependency/metadata changes beyond a plain version+sha autobump).

Upstream release: https://github.com/panoptes-organization/panoptes/releases/tag/v1.0.0