### PR TITLE
Add methylsieve 0.1.0

### DIFF
--- a/recipes/methylsieve/build.sh
+++ b/recipes/methylsieve/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -euo pipefail
+
+export RUST_BACKTRACE=1
+
+cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
+
+cargo install --no-track --locked --verbose --root "${PREFIX}" --path .

--- a/recipes/methylsieve/meta.yaml
+++ b/recipes/methylsieve/meta.yaml
@@ -1,0 +1,43 @@
+{% set name = "methylsieve" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/fulcrumgenomics/{{ name }}/archive/v{{ version }}.tar.gz
+  sha256: 5b643592f4da414f4a5fc8fe0b92a69e67c40867aed86a51ee5b4ba3494b4861
+
+build:
+  number: 0
+  run_exports:
+    - {{ pin_subpackage("methylsieve", max_pin="x.x") }}
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('rust') }}
+    - cargo-bundle-licenses
+
+test:
+  commands:
+    - methylsieve --help
+
+about:
+  home: https://github.com/fulcrumgenomics/methylsieve
+  license: MIT
+  license_file:
+    - LICENSE
+    - THIRDPARTY.yml
+  summary: Fast per-template tagging and filtering of unconverted reads in bisulfite / EM-seq SAM/BAM files
+  dev_url: https://github.com/fulcrumgenomics/methylsieve
+
+extra:
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64
+  skip-lints:
+    - compiler_needs_stdlib_c  # until https://github.com/bioconda/bioconda-utils/issues/1095 is resolved
+  recipe-maintainers:
+    - tfenne


### PR DESCRIPTION
New recipe for methylsieve, a fast per-template tagger/filter for unconverted reads in bisulfite / EM-seq SAM/BAM files (https://github.com/fulcrumgenomics/methylsieve). Builds the Rust binary from the v0.1.0 GitHub release tarball.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
