### PR TITLE
update epytope: add pyensembl runtime dependency

### DIFF
--- a/recipes/epytope/meta.yaml
+++ b/recipes/epytope/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 973fd751095f0aa3f331f649f0ee04deb202b5b846dae8f85e331dcc07956651
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: "{{ PYTHON }} -m pip install . -vv"
   run_exports:
@@ -25,6 +25,7 @@ requirements:
     - beautifulsoup4
     - biopython
     - pandas >=2.1
+    - pyensembl
     - pymysql
     - pyomo >=4.0
     - python >=3.11


### PR DESCRIPTION
Adds `pyensembl` as a runtime dependency to epytope so the biocontainer ships it, enabling epytope's offline `PyEnsemblAdapter` (used by nf-core/epitopeprediction).

Version is unchanged (4.0.0); this is a recipe-only change, so the build number is bumped 0 -> 1.

----

### General instructions

* [x] If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* [x] This is an update to an existing recipe relevant to the biological sciences.
* [x] PRs require reviews prior to being merged.

### run_exports

* [x] `run_exports` is already present in the recipe and unchanged.