### PR TITLE
Fix seqera segfault: disable binary relocation

### DIFF
--- a/recipes/seqera/meta.yaml
+++ b/recipes/seqera/meta.yaml
@@ -14,7 +14,9 @@ source:
     sha256: d96f99ddc911e13e036b7acdcb913e8dfecdea406076052a8f129ddbf51dd307  # [osx and arm64]
 
 build:
-  number: 0
+  number: 1
+  binary_relocation: false
+  detect_binary_files_with_prefix: false
   run_exports:
     - {{ pin_subpackage(name, max_pin="x") }}
 


### PR DESCRIPTION
<!-- Please read the guidelines for Bioconda recipes before submitting: https://bioconda.github.io/contributor/index.html -->

## Summary

`seqera` 1.8.0 segfaults immediately on launch on Linux. The fault is inside `ld-linux-x86-64.so.2` at a constant address, *before* the CLI's own code runs.

## Root cause

`seqera` is the Bun-compiled single-file CLI shipped via `@seqera/cli-linux-x64` (npm). Bun appends its JavaScript bundle *after* the ELF section table and locates it at runtime via a trailer offset computed from the original on-disk file layout.

conda-build's default `binary_relocation: true` runs a patchelf pass that rewrites the ELF header and section table (`e_entry`, `e_shoff`, `e_shnum`). This desyncs the header from Bun's trailer offset, so the dynamic loader faults before the CLI starts.

### Evidence

Comparing the conda-built (relocated) binary against an unrelocated copy of the same upstream file, they differ **only** in ELF header bytes:

```
$ cmp -l relocated/seqera unrelocated/seqera
   26  ...   # e_entry
   41  ...   # e_shoff
   42  ...
   43  ...
   57  ...   # e_shnum / e_shoff tail
   63  ...
```

The unrelocated copy runs correctly on the same host. AVX2/SSE4.2 instruction support and glibc version were ruled out as causes.

## Fix

```yaml
build:
  number: 1
  binary_relocation: false
  detect_binary_files_with_prefix: false
```

This leaves the binary byte-identical to upstream, so Bun's trailer offset stays valid. The version is unchanged; only the build number is bumped.

The **darwin** tarballs are covered by the same change: on macOS the relocation pass uses `install_name_tool`, which would corrupt the Mach-O binary equivalently.

## Why this shipped broken

The recipe's only test is `which seqera` — it never executes the binary. The binary requires glibc >=2.25, but Bioconda CI runs in CentOS 7 (glibc 2.17), so it cannot be run pre-publish and the segfault was never caught.

## Proposed follow-up (not in this PR)

Add an execution smoke test gated on a sufficiently new glibc, e.g.:

```yaml
test:
  commands:
    - which seqera
    - seqera --version  # [linux and not (glibc < 2.25)]
```

so a regression in the binary itself (not just packaging) is caught when the runner's glibc allows execution. Left out here to keep the fix minimal and because the gating mechanism needs discussion.

Generated by Claude Code