### PR TITLE
Add labretriever

### DIFF
--- a/recipes/labretriever/meta.yaml
+++ b/recipes/labretriever/meta.yaml
@@ -1,0 +1,54 @@
+{% set version = "1.1.3" %}
+
+package:
+  name: labretriever
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/l/labretriever/labretriever-{{ version }}.tar.gz
+  sha256: 6ee7aba735f6db9dfc4f25c6c7f46958e543602414772bec4978c5272111db31
+
+build:
+  run_exports:
+    - {{ pin_subpackage('labretriever', max_pin="x") }}
+  entry_points:
+    - labretriever-mcp = labretriever.mcp_server:vdb_main
+    - labretriever-mcp-repo = labretriever.mcp_server:repo_main
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python >=3.11,<4.0
+    - poetry-core
+    - pip
+  run:
+    - python >=3.11.0,<4.0.0
+    - requests >=2.32.3,<3.0.0
+    - pandas >=2.3.1,<3.0.0
+    - huggingface_hub >=0.34.4,<0.35.0
+    - python-duckdb >=1.3.2,<2.0.0
+    - pydantic >=2.11.9,<3.0.0
+    - mcp >=1.27.1,<2.0.0
+
+test:
+  imports:
+    - labretriever
+  commands:
+    - pip check
+    - labretriever-mcp --help
+    - labretriever-mcp-repo --help
+  requires:
+    - pip
+    - python
+
+about:
+  home: https://pypi.org/project/labretriever/
+  summary: A collection of classes and functions to facilitate interaction with django.tfbindingandmodeling.com
+  license: GPL-3.0-or-later
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - chasem

--- a/recipes/labretriever/meta.yaml
+++ b/recipes/labretriever/meta.yaml
@@ -45,7 +45,11 @@ test:
 
 about:
   home: https://pypi.org/project/labretriever/
-  summary: A collection of classes and functions to facilitate interaction with django.tfbindingandmodeling.com
+  summary: >-
+    This package defines an extended datacard format based on the Huggingface datacard specification
+    that allows for the precise documentation of experimental data with complex heterogenous designs.
+    It provides a coordination layer to define common fields across datasets, and a query API to
+    coordinate and search the collection as if it were a structured database.
   license: GPL-3.0-or-later
   license_file: LICENSE
 


### PR DESCRIPTION
Add labretriever, a package for managing the metadata and providing a query API on genomics datasets. See https://huggingface.co/collections/BrentLab/yeastresources
