### PR TITLE
Update fastaguard to 0.4.0

### DIFF
--- a/recipes/fastaguard/meta.yaml
+++ b/recipes/fastaguard/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "fastaguard" %}
-{% set version = "0.3.0" %}
+{% set version = "0.4.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/ehsanestaji/FastaGuard/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 643d5d0107b6dc237f3be782a8463414880b95c45964397b773dac7e794e4fde
+  sha256: 04b42085dda1a0aebec9ce90bfac681e863f004d331b0d9a799f212cd952cf59
 
 build:
   number: 0


### PR DESCRIPTION
## Summary
- Update `fastaguard` from `0.3.0` to `0.4.0`.
- Refresh the source archive SHA256 to `04b42085dda1a0aebec9ce90bfac681e863f004d331b0d9a799f212cd952cf59`.
- Source release: https://github.com/ehsanestaji/FastaGuard/releases/tag/v0.4.0

## Local validation
- Static recipe assertions passed for version, SHA256, `test`, `run_exports`, `stdlib`, and `cargo-bundle-licenses`.
- Source archive SHA256 verified locally with `shasum -a 256 -c`.
- `git diff --check` passed.

Note: `bioconda-utils` and `conda-build` were not available in my local environment, so render/lint/build validation is left to Bioconda CI.