### PR TITLE
update build, switch source to new nemo-release repo for 2.4.0

### DIFF
--- a/recipes/nemo/build.sh
+++ b/recipes/nemo/build.sh
@@ -5,8 +5,14 @@ export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib"
 export CXXFLAGS="${CXXFLAGS} -O3"
 
 mkdir -p "${PREFIX}/bin"
+# The release tarball is a git archive and does not ship the (gitignored) bin/
+# output directory, so create it before building.
+mkdir -p bin/
 
-case $(uname -m) in
+
+ARCH=$(uname -m)
+
+case "$ARCH" in
     aarch64)
 	export CXXFLAGS="${CXXFLAGS} -march=armv8-a"
 	;;
@@ -18,7 +24,9 @@ case $(uname -m) in
 	;;
 esac
 
-case $(uname -m) in
+# The Makefile hard-codes "-march=native"; replace it with portable,
+# architecture-specific flags so the build is reproducible on CI.
+case "$ARCH" in
     aarch64)
 	sed -i.bak 's|-march=native|-O3 -std=c++14 -march=armv8-a -Wno-narrowing|' Makefile
 	;;
@@ -31,7 +39,22 @@ case $(uname -m) in
 esac
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
-	C_OPTS="${CPPFLAGS} ${CXXFLAGS}" make GSL_PATH="$PREFIX/" CC="$CXX" SHELL="/bin/bash" MAC=1 -j"${CPU_COUNT}"
+    
+	case "$ARCH" in
+        arm64|aarch64)
+            # Apple Silicon (M1, M2, M3, etc.) -> ARM architecture
+            C_OPTS="${CPPFLAGS} ${CXXFLAGS}" make GSL_PATH="$PREFIX/" CC="$CXX" SHELL="/bin/bash" MAC_ARM=1 -j"${CPU_COUNT}"
+            ;;
+        x86_64|i386)
+            # Legacy Intel architecture (or generic x86 container build)
+            C_OPTS="${CPPFLAGS} ${CXXFLAGS}" make GSL_PATH="$PREFIX/" CC="$CXX" SHELL="/bin/bash" MAC_x86=1 -j"${CPU_COUNT}"
+            ;;
+        *)
+            # Fallback or error handling for unexpected architectures
+            echo "Warning: Unknown macOS architecture detected ($ARCH). Using ARM fallback."
+            C_OPTS="${CPPFLAGS} ${CXXFLAGS}" make GSL_PATH="$PREFIX/" CC="$CXX" SHELL="/bin/bash" MAC_ARM=1 -j"${CPU_COUNT}"
+            ;;
+    esac
 else
 	C_OPTS="${CPPFLAGS} ${CXXFLAGS}" make GSL_PATH="$PREFIX/" CC="$CXX" SHELL="/bin/bash" -j"${CPU_COUNT}"
 fi

--- a/recipes/nemo/build.sh
+++ b/recipes/nemo/build.sh
@@ -59,8 +59,11 @@ else
 	C_OPTS="${CPPFLAGS} ${CXXFLAGS}" make GSL_PATH="$PREFIX/" CC="$CXX" SHELL="/bin/bash" -j"${CPU_COUNT}"
 fi
 
-make install BIN_INSTALL="$PREFIX/bin/" LIB_INSTALL="$PREFIX/lib/"
-
-# The Makefile installs a version-stamped binary (nemo<MAJOR>.<MINOR>.<REV>);
-# expose it under the package's command name.
-# mv "${PREFIX}/bin/nemo2.4.0" "${PREFIX}/bin/nemo"
+mkdir -p "${PREFIX}/bin"
+# `make` builds a single version-stamped binary into bin/. On macOS the
+# MAC_ARM / MAC_x86 flags suffix its name (e.g. nemo<ver>-macARM); the
+# Makefile's `install` target recomputes BIN_NAME *without* those flags and
+# looks for the unsuffixed name, which fails on osx-arm64. Install the binary
+# that was actually produced, under the canonical command name (nemo<version>).
+built="$(ls -1 bin/nemo* | head -n1)"
+cp "${built}" "${PREFIX}/bin/nemo${PKG_VERSION}"

--- a/recipes/nemo/build.sh
+++ b/recipes/nemo/build.sh
@@ -60,3 +60,7 @@ else
 fi
 
 make install BIN_INSTALL="$PREFIX/bin/" LIB_INSTALL="$PREFIX/lib/"
+
+# The Makefile installs a version-stamped binary (nemo<MAJOR>.<MINOR>.<REV>);
+# expose it under the package's command name.
+# mv "${PREFIX}/bin/nemo2.4.0" "${PREFIX}/bin/nemo"

--- a/recipes/nemo/meta.yaml
+++ b/recipes/nemo/meta.yaml
@@ -1,19 +1,25 @@
 {% set version = "2.4.0" %}
+{% set commit = "e9e3a9ee947ca3140343c594a3e776783d292020" %}
 
 package:
   name: nemo
   version: {{ version }}
 
 source:
-  url: https://sourceforge.net/projects/nemo2/files/Nemo/{{ version }}/Nemo-{{ version }}-src.tgz
-  sha256: 4633d1b62186f672dd27761487e984016cdf98354f5cf78fa9e1a462191ef6b9
+  # Immutable, commit-pinned tarball from the public release repository.
+  # (Replaces the SourceForge tarball, whose contents were not stable.)
+  url: https://bitbucket.org/ecoevo/nemo-release/get/{{ commit }}.tar.gz
+  sha256: ea4b9361925bd06a89fe6c9c48d4c0ad8d0da3884f1e70f741d6cdd8c9310a54
 
 build:
-  number: 0
-  # Undefined symbols for architecture x86_64: "vtable for TTQuanti_diallelic_bitstring_no_pleio", referenced from:
-  # TProtoQuanti::hatch() in ttquanti.o
-  # NOTE: a missing vtable usually means the first non-inline virtual member function has no definition.
-  skip: True  # [osx and x86_64]
+  number: 1
+  # osx x86_64 fails to link:
+  #   Undefined symbols for architecture x86_64: "vtable for
+  #   TTQuanti_diallelic_bitstring_no_pleio", referenced from
+  #   TProtoQuanti::hatch() in ttquanti.o
+  # A missing vtable usually means the first non-inline virtual member function
+  # has no definition. Untested in new build #1
+  skip: true  # [osx and x86_64]
   run_exports:
     - {{ pin_subpackage('nemo', max_pin="x") }}
 
@@ -41,13 +47,13 @@ test:
     - nemo | grep "{{ version }}"
 
 about:
-  home: "https://nemo2.sourceforge.io"
+  home: "https://bitbucket.org/ecoevo/nemo-release"
   summary: "Individual-based forward-time genetics simulation software."
   license: "GPL-2.0-or-later"
   license_family: GPL
   license_file: COPYING
   doc_url: "https://nemo2.sourceforge.io"
-  dev_url: "https://sourceforge.net/projects/nemo2"
+  dev_url: "https://bitbucket.org/ecoevo/nemo-release"
 
 extra:
   additional-platforms:
@@ -55,3 +61,6 @@ extra:
     - osx-arm64
   identifiers:
     - doi:10.1093/bioinformatics/btl415
+  recipe-maintainers:
+    - fredgui
+    - mencian

--- a/recipes/nemo/meta.yaml
+++ b/recipes/nemo/meta.yaml
@@ -44,7 +44,7 @@ requirements:
 
 test:
   commands:
-    - nemo | grep "{{ version }}"
+    - nemo{{ version }} | grep "{{ version }}"
 
 about:
   home: "https://bitbucket.org/ecoevo/nemo-release"


### PR DESCRIPTION
 - switch source to new nemo-release repo at bitbucket.org/ecoevo/nemo-release
 - replaced deprecated MAC compile flag with arch-spec MAC_ARM and MAC_x86 flags in Makefile, moded `build.sh`
 - added recipe-maintainers in meta.yaml: fredgui & mencian

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

