### PR TITLE
Add bamboo-hts 0.1.0

### DIFF
--- a/recipes/bamboo-hts/build.sh
+++ b/recipes/bamboo-hts/build.sh
@@ -3,13 +3,15 @@ set -exuo pipefail
 
 if [ "$(uname)" == "Darwin" ]; then
     SHLIB_EXT="dylib"
-    export DYLD_FALLBACK_LIBRARY_PATH="${BUILD_PREFIX}/lib:${DYLD_FALLBACK_LIBRARY_PATH:-}"
+    CLANG_ROOT="${PREFIX}"
+    export DYLD_FALLBACK_LIBRARY_PATH="${CLANG_ROOT}/lib:${DYLD_FALLBACK_LIBRARY_PATH:-}"
 else
     SHLIB_EXT="so"
-    export LD_LIBRARY_PATH="${BUILD_PREFIX}/lib:${LD_LIBRARY_PATH:-}"
+    CLANG_ROOT="${BUILD_PREFIX}"
+    export LD_LIBRARY_PATH="${CLANG_ROOT}/lib:${LD_LIBRARY_PATH:-}"
 fi
 
-export LIBCLANG_PATH="${BUILD_PREFIX}/lib"
+export LIBCLANG_PATH="${CLANG_ROOT}/lib"
 export BINDGEN_EXTRA_CLANG_ARGS="-I${PREFIX}/include"
 TARGET_LIB="${LIBCLANG_PATH}/libclang.${SHLIB_EXT}"
 

--- a/recipes/bamboo-hts/build.sh
+++ b/recipes/bamboo-hts/build.sh
@@ -10,6 +10,7 @@ else
 fi
 
 export LIBCLANG_PATH="${BUILD_PREFIX}/lib"
+export BINDGEN_EXTRA_CLANG_ARGS="-I${PREFIX}/include"
 TARGET_LIB="${LIBCLANG_PATH}/libclang.${SHLIB_EXT}"
 
 if [ ! -f "${TARGET_LIB}" ]; then

--- a/recipes/bamboo-hts/build.sh
+++ b/recipes/bamboo-hts/build.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -exuo pipefail
+
+if [ "$(uname)" == "Darwin" ]; then
+    SHLIB_EXT="dylib"
+    export DYLD_FALLBACK_LIBRARY_PATH="${BUILD_PREFIX}/lib:${DYLD_FALLBACK_LIBRARY_PATH:-}"
+else
+    SHLIB_EXT="so"
+    export LD_LIBRARY_PATH="${BUILD_PREFIX}/lib:${LD_LIBRARY_PATH:-}"
+fi
+
+export LIBCLANG_PATH="${BUILD_PREFIX}/lib"
+TARGET_LIB="${LIBCLANG_PATH}/libclang.${SHLIB_EXT}"
+
+if [ ! -f "${TARGET_LIB}" ]; then
+    FOUND_LIB="$(find "${LIBCLANG_PATH}" -name "libclang*.${SHLIB_EXT}*" ! -name "*cpp*" | head -n 1 || true)"
+    if [ -n "${FOUND_LIB}" ]; then
+        ln -sf "${FOUND_LIB}" "${TARGET_LIB}"
+    fi
+fi
+
+"${PYTHON}" -m pip install . --no-deps --no-build-isolation -vvv

--- a/recipes/bamboo-hts/meta.yaml
+++ b/recipes/bamboo-hts/meta.yaml
@@ -30,9 +30,8 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - {{ stdlib('c') }}
-    - clangdev >=18,<19  # [linux]
-    - llvm-tools >=18,<19  # [linux]
-    - clang  # [osx]
+    - clangdev >=18,<19
+    - llvm-tools >=18,<19
     - libclang  # [osx]
     - pkg-config
   host:

--- a/recipes/bamboo-hts/meta.yaml
+++ b/recipes/bamboo-hts/meta.yaml
@@ -28,11 +28,10 @@ requirements:
   build:
     - {{ compiler('rust') }}
     - {{ compiler('c') }}
-    - {{ compiler('cxx') }}  # [linux]
+    - {{ compiler('cxx') }}
     - {{ stdlib('c') }}
-    - clangdev >=18,<19
-    - llvm-tools >=18,<19
-    - libclang  # [osx]
+    - clangdev >=18,<19  # [linux]
+    - llvm-tools >=18,<19  # [linux]
     - pkg-config
   host:
     - python >=3.10,<3.13
@@ -45,6 +44,9 @@ requirements:
     - libdeflate
     - libcurl
     - openssl  # [not osx]
+    - clangdev >=18,<19  # [osx]
+    - llvm-tools >=18,<19  # [osx]
+    - libclang  # [osx]
   run:
     - python >=3.10,<3.13
     - pyarrow >=16

--- a/recipes/bamboo-hts/meta.yaml
+++ b/recipes/bamboo-hts/meta.yaml
@@ -1,0 +1,64 @@
+{% set name = "bamboo-hts" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 30551a54dde231a268eaa40c0077d6e60e689911d837656701832e8b469d9383
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vvv
+  run_exports:
+    - {{ pin_subpackage('bamboo-hts', max_pin="x.x") }}
+  missing_dso_whitelist:
+    - "**/*.so"
+
+requirements:
+  build:
+    - {{ compiler('rust') }}
+    - {{ compiler('c') }}
+    - pkg-config
+  host:
+    - python
+    - pip
+    - maturin >=1.5,<2
+    - pyarrow >=16
+    - zlib
+    - bzip2
+    - xz
+    - libdeflate
+    - libcurl
+    - openssl  # [not osx]
+  run:
+    - python
+    - pyarrow >=16
+
+test:
+  imports:
+    - bamboo
+  commands:
+    - python -c "import bamboo as bm; print(bm.__version__)"
+    - python -c "from bamboo.compat import pysam"
+
+about:
+  home: https://github.com/donncha/bamboo
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: High-performance Python library for HTS data (BAM, CRAM, VCF)
+  description: |
+    Bamboo provides fast, pysam-compatible BAM/CRAM/VCF reading with native
+    Arrow columnar export for modern genomics workflows.
+  dev_url: https://github.com/donncha/bamboo
+  doc_url: https://github.com/donncha/bamboo/blob/main/MIGRATION.md
+
+extra:
+  recipe-maintainers:
+    - dnncha
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64

--- a/recipes/bamboo-hts/meta.yaml
+++ b/recipes/bamboo-hts/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: f281221bdc0b7b1275a585f8b32ce81abfc5bd47a2e7ef6186e335781c28480f
 
 build:
-  number: 1
+  number: 0
   script:
     - export LIBCLANG_PATH="$BUILD_PREFIX/lib"
     - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vvv

--- a/recipes/bamboo-hts/meta.yaml
+++ b/recipes/bamboo-hts/meta.yaml
@@ -1,3 +1,11 @@
+# Submit this file to bioconda-recipes as recipes/bamboo-hts/meta.yaml
+# Update version, sha256, and build number on each release.
+#
+#   1. Tag and push: git tag v0.1.0 && git push origin v0.1.0
+#   2. Wait for PyPI publish (release workflow)
+#   3. sha256sum dist/bamboo-0.1.0.tar.gz  (or curl PyPI sdist)
+#   4. Open PR: https://github.com/bioconda/bioconda-recipes (recipes/bamboo-hts/)
+
 {% set name = "bamboo-hts" %}
 {% set version = "0.1.0" %}
 
@@ -11,9 +19,7 @@ source:
 
 build:
   number: 0
-  script:
-    - export LIBCLANG_PATH="$BUILD_PREFIX/lib"
-    - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vvv
+  script: build.sh
   run_exports:
     - {{ pin_subpackage('bamboo-hts', max_pin="x.x") }}
   missing_dso_whitelist:
@@ -25,8 +31,10 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - {{ stdlib('c') }}
-    - clangdev >=18,<19
-    - llvm-tools >=18,<19
+    - clangdev >=18,<19  # [linux]
+    - llvm-tools >=18,<19  # [linux]
+    - clang  # [osx]
+    - libclang  # [osx]
     - pkg-config
   host:
     - python >=3.10,<3.13

--- a/recipes/bamboo-hts/meta.yaml
+++ b/recipes/bamboo-hts/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - llvm-tools >=18,<19
     - pkg-config
   host:
-    - python
+    - python >=3.10,<3.13
     - pip
     - maturin >=1.5,<2
     - pyarrow >=16
@@ -40,7 +40,7 @@ requirements:
     - libcurl
     - openssl  # [not osx]
   run:
-    - python
+    - python >=3.10,<3.13
     - pyarrow >=16
 
 test:

--- a/recipes/bamboo-hts/meta.yaml
+++ b/recipes/bamboo-hts/meta.yaml
@@ -30,8 +30,10 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - {{ stdlib('c') }}
-    - clangdev >=18,<19
-    - llvm-tools >=18,<19
+    - clangdev >=18,<19  # [linux]
+    - llvm-tools >=18,<19  # [linux]
+    - clangdev  # [osx]
+    - llvm-tools  # [osx]
     - libclang  # [osx]
     - pkg-config
   host:

--- a/recipes/bamboo-hts/meta.yaml
+++ b/recipes/bamboo-hts/meta.yaml
@@ -19,7 +19,6 @@ source:
 
 build:
   number: 0
-  script: build.sh
   run_exports:
     - {{ pin_subpackage('bamboo-hts', max_pin="x.x") }}
   missing_dso_whitelist:

--- a/recipes/bamboo-hts/meta.yaml
+++ b/recipes/bamboo-hts/meta.yaml
@@ -21,6 +21,9 @@ requirements:
   build:
     - {{ compiler('rust') }}
     - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - {{ stdlib('c') }}
+    - clangdev
     - pkg-config
   host:
     - python
@@ -58,7 +61,7 @@ about:
 
 extra:
   recipe-maintainers:
-    - donncha
+    - dnncha
   additional-platforms:
     - linux-aarch64
     - osx-arm64

--- a/recipes/bamboo-hts/meta.yaml
+++ b/recipes/bamboo-hts/meta.yaml
@@ -6,8 +6,8 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 30551a54dde231a268eaa40c0077d6e60e689911d837656701832e8b469d9383
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/bamboo_hts-{{ version }}.tar.gz
+  sha256: f281221bdc0b7b1275a585f8b32ce81abfc5bd47a2e7ef6186e335781c28480f
 
 build:
   number: 0
@@ -58,7 +58,7 @@ about:
 
 extra:
   recipe-maintainers:
-    - dnncha
+    - donncha
   additional-platforms:
     - linux-aarch64
     - osx-arm64

--- a/recipes/bamboo-hts/meta.yaml
+++ b/recipes/bamboo-hts/meta.yaml
@@ -10,8 +10,10 @@ source:
   sha256: f281221bdc0b7b1275a585f8b32ce81abfc5bd47a2e7ef6186e335781c28480f
 
 build:
-  number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vvv
+  number: 1
+  script:
+    - export LIBCLANG_PATH="$BUILD_PREFIX/lib"
+    - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vvv
   run_exports:
     - {{ pin_subpackage('bamboo-hts', max_pin="x.x") }}
   missing_dso_whitelist:
@@ -23,7 +25,8 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - {{ stdlib('c') }}
-    - clangdev
+    - clangdev >=18,<19
+    - llvm-tools >=18,<19
     - pkg-config
   host:
     - python

--- a/recipes/bamboo-hts/meta.yaml
+++ b/recipes/bamboo-hts/meta.yaml
@@ -28,12 +28,10 @@ requirements:
   build:
     - {{ compiler('rust') }}
     - {{ compiler('c') }}
-    - {{ compiler('cxx') }}
+    - {{ compiler('cxx') }}  # [linux]
     - {{ stdlib('c') }}
-    - clangdev >=18,<19  # [linux]
-    - llvm-tools >=18,<19  # [linux]
-    - clangdev  # [osx]
-    - llvm-tools  # [osx]
+    - clangdev >=18,<19
+    - llvm-tools >=18,<19
     - libclang  # [osx]
     - pkg-config
   host:


### PR DESCRIPTION
Adds [bamboo-hts](https://github.com/donncha/bamboo) — high-performance Python HTS library (BAM/CRAM/VCF) with pysam-compatible API and native Arrow columnar export.

**PyPI:** https://pypi.org/project/bamboo-hts/ (publish in progress — CI may need a re-run after wheels land)

**Install:** `pip install bamboo-hts` → `import bamboo`

Recipe maintainer: @dnncha