### PR TITLE
Update get_mnv to 1.1.4

### DIFF
--- a/recipes/get_mnv/meta.yaml
+++ b/recipes/get_mnv/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "get_mnv" %}
-{% set version = "1.1.3" %}
-{% set sha256 = "85116fddf639eefdf4244d870391748ccd93ac95de69ad224a3217cedfdb3fc8" %}
+{% set version = "1.1.4" %}
+{% set sha256 = "482f3d0c4cb41134c37559c0b7cf9b9a6076a8075930804a13a64752c19ff0ec" %}
 
 package:
   name: "{{ name|lower }}"

--- a/recipes/get_mnv/meta.yaml
+++ b/recipes/get_mnv/meta.yaml
@@ -17,6 +17,7 @@ build:
     export LANG=C.UTF-8
     export LC_ALL=C.UTF-8
     export RUST_BACKTRACE=1
+    cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
     cargo install --no-track --locked --verbose --root "${PREFIX}" --path . --bin get_mnv
   run_exports:
     - {{ pin_subpackage(name, max_pin="x") }}
@@ -26,6 +27,7 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('rust') }}
     - {{ stdlib('c') }}
+    - cargo-bundle-licenses
     - pkg-config
 
 test:
@@ -37,7 +39,9 @@ about:
   home: "https://github.com/PathoGenOmics-Lab/get_mnv"
   license: "AGPL-3.0-or-later"
   license_family: AGPL
-  license_file: LICENSE
+  license_file:
+    - LICENSE
+    - THIRDPARTY.yml
   summary: "Tool to identify Multi-Nucleotide Variants (MNVs) in genomic sequences."
   description: |
     get_MNV is a tool designed to identify Multi-Nucleotide Variants (MNVs) within the same codon in genomic sequences, providing more accurate annotation for genomic data. Pure Rust implementation with no C dependencies.


### PR DESCRIPTION
Update get_mnv to version 1.1.4.

Changes:
- bump version from 1.1.3 to 1.1.4
- update the source sha256 for the 1.1.4 tag

Validation:
- verified source tarball sha256
- ran git diff --check

The existing recipe structure from the previous get_mnv update is unchanged.