### PR TITLE
Update aviary to v0.13.0

### DIFF
--- a/recipes/aviary/meta.yaml
+++ b/recipes/aviary/meta.yaml
@@ -32,14 +32,12 @@ requirements:
     - pandas
     - polars
     - biopython
-    - mamba >=1.5.12
     - pigz >=2.6
     - parallel
     - bbmap
     - extern
     - pyopenssl >22.1.0
     - bird_tool_utils_python
-    - flask >=2.3
 
 test:
   commands:

--- a/recipes/aviary/meta.yaml
+++ b/recipes/aviary/meta.yaml
@@ -1,13 +1,13 @@
-{% set version = "0.12.0" %}
+{% set version = "0.13.0" %}
 {% set name = "aviary" %}
-{% set sha256 = "aa097db9fa8304aa11d447c3610e56606c9c962013ca47d07a77b6f73a0396c7" %}
+{% set sha256 = "c7fc48fec5211b93c45f010d260879be59dfed39b7a9a929e839bb3c916c10e1" %}
 
 package:
   name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/{{ name[0] }}/aviary-genome/aviary_genome-v{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/aviary-genome/aviary_genome-{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:
@@ -21,21 +21,25 @@ build:
 
 requirements:
   host:
-    - python >=3.8,<3.12
+    - python >=3.8
     - pip
     - setuptools
   run:
-    - python >=3.8,<3.12
-    - snakemake-minimal >=7.0.0,<=7.32.4
+    - python >=3.8
+    - snakemake-minimal 9.*
     - ruamel.yaml >=0.15.99
     - numpy
     - pandas
+    - polars
     - biopython
     - mamba >=1.5.12
-    - pigz
+    - pigz >=2.6
     - parallel
     - bbmap
     - extern
+    - pyopenssl >22.1.0
+    - bird_tool_utils_python
+    - flask >=2.3
 
 test:
   commands:


### PR DESCRIPTION
Update aviary to v0.13.0

Updates the aviary recipe from v0.12.0 to v0.13.0.

Changes
- Version bump to 0.13.0 with updated SHA256
- Fixed source URL (removed erroneous v prefix from tarball filename)
- Updated snakemake-minimal constraint from >=7.0.0,<=7.32.4 to 9.* (aviary now targets snakemake 9)
- Removed Python <3.12 upper bound (aviary dev environment now uses Python 3.12)
- Added new dependencies: polars, pyopenssl >22.1.0, bird_tool_utils_python, flask >=2.3
- Added version constraint pigz >=2.6
