### PR TITLE
Update snakesee: add missing TUI runtime deps (textual, rich-pixels, pillow)

### DIFF
--- a/recipes/snakesee/meta.yaml
+++ b/recipes/snakesee/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 57040197887d50a60faa078128df22e1d03a10df1e90fb3a234d9050c3ebc92d
 
 build:
-  number: 0
+  number: 1
   noarch: python
   entry_points:
     - snakesee = snakesee.cli:main
@@ -29,21 +29,26 @@ requirements:
     - defopt >=6.4.0
     - orjson >=3.9.0
     - snakemake >=8.0.0
+    - textual >=0.80.0
+    - rich-pixels >=3.0.1
+    - pillow >=10.0.0
 
 test:
   imports:
     - snakesee
+    - snakesee.tui.app
   commands:
     - snakesee --help
+    - python -c "import rich_pixels, PIL"
 
 about:
-  home: https://github.com/nh13/snakesee
+  home: https://github.com/fg-labs/snakesee
   license: MIT
   license_family: MIT
   license_file: LICENSE
   summary: A terminal UI for monitoring Snakemake workflows
   doc_url: https://snakesee.readthedocs.io
-  dev_url: https://github.com/nh13/snakesee
+  dev_url: https://github.com/fg-labs/snakesee
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
The `snakesee` recipe’s `run:` requirements drifted from upstream `pyproject.toml`: `textual`, `rich-pixels`, and `pillow` are declared upstream but were missing from the recipe. Because the recipe installs with `--no-deps`, those three are never pulled in, so a clean install crashes on launch:

```
$ snakesee watch .
ModuleNotFoundError: No module named 'textual'
```

(reported in https://github.com/fg-labs/snakesee/issues/86)

This PR:

- Adds `textual >=0.80.0`, `rich-pixels >=3.0.1`, and `pillow >=10.0.0` to `run:`, mirroring `pyproject.toml`.
- Bumps the build number to 1 (same version, 0.8.1).
- Hardens the test so this class of drift fails CI in future: imports `snakesee.tui.app` (which imports `textual` at module load) and runs `python -c "import rich_pixels, PIL"` (these are lazily imported inside `snakesee/tui/renderables.py`, so a plain module-import test would not surface them).
- Fixes the stale `home`/`dev_url` (the project now lives at `github.com/fg-labs/snakesee`).

**Dependency:** `rich-pixels` is not yet on conda-forge; a conda-forge/staged-recipes PR adding it is required before this CI can pass. `textual` and `pillow` are already on conda-forge.

##### Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

- [x] This PR adds a new recipe / updates an existing recipe.
- [x] AFAIK, the recipe is compliant with the Bioconda guidelines.
- [x] The build number was bumped (same version).
- [ ] If this is a new recipe, I have added it to the appropriate list of recipes.