### PR TITLE
Add RNAvigate recipe

### DIFF
--- a/recipes/rnavigate/meta.yaml
+++ b/recipes/rnavigate/meta.yaml
@@ -12,6 +12,8 @@ build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
+  run_exports:
+    - {{ pin_subpackage('rnavigate', max_pin="x") }}
 
 requirements:
   host:
@@ -22,18 +24,14 @@ requirements:
   run:
     - python >=3.9
     - biopython >=1.78
-    - ipython >=8.18.1
-    - jedi >=0.19.2
     - matplotlib-base >=3.8
     - numpy >=1.20.1
-    - openpyxl >=3.1.2
     - pandas >=1.4.4
     - py3dmol >=2.0.0
-    - requests
+    - requests >=2.28.0
     - scikit-learn >=1.0.2
     - scipy >=1.6.2
     - seaborn >=0.13.0
-    - statsmodels >=0.14.1
 
 test:
   imports:

--- a/recipes/rnavigate/meta.yaml
+++ b/recipes/rnavigate/meta.yaml
@@ -24,14 +24,18 @@ requirements:
   run:
     - python >=3.9
     - biopython >=1.78
+    - ipython >=8.18.1
+    - jedi >=0.19.2
     - matplotlib-base >=3.8
     - numpy >=1.20.1
+    - openpyxl >=3.1.2
     - pandas >=1.4.4
     - py3dmol >=2.0.0
-    - requests >=2.28.0
+    - requests
     - scikit-learn >=1.0.2
     - scipy >=1.6.2
     - seaborn >=0.13.0
+    - statsmodels >=0.14.1
 
 test:
   imports:

--- a/recipes/rnavigate/meta.yaml
+++ b/recipes/rnavigate/meta.yaml
@@ -1,0 +1,56 @@
+{% set version = "1.1.1" %}
+
+package:
+  name: rnavigate
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/R/RNAvigate/rnavigate-{{ version }}.tar.gz
+  sha256: edc605fb8f977a8ea64dca0604f7f93b2051faca758910cd6d34cd678776ec0e
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python >=3.9
+    - setuptools >=61
+    - wheel
+    - pip
+  run:
+    - python >=3.9
+    - biopython >=1.78
+    - ipython >=8.18.1
+    - jedi >=0.19.2
+    - matplotlib-base >=3.8
+    - numpy >=1.20.1
+    - openpyxl >=3.1.2
+    - pandas >=1.4.4
+    - py3dmol >=2.0.0
+    - requests
+    - scikit-learn >=1.0.2
+    - scipy >=1.6.2
+    - seaborn >=0.13.0
+    - statsmodels >=0.14.1
+
+test:
+  imports:
+    - rnavigate
+  commands:
+    - pip check
+  requires:
+    - pip
+    - python
+
+about:
+  home: https://github.com/Weeks-UNC/RNAvigate
+  summary: RNA visualization and graphical analysis toolset
+  doc_url: https://rnavigate.readthedocs.io/en/latest/
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - Psirving


### PR DESCRIPTION
This PR adds RNAvigate, a Python library for analyzing and visualizing RNA chemical probing data alongside secondary and tertiary structures. Used by RNA structure biologists in Jupyter Notebook workflows.