### PR TITLE
Update panoptes-ui to 1.1.0

### DIFF
--- a/recipes/panoptes-ui/meta.yaml
+++ b/recipes/panoptes-ui/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "panoptes-ui" %}
-{% set version = "1.0.0" %}
+{% set version = "1.1.0" %}
 
 package:
   name: "{{ name|lower }}"
@@ -7,7 +7,7 @@ package:
 
 source:
   url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name|replace('-', '_') }}-{{ version }}.tar.gz"
-  sha256: 5f539b9f30ea88a3459d7cb647d2b9e52ee83c21e3a965ff2d6592581886f038
+  sha256: 6bff3f4d3949009209838a175cd85a2400dd63e319f8c6f085b1e22e3c0dff76
 
 build:
   noarch: python


### PR DESCRIPTION
Version + sha256 bump for [panoptes 1.1.0](https://github.com/panoptes-organization/panoptes/releases/tag/v1.1.0).

1.1.0 adds reuse-by-name support on `/create_workflow` (server side of the `snakemake-logger-plugin-panoptes` `--logger-panoptes-name` feature). No dependency or metadata changes from 1.0.0, so this is a straight version/sha update on top of the recipe merged in #65730.