### PR TITLE
Update fastaguard to 0.3.0

### DIFF
--- a/recipes/fastaguard/meta.yaml
+++ b/recipes/fastaguard/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "fastaguard" %}
-{% set version = "0.2.0" %}
+{% set version = "0.3.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/ehsanestaji/FastaGuard/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: ad1c2243a7feeb25622bd139b609de942be8219ad5f62176e8e98f46f0d155cf
+  sha256: 643d5d0107b6dc237f3be782a8463414880b95c45964397b773dac7e794e4fde
 
 build:
   number: 0
@@ -23,6 +23,7 @@ requirements:
 
 test:
   commands:
+    - fastaguard --version | grep {{ version }}
     - fastaguard --help
     - fastaguard --schema
     - fastaguard --finding-catalog


### PR DESCRIPTION
Update `fastaguard` from `0.2.0` to `0.3.0`.

Changes:
- Bump recipe version to `0.3.0`.
- Update the source archive SHA256 for `v0.3.0`.
- Add a small `fastaguard --version | grep {{ version }}` smoke test.

Release:
- https://github.com/ehsanestaji/FastaGuard/releases/tag/v0.3.0

Local checks:
- `git diff --check`
- trailing whitespace scan on `recipes/fastaguard/meta.yaml`
- verified the GitHub source archive SHA256 matches the recipe value
- verified the source archive contains `Cargo.toml` and bundled schema files

Note: I could not run `conda render` locally because this environment has `conda` but not `conda-build`; leaving full recipe build validation to Bioconda CI.
