### PR TITLE
Add tirvish-rs 0.1.0

### DIFF
--- a/recipes/tirvish-rs/build.sh
+++ b/recipes/tirvish-rs/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+
+# Build + install only the tirvish binary (the crate also carries dev-only
+# validator bins) into the conda prefix.
+cargo install --no-track --locked --root "$PREFIX" --path . --bin tirvish
+
+# Package is tirvish-rs; expose the crate name as an alias for discoverability.
+ln -sf tirvish "$PREFIX/bin/tirvish_rs"

--- a/recipes/tirvish-rs/meta.yaml
+++ b/recipes/tirvish-rs/meta.yaml
@@ -1,0 +1,44 @@
+{% set name = "tirvish-rs" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/KGerhardt/tirvish_rs/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: c39570ccc164e1478bd37ac129a1a36ba9ecce74023f3cfb00b58b1bc4644b36
+
+build:
+  number: 0
+  run_exports:
+    - {{ pin_subpackage('tirvish-rs', max_pin="x.x") }}
+
+requirements:
+  build:
+    - {{ compiler('rust') }}
+    - {{ compiler('c') }}
+    - {{ stdlib('c') }}
+
+test:
+  commands:
+    - command -v tirvish
+    - command -v tirvish_rs
+
+about:
+  home: https://github.com/KGerhardt/tirvish_rs
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  license_file: LICENSE
+  summary: "Fast, faithful Rust port of gt tirvish (GenomeTools 1.6.5) TIR detection, used by TIR-Learner."
+  description: |
+    tirvish_rs is a from-scratch Rust reimplementation of GenomeTools' `gt tirvish`
+    de-novo terminal-inverted-repeat (TIR) transposon detection, built to replace the
+    slow gt tirvish step in TIR-Learner on repeat-rich genomes. Output is bit-exact
+    with gt tirvish (all five stages validated against an instrumented 1.6.5
+    reference). It runs directly on a FASTA (no pre-built mirrored index) and accepts
+    the gt tirvish options. Installs the `tirvish` binary and a `tirvish_rs` alias.
+
+extra:
+  recipe-maintainers:
+    - KGerhardt


### PR DESCRIPTION
Adds a recipe for **tirvish-rs** (v0.1.0): a from-scratch Rust reimplementation of
GenomeTools' `gt tirvish` de-novo terminal-inverted-repeat (TIR) transposon
detection, used by TIR-Learner to replace the slow `gt tirvish` step on
repeat-rich genomes. Output is **bit-exact** with `gt tirvish` (all five stages
validated against an instrumented 1.6.5 reference).

- Source: https://github.com/KGerhardt/tirvish_rs (GPL-3.0-or-later), tag `v0.1.0`
- Builds with `cargo install --bin tirvish` (Rust + C compiler for the `libsais` dep); installs `tirvish` and a `tirvish_rs` alias.
- Same packaging pattern as the existing `grfmite-rs` recipe (same maintainer / project family).
- Recipe build verified locally.
