### PR TITLE
tir-learner: v4.04 — grfmite-rs dependency, CLI TIR-Learner + tirlearner4 alias

### DIFF
--- a/recipes/tir-learner/build.sh
+++ b/recipes/tir-learner/build.sh
@@ -8,10 +8,11 @@ cp -r TIR-Learner4/* "$PREFIX/lib/tir-learner4/"
 # Fix shebang in main script (original has #!/usr/app/env python3, a typo)
 sed -i '1s|.*|#!/usr/bin/env python3|' "$PREFIX/lib/tir-learner4/TIR-Learner.py"
 
-# Create CLI wrapper
+# Create CLI wrapper. TIR-Learner is the canonical command name, and what EDTA
+# locates via `command -v TIR-Learner`, so install directly under it.
 mkdir -p "$PREFIX/bin"
-cat > "$PREFIX/bin/tirlearner4" << EOF
+cat > "$PREFIX/bin/TIR-Learner" << EOF
 #!/usr/bin/env bash
 exec python3 "$PREFIX/lib/tir-learner4/TIR-Learner.py" "\$@"
 EOF
-chmod +x "$PREFIX/bin/tirlearner4"
+chmod +x "$PREFIX/bin/TIR-Learner"

--- a/recipes/tir-learner/build.sh
+++ b/recipes/tir-learner/build.sh
@@ -16,3 +16,6 @@ cat > "$PREFIX/bin/TIR-Learner" << EOF
 exec python3 "$PREFIX/lib/tir-learner4/TIR-Learner.py" "\$@"
 EOF
 chmod +x "$PREFIX/bin/TIR-Learner"
+
+# Also expose tirlearner4 as an alias of the default TIR-Learner command
+ln -sf TIR-Learner "$PREFIX/bin/tirlearner4"

--- a/recipes/tir-learner/meta.yaml
+++ b/recipes/tir-learner/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "TIR-Learner" %}
 {% set version = "4.04" %}
-{% set sha256 = "aedf94d8285dbc5bc4d3e13c79fab3347972aed6b664dc0265783df9f5a28032" %}
+{% set sha256 = "0d10146bbb6a6eded2fe47ae2c5f479248231a4ff2597ece6ab03caf744067d5" %}
 
 package:
   name: {{ name | lower }}
@@ -25,13 +25,14 @@ requirements:
     - keras
     - pytorch
     - genometools-genometools
-    - genericrepeatfinder
+    - grfmite-rs
     - blast
     - pigz
 
 test:
   commands:
     - TIR-Learner --help
+    - tirlearner4 --help
 
 about:
   home: https://github.com/KGerhardt/{{ name }}

--- a/recipes/tir-learner/meta.yaml
+++ b/recipes/tir-learner/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "TIR-Learner" %}
-{% set version = "4.03" %}
-{% set sha256 = "acdc4c475f9400eff50dc22a38b79e80baa8844d1fa59d77db6b3d958bff2330" %}
+{% set version = "4.04" %}
+{% set sha256 = "aedf94d8285dbc5bc4d3e13c79fab3347972aed6b664dc0265783df9f5a28032" %}
 
 package:
   name: {{ name | lower }}
@@ -31,7 +31,7 @@ requirements:
 
 test:
   commands:
-    - tirlearner4 --help
+    - TIR-Learner --help
 
 about:
   home: https://github.com/KGerhardt/{{ name }}


### PR DESCRIPTION
Updates the `tir-learner` recipe:

- Bumps source to the [v4.04 release](https://github.com/KGerhardt/TIR-Learner/releases/tag/v4.04), which adds `-k`/`--cnn_ratio` (CPU cores per CNN process; #processes = `-p // k`, fewer in-memory model copies / lower peak RAM; default 4).
- Installs the CLI wrapper as `TIR-Learner` instead of `tirlearner4` so that EDTA, which locates the tool via `command -v TIR-Learner`, resolves it.

Build number stays 0 (new version).