### PR TITLE
Add minibwa 0.1

### DIFF
--- a/recipes/minibwa/build.sh
+++ b/recipes/minibwa/build.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -xe
+
+mkdir -p "${PREFIX}/bin" "${PREFIX}/lib" "${PREFIX}/include"
+
+# CC drives the Makefile's OpenMP auto-detection. The override-makefile.patch
+# lets the Makefile append its OpenMP/GPL/SSE4.2 flags on top of conda's
+# CFLAGS/CPPFLAGS rather than having them clobbered by the command line.
+# LIBS is left untouched so the Makefile keeps -lpthread -lz -lm.
+make \
+    CC="${CC}" \
+    CFLAGS="${CFLAGS}" \
+    CPPFLAGS="${CPPFLAGS}" \
+    LDFLAGS="${LDFLAGS}" \
+    -j"${CPU_COUNT}" \
+    minibwa
+
+install -m 0755 minibwa "${PREFIX}/bin"
+install -m 0644 libminibwa.a "${PREFIX}/lib"
+install -m 0644 minibwa.h "${PREFIX}/include"

--- a/recipes/minibwa/build.sh
+++ b/recipes/minibwa/build.sh
@@ -4,6 +4,15 @@ set -xe
 
 mkdir -p "${PREFIX}/bin" "${PREFIX}/lib" "${PREFIX}/include"
 
+# The bundled SSE->NEON shim (s2n-lite.h) reinterprets uint32x4_t results
+# through signed int32x4_t intrinsics, which GCC on aarch64 rejects. Permit
+# the conversion as GCC itself suggests (clang/macOS already accepts it).
+case "$(uname -m)" in
+    aarch64 | arm64)
+        export CFLAGS="${CFLAGS} -flax-vector-conversions"
+        ;;
+esac
+
 # CC drives the Makefile's OpenMP auto-detection. The override-makefile.patch
 # lets the Makefile append its OpenMP/GPL/SSE4.2 flags on top of conda's
 # CFLAGS/CPPFLAGS rather than having them clobbered by the command line.

--- a/recipes/minibwa/meta.yaml
+++ b/recipes/minibwa/meta.yaml
@@ -23,6 +23,9 @@ requirements:
     - {{ stdlib("c") }}
   host:
     - zlib
+    - llvm-openmp  # [osx]
+  run:
+    - llvm-openmp  # [osx]
 
 test:
   commands:

--- a/recipes/minibwa/meta.yaml
+++ b/recipes/minibwa/meta.yaml
@@ -1,0 +1,44 @@
+{% set name = "minibwa" %}
+{% set version = "0.1" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/lh3/{{ name }}/archive/v{{ version }}.tar.gz
+  sha256: 6a50361f7a16dadd5eb4ba71f583a8a4ab798611d954b234f747af488518f505
+  patches:
+    - override-makefile.patch
+
+build:
+  number: 0
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x.x") }}
+
+requirements:
+  build:
+    - make
+    - {{ compiler('c') }}
+    - {{ stdlib("c") }}
+  host:
+    - zlib
+
+test:
+  commands:
+    - minibwa version | grep {{ version }}
+    - minibwa 2>&1 | grep 'Usage'
+    - test -e $PREFIX/lib/libminibwa.a
+    - test -e $PREFIX/include/minibwa.h
+
+about:
+  home: "https://github.com/lh3/minibwa"
+  license: GPL-2.0-or-later
+  license_family: GPL2
+  license_file: "LICENSE.txt"
+  summary: 'Aligning short and accurate long reads to a reference genome, the successor of bwa-mem.'
+  dev_url: "https://github.com/lh3/minibwa"
+
+extra:
+  additional-platforms:
+    - linux-aarch64

--- a/recipes/minibwa/override-makefile.patch
+++ b/recipes/minibwa/override-makefile.patch
@@ -1,0 +1,32 @@
+diff --git a/Makefile b/Makefile
+index 92d3be2..8c97ef7 100644
+--- a/Makefile
++++ b/Makefile
+@@ -19,14 +19,14 @@ ifneq ($(asan),)
+ endif
+ 
+ ifeq ($(omp),1)
+-	CPPFLAGS+=-DLIBSAIS_OPENMP
+-	CFLAGS+=-fopenmp
+-	LIBS+=-fopenmp
++	override CPPFLAGS+=-DLIBSAIS_OPENMP
++	override CFLAGS+=-fopenmp
++	override LIBS+=-fopenmp
+ endif
+ 
+ ifneq ($(gpl),0)
+ 	AOBJS+=QSufSort.o bwtgen.o
+-	CPPFLAGS+=-DUSE_GPL
++	override CPPFLAGS+=-DUSE_GPL
+ endif
+ 
+ ifeq ($(mimalloc),0)
+@@ -35,7 +35,7 @@ ifeq ($(mimalloc),0)
+ endif
+ 
+ ifeq ($(ARCH), x86_64)
+-	CFLAGS+=-msse4.2 -mpopcnt
++	override CFLAGS+=-msse4.2 -mpopcnt
+ endif
+ 
+ .SUFFIXES:.c .o


### PR DESCRIPTION
Adds a recipe for [minibwa](https://github.com/lh3/minibwa) (v0.1), a short- and accurate-long-read aligner by Heng Li, described as the successor of bwa-mem.

### Notes

- Single C binary `minibwa`; also installs the static library `libminibwa.a` and public header `minibwa.h` (mirrors the existing `minimap2` recipe by the same author).
- `override-makefile.patch` switches the Makefile's conditional `+=` flag lines to `override CFLAGS+=` / `override CPPFLAGS+=` / `override LIBS+=` so the conda toolchain flags inject without clobbering the upstream OpenMP/GPL/SSE4.2 flags. Same approach as `minimap2`'s `override-makefile.patch`.
- License: the default build links GPL-2.0 code (`bwtgen.c`) for low-memory BWT construction, so the package is `GPL-2.0-or-later` even though the core is MIT.
- `linux-aarch64` enabled via `additional-platforms` (upstream ships a NEON shim, `s2n-lite.h`); on aarch64 the build adds `-flax-vector-conversions` because GCC rejects a signed/unsigned vector reinterpret in the shim that clang accepts.
- macOS (osx-64) is supported and passes CI: the Makefile auto-enables OpenMP, so `llvm-openmp` is declared as a host/run dependency on osx to provide `libomp.dylib` at runtime (on Linux the GCC `run_exports` supplies libgomp).
- Built and tested locally with `bioconda-utils build` (linux-64): build succeeds and all test commands pass (`minibwa version` reports `0.1-r363`).
