### PR TITLE
Add mr-mega

### DIFF
--- a/recipes/mr-mega/build.sh
+++ b/recipes/mr-mega/build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -eux -o pipefail
+
+# Respect Conda compiler/linker flags and link zlib from the host environment.
+sed -i.bak 's/^CC = g++/CXX ?= g++/' Makefile
+sed -i.bak 's/^DEBUGFLAGS = -Wno-deprecated -O1 -lz/DEBUGFLAGS ?= -Wno-deprecated -O1/' Makefile
+sed -i.bak 's/^	g++ /	$(CXX) $(CXXFLAGS) $(CPPFLAGS) /' Makefile
+sed -i.bak 's/ $(DEBUGFLAGS) -o MR-MEGA/ $(DEBUGFLAGS) $(LDFLAGS) -o MR-MEGA -lz/' Makefile
+
+make
+
+mkdir -p "${PREFIX}/bin"
+install -m 775 MR-MEGA "${PREFIX}/bin/"

--- a/recipes/mr-mega/meta.yaml
+++ b/recipes/mr-mega/meta.yaml
@@ -1,0 +1,42 @@
+{% set version = "0.2" %}
+
+package:
+  name: mr-mega
+  version: {{ version }}
+
+source:
+  url: https://tools.gi.ut.ee/tools/MR-MEGA_v{{ version }}.zip
+  sha256: e91eb5bdba0a398619e6cd98c351ea72d94e09d6f5a1d25bb7da8a66da938ffe
+
+build:
+  number: 0
+  run_exports:
+    - {{ pin_subpackage('mr-mega', max_pin="x.x") }}
+
+requirements:
+  build:
+    - make
+    - {{ compiler('cxx') }}
+    - {{ stdlib('c') }}
+  host:
+    - zlib
+
+test:
+  commands:
+    - MR-MEGA --help | grep "MR-MEGA"
+    - MR-MEGA --version | grep "{{ version }}"
+
+about:
+  home: https://genomics.ut.ee/en/tools
+  license: GPL-2.0-or-later AND BSD-3-Clause AND MIT
+  license_file:
+    - main.cpp
+    - igammaf.cpp
+    - Arg.h
+  summary: Meta-regression of multi-ancestry genetic association results
+
+extra:
+  identifiers:
+    - doi:10.1093/hmg/ddx280
+  recipe-maintainers:
+    - lyh970817


### PR DESCRIPTION
Adds a new recipe for MR-MEGA 0.2.

MR-MEGA is a GWAS/statistical genetics command-line tool for meta-regression of multi-ancestry genetic association results, so it fits Bioconda’s biological-sciences scope.

Packaging notes:
- Builds the upstream C++ source archive from the University of Tartu tools site.
- Patches the upstream Makefile to respect Conda compiler, compiler flag, linker flag, and zlib settings.
- Adds `run_exports` with minor-version pinning for the 0.x compiled CLI.
- Upstream does not ship a standalone license file, so the recipe packages embedded license headers from `main.cpp`, `igammaf.cpp`, and `Arg.h`.

Validation:
- `bioconda-utils lint recipes config.yml --packages mr-mega`
- `bioconda-utils build recipes config.yml --packages mr-mega --no-fast-resolve`