### PR TITLE
bump mehari and mehari-python to 0.43.3

### DIFF
--- a/recipes/mehari-python/meta.yaml
+++ b/recipes/mehari-python/meta.yaml
@@ -14,7 +14,7 @@ build:
   number: 0
   skip: True  # [osx or py<312]
   run_exports:
-    - {{ pin_subpackage('{{ name }}', max_pin="x.x") }}
+    - {{ pin_subpackage(name, max_pin="x.x") }}
 
 requirements:
   build:

--- a/recipes/mehari-python/meta.yaml
+++ b/recipes/mehari-python/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/varfish-org/mehari/archive/v{{ version }}.tar.gz
+  url: https://github.com/varfish-org/mehari/archive/{{ name }}-v{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:

--- a/recipes/mehari-python/meta.yaml
+++ b/recipes/mehari-python/meta.yaml
@@ -1,8 +1,9 @@
 {% set version = "0.43.3" %}
 {% set sha256 = "c765e66e8124200aefc3afd4fd4176d15cdfc6927d4f108af5fe020c31d53b6b" %}
+{% set name = "mehari-python" %}
 
 package:
-  name: mehari-python
+  name: {{ name }}
   version: {{ version }}
 
 source:
@@ -13,7 +14,7 @@ build:
   number: 0
   skip: True  # [osx or py<312]
   run_exports:
-    - {{ pin_subpackage('mehari-python', max_pin="x.x") }}
+    - {{ pin_subpackage('{{ name }}', max_pin="x.x") }}
 
 requirements:
   build:
@@ -55,7 +56,7 @@ about:
   license_file: "LICENSE.txt"
   summary: "Python bindings for mehari."
   dev_url: "https://github.com/varfish-org/mehari"
-  doc_url: "https://github.com/varfish-org/mehari/blob/v{{ version }}/mehari-python/README.md"
+  doc_url: "https://github.com/varfish-org/mehari/blob/v{{ version }}/{{ name }}/README.md"
 
 extra:
   additional-platforms:

--- a/recipes/mehari-python/meta.yaml
+++ b/recipes/mehari-python/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "0.43.2" %}
-{% set sha256 = "03104fdc9cdcbd7060aec376ef7c136dcf369a522fbc1824b3c423817d4f5238" %}
+{% set version = "0.43.3" %}
+{% set sha256 = "c765e66e8124200aefc3afd4fd4176d15cdfc6927d4f108af5fe020c31d53b6b" %}
 
 package:
   name: mehari-python

--- a/recipes/mehari/meta.yaml
+++ b/recipes/mehari/meta.yaml
@@ -1,8 +1,9 @@
 {% set version = "0.43.3" %}
 {% set sha256 = "6a6263c12ee66e21fcc33bb58a5166b1cb385d72db61621b973f9e04ca0d23b1" %}
+{% set name = "mehari" %}
 
 package:
-  name: mehari
+  name: {{ name }}
   version: {{ version }}
 
 source:
@@ -13,7 +14,7 @@ build:
   number: 0
   skip: True  # [osx]
   run_exports:
-    - {{ pin_subpackage('mehari', max_pin="x.x") }}
+    - {{ pin_subpackage('{{ name }}', max_pin="x.x") }}
 
 requirements:
   build:

--- a/recipes/mehari/meta.yaml
+++ b/recipes/mehari/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/varfish-org/mehari/archive/v{{ version }}.tar.gz
+  url: https://github.com/varfish-org/mehari/archive/{{ name }}-v{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:

--- a/recipes/mehari/meta.yaml
+++ b/recipes/mehari/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "0.43.2" %}
-{% set sha256 = "03104fdc9cdcbd7060aec376ef7c136dcf369a522fbc1824b3c423817d4f5238" %}
+{% set version = "0.43.3" %}
+{% set sha256 = "6a6263c12ee66e21fcc33bb58a5166b1cb385d72db61621b973f9e04ca0d23b1" %}
 
 package:
   name: mehari

--- a/recipes/mehari/meta.yaml
+++ b/recipes/mehari/meta.yaml
@@ -14,7 +14,7 @@ build:
   number: 0
   skip: True  # [osx]
   run_exports:
-    - {{ pin_subpackage('{{ name }}', max_pin="x.x") }}
+    - {{ pin_subpackage(name, max_pin="x.x") }}
 
 requirements:
   build:


### PR DESCRIPTION
For some reason, autobump didn't pick these up correctly.