### PR TITLE
Update eastr-cpp to 2.1.1

### DIFF
--- a/recipes/eastr-cpp/meta.yaml
+++ b/recipes/eastr-cpp/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "eastr-cpp" %}
-{% set version = "2.1.0" %}
+{% set version = "2.1.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   - url: https://github.com/ishinder/eastr-cpp/archive/v{{ version }}.tar.gz
-    sha256: 86890b3345f960b0decb514161cb32154f1afda5273e0c6cc1cc2a1542ff8f62
+    sha256: b5066cb4763853c9e1d645d7b13c2874b35636732131f5dc61c0b6c70056ada9
   - url: https://github.com/lh3/minimap2/archive/v2.28.tar.gz
     sha256: 5ea6683b4184b5c49f6dbaef2bc5b66155e405888a0790d1b21fd3c93e474278
     folder: external/minimap2


### PR DESCRIPTION
Patch release of the `eastr-cpp` recipe to upstream **v2.1.1**.

### Changes
- Bump `version` 2.1.0 → 2.1.1 and update source `sha256`.

### What's in 2.1.1
Bug fix: a single-BAM `--out_filtered_bam <file>` with a bare filename (e.g. `--out_filtered_bam filtered.bam`) created a *directory* named after the output instead of writing the file. Now it writes the file as intended.

(linux-aarch64 + `eastr --version` test from the 2.1.0 recipe are retained.)

I'm the package author and listed recipe maintainer (`ishinder`).