### PR TITLE
Add mph

### DIFF
--- a/recipes/mph/build.sh
+++ b/recipes/mph/build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -eux -o pipefail
+
+export CXXFLAGS="${CXXFLAGS} -O3 -std=c++11 -fopenmp -I${PREFIX}/include"
+export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib"
+export MKL_THREADING_LAYER="GNU"
+
+make \
+  CXX="${CXX}" \
+  CXXFLAGS="${CXXFLAGS}" \
+  INCLUDES="-I${PREFIX}/include/eigen3" \
+  LDFLAGS="${LDFLAGS}" \
+  LDLIBS="-lmkl_rt -lgomp -lpthread -lm -ldl" \
+  -j"${CPU_COUNT}"
+
+install -d "${PREFIX}/bin"
+install -m 0755 mph "${PREFIX}/bin/mph"

--- a/recipes/mph/meta.yaml
+++ b/recipes/mph/meta.yaml
@@ -1,0 +1,56 @@
+{% set name = "mph" %}
+{% set version = "0.55.1" %}
+{% set sha256 = "4c49ea8d8e08a7e7b132c129650bbafae54e79b8aedd3acf4106b89f1b4a7ad3" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/jiang18/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+  patches:
+    # Use Conda compiler, dependency, and linker flags instead of Intel/local paths.
+    - patches/makefile-conda.patch
+    # Materialize Eigen permutation indices before sorting with newer compilers.
+    - patches/reml-mutable-indices.patch
+
+build:
+  number: 0
+  skip: True  # [not linux64]
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x.x") }}
+
+requirements:
+  build:
+    - {{ compiler('cxx') }}
+    - {{ stdlib("c") }}
+    - make
+  host:
+    - eigen >=3.4.0,<4
+    - libgomp
+    - mkl >=2024,<2025
+    - mkl-include
+  run:
+    - libgomp
+    - mkl >=2024,<2025
+
+test:
+  commands:
+    - mph 2>&1 | grep "MINQUE for Partitioning Heritability"
+    - mph 2>&1 | grep "Version {{ version }}"
+
+about:
+  home: https://jiang18.github.io/mph/
+  license: GPL-3.0-only
+  license_family: GPL3
+  license_file: LICENSE
+  summary: Fast REML estimation of genetic covariance components for partitioning heritability
+  dev_url: https://github.com/jiang18/mph
+  doc_url: https://jiang18.github.io/mph/
+
+extra:
+  identifiers:
+    - doi:10.1093/bioinformatics/btae298
+  recipe-maintainers:
+    - lyh970817

--- a/recipes/mph/patches/makefile-conda.patch
+++ b/recipes/mph/patches/makefile-conda.patch
@@ -1,0 +1,28 @@
+--- Makefile.orig
++++ Makefile
+@@ -8,13 +8,13 @@
+ EFILE = mph
+ 
+ # Intel oneAPI DPC++/C++ Compiler
+-CXX = icpx
++CXX ?= g++
+ 
+ # Compiler flags
+-CXXFLAGS = -Wall -O3 -qmkl -qopenmp -std=c++11 -static 
++CXXFLAGS ?= -Wall -O3 -std=c++11
+ # Includes
+ # Change the EIGEN path before compiling.
+-INCLUDES = -I/home/jjiang26/software/eigen-3.4.0
++INCLUDES ?=
+ 
+ SRC_DIR := ./src
+ SRCS := $(wildcard $(SRC_DIR)/*.cpp)
+@@ -28,7 +28,7 @@
+ 	$(CXX) $(CXXFLAGS) $(INCLUDES) -c $< -o $@
+ 
+ $(EFILE) : $(OBJS)
+-	$(CXX) $(CXXFLAGS) -o $(EFILE) $(OBJS)
++	$(CXX) $(CXXFLAGS) $(LDFLAGS) -o $(EFILE) $(OBJS) $(LDLIBS)
+ 
+ .PHONY: clean
+ clean: 

--- a/recipes/mph/patches/reml-mutable-indices.patch
+++ b/recipes/mph/patches/reml-mutable-indices.patch
@@ -1,0 +1,19 @@
+--- src/reml.cpp
++++ src/reml.cpp
+@@ -186,11 +186,12 @@
+ 		std::cout<<"Warning: the covariate matrix is not of full rank.\n";
+ 		MatrixXf indep_xmat(xmat.rows(), qr.rank());
+ 		std::vector<std::string> indep_covar_names(qr.rank());
+-		VectorXi indep_indices = qr.colsPermutation().indices().head(qr.rank());
+-		std::sort(indep_indices.data(), indep_indices.data()+indep_indices.size());
++		std::vector<int> indep_indices(qr.rank());
++		for(i=0; i<qr.rank(); ++i) indep_indices[i] = qr.colsPermutation().indices()(i);
++		std::sort(indep_indices.begin(), indep_indices.end());
+ 		for(i=0; i<indep_indices.size(); ++i) {
+-			indep_xmat.col(i) = xmat.col(indep_indices(i));
+-			indep_covar_names[i] = covar_names[indep_indices(i)];
++			indep_xmat.col(i) = xmat.col(indep_indices[i]);
++			indep_covar_names[i] = covar_names[indep_indices[i]];
+ 		}
+ 		
+ 		xmat = indep_xmat;


### PR DESCRIPTION
Adds a recipe for mph 0.55.1, a program for REML estimation of genetic covariance components and partitioning heritability.

Build notes:
- Builds from the upstream v0.55.1 source tag.
- Uses Conda-provided compiler, Eigen, MKL, and OpenMP dependencies instead of upstream hard-coded Intel/local build paths.
- Limits the recipe to linux64 because the build uses MKL/OpenMP dependencies available for that platform.
- Includes run_exports with max_pin="x.x" because upstream is currently in the 0.x series.
- Carries a small GCC/Eigen compatibility patch that materializes Eigen permutation indices before sorting.

Validation:
- bioconda-utils lint recipes config.yml --packages mph
- bioconda-utils build recipes config.yml --packages mph --force