### PR TITLE
Add susiex

### DIFF
--- a/recipes/susiex/build.sh
+++ b/recipes/susiex/build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -eux -o pipefail
+
+# Upstream hard-codes g++, so patch the Makefile to use Conda's compiler and flags.
+sed -i.bak \
+  -e 's|g++ main.cpp data.o model.o -O3|$(CXX) $(CXXFLAGS) $(CPPFLAGS) main.cpp data.o model.o $(LDFLAGS) -O3|' \
+  -e 's|g++ -c |$(CXX) $(CXXFLAGS) $(CPPFLAGS) -c |' \
+  src/makefile
+
+make -C src -j"${CPU_COUNT}"
+
+install -d "${PREFIX}/bin"
+install -m 0755 bin/SuSiEx "${PREFIX}/bin/"

--- a/recipes/susiex/meta.yaml
+++ b/recipes/susiex/meta.yaml
@@ -1,0 +1,49 @@
+{% set name = "susiex" %}
+{% set version = "1.1.2" %}
+{% set sha256 = "87bb8bb6dcc73dce00e9be694e5eadc106b070eb2e05b71244a1d5a7fcde07d2" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/getian107/SuSiEx/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x") }}
+
+requirements:
+  build:
+    - make
+    - {{ compiler('cxx') }}
+    - {{ stdlib("c") }}
+  host:
+    - libgomp      # [linux]
+    - llvm-openmp  # [osx]
+  run:
+    - libgomp      # [linux]
+    - llvm-openmp  # [osx]
+    - plink
+
+test:
+  commands:
+    - "SuSiEx --help | grep 'Usage: SuSiEx'"
+
+about:
+  home: https://github.com/getian107/SuSiEx
+  license: MIT
+  license_file: LICENSE
+  summary: Cross-ancestry fine-mapping using GWAS summary statistics and LD reference panels
+  dev_url: https://github.com/getian107/SuSiEx
+
+extra:
+  identifiers:
+    - doi:10.1038/s41588-024-01870-z
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64
+  recipe-maintainers:
+    - lyh970817


### PR DESCRIPTION
Add a new Bioconda recipe for SuSiEx v1.1.2.

SuSiEx is a C++ command-line tool for cross-ancestry fine-mapping using GWAS summary statistics and LD reference panels, so it is directly relevant to statistical genetics workflows.

Packaging notes:
- Builds the upstream C++ executable from the tagged source archive rather than using the bundled static binary.
- Patches the upstream Makefile to use Conda's C++ compiler and build flags instead of hard-coded g++.
- Declares OpenMP runtime dependencies for Linux and macOS.
- Declares plink as a runtime dependency because SuSiEx shells out to PLINK for LD calculations.
- Includes run_exports with major-version pinning.

Validation performed locally:
- Ran the repository indentation fixer on the recipe.
- Ran git diff --check for the new recipe.
- Ran bash -n on build.sh.
- Ran a source-level build smoke test using the new build.sh; the installed SuSiEx executable printed the expected help banner.
- Ran bioconda-utils lint for susiex with only the channel-repodata checks excluded because this environment cannot reliably reach conda.anaconda.org; all remaining checks passed.