### PR TITLE
Update grz-db: sync dependencies between pyproject and meta

### DIFF
--- a/recipes/grz-db/meta.yaml
+++ b/recipes/grz-db/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage(name, max_pin="x.x") }}
 
@@ -23,7 +23,7 @@ requirements:
     - pip
   run:
     - alembic >=1.16.1
-    - cryptography >=45.0.3
+    - cryptography >=45.0.3,<49
     - sqlmodel >=0.0.27
     - grz-pydantic-models >=2.7,<3
     - psycopg >=3.2,<4


### PR DESCRIPTION
dependencies did not reflect pyproject.toml correctly; updated accordingly, build number bumped to 1.