### PR TITLE
Add rammap recipe

### DIFF
--- a/recipes/rammap/build.sh
+++ b/recipes/rammap/build.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Bundle licenses of all vendored Rust dependencies for the MIT-compliant package.
+cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
+
+# rammap is a Cargo workspace; the binary lives in the `rammap` member crate.
+cargo install --no-track --locked --root "$PREFIX" --path rammap

--- a/recipes/rammap/meta.yaml
+++ b/recipes/rammap/meta.yaml
@@ -1,0 +1,45 @@
+{% set name = "rammap" %}
+{% set version = "1.1.1" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/jwanglab/rammap/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 1693880fd550b28c49f143ddb22f8a17941a80935eebd0f82bef6e93e65c9f6f
+
+build:
+  number: 0
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x") }}
+
+requirements:
+  build:
+    - {{ compiler('rust') }}
+    - {{ compiler('c') }}
+    - {{ stdlib('c') }}
+    - cargo-bundle-licenses
+
+test:
+  commands:
+    - rammap --version
+    - rammap --help
+
+about:
+  home: https://github.com/jwanglab/rammap
+  license: MIT
+  license_family: MIT
+  license_file:
+    - LICENSE
+    - THIRDPARTY.yml
+  summary: "An extensible and performant aligner and read mapper"
+  description: |
+    rammap is a pure-Rust, minimap2-compatible sequence aligner and read mapper.
+    It is designed to be extensible and performant for mapping sequencing reads
+    against reference sequences.
+  dev_url: https://github.com/jwanglab/rammap
+
+extra:
+  recipe-maintainers:
+    - thanhleviet


### PR DESCRIPTION
rammap is an extensible, performant, pure-Rust, minimap2-compatible sequence aligner and read mapper.

Upstream: https://github.com/jwanglab/rammap
Release: https://github.com/jwanglab/rammap/releases/tag/v1.1.1

Recipe notes:
- Builds the `rammap` binary from the v1.1.1 source tarball with `cargo install --locked`.
- rammap is a Cargo workspace; the binary lives in the `rammap` member crate, so the build uses `--path rammap`.
- Pure-Rust default build (no C/openssl dependencies); the jemalloc/mimalloc allocator features are opt-in and not enabled.
- Uses `cargo-bundle-licenses` with `THIRDPARTY.yml` added to `license_file` alongside the MIT `LICENSE`.
- `run_exports` pinned with `max_pin="x"` for the 1.x series.

sha256 of the v1.1.1 tarball verified locally: `1693880fd550b28c49f143ddb22f8a17941a80935eebd0f82bef6e93e65c9f6f`