### PR TITLE
Update tir-learner to 4.08

### DIFF
--- a/recipes/tir-learner/meta.yaml
+++ b/recipes/tir-learner/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "TIR-Learner" %}
-{% set version = "4.07" %}
-{% set sha256 = "34f22246e71238a06ac65000f5b12d4f9bed752f5f40c76bb81b6a910816d32d" %}
+{% set version = "4.08" %}
+{% set sha256 = "42ef9f3d8257456e45878f66b361cb9abefd9ae8fd6812c695cc9ee9221a79db" %}
 
 package:
   name: {{ name | lower }}
@@ -24,7 +24,7 @@ requirements:
     - pywfa
     - keras
     - pytorch
-    - genometools-genometools
+    - tirvish-rs >=0.1.0
     - grfmite-rs >=0.3.0
     - blast
     - pigz


### PR DESCRIPTION
Updates **tir-learner** to 4.08.

Main change: the TIR detection step no longer shells out to `gt tirvish` (GenomeTools). It now uses **tirvish-rs**, a faithful Rust reimplementation whose output is validated bit-exact against `gt tirvish` on a 1153-element oracle. This drops the `genometools-genometools` dependency and adds `tirvish-rs`.

- `genometools-genometools` → removed
- `tirvish-rs >=0.1.0` → added
- source bumped to v4.08

Upstream: https://github.com/KGerhardt/TIR-Learner