### PR TITLE
Update ecmsd 1.1.0 -> 1.2.0 (add r-gridextra, r-data.table)

### DIFF
--- a/recipes/ecmsd/meta.yaml
+++ b/recipes/ecmsd/meta.yaml
@@ -22,6 +22,8 @@ requirements:
     - bbmap
     - r-base
     - r-tidyverse
+    - r-gridextra
+    - r-data.table
     - pigz
     - wget
     - python >=3.6

--- a/recipes/ecmsd/meta.yaml
+++ b/recipes/ecmsd/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "ECMSD" %}
-{% set version = "1.1.0" %}
-{% set sha256 = "faa83378592d684f410515be28383b81b8b8c22537dbd029ff1811e1bc49b19b" %}
+{% set version = "1.2.0" %}
+{% set sha256 = "4cc8c1d095ca53ca4d1a139079e9dfd482feed0121865731a772fe81c4f6d0e6" %}
 
 package:
   name: "{{ name|lower }}"


### PR DESCRIPTION
Supersedes #66066 (autobump PR).

Same version bump `1.1.0 → 1.2.0` but adds two new runtime dependencies introduced in v1.2.0:

- `r-gridextra` — used in `scripts/plot_paf_alignments.R`
- `r-data.table` — used in `scripts/plot_paf_alignments.R` and `scripts/process_files.R`

Both packages are available on conda-forge.