### PR TITLE
update hapfold to v0.2.0

### DIFF
--- a/recipes/hapfold/meta.yaml
+++ b/recipes/hapfold/meta.yaml
@@ -6,9 +6,9 @@ package:
 
 source:
   url: https://github.com/LuoGroup2023/HapFold/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 02512e93ef78dfbdbbad91cb83e31efa8e2393195b507431a1dfe6c82ba21fe6
+  sha256: 898f81ca452fa2954bed369b1dfa763b522ba721ef998bc71cd695b760827004
 build:
-  number: 0
+  number: 1
   skip: True # [osx]
   run_exports:
     - {{ pin_subpackage('hapfold', max_pin="x.x") }}


### PR DESCRIPTION
add build number and update sha256 for hapfold v0.2.0
