### PR TITLE
Update eastr-cpp to 2.1.0 and enable linux-aarch64

### DIFF
--- a/recipes/eastr-cpp/conda_build_config.yaml
+++ b/recipes/eastr-cpp/conda_build_config.yaml
@@ -1,0 +1,8 @@
+# EASTR uses std::filesystem, which on macOS requires a 10.15+ deployment
+# target. The default osx-64 target is older, so bump it for the Intel macOS
+# build (osx-arm64 is already >= 11.0). See:
+# https://conda-forge.org/docs/maintainer/knowledge_base/#newer-c-features-with-old-sdk
+c_stdlib_version:            # [osx and x86_64]
+  - "10.15"                  # [osx and x86_64]
+MACOSX_DEPLOYMENT_TARGET:    # [osx and x86_64]
+  - "10.15"                  # [osx and x86_64]

--- a/recipes/eastr-cpp/meta.yaml
+++ b/recipes/eastr-cpp/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "eastr-cpp" %}
-{% set version = "2.0.2" %}
+{% set version = "2.1.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   - url: https://github.com/ishinder/eastr-cpp/archive/v{{ version }}.tar.gz
-    sha256: 811bc0fbc3883626c5c8903ecd11c90fd411ef22ad2c496b5d7cb88f8b7b234b
+    sha256: 86890b3345f960b0decb514161cb32154f1afda5273e0c6cc1cc2a1542ff8f62
   - url: https://github.com/lh3/minimap2/archive/v2.28.tar.gz
     sha256: 5ea6683b4184b5c49f6dbaef2bc5b66155e405888a0790d1b21fd3c93e474278
     folder: external/minimap2
@@ -34,6 +34,7 @@ requirements:
 test:
   commands:
     - eastr --help
+    - eastr --version
 
 about:
   home: https://github.com/ishinder/eastr-cpp
@@ -55,3 +56,5 @@ extra:
   identifiers:
     - doi:10.1038/s41467-023-43017-4
     - biotools:eastr
+  additional_platforms:
+    - linux-aarch64

--- a/recipes/eastr-cpp/meta.yaml
+++ b/recipes/eastr-cpp/meta.yaml
@@ -22,6 +22,7 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - {{ stdlib('c') }}
     - cmake >=3.16
     - make
     - git


### PR DESCRIPTION
Updates the `eastr-cpp` recipe to the new upstream release **v2.1.0** and enables **linux-aarch64**.

### Changes
- Bump `version` 2.0.2 → 2.1.0 and update source `sha256`.
- Add `extra: additional_platforms: [linux-aarch64]` — ARM matters for Galaxy compute (AWS Graviton / linux-aarch64). Upstream builds and tests cleanly on linux-aarch64 in CI (the code uses minimap2's sse2neon path on ARM).
- Add an `eastr --version` smoke test (the version flag is new in 2.1.0).

### Notes
- v2.1.0 adds a `--version` flag, content-based input detection, and file-path outputs for single inputs; see the upstream changelog.
- I'm the package author and listed recipe maintainer (`ishinder`).

---
Please review and merge, thanks!