### PR TITLE
Update epytope to 4.0.0

### DIFF
--- a/recipes/epytope/meta.yaml
+++ b/recipes/epytope/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "epytope" %}
-{% set version = "3.3.1" %}
+{% set version = "4.0.0" %}
 
 package:
   name: "{{ name|lower }}"
   version: "{{ version }}"
 
 source:
-  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}-1682423381.tar.gz"
-  sha256: d6ab7d472d4025c7ac9f3db39cffaf500c011c5d3efb6d9423c826d138ae341e
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  sha256: 973fd751095f0aa3f331f649f0ee04deb202b5b846dae8f85e331dcc07956651
 
 build:
   number: 0
@@ -16,22 +16,19 @@ build:
 
 requirements:
   host:
-    - python
+    - python >=3.11
     - pip
+    - setuptools >=64
   run:
     - beautifulsoup4
     - biopython
-    - h5py <=2.10.0
-    - keras <=2.3.1
-    - mhcflurry <=1.4.3
-    - mhcnuggets ==2.3.2
-    - pandas >=1.3.5
+    - pandas >=2.1
     - pymysql
     - pyomo >=4.0
-    - python
+    - python >=3.11
     - pyvcf3
     - requests
-    - setuptools
+    - urllib3
 
 test:
   imports:
@@ -88,7 +85,7 @@ test:
 
 about:
   home: "https://github.com/KohlbacherLab/epytope"
-  license: BSD
+  license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE.txt
   summary: "A Framework for Epitope Detection and Vaccine Design"

--- a/recipes/epytope/meta.yaml
+++ b/recipes/epytope/meta.yaml
@@ -13,6 +13,8 @@ build:
   number: 0
   noarch: python
   script: "{{ PYTHON }} -m pip install . -vv"
+  run_exports:
+    - {{ pin_subpackage('epytope', max_pin="x") }}
 
 requirements:
   host:


### PR DESCRIPTION

Recipe changes:
- Bump version to 4.0.0, refresh sha256.
- Switch the source URL to the standard `{{ name }}-{{ version }}.tar.gz` form (the previous URL carried a non-standard build-timestamp suffix that prevented the autobump bot from detecting new releases).
- Dependency review against 4.0.0 `requires_dist`: drop `h5py`, `keras`, `mhcflurry`, and `mhcnuggets` (no longer core dependencies — `mhcflurry` is now an optional `[mhcflurry]` extra), drop runtime `setuptools`, add `urllib3`, bump `pandas >=2.1`, and require `python >=3.11`.
- Add `run_exports`.

----

* [x] This PR adds or updates a recipe and uses "Update" as the first word in its title.