### PR TITLE
Update nf-metro deps: add lark and jsonschema

### DIFF
--- a/recipes/nf-metro/meta.yaml
+++ b/recipes/nf-metro/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage("nf-metro", max_pin="x") }}
 
@@ -25,8 +25,10 @@ requirements:
     - python >=3.10
     - click >=8.0
     - drawsvg >=2.0
+    - lark >=1.1
     - networkx >=3.0
     - pillow >=9.0
+    - jsonschema >=4.0
 
 test:
   commands:


### PR DESCRIPTION
Aligns the `nf-metro` recipe's runtime requirements with the package's current dependencies, ahead of the next release.

### Changes
- Add `lark >=1.1` — nf-metro's parser now depends on lark as a core runtime dependency, but it was missing from the recipe.
- Add `jsonschema >=4.0` — used by the `nf-metro validate-svg` subcommand so it works out of the box.
- Bump `build.number` 0 → 1 for the rebuild on the existing 0.7.2 version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)