### PR TITLE
Update mags-visualization 0.0.9 - Corrected python-kaleido pin

### DIFF
--- a/recipes/mags-visualization/meta.yaml
+++ b/recipes/mags-visualization/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script:
     - python -m pip install . --no-deps -vv
   run_exports:
@@ -32,7 +32,7 @@ requirements:
     - seaborn
     - plotly
     - networkx
-    - python-kaleido ==0.2.1
+    - python-kaleido =0.2.1
 
 test:
   imports:


### PR DESCRIPTION
Rebuild of mags-visualization 0.0.9 with corrected python-kaleido pin. The previous build did not include the version pin, causing kaleido v1.3.0 to be installed which requires Chrome. Pinning to 0.2.1.