### PR TITLE
Add salmon-cpp: the final C++ salmon (1.12.0)

### DIFF
--- a/recipes/salmon-cpp/build.sh
+++ b/recipes/salmon-cpp/build.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BUILD_DIR="${SRC_DIR}/build"
+DEPS_PREFIX="${SRC_DIR}/_deps_prefix"
+THIRDPARTY_DIR="${SRC_DIR}/_thirdparty"
+CMAKE_SHIM_DIR="${SRC_DIR}/_cmake_shims"
+
+ZLIBNG_VERSION="2.3.3"
+ZLIBNG_URL="https://github.com/zlib-ng/zlib-ng/archive/refs/tags/${ZLIBNG_VERSION}.tar.gz"
+ZLIBNG_TARBALL="${THIRDPARTY_DIR}/zlib-ng-${ZLIBNG_VERSION}.tar.gz"
+ZLIBNG_SRC_DIR="${THIRDPARTY_DIR}/zlib-ng-${ZLIBNG_VERSION}"
+
+mkdir -p "${BUILD_DIR}" "${DEPS_PREFIX}" "${THIRDPARTY_DIR}" "${CMAKE_SHIM_DIR}"
+
+# Build zlib-ng (compat mode)
+curl -L --fail "${ZLIBNG_URL}" -o "${ZLIBNG_TARBALL}"
+tar -xzf "${ZLIBNG_TARBALL}" -C "${THIRDPARTY_DIR}"
+
+cmake -S "${ZLIBNG_SRC_DIR}" -B "${ZLIBNG_SRC_DIR}/build" -G Ninja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX="${DEPS_PREFIX}" \
+  -DZLIB_COMPAT=ON \
+  -DBUILD_SHARED_LIBS=OFF \
+  -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+  -DZLIB_ENABLE_TESTS=OFF \
+  -DWITH_GTEST=OFF \
+  -DWITH_FUZZERS=OFF \
+  -DWITH_BENCHMARKS=OFF \
+  -DWITH_BENCHMARK_APPS=OFF
+
+cmake --build "${ZLIBNG_SRC_DIR}/build" --parallel "${CPU_COUNT:-4}"
+cmake --install "${ZLIBNG_SRC_DIR}/build"
+
+# Detect libdir
+if [[ -f "${DEPS_PREFIX}/lib64/libz.a" ]]; then
+  ZLIB_LIBDIR="${DEPS_PREFIX}/lib64"
+elif [[ -f "${DEPS_PREFIX}/lib/libz.a" ]]; then
+  ZLIB_LIBDIR="${DEPS_PREFIX}/lib"
+else
+  echo "ERROR: libz.a not found under ${DEPS_PREFIX}/lib64 or ${DEPS_PREFIX}/lib"
+  exit 1
+fi
+
+# Provide FindZLIBNG.cmake shim
+cat > "${CMAKE_SHIM_DIR}/FindZLIBNG.cmake" <<EOF
+find_package(ZLIB CONFIG REQUIRED
+  PATHS "${ZLIB_LIBDIR}/cmake/ZLIB"
+  NO_DEFAULT_PATH)
+
+if(TARGET ZLIB::ZLIB AND NOT TARGET ZLIBNG::ZLIBNG)
+  add_library(ZLIBNG::ZLIBNG INTERFACE IMPORTED)
+  target_link_libraries(ZLIBNG::ZLIBNG INTERFACE ZLIB::ZLIB)
+endif()
+
+set(ZLIBNG_FOUND TRUE)
+set(ZLIBNG_INCLUDE_DIR "${DEPS_PREFIX}/include")
+set(ZLIBNG_LIBRARY ZLIBNG::ZLIBNG)
+EOF
+
+# Diagnostics
+echo "Using DEPS_PREFIX=${DEPS_PREFIX}"
+echo "Using ZLIB_LIBDIR=${ZLIB_LIBDIR}"
+test -f "${ZLIB_LIBDIR}/libz.a"
+test -f "${CMAKE_SHIM_DIR}/FindZLIBNG.cmake"
+
+# Build Salmon:
+# - allow fetch fallback for deps/submodules (needed for pufferfish recursive submodules)
+# - keep system deps ON so available conda libs are used first
+cmake -S . -B "${BUILD_DIR}" -G Ninja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+  -DCMAKE_INSTALL_LIBDIR=lib \
+  -DCMAKE_PREFIX_PATH="${DEPS_PREFIX};${PREFIX}" \
+  -DCMAKE_MODULE_PATH="${CMAKE_SHIM_DIR}" \
+  -DCMAKE_LIBRARY_PATH="${ZLIB_LIBDIR};${PREFIX}/lib" \
+  -DCMAKE_INCLUDE_PATH="${DEPS_PREFIX}/include;${PREFIX}/include" \
+  -DSALMON_ENABLE_TESTS=OFF \
+  -DSALMON_USE_SYSTEM_DEPS=ON \
+  -DSALMON_FETCH_MISSING_DEPS=ON \
+  -DSALMON_USE_ZLIB_NG=REQUIRED \
+  -DSALMON_USE_HTSLIB=REQUIRED \
+  -DSALMON_BOOST_USE_STATIC_LIBS=OFF \
+  -DSALMON_PUFFERFISH_GIT_REPOSITORY="https://github.com/COMBINE-lab/pufferfish.git" \
+  -DSALMON_PUFFERFISH_GIT_TAG="5dce7f41a772aa3845095cd9a0539c5cd1cf5716" \
+  -DSALMON_FQFEEDER_GIT_REPOSITORY="https://github.com/rob-p/FQFeeder.git" \
+  -DSALMON_FQFEEDER_GIT_TAG="f5b08d1002351c192b69048ac9f6cf4c7c116265"
+
+
+cmake --build "${BUILD_DIR}" --parallel "${CPU_COUNT:-4}"
+
+## temp until 1.11.4
+# libgff install-path workaround for FetchContent builds
+if [[ ! -f "${BUILD_DIR}/libgff.a" ]]; then
+  GFF_ARCHIVE="$(find "${BUILD_DIR}/_deps/salmon_libgff-build" -type f -name 'libgff.a' | head -n 1 || true)"
+  if [[ -n "${GFF_ARCHIVE}" && -f "${GFF_ARCHIVE}" ]]; then
+    cp -f "${GFF_ARCHIVE}" "${BUILD_DIR}/libgff.a"
+  fi
+fi
+
+cmake --install "${BUILD_DIR}"
+

--- a/recipes/salmon-cpp/meta.yaml
+++ b/recipes/salmon-cpp/meta.yaml
@@ -1,0 +1,84 @@
+{% set name = "salmon-cpp" %}
+{% set version = "1.12.0" %}
+# v1.12.0 is the final C++ release tag (immutable; the C++ tree also lives on the
+# `cpp` branch). This recipe preserves the C++ line for reproducibility and
+# emergency fixes after the primary `salmon` package moves to the Rust 2.0 build.
+{% set sha256 = "acef41e166ee60697f7199f9fd28c63f835f188638629795d2509e9a56bfced4" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  - url: https://github.com/COMBINE-lab/salmon/archive/refs/tags/v{{ version }}.tar.gz
+    sha256: {{ sha256 }}
+
+build:
+  number: 0
+  run_exports:
+    - {{ pin_subpackage("salmon-cpp", max_pin="x") }}
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - {{ stdlib('c') }}
+    - cmake <4.0.0
+    - ninja
+    - make
+    - pkg-config
+  host:
+    - cereal >=1.3.2
+    - boost-cpp >=1.84
+    - tbb >=2021.4
+    - htslib >=1.23
+    - mimalloc >=3.2.8
+    - tbb-devel >=2022.3.0
+    - libiconv
+    - bzip2
+    - xz
+    - curl
+  run:
+    - {{ pin_compatible('htslib') }}
+    - {{ pin_compatible('boost-cpp') }}
+    - tbb
+    - bzip2
+    - xz
+    - curl
+    - boost-cpp
+    - icu
+
+test:
+  source_files:
+    - sample_data.tgz
+  commands:
+    - salmon --help
+    - salmon --version | grep -q 1.12.0
+
+about:
+  home: "https://github.com/COMBINE-lab/salmon"
+  license: "GPL-3.0-or-later"
+  license_family: GPL3
+  license_file: LICENSE
+  summary: "salmon 1.12.0 — the final C++ release (selective-alignment transcript quantification). Use the `salmon` package for the maintained Rust 2.0 build."
+  dev_url: "https://github.com/COMBINE-lab/salmon"
+  doc_url: "https://salmon.readthedocs.io"
+
+extra:
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64
+  recipe-maintainers:
+    - rob-p
+    - k3yavi
+    - mjsteinbaugh
+  identifiers:
+    - doi:10.1038/nmeth.4197
+  notes: |
+    This package installs the `salmon` binary built from the final C++ release
+    (1.12.0). It therefore CONFLICTS with the `salmon` package (which is the Rust
+    2.0 build, also providing a `salmon` binary) — install one or the other, not
+    both, in the same environment. `salmon-cpp` exists for users who need the C++
+    line for reproducibility or emergency fixes; new work should use `salmon`
+    (2.0). The pufferfish dependency is pinned to 5dce7f41 (the streaming
+    getRefPos k-mer orientation fix shipped in 1.12.0).


### PR DESCRIPTION
This adds a new recipe, **`salmon-cpp`**, packaging the final **C++** release of
salmon (`1.12.0`).

salmon 2.0 is a from-scratch **Rust** rewrite; the primary `salmon` recipe is
moving to that build (a separate autobump PR). `salmon-cpp` preserves the C++
line for reproducibility and emergency fixes.

Notes for reviewers:
- It builds the `v1.12.0` source tarball with the same CMake build the `salmon`
  1.12.0 recipe used, with the pufferfish dependency pinned to `5dce7f41` (the
  streaming `getRefPos` k-mer-orientation fix shipped in 1.12.0).
- It installs a `salmon` binary, so it **conflicts with the `salmon` package** by
  design — users install one or the other. (salmon-cpp is for those who need the
  C++ line specifically.)
- Maintainers: rob-p (salmon author), k3yavi, mjsteinbaugh.

@BiocondaBot please add label