### PR TITLE
Add phageflow 1.0.0

### DIFF
--- a/recipes/phageflow/meta.yaml
+++ b/recipes/phageflow/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "phageflow" %}
-{% set version = "0.2.2" %}
+{% set version = "1.0.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,14 +7,14 @@ package:
 
 source:
   url: https://github.com/fcabezasmera/PhageFlow/archive/v{{ version }}.tar.gz
-  sha256: 80bb4cfe0081272b021c60b7b91bd972d9696cc339d5352f96af8eadb9e48284
+  sha256: c935c1e1879809f5ba442923820a47cfe23ecb50abc390eea78ec12d8a3e51e0
 
 build:
   number: 0
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   run_exports:
-    - {{ pin_subpackage("phageflow", max_pin="x.x") }}
+    - {{ pin_subpackage("phageflow", max_pin="x") }}
 
 requirements:
   host:
@@ -29,35 +29,28 @@ requirements:
     - biopython >=1.80
     - pandas >=2.0
     - numpy >=1.24
-    - matplotlib-base >=3.7
+    - matplotlib-base
     - pygenomeviz >=0.4.0
-    # ── QC ───────────────────────────────────────────────────────────────────
-    - fastp >=1.3
-    - fastqc >=0.12
-    - multiqc >=1.35
-    # ── Host removal ─────────────────────────────────────────────────────────
+    - fastp
+    - fastqc
+    - multiqc
     - bwa-mem2
-    - samtools >=1.23
+    - samtools >=1.15
     - seqtk
     - kraken2 >=2.1
     - ncbi-datasets-cli
-    # ── Assembly ─────────────────────────────────────────────────────────────
-    - spades >=4.2
+    - spades >=3.15
     - megahit >=1.2.9
     - cd-hit
-    # ── Coverage ─────────────────────────────────────────────────────────────
-    - coverm >=0.7
-    # ── Viral ID ─────────────────────────────────────────────────────────────
-    - genomad >=1.8
-    # ── Quality ──────────────────────────────────────────────────────────────
-    - checkv >=1.1
+    - coverm >=0.6
+    - genomad >=1.7
+    - checkv >=1.0
     - mash >=2.3
     - minimap2 >=2.24
-    - blast >=2.14          # provides blastn + makeblastdb
-    # ── Annotation ───────────────────────────────────────────────────────────
-    - pharokka >=1.9
-    - phold >=1.2
-    - dnaapler >=1.3
+    - blast >=2.14
+    - pharokka >=1.7
+    - phold >=1.0
+    - dnaapler >=0.7
     - pigz
 
 test:


### PR DESCRIPTION
First production release of PhageFlow — a modular bacteriophage genomics pipeline
for complete and high-quality viral genome recovery from Illumina paired-end sequencing.

Validated end-to-end on an HPC cluster (4 distinct phage genomes recovered from a
single K. pneumoniae sample) across purified phage, virome, and metagenome datasets.

sha256 verified against the GitHub release tarball. run_exports uses max_pin="x"
per semver for 1.x.

This replaces the earlier #65887 (0.2.x), whose branch accumulated merge conflicts.
Opened a clean single-commit branch from current master instead.