### PR TITLE
Update bowtie tests and rebuild

### DIFF
--- a/recipes/bowtie/meta.yaml
+++ b/recipes/bowtie/meta.yaml
@@ -12,8 +12,7 @@ source:
     - rename_version_to_version_txt.patch
 
 build:
-  skip: True  # [py<30]
-  number: 10
+  number: 11
   run_exports:
     - {{ pin_subpackage("bowtie", max_pin="x.x") }}
 
@@ -24,7 +23,6 @@ requirements:
     - {{ compiler('cxx') }}
     - zlib
   host:
-    - python
     - tbb
     - tbb-devel
     - zlib
@@ -45,6 +43,13 @@ test:
     - bowtie-inspect --help
     - bowtie-inspect-l --help
     - bowtie-inspect-s --help
+    - printf ">ref\nACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT\n" > ref.fa
+    - bowtie-build ref.fa ref
+    - printf "@read1\nACGTACGTACGTACGTACGTACGTACGTACGT\n+\nIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII\n" > reads.fq
+    - bowtie -S ref reads.fq > out.sam
+    - grep -q "^read1" out.sam
+    - bowtie-inspect ref > inspected.fa
+    - grep -q "^>ref" inspected.fa
 
 about:
   home: https://github.com/BenLangmead/bowtie

--- a/recipes/bowtie/meta.yaml
+++ b/recipes/bowtie/meta.yaml
@@ -20,6 +20,7 @@ requirements:
   build:
     - make
     - patch  # [osx]
+    - {{ stdlib("c") }}
     - {{ compiler('cxx') }}
     - zlib
   host:


### PR DESCRIPTION
This PR removes the unnecessary Python host dependency from the bowtie recipe.

Bowtie itself is not a Python package and does not require Python at runtime. However, the current recipe includes Python in the host requirements and also has a Python-version-based build skip selector. This can cause dependency resolution issues in Python 3.13 environments, where conda may resolve to an older bowtie package such as bowtie v1.0.0 instead of the latest available bowtie v1.3.1.

Changes:

* Remove Python from the host requirements
* Remove the Python-version-based build skip selector
* Bump the build number from 10 to 11
* Add a minimal functional test for bowtie-build, bowtie, and bowtie-inspect using a tiny FASTA/FASTQ example

No upstream version update is included; the latest Bowtie release remains v1.3.1.


----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
