### PR TITLE
Constrain graphbin2 to Python <3.13

### DIFF
--- a/recipes/graphbin2/meta.yaml
+++ b/recipes/graphbin2/meta.yaml
@@ -10,21 +10,21 @@ source:
   sha256: 03ab89dbb6d26c9b414ff808598c295cf22fd3af22816a5c9fada94104a79686
 
 build:
-  number: 0
+  number: 1
   noarch: python
   run_exports:
     - {{ pin_subpackage('graphbin2', max_pin="x.x") }}
   script:
-    - "{{ PYTHON }} -m pip install . -vv"
+    - "{{ PYTHON }} -m pip install . --no-deps --no-build-isolation --no-cache-dir -vv"
 
 requirements:
   host:
     - pip
-    - python
+    - python >=3.9,<3.13
     - flit-core
   run:
     - cairocffi
-    - python >=3.9
+    - python >=3.9,<3.13
     - python-igraph
     - cogent3
     - tqdm


### PR DESCRIPTION
## Summary
- Constrain `graphbin2` to Python `>=3.9,<3.13`, matching upstream package metadata.
- Bump the build number so the corrected dependency metadata is rebuilt.
- Make the pip install invocation use `--no-deps --no-build-isolation --no-cache-dir` for a more deterministic Bioconda build.

## Why
Upstream `graphbin2` 1.3.3 declares `requires_python = >=3.9,<3.13`, but the Bioconda recipe only constrained runtime Python to `>=3.9`. This can allow incompatible Python 3.13+ environments for an assembly-graph binning tool.

## Checks
- [x] `bioconda-utils lint --packages graphbin2`
- [x] `bioconda-utils build --docker --mulled-test --force --pkg-dir "$PWD/.bioconda-build" --packages graphbin2`