### PR TITLE
Add dupblaster 0.1.0

### DIFF
--- a/recipes/dupblaster/build.sh
+++ b/recipes/dupblaster/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -euo pipefail
+
+export RUST_BACKTRACE=1
+
+cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
+
+cargo install --no-track --locked --verbose --root "${PREFIX}" --path .

--- a/recipes/dupblaster/meta.yaml
+++ b/recipes/dupblaster/meta.yaml
@@ -18,6 +18,7 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('rust') }}
+    - {{ stdlib('c') }}
     - cargo-bundle-licenses
 
 test:
@@ -27,17 +28,17 @@ test:
 about:
   home: https://github.com/fulcrumgenomics/dupblaster
   license: MIT
+  license_family: MIT
   license_file:
     - LICENSE
     - THIRDPARTY.yml
   summary: Fast duplicate marking for query-grouped SAM/BAM files, inspired by samblaster and Picard MarkDuplicates
   dev_url: https://github.com/fulcrumgenomics/dupblaster
+  doc_url: https://github.com/fulcrumgenomics/dupblaster/blob/main/README.md
 
 extra:
   additional-platforms:
     - linux-aarch64
     - osx-arm64
-  skip-lints:
-    - compiler_needs_stdlib_c  # until https://github.com/bioconda/bioconda-utils/issues/1095 is resolved
   recipe-maintainers:
     - tfenne

--- a/recipes/dupblaster/meta.yaml
+++ b/recipes/dupblaster/meta.yaml
@@ -1,0 +1,43 @@
+{% set name = "dupblaster" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/fulcrumgenomics/{{ name }}/archive/v{{ version }}.tar.gz
+  sha256: 6feb059645a63fe627009a27e91363f7372ddee2116d56cd2693e715bcdae7a0
+
+build:
+  number: 0
+  run_exports:
+    - {{ pin_subpackage("dupblaster", max_pin="x.x") }}
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('rust') }}
+    - cargo-bundle-licenses
+
+test:
+  commands:
+    - dupblaster --help
+
+about:
+  home: https://github.com/fulcrumgenomics/dupblaster
+  license: MIT
+  license_file:
+    - LICENSE
+    - THIRDPARTY.yml
+  summary: Fast duplicate marking for query-grouped SAM/BAM files, inspired by samblaster and Picard MarkDuplicates
+  dev_url: https://github.com/fulcrumgenomics/dupblaster
+
+extra:
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64
+  skip-lints:
+    - compiler_needs_stdlib_c  # until https://github.com/bioconda/bioconda-utils/issues/1095 is resolved
+  recipe-maintainers:
+    - tfenne


### PR DESCRIPTION
Adds a new recipe for `dupblaster`.  A new duplicate marking tool that extends the ideas from samblaster with a 100% picard-concordance mode, better performance, methylathion mode, and various other QOL improvements.

See https://github.com/fulcrumgenomics/dupblaster.  

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
