### PR TITLE
Add grfmite-rs

### DIFF
--- a/recipes/grfmite-rs/build.sh
+++ b/recipes/grfmite-rs/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+
+# Build + install the release binary (named grf_rs) into the conda prefix.
+cargo install --no-track --locked --root "$PREFIX" --path .
+
+# The package is named grfmite-rs; also expose that as a command for discoverability.
+# (TIR-Learner's grf_new.py looks for `grf_rs` on PATH by default.)
+ln -sf grf_rs "$PREFIX/bin/grfmite-rs"

--- a/recipes/grfmite-rs/meta.yaml
+++ b/recipes/grfmite-rs/meta.yaml
@@ -11,11 +11,14 @@ source:
 
 build:
   number: 0
+  run_exports:
+    - {{ pin_subpackage('grfmite-rs', max_pin="x.x") }}
 
 requirements:
   build:
     - {{ compiler('rust') }}
     - {{ compiler('c') }}
+    - {{ stdlib('c') }}
 
 test:
   commands:

--- a/recipes/grfmite-rs/meta.yaml
+++ b/recipes/grfmite-rs/meta.yaml
@@ -1,0 +1,40 @@
+{% set name = "grfmite-rs" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/KGerhardt/grfmite-rs/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 4be41899f72ce200f95c97fc9bd163ef7379fb34bcff4903dd516ef76a4dcab7
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - {{ compiler('rust') }}
+    - {{ compiler('c') }}
+
+test:
+  commands:
+    - command -v grf_rs
+    - command -v grfmite-rs
+
+about:
+  home: https://github.com/KGerhardt/grfmite-rs
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  license_file: LICENSE
+  summary: "Fast parallel Rust reimplementation of GRF MITE detection (grf-main -c 1), used by TIR-Learner."
+  description: |
+    grfmite-rs is a from-scratch Rust implementation of the single GRF mode TIR-Learner
+    uses: grf-main -c 1 (MITE candidate detection). It is a drop-in, work-stealing,
+    parallel replacement that removes GRF's per-chunk runtime tail. It is NOT a full GRF
+    port -- only the MITE path is implemented; a complete GRF overhaul is future work.
+    The package installs the `grf_rs` binary and a `grfmite-rs` alias.
+
+extra:
+  recipe-maintainers:
+    - KGerhardt


### PR DESCRIPTION
New recipe: **grfmite-rs** 0.1.0 — https://github.com/KGerhardt/grfmite-rs

A fast, parallel Rust reimplementation of GRF's MITE detection (`grf-main -c 1`), the one
GRF mode [TIR-Learner](https://github.com/KGerhardt/TIR-Learner) uses. It is a clean-room
reimplementation: byte-identical to stock GRF (`genericrepeatfinder`) detection + `grf-filter`
in `--rle-cigar` mode, and ~40–55× faster single-threaded, with intra-chunk work-stealing to
absorb the repeat-dense "pathological" chunks that dominate GRF's runtime at scale.

- License: GPL-3.0-or-later (`LICENSE` bundled).
- Build: cargo (`{{ compiler('rust') }}`); installs `grf_rs` plus a `grfmite-rs` alias.
- Scope: MITE path only (not a full GRF port).

---
Recipe author / maintainer: @KGerhardt