### PR TITLE
Update tir-learner to 4.07 (pin grfmite-rs >=0.3.0)

### DIFF
--- a/recipes/tir-learner/meta.yaml
+++ b/recipes/tir-learner/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "TIR-Learner" %}
-{% set version = "4.05" %}
-{% set sha256 = "c04ebe0dd3b8a5455245f16660cbf7ac6a9eace5d492422ecc2aac29f49119dd" %}
+{% set version = "4.07" %}
+{% set sha256 = "34f22246e71238a06ac65000f5b12d4f9bed752f5f40c76bb81b6a910816d32d" %}
 
 package:
   name: {{ name | lower }}
@@ -25,7 +25,7 @@ requirements:
     - keras
     - pytorch
     - genometools-genometools
-    - grfmite-rs
+    - grfmite-rs >=0.3.0
     - blast
     - pigz
 


### PR DESCRIPTION
Supersedes the autobump #66096, which bumps to 4.07 but leaves `grfmite-rs` unpinned.

TIR-Learner v4.07 reads grfmite-rs's new streamed line format (`<base>.grf.txt`) candidate output. grfmite-rs **< 0.3.0** emits the previous columnar `candidate.json`, so tir-learner 4.07 + grfmite-rs 0.2.x is an installable-but-broken combination. This is identical to the autobump (version 4.07, same sha256) plus the required run pin `grfmite-rs >=0.3.0`. grfmite-rs 0.3.0 is in #66154 and should merge first.