### PR TITLE
Add salmon 1.12 subrecipe: the final C++ salmon

### DIFF
--- a/recipes/salmon/1.12/build.sh
+++ b/recipes/salmon/1.12/build.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BUILD_DIR="${SRC_DIR}/build"
+DEPS_PREFIX="${SRC_DIR}/_deps_prefix"
+THIRDPARTY_DIR="${SRC_DIR}/_thirdparty"
+CMAKE_SHIM_DIR="${SRC_DIR}/_cmake_shims"
+
+ZLIBNG_VERSION="2.3.3"
+ZLIBNG_URL="https://github.com/zlib-ng/zlib-ng/archive/refs/tags/${ZLIBNG_VERSION}.tar.gz"
+ZLIBNG_TARBALL="${THIRDPARTY_DIR}/zlib-ng-${ZLIBNG_VERSION}.tar.gz"
+ZLIBNG_SRC_DIR="${THIRDPARTY_DIR}/zlib-ng-${ZLIBNG_VERSION}"
+
+mkdir -p "${BUILD_DIR}" "${DEPS_PREFIX}" "${THIRDPARTY_DIR}" "${CMAKE_SHIM_DIR}"
+
+# Build zlib-ng (compat mode)
+curl -L --fail "${ZLIBNG_URL}" -o "${ZLIBNG_TARBALL}"
+tar -xzf "${ZLIBNG_TARBALL}" -C "${THIRDPARTY_DIR}"
+
+cmake -S "${ZLIBNG_SRC_DIR}" -B "${ZLIBNG_SRC_DIR}/build" -G Ninja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX="${DEPS_PREFIX}" \
+  -DZLIB_COMPAT=ON \
+  -DBUILD_SHARED_LIBS=OFF \
+  -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+  -DZLIB_ENABLE_TESTS=OFF \
+  -DWITH_GTEST=OFF \
+  -DWITH_FUZZERS=OFF \
+  -DWITH_BENCHMARKS=OFF \
+  -DWITH_BENCHMARK_APPS=OFF
+
+cmake --build "${ZLIBNG_SRC_DIR}/build" --parallel "${CPU_COUNT:-4}"
+cmake --install "${ZLIBNG_SRC_DIR}/build"
+
+# Detect libdir
+if [[ -f "${DEPS_PREFIX}/lib64/libz.a" ]]; then
+  ZLIB_LIBDIR="${DEPS_PREFIX}/lib64"
+elif [[ -f "${DEPS_PREFIX}/lib/libz.a" ]]; then
+  ZLIB_LIBDIR="${DEPS_PREFIX}/lib"
+else
+  echo "ERROR: libz.a not found under ${DEPS_PREFIX}/lib64 or ${DEPS_PREFIX}/lib"
+  exit 1
+fi
+
+# Provide FindZLIBNG.cmake shim
+cat > "${CMAKE_SHIM_DIR}/FindZLIBNG.cmake" <<EOF
+find_package(ZLIB CONFIG REQUIRED
+  PATHS "${ZLIB_LIBDIR}/cmake/ZLIB"
+  NO_DEFAULT_PATH)
+
+if(TARGET ZLIB::ZLIB AND NOT TARGET ZLIBNG::ZLIBNG)
+  add_library(ZLIBNG::ZLIBNG INTERFACE IMPORTED)
+  target_link_libraries(ZLIBNG::ZLIBNG INTERFACE ZLIB::ZLIB)
+endif()
+
+set(ZLIBNG_FOUND TRUE)
+set(ZLIBNG_INCLUDE_DIR "${DEPS_PREFIX}/include")
+set(ZLIBNG_LIBRARY ZLIBNG::ZLIBNG)
+EOF
+
+# Diagnostics
+echo "Using DEPS_PREFIX=${DEPS_PREFIX}"
+echo "Using ZLIB_LIBDIR=${ZLIB_LIBDIR}"
+test -f "${ZLIB_LIBDIR}/libz.a"
+test -f "${CMAKE_SHIM_DIR}/FindZLIBNG.cmake"
+
+# Build Salmon:
+# - allow fetch fallback for deps/submodules (needed for pufferfish recursive submodules)
+# - keep system deps ON so available conda libs are used first
+cmake -S . -B "${BUILD_DIR}" -G Ninja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+  -DCMAKE_INSTALL_LIBDIR=lib \
+  -DCMAKE_PREFIX_PATH="${DEPS_PREFIX};${PREFIX}" \
+  -DCMAKE_MODULE_PATH="${CMAKE_SHIM_DIR}" \
+  -DCMAKE_LIBRARY_PATH="${ZLIB_LIBDIR};${PREFIX}/lib" \
+  -DCMAKE_INCLUDE_PATH="${DEPS_PREFIX}/include;${PREFIX}/include" \
+  -DSALMON_ENABLE_TESTS=OFF \
+  -DSALMON_USE_SYSTEM_DEPS=ON \
+  -DSALMON_FETCH_MISSING_DEPS=ON \
+  -DSALMON_USE_ZLIB_NG=REQUIRED \
+  -DSALMON_USE_HTSLIB=REQUIRED \
+  -DSALMON_BOOST_USE_STATIC_LIBS=OFF \
+  -DSALMON_PUFFERFISH_GIT_REPOSITORY="https://github.com/COMBINE-lab/pufferfish.git" \
+  -DSALMON_PUFFERFISH_GIT_TAG="5dce7f41a772aa3845095cd9a0539c5cd1cf5716" \
+  -DSALMON_FQFEEDER_GIT_REPOSITORY="https://github.com/rob-p/FQFeeder.git" \
+  -DSALMON_FQFEEDER_GIT_TAG="f5b08d1002351c192b69048ac9f6cf4c7c116265"
+
+
+cmake --build "${BUILD_DIR}" --parallel "${CPU_COUNT:-4}"
+
+## temp until 1.11.4
+# libgff install-path workaround for FetchContent builds
+if [[ ! -f "${BUILD_DIR}/libgff.a" ]]; then
+  GFF_ARCHIVE="$(find "${BUILD_DIR}/_deps/salmon_libgff-build" -type f -name 'libgff.a' | head -n 1 || true)"
+  if [[ -n "${GFF_ARCHIVE}" && -f "${GFF_ARCHIVE}" ]]; then
+    cp -f "${GFF_ARCHIVE}" "${BUILD_DIR}/libgff.a"
+  fi
+fi
+
+cmake --install "${BUILD_DIR}"
+

--- a/recipes/salmon/1.12/meta.yaml
+++ b/recipes/salmon/1.12/meta.yaml
@@ -16,7 +16,10 @@ source:
     sha256: {{ sha256 }}
 
 build:
-  number: 0
+  # 1.12.0 build 0 (linux-64/osx-64) was published from the old top-level C++
+  # recipe before salmon moved to the Rust 2.0 build. This subrecipe rebuilds the
+  # same version at a higher build number (also adding linux-aarch64/osx-arm64).
+  number: 1
   run_exports:
     - {{ pin_subpackage("salmon", max_pin="x") }}
 
@@ -60,7 +63,12 @@ about:
   license: "GPL-3.0-or-later"
   license_family: GPL3
   license_file: LICENSE
-  summary: "salmon 1.12.0 — the final C++ release (selective-alignment transcript quantification). The default `salmon` package is the maintained Rust 2.0 build; install this legacy line with `conda install \"salmon=1.12\"`."
+  summary: "Transcript-level quantification from RNA-seq reads (final C++ salmon, 1.12.0)."
+  description: |
+    salmon 1.12.0 is the final C++ release of salmon (selective-alignment
+    transcript quantification). The default `salmon` package is the maintained
+    Rust 2.0 build; install this legacy C++ line explicitly with
+    `conda install "salmon=1.12"`, ideally in a dedicated environment.
   dev_url: "https://github.com/COMBINE-lab/salmon"
   doc_url: "https://salmon.readthedocs.io"
 

--- a/recipes/salmon/1.12/meta.yaml
+++ b/recipes/salmon/1.12/meta.yaml
@@ -1,0 +1,89 @@
+{% set name = "salmon" %}
+{% set version = "1.12.0" %}
+# salmon 1.12.0 is the final C++ release. This is a *version-pinned subrecipe*: it
+# builds the same `salmon` package as recipes/salmon/meta.yaml (the Rust 2.0 line),
+# but at the legacy 1.12.x C++ version. Users who need the C++ build install it
+# explicitly with `conda install "salmon=1.12"`. v1.12.0 is an immutable tag; the
+# C++ tree also lives on the `cpp` branch for future maintenance.
+{% set sha256 = "acef41e166ee60697f7199f9fd28c63f835f188638629795d2509e9a56bfced4" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  - url: https://github.com/COMBINE-lab/salmon/archive/refs/tags/v{{ version }}.tar.gz
+    sha256: {{ sha256 }}
+
+build:
+  number: 0
+  run_exports:
+    - {{ pin_subpackage("salmon", max_pin="x") }}
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - {{ stdlib('c') }}
+    - cmake <4.0.0
+    - ninja
+    - make
+    - pkg-config
+  host:
+    - cereal >=1.3.2
+    - boost-cpp >=1.84
+    - tbb >=2021.4
+    - htslib >=1.23
+    - mimalloc >=3.2.8
+    - tbb-devel >=2022.3.0
+    - libiconv
+    - bzip2
+    - xz
+    - curl
+  run:
+    - {{ pin_compatible('htslib') }}
+    - {{ pin_compatible('boost-cpp') }}
+    - tbb
+    - bzip2
+    - xz
+    - curl
+    - boost-cpp
+    - icu
+
+test:
+  commands:
+    - salmon --help
+    - salmon --version | grep -q 1.12.0
+
+about:
+  home: "https://github.com/COMBINE-lab/salmon"
+  license: "GPL-3.0-or-later"
+  license_family: GPL3
+  license_file: LICENSE
+  summary: "salmon 1.12.0 — the final C++ release (selective-alignment transcript quantification). The default `salmon` package is the maintained Rust 2.0 build; install this legacy line with `conda install \"salmon=1.12\"`."
+  dev_url: "https://github.com/COMBINE-lab/salmon"
+  doc_url: "https://salmon.readthedocs.io"
+
+extra:
+  # Version-pinned subrecipe: frozen w.r.t. the autobump bot (subrecipes are
+  # excluded by default; this makes the intent explicit). Future C++ bugfixes are
+  # bumped here by hand from a new tag cut off the `cpp` branch.
+  autobump:
+    enable: false
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64
+  recipe-maintainers:
+    - rob-p
+    - k3yavi
+    - mjsteinbaugh
+  identifiers:
+    - doi:10.1038/nmeth.4197
+  notes: |
+    This subrecipe builds the `salmon` binary from the final C++ release (1.12.0).
+    Because it is the same package name as the Rust 2.0 build, conda installs one
+    or the other in a given environment — `conda install salmon` gets the latest
+    (Rust 2.0); `conda install "salmon=1.12"` (e.g. in a dedicated env) gets this
+    C++ line. The C++ build uses a new index format incompatible with Rust 2.0
+    indices, so rebuild indices when switching. The pufferfish dependency is pinned
+    to 5dce7f41 (the streaming getRefPos k-mer orientation fix shipped in 1.12.0).


### PR DESCRIPTION
Adds a version-pinned subrecipe `recipes/salmon/1.12/` that builds the **same `salmon` package** at the final C++ release (**1.12.0**), alongside the existing `recipes/salmon/` (the Rust 2.0 line).

This follows @bgruening's suggestion in #66284 to use a subfolder rather than a separate `salmon-cpp` package. Closing #66284 in favor of this.

- Same package name `salmon`; users install the legacy C++ line with `conda install "salmon=1.12"` (ideally in a dedicated env). `conda install salmon` continues to get the latest (Rust 2.0).
- Sourced from the immutable `v1.12.0` tag (the C++ tree also lives on the `cpp` branch for future maintenance).
- Marked `extra: autobump: enable: false` — subrecipes are excluded from autobump by default anyway; 1.12.0 is the final C++ release, so the rare future bugfix will be a manual version bump here. The top-level recipe keeps auto-bumping the 2.0 line.
- C++ build via CMake; pufferfish pinned to `5dce7f41` (the streaming `getRefPos` orientation fix shipped in 1.12.0).

Supersedes #66284.
