### PR TITLE
Add deeptaxa-rrna

### DIFF
--- a/recipes/deeptaxa-rrna/meta.yaml
+++ b/recipes/deeptaxa-rrna/meta.yaml
@@ -1,0 +1,64 @@
+{% set name = "deeptaxa-rrna" %}
+{% set version = "1.0.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  # The PyPI sdist is named with underscores (deeptaxa_rrna-<version>.tar.gz).
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name|replace('-', '_') }}-{{ version }}.tar.gz
+  sha256: ef69f222733f7b0d322e06959f3d2f6b0c1ca11b304f1cf18baf46b4f09e2342
+
+build:
+  noarch: python
+  number: 0
+  script:
+    - export SETUPTOOLS_SCM_PRETEND_VERSION={{ version }}
+    - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  entry_points:
+    - deeptaxa = deeptaxa.cli:main
+
+requirements:
+  host:
+    - python >=3.10
+    - pip
+    - setuptools >=77
+    - setuptools-scm >=6.2
+    - wheel
+  run:
+    - python >=3.10
+    - pytorch
+    - numpy
+    - transformers
+    - pandas
+    - tqdm
+    - scikit-learn
+    - biopython
+    - h5py
+    - optuna
+
+test:
+  imports:
+    - deeptaxa
+  commands:
+    - deeptaxa --version
+
+about:
+  home: https://github.com/systems-genomics-lab/deeptaxa
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: "Hybrid CNN-BERT deep learning framework for taxonomic classification of 16S rRNA gene sequences"
+  description: |
+    DeepTaxa is a hybrid CNN-BERT deep learning framework for multi-rank
+    taxonomic classification of 16S rRNA gene sequences across the seven
+    Linnean ranks (domain through species). It is distributed on PyPI and
+    Bioconda as "deeptaxa-rrna"; the import package and command-line tool
+    are both named "deeptaxa".
+  doc_url: https://systems-genomics-lab.github.io/deeptaxa/
+  dev_url: https://github.com/systems-genomics-lab/deeptaxa
+
+extra:
+  recipe-maintainers:
+    - ahmedmoustafa

--- a/recipes/deeptaxa-rrna/meta.yaml
+++ b/recipes/deeptaxa-rrna/meta.yaml
@@ -13,6 +13,8 @@ source:
 build:
   noarch: python
   number: 0
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x") }}
   script:
     - export SETUPTOOLS_SCM_PRETEND_VERSION={{ version }}
     - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation


### PR DESCRIPTION
Adds a recipe for **deeptaxa-rrna**, a hybrid CNN-BERT deep-learning framework for taxonomic classification of 16S rRNA gene sequences (published in *Bioinformatics Advances*, https://doi.org/10.1093/bioadv/vbag166).

- Source: PyPI sdist (`deeptaxa-rrna` 1.0.1)
- Pure Python (`noarch: python`)
- Import package and CLI are both `deeptaxa`; test runs `deeptaxa --version`
- Upstream: https://github.com/systems-genomics-lab/deeptaxa
- Docs/tutorials: https://systems-genomics-lab.github.io/deeptaxa/

Maintainer: @ahmedmoustafa