### PR TITLE
Add logan_blaster recipe v0.1.1

### DIFF
--- a/recipes/logan_blaster/fix_setup.patch
+++ b/recipes/logan_blaster/fix_setup.patch
@@ -1,0 +1,11 @@
+--- a/setup.py
++++ b/setup.py
+@@ -13,7 +13,7 @@
+         ],
+     },
+     author_email = 'pierre.peterlongo@inria.fr',
+-    maintainer = logan_blaster.__author__,
++    maintainer = 'Pierre Peterlongo',
+     maintainer_email = 'pierre.peterlongo@inria.fr',
+     download_url = 'https://github.com/pierrepeterlongo/logan_blaster',
+     url = 'https://github.com/pierrepeterlongo/logan_blaster',

--- a/recipes/logan_blaster/fix_setup.patch
+++ b/recipes/logan_blaster/fix_setup.patch
@@ -1,3 +1,11 @@
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,4 +1,4 @@
+ [build-system]
+ requires = ["setuptools>=45", "setuptools_scm[toml]>=6.2"]
+-build-backend = "setuptools.backends.legacy:build"
++build-backend = "setuptools.build_meta"
+
 --- a/setup.py
 +++ b/setup.py
 @@ -13,7 +13,7 @@

--- a/recipes/logan_blaster/meta.yaml
+++ b/recipes/logan_blaster/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "logan_blaster" %}
-{% set version = "0.1.1" %}
+{% set version = "0.1.3" %}
 
 package:
   name: {{ name|lower }}

--- a/recipes/logan_blaster/meta.yaml
+++ b/recipes/logan_blaster/meta.yaml
@@ -1,0 +1,51 @@
+{% set name = "logan_blaster" %}
+{% set version = "0.1.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/pierrepeterlongo/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: aecacb749ea44fa8ac88d887fb25e1144e412847d4b536cef992fce12dfa5944
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  entry_points:
+    - logan_blaster = logan_blaster:main
+
+requirements:
+  host:
+    - python >=3.8
+    - pip
+    - setuptools
+  run:
+    - python >=3.8
+    - blast
+    - jq
+    - back_to_sequences
+    - wget
+
+test:
+  commands:
+    - logan_blaster --version
+    - logan_blaster --help
+
+about:
+  home: https://github.com/pierrepeterlongo/logan_blaster
+  summary: Align genomic sequences against Logan contigs or unitigs
+  description: |
+    logan_blaster downloads Logan contigs or unitigs for a list of SRA accessions,
+    recruits sequences sharing k-mers with a query using back_to_sequences, and
+    aligns them against the query with BLAST. It can also process a session ID
+    from the Logan search portal (logan-search.org).
+  license: GPL-3.0-only
+  license_file: LICENSE
+  doc_url: https://github.com/pierrepeterlongo/logan_blaster/blob/main/README.md
+  dev_url: https://github.com/pierrepeterlongo/logan_blaster
+
+extra:
+  recipe-maintainers:
+    - pierrepeterlongo

--- a/recipes/logan_blaster/meta.yaml
+++ b/recipes/logan_blaster/meta.yaml
@@ -13,6 +13,8 @@ build:
   number: 0
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  run_exports:
+    - {{ pin_subpackage('logan_blaster', max_pin="x.x") }}
   entry_points:
     - logan_blaster = logan_blaster:main
 

--- a/recipes/logan_blaster/meta.yaml
+++ b/recipes/logan_blaster/meta.yaml
@@ -8,13 +8,17 @@ package:
 source:
   url: https://github.com/pierrepeterlongo/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
   sha256: 7a986ec6d906bc14109099111af411236770f5d29a145377149f0c84a7672f2f
+  patches:
+    - fix_setup.patch
 
 build:
   number: 0
   noarch: python
   script:
+    - export SETUPTOOLS_SCM_PRETEND_VERSION={{ version }}
     - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-
+  entry_points:
+    - logan_blaster = logan_blaster:main
 
 requirements:
   host:
@@ -22,6 +26,7 @@ requirements:
     - pip
     - setuptools
     - wheel
+    - setuptools-scm
   run:
     - python >=3.8
     - blast

--- a/recipes/logan_blaster/meta.yaml
+++ b/recipes/logan_blaster/meta.yaml
@@ -12,13 +12,9 @@ source:
 build:
   number: 0
   noarch: python
-  run_exports:
-    - {{ pin_subpackage('logan_blaster', max_pin='x') }}
   script:
-    - export SETUPTOOLS_SCM_PRETEND_VERSION={{ version }}
     - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-  entry_points:
-    - logan_blaster = logan_blaster:main
+
 
 requirements:
   host:
@@ -26,7 +22,6 @@ requirements:
     - pip
     - setuptools
     - wheel
-    - setuptools-scm
   run:
     - python >=3.8
     - blast

--- a/recipes/logan_blaster/meta.yaml
+++ b/recipes/logan_blaster/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/pierrepeterlongo/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: aecacb749ea44fa8ac88d887fb25e1144e412847d4b536cef992fce12dfa5944
+  sha256: 7a986ec6d906bc14109099111af411236770f5d29a145377149f0c84a7672f2f
 
 build:
   number: 0

--- a/recipes/logan_blaster/meta.yaml
+++ b/recipes/logan_blaster/meta.yaml
@@ -12,9 +12,9 @@ source:
 build:
   number: 0
   noarch: python
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-  run_exports:
-    - {{ pin_subpackage('logan_blaster', max_pin="x.x") }}
+  script:
+    - export SETUPTOOLS_SCM_PRETEND_VERSION={{ version }}
+    - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:
     - logan_blaster = logan_blaster:main
 

--- a/recipes/logan_blaster/meta.yaml
+++ b/recipes/logan_blaster/meta.yaml
@@ -19,6 +19,8 @@ build:
     - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:
     - logan_blaster = logan_blaster:main
+  run_exports:
+    - {{ pin_subpackage('logan_blaster', max_pin="x.x") }}
 
 requirements:
   host:

--- a/recipes/logan_blaster/meta.yaml
+++ b/recipes/logan_blaster/meta.yaml
@@ -23,6 +23,8 @@ requirements:
     - python >=3.8
     - pip
     - setuptools
+    - wheel
+    - setuptools-scm
   run:
     - python >=3.8
     - blast

--- a/recipes/logan_blaster/meta.yaml
+++ b/recipes/logan_blaster/meta.yaml
@@ -12,6 +12,8 @@ source:
 build:
   number: 0
   noarch: python
+  run_exports:
+    - {{ pin_subpackage('logan_blaster', max_pin='x') }}
   script:
     - export SETUPTOOLS_SCM_PRETEND_VERSION={{ version }}
     - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv


### PR DESCRIPTION
## Description

Add recipe for `logan_blaster` v0.1.3.

`logan_blaster` is a Python tool that:
- Downloads Logan contigs or unitigs for a list of SRA accessions
- Recruits sequences sharing k-mers with a query using `back_to_sequences`
- Aligns recruited sequences against the query with BLAST
- Can also process a session ID from the Logan search portal (logan-search.org)

## Links

- GitHub: https://github.com/pierrepeterlongo/logan_blaster
- License: GPL-3.0

## Tests

```
logan_blaster --version
logan_blaster --help
```