### PR TITLE
Update dotmatch to 0.1.8

### DIFF
--- a/recipes/dotmatch/meta.yaml
+++ b/recipes/dotmatch/meta.yaml
@@ -38,7 +38,7 @@ test:
     - dotmatch --version | grep '^dotmatch {{ version }}$'
     - dotmatch dist ACGT AGGT | grep '^1$'
     - dotmatch leq 1 ACGT AGGT | grep '^true$'
-    - dotmatch citation | grep 'Citation metadata: CITATION.cff'
+    - "dotmatch citation | grep 'Citation metadata: CITATION.cff'"
     - dotmatch --help | grep 'Workflow namespaces'
     - dotmatch count --help | grep 'Hamming supports k=0..3'
     - dotmatch crispr-count --help | grep 'MAGeCK-ready'

--- a/recipes/dotmatch/meta.yaml
+++ b/recipes/dotmatch/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "dotmatch" %}
-{% set version = "0.1.7" %}
-{% set sha256 = "eb68691651dc1c408aa0f94b2aff58ed6f9cf7f58a3b5ea4def0e4cd6c6279ac" %}
+{% set version = "0.1.8" %}
+{% set sha256 = "ec3819bc773431454910287559d0809aca6ec1d81959f29d3d522650edb74904" %}
 
 package:
   name: {{ name|lower }}
@@ -38,6 +38,7 @@ test:
     - dotmatch --version | grep '^dotmatch {{ version }}$'
     - dotmatch dist ACGT AGGT | grep '^1$'
     - dotmatch leq 1 ACGT AGGT | grep '^true$'
+    - dotmatch citation | grep 'Citation metadata: CITATION.cff'
     - dotmatch --help | grep 'Workflow namespaces'
     - dotmatch count --help | grep 'Hamming supports k=0..3'
     - dotmatch crispr-count --help | grep 'MAGeCK-ready'
@@ -82,13 +83,13 @@ about:
   home: https://github.com/dnncha/dotmatch
   license: Apache-2.0
   license_file: LICENSE
-  summary: Fast exact short-DNA known-target assignment
+  summary: Deterministic short-DNA known-target assignment
   description: |
     DotMatch is a deterministic known-target short-DNA assignment engine for
     CRISPR guides, barcodes, primers, panels, and whitelist-style target sets.
     It is not a genome aligner and does not emit SAM/BAM or CIGAR output.
   dev_url: https://github.com/dnncha/dotmatch
-  doc_url: https://github.com/dnncha/dotmatch#readme
+  doc_url: https://dotmatch.readthedocs.io/
 
 extra:
   additional-platforms:


### PR DESCRIPTION
Update dotmatch to 0.1.8.\n\nRelease: https://github.com/dnncha/dotmatch/releases/tag/v0.1.8\nPyPI: https://pypi.org/project/dotmatch/0.1.8/\nTarball SHA256: ec3819bc773431454910287559d0809aca6ec1d81959f29d3d522650edb74904\n\nChanges include the 0.1.8 source tarball, the existing osx-arm64 additional-platform opt-in, and a small citation CLI smoke test for the published package.