### PR TITLE
Add vcfclick recipe

### DIFF
--- a/recipes/vcfclick/meta.yaml
+++ b/recipes/vcfclick/meta.yaml
@@ -1,0 +1,88 @@
+{% set name = "vcfclick" %}
+{% set version = "0.3.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/v/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  # SHA256 of the v0.3.1 sdist published to PyPI on 2026-06-08.
+  # Verified to match `shasum -a 256 dist/vcfclick-0.3.1.tar.gz` from
+  # the local `uv build` (deterministic for this version's metadata).
+  sha256: a2707612651b62c58452dfcbb3db6d3d78d90d9affa3852ca985e32981f1648f
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  run_exports:
+    - {{ pin_subpackage(name|lower, max_pin="x.x") }}
+  entry_points:
+    - vcfclick = cli.main:cli
+
+requirements:
+  host:
+    - python >=3.11
+    - pip
+    - hatchling
+  run:
+    - python >=3.11
+    # Variant store. We ship DuckDB only on bioconda; the chDB
+    # ClickHouse engine isn't packageable for conda-forge (see
+    # https://github.com/chdb-io/chdb/issues/189 — closed wontfix
+    # in 2024 because chDB only releases binary wheels and conda
+    # requires source builds with non-clang toolchains). vcfclick
+    # auto-detects: with chdb absent, it runs on DuckDB.
+    - duckdb >=1.0
+    # VCF parsing (htslib via Python).
+    - cyvcf2 >=0.31
+    # Columnar interchange + chDB-compatible Parquet schemas.
+    - pyarrow >=15
+    # MCP server for natural-language queries.
+    - mcp >=1.0
+    # CLI framework.
+    - click >=8.1
+
+test:
+  imports:
+    - storage
+    - ingest
+    - cli
+    - vcfclick_mcp
+  commands:
+    - vcfclick --version
+    - vcfclick db --help
+    # The smoke test below confirms the DuckDB backend actually
+    # works end-to-end inside the conda environment — catches the
+    # case where one of duckdb / cyvcf2 / pyarrow / mcp has a
+    # binary-incompatibility on a target platform.
+    - VCFCLICK_BACKEND=duckdb vcfclick db create smoke
+    - VCFCLICK_BACKEND=duckdb vcfclick db rm --yes smoke
+
+about:
+  home: https://github.com/nuin/vcfclick
+  license: Apache-2.0
+  license_family: Apache
+  license_file: LICENSE
+  summary: Embedded VCF databases with auditable natural-language queries
+  description: |
+    vcfclick is an embedded analytical store for cohort Variant Call Format
+    (VCF) data. One cohort lives in one directory; queries run in the calling
+    process with no daemon, no client/server hop. Variants, genotypes, and
+    samples are held in DuckDB (the bioconda variant) or chDB (an optional pip
+    extra), alongside a DuckDB file of gene and ClinVar annotations. A bundled
+    Model Context Protocol server exposes a small set of tools that lets a
+    language-model client query the cohort in natural language and see the SQL
+    it generated.
+
+    Designed for the gap between bcftools/cyvcf2 (single-file, no persistence)
+    and Hail/TileDB-VCF (cluster-scale). Atomic two-phase ingest with rollback;
+    sparse-aware cohort allele-frequency math; Arrow/Parquet as a public
+    interchange format via `db dump` and `db ingest-parquet`.
+  doc_url: https://github.com/nuin/vcfclick/blob/main/docs/SCHEMA.md
+  dev_url: https://github.com/nuin/vcfclick
+
+extra:
+  recipe-maintainers:
+    - nuin

--- a/recipes/vcfclick/meta.yaml
+++ b/recipes/vcfclick/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "vcfclick" %}
-{% set version = "0.3.1" %}
+{% set version = "0.8.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/v/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: a2707612651b62c58452dfcbb3db6d3d78d90d9affa3852ca985e32981f1648f
+  sha256: 18ae95bcb80671acf636aa65e143c415423e0c36025b3931b0640fd0df877c37
 
 build:
   noarch: python
@@ -30,6 +30,8 @@ requirements:
     - pyarrow >=15
     - mcp >=1.0
     - click >=8.1
+    - pyfaidx >=0.8
+    - numpy >=1.24
 
 test:
   imports:
@@ -37,9 +39,11 @@ test:
     - ingest
     - cli
     - vcfclick_mcp
+    - benchmark
   commands:
     - vcfclick --version
     - vcfclick db --help
+    - vcfclick benchmark --help
     - VCFCLICK_BACKEND=duckdb vcfclick db create smoke
     - VCFCLICK_BACKEND=duckdb vcfclick db rm --yes smoke
 
@@ -62,8 +66,10 @@ about:
     are available as a public interchange format via `db dump` and
     `db ingest-parquet`.
 
-    New versions will add VCF merging like GATK3 and variant detection on
-    trios using different genotype models.
+    It also reimplements GATK3-style CombineVariants (`combine`), trio
+    analysis across Mendelian inheritance models (`db trio`), and a native
+    truth-vs-query concordance benchmark (`benchmark`) with normalized and
+    local-haplotype engines and GA4GH-shaped reports.
   doc_url: https://github.com/nuin/vcfclick/blob/main/docs/SCHEMA.md
   dev_url: https://github.com/nuin/vcfclick
 

--- a/recipes/vcfclick/meta.yaml
+++ b/recipes/vcfclick/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "vcfclick" %}
-{% set version = "0.8.0" %}
+{% set version = "0.8.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/v/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 18ae95bcb80671acf636aa65e143c415423e0c36025b3931b0640fd0df877c37
+  sha256: 6ab28ac8dd09a8456457526d51fd2c79c55049acd938bb5d828707509f183842
 
 build:
   noarch: python

--- a/recipes/vcfclick/meta.yaml
+++ b/recipes/vcfclick/meta.yaml
@@ -7,9 +7,6 @@ package:
 
 source:
   url: https://pypi.io/packages/source/v/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  # SHA256 of the v0.3.1 sdist published to PyPI on 2026-06-08.
-  # Verified to match `shasum -a 256 dist/vcfclick-0.3.1.tar.gz` from
-  # the local `uv build` (deterministic for this version's metadata).
   sha256: a2707612651b62c58452dfcbb3db6d3d78d90d9affa3852ca985e32981f1648f
 
 build:
@@ -28,20 +25,10 @@ requirements:
     - hatchling
   run:
     - python >=3.11
-    # Variant store. We ship DuckDB only on bioconda; the chDB
-    # ClickHouse engine isn't packageable for conda-forge (see
-    # https://github.com/chdb-io/chdb/issues/189 — closed wontfix
-    # in 2024 because chDB only releases binary wheels and conda
-    # requires source builds with non-clang toolchains). vcfclick
-    # auto-detects: with chdb absent, it runs on DuckDB.
     - duckdb >=1.0
-    # VCF parsing (htslib via Python).
     - cyvcf2 >=0.31
-    # Columnar interchange + chDB-compatible Parquet schemas.
     - pyarrow >=15
-    # MCP server for natural-language queries.
     - mcp >=1.0
-    # CLI framework.
     - click >=8.1
 
 test:
@@ -53,10 +40,6 @@ test:
   commands:
     - vcfclick --version
     - vcfclick db --help
-    # The smoke test below confirms the DuckDB backend actually
-    # works end-to-end inside the conda environment — catches the
-    # case where one of duckdb / cyvcf2 / pyarrow / mcp has a
-    # binary-incompatibility on a target platform.
     - VCFCLICK_BACKEND=duckdb vcfclick db create smoke
     - VCFCLICK_BACKEND=duckdb vcfclick db rm --yes smoke
 
@@ -68,18 +51,19 @@ about:
   summary: Embedded VCF databases with auditable natural-language queries
   description: |
     vcfclick is an embedded analytical store for cohort Variant Call Format
-    (VCF) data. One cohort lives in one directory; queries run in the calling
-    process with no daemon, no client/server hop. Variants, genotypes, and
-    samples are held in DuckDB (the bioconda variant) or chDB (an optional pip
-    extra), alongside a DuckDB file of gene and ClinVar annotations. A bundled
-    Model Context Protocol server exposes a small set of tools that lets a
-    language-model client query the cohort in natural language and see the SQL
-    it generated.
+    (VCF) data. The cohort is stored in its own directory, and queries run
+    without a daemon, fully serverless. For Bioconda, DuckDB is used for
+    storage of all variants, genotypes, and annotations if needed. chDB can
+    be used after being installed by pip. DuckDB also stores annotations as
+    one extra file per cohort, added with a separate command.
 
-    Designed for the gap between bcftools/cyvcf2 (single-file, no persistence)
-    and Hail/TileDB-VCF (cluster-scale). Atomic two-phase ingest with rollback;
-    sparse-aware cohort allele-frequency math; Arrow/Parquet as a public
-    interchange format via `db dump` and `db ingest-parquet`.
+    MCP is bundled in the package, exposing the underlying query system so
+    an LLM can query the databases across different cohorts. Arrow/Parquet
+    are available as a public interchange format via `db dump` and
+    `db ingest-parquet`.
+
+    New versions will add VCF merging like GATK3 and variant detection on
+    trios using different genotype models.
   doc_url: https://github.com/nuin/vcfclick/blob/main/docs/SCHEMA.md
   dev_url: https://github.com/nuin/vcfclick
 


### PR DESCRIPTION
Adds a new Bioconda recipe for vcfclick 0.3.1.

Package notes:
- Source is the published PyPI sdist for 0.3.1 with verified SHA256: a2707612651b62c58452dfcbb3db6d3d78d90d9affa3852ca985e32981f1648f.
- Bioconda recipe uses the DuckDB backend only; chDB is intentionally omitted because it is not packageable for conda-forge.
- Smoke tests exercise the CLI and create/remove a DuckDB-backed database.

Upstream validation before submission:
- GitHub release workflow for v0.3.1: passed and published to PyPI.
- PyPI JSON confirms vcfclick-0.3.1.tar.gz sdist hash matches the recipe.
- npx aislop scan: clean, 100/100.
- VCFCLICK_BACKEND=duckdb uv run pytest: 106 passed, 11 skipped.
- Focused default-backend checks: 4 passed.

Local default chDB full-suite note: macOS full-suite runs still show intermittent chDB subprocess aborts (rc=-5/-6) in unrelated integration tests; the isolated failures pass when rerun and the DuckDB backend used by this Bioconda recipe is clean.