### PR TITLE
Update grz-common: sync dependencies between pyproject and meta

### DIFF
--- a/recipes/grz-common/meta.yaml
+++ b/recipes/grz-common/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 67ffe695313f22d79fa6945895e3cf9eb1a7c1f672f4b51f84bd0106854cd32c
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --no-cache-dir -vvv
   run_exports:
@@ -26,7 +26,7 @@ requirements:
     - boto3 >=1.36,<2
     - click >=8.2,<9
     - python-crypt4gh >=1.8.6,<2
-    - cryptography >=45.0.3
+    - cryptography >=45.0.3,<49
     - packaging >=23,<27
     - pyyaml >=6.0.2,<7
     - tqdm >=4.66.5,<5


### PR DESCRIPTION
dependencies did not reflect pyproject.toml correctly; updated accordingly, build number bumped to 1.