### PR TITLE
Update fastan to 0.8 (masking-enabled)

### DIFF
--- a/recipes/fastan/0001-Makefile.patch
+++ b/recipes/fastan/0001-Makefile.patch
@@ -3,21 +3,30 @@
 @@ -1,8 +1,8 @@
 -DEST_DIR = ~/bin
 +DEST_DIR = $(PREFIX)/bin
- 
+
 -CFLAGS = -O3 -Wall -Wextra -Wno-unused-result -fno-strict-aliasing
 +CFLAGS = -O3 -Wall -Wextra -Wno-unused-result -fno-strict-aliasing -I$(PREFIX)/include -L$(PREFIX)/lib
- 
+
 -CC = gcc
 +CC ?= gcc
- 
+
  ALL = FasTAN
- 
+
+@@ -12,7 +12,7 @@
+ GDB.h: gene_core.h
+
+ FasTAN: FasTAN.c alncode.c alncode.h ANO.c ANO.h GDB.c GDB.h ONElib.c ONElib.h align.c align.h
+-	$(CC) $(CFLAGS) -o FasTAN FasTAN.c alncode.c align.c ANO.c GDB.c gene_core.c ONElib.c -lm -lz
++	$(CC) $(CFLAGS) -o FasTAN FasTAN.c alncode.c align.c ANO.c GDB.c gene_core.c ONElib.c -lm -lz -lpthread
+
+ clean:
+ 	rm -f $(ALL)
 @@ -20,7 +20,7 @@
  	rm -f FasTAN.tar.gz
- 
+
  install:
 -	cp $(ALL) $(DEST_DIR)
 +	install -v -m 0755 $(ALL) $(DEST_DIR)
- 
+
  package:
  	make clean

--- a/recipes/fastan/0001-Makefile.patch
+++ b/recipes/fastan/0001-Makefile.patch
@@ -1,5 +1,3 @@
-diff --git a/Makefile b/Makefile
-index 63cee36..5afde18 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -1,8 +1,8 @@
@@ -7,14 +5,14 @@ index 63cee36..5afde18 100644
 +DEST_DIR = $(PREFIX)/bin
  
 -CFLAGS = -O3 -Wall -Wextra -Wno-unused-result -fno-strict-aliasing
-+CFLAGS = -O3 -Wall -Wextra -Wno-unused-result -fno-strict-aliasing -I$(PREFIX)/include -L$(PREFIX)/lib -pthread
++CFLAGS = -O3 -Wall -Wextra -Wno-unused-result -fno-strict-aliasing -I$(PREFIX)/include -L$(PREFIX)/lib
  
 -CC = gcc
 +CC ?= gcc
  
- ALL = FasTAN # NewTAN
+ ALL = FasTAN
  
-@@ -23,7 +23,7 @@ clean:
+@@ -20,7 +20,7 @@
  	rm -f FasTAN.tar.gz
  
  install:

--- a/recipes/fastan/meta.yaml
+++ b/recipes/fastan/meta.yaml
@@ -7,9 +7,9 @@ package:
   version: {{ version }}
 
 source:
-  # Upstream README declares "Release v0.8 (2026-04-25)" but has not git-tagged
-  # it; pin the masking-enabled master commit (adds -m / .1ano tandem-mask output
-  # that v0.5 lacks). Please tag a release upstream so this can pin a tag.
+  # Upstream README declares "Release v0.8 (2026-04-25)" but has not git-tagged it;
+  # pin the masking-enabled master commit (adds -m / .1ano tandem-mask output that
+  # v0.5 lacks). Please tag a release upstream so this can pin a tag.
   url: https://github.com/thegenemyers/FASTAN/archive/{{ commit }}.tar.gz
   sha256: de332704eb65e01dbf007a5d323b73773827247824434451bbcd93abe04dfd0d
   patches:

--- a/recipes/fastan/meta.yaml
+++ b/recipes/fastan/meta.yaml
@@ -1,13 +1,17 @@
 {% set name = "fastan" %}
-{% set version = "0.5" %}
+{% set version = "0.8" %}
+{% set commit = "78fdc78a519319d70bda0ab6f49e5eb58d2eb7f9" %}
 
 package:
   name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://github.com/thegenemyers/FASTAN/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 0dbddc3b57e335574051311e49e45dfab45f38b5ffdf3865ad3a1a4c54df13c6
+  # Upstream README declares "Release v0.8 (2026-04-25)" but has not git-tagged
+  # it; pin the masking-enabled master commit (adds -m / .1ano tandem-mask output
+  # that v0.5 lacks). Please tag a release upstream so this can pin a tag.
+  url: https://github.com/thegenemyers/FASTAN/archive/{{ commit }}.tar.gz
+  sha256: de332704eb65e01dbf007a5d323b73773827247824434451bbcd93abe04dfd0d
   patches:
     - 0001-Makefile.patch
 

--- a/recipes/fastan/meta.yaml
+++ b/recipes/fastan/meta.yaml
@@ -23,6 +23,7 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
+    - {{ stdlib('c') }}
     - make
   host:
     - zlib


### PR DESCRIPTION
Bumps `fastan` from 0.5 to 0.8.

**Why:** the 0.5 release does not implement masking — its `-m` flag prints
"not yet implemented" and it only emits a `.1aln` alignment file. The 0.8 line
adds the `-m` / `.1ano` tandem-repeat **mask annotation** output (a BED-like
interval set), which is what downstream consumers need.

**Source pin:** upstream's README declares "Release v0.8 (2026-04-25)" but the
repository has **not git-tagged it** (only `v0.5` exists), so this pins the
masking-enabled `master` commit `78fdc78a519319d70bda0ab6f49e5eb58d2eb7f9`.
Happy to switch to a tag if the maintainers prefer — it may be worth asking
@thegenemyers to cut a `v0.8` release tag.

**Patch:** refreshed `0001-Makefile.patch` against the new Makefile
(`DEST_DIR=$(PREFIX)/bin`, add `-I$(PREFIX)/include -L$(PREFIX)/lib`, `CC ?= gcc`,
`install -m 0755`). Verified it applies (`patch -p1` / `git apply`) and builds
cleanly against the pinned commit.

---
- [x] Recipe updated (version, source url+sha256, refreshed patch)
- [x] Patch verified to apply and build
