### PR TITLE
Update gottcha2 entry point

### DIFF
--- a/recipes/gottcha2/meta.yaml
+++ b/recipes/gottcha2/meta.yaml
@@ -7,25 +7,25 @@ package:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install -vvv --no-deps --no-build-isolation --no-cache-dir .
   entry_points:
-    - gottcha2 = gottcha.scripts.cmd:gottcha2_command
+    - gottcha2 = gottcha.gottcha2:cli
   run_exports:
     - {{ pin_subpackage('gottcha2', max_pin='x') }}
 
 source:
-  url: https://github.com/poeli/GOTTCHA2/archive/refs/tags/{{ version }}.tar.gz
+  url: https://github.com/poeli-lanl/GOTTCHA2/archive/refs/tags/{{ version }}.tar.gz
   sha256: 96f3f2433eb96dd185851e65d6d52fc7d134eaa43cbb6de805a94c0aa43a0006
 
 requirements:
   host:
-    - python >=3.6
+    - python >=3.9
     - pip
     - setuptools
     - pandas
   run:
-    - python >=3.6
+    - python >=3.9
     - minimap2 >=2.17
     - gawk
     - biom-format >=2.1.7
@@ -33,21 +33,22 @@ requirements:
     - pandas
     - requests
     - tqdm
+    - pysam >=0.22.0
 
 test:
   commands:
     - minimap2 -h
-    - gawk -h
-    - gottcha2.py --version
+    - python -c "import gottcha.gottcha2 as g; assert g.__version__ == '{{ version }}'"
+    - gottcha2 version
 
 about:
-  home: https://github.com/poeli/GOTTCHA2
-  license: BSD-3-Clause
+  home: https://github.com/poeli-lanl/GOTTCHA2
+  license: BSD-3
   license_family: BSD
   license_file: LICENSE
   summary: 'Genomic Origin Through Taxonomic CHAllenge (GOTTCHA) v2.'
-  dev_url: https://github.com/poeli/GOTTCHA2
-  doc_url: https://github.com/poeli/GOTTCHA2/wiki
+  dev_url: https://github.com/poeli-lanl/GOTTCHA2
+  doc_url: https://github.com/poeli-lanl/GOTTCHA2/wiki
 
 extra:
   identifiers:


### PR DESCRIPTION
This PR fixes the `gottcha2` Bioconda package for version 2.4.0.

The current Bioconda recipe creates the console entry point:

```yaml
gottcha2 = gottcha.scripts.cmd:gottcha2_command
```

However, the upstream package now defines the entry point as:

```yaml
gottcha2 = gottcha.gottcha2:cli
```

Because the old `gottcha.scripts.cmd` module no longer exists in the current upstream source, installing `gottcha2` from Bioconda currently produces this runtime error:

```text
ModuleNotFoundError: No module named 'gottcha.scripts'
```

This PR updates the recipe to match the current upstream package layout.

Changes included:

* Updates the `gottcha2` entry point to `gottcha.gottcha2:cli`
* Bumps the build number from `0` to `1`
* Updates the Python requirement to match the upstream package
* Adds `pysam` as a runtime dependency
* Updates the test commands to verify the installed Python module and CLI
* Keeps the existing `run_exports` section unchanged

This is a recipe-only rebuild for the existing 2.4.0 release.
