### PR TITLE
Rebuild cyvcf2 for Python 3.14

### DIFF
--- a/recipes/cyvcf2/meta.yaml
+++ b/recipes/cyvcf2/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   skip: True  # [py < 37]
   script:
     - export CFLAGS="${CFLAGS} -O3 -Wno-implicit-function-declaration -Wno-int-conversion"


### PR DESCRIPTION
Bumps the `cyvcf2` build number (`0 → 1`) to rebuild 0.33.0 under the current pinning, which now includes Python 3.14.

cyvcf2 0.33.0 already supports 3.14 (it ships `cp314` wheels on PyPI) and the recipe has no upper Python skip (`skip: True  # [py < 37]` only). Its published artifacts stop at `py313` simply because 0.33.0 was built before 3.14 entered bioconda's matrix. Other compiled bioconda packages (e.g. `pysam`) already have `py314` builds, so the infrastructure is ready.

No source or version change — build-number bump only.