### PR TITLE
Allow python 3.14 in cyvcf2

### DIFF
--- a/recipes/cyvcf2/conda_build_config.yaml
+++ b/recipes/cyvcf2/conda_build_config.yaml
@@ -1,0 +1,36 @@
+# Extend the Python build matrix to include 3.14 (cp314); the conda-forge
+# default pinning does not yet enable 3.14 on linux/osx. cyvcf2 supports 3.14
+# upstream (0.33.0 ships cp314 wheels on PyPI). numpy is pinned to the oldest
+# numpy-2 release per Python (numpy-2 forward-compatible ABI), which satisfies
+# the recipe's `numpy >=2.0.0` build requirement.
+# Extra dependency versions: https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/main/recipe/conda_build_config.yaml
+zip_keys:
+  - [python, python_impl, numpy, is_python_min]
+
+python:
+  - 3.10.* *_cpython
+  - 3.11.* *_cpython
+  - 3.12.* *_cpython
+  - 3.13.* *_cp313
+  - 3.14.* *_cp314
+
+python_impl:
+  - cpython
+  - cpython
+  - cpython
+  - cpython
+  - cpython
+
+numpy:
+  - 2.0
+  - 2.0
+  - 2.0
+  - 2.1
+  - 2.3
+
+is_python_min:
+  - false
+  - false
+  - false
+  - false
+  - false

--- a/recipes/cyvcf2/meta.yaml
+++ b/recipes/cyvcf2/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 2
   skip: True  # [py < 37]
   script:
     - export CFLAGS="${CFLAGS} -O3 -Wno-implicit-function-declaration -Wno-int-conversion"


### PR DESCRIPTION
Adds `recipes/cyvcf2/conda_build_config.yaml` to extend the Python build matrix to include 3.14 (`cp314`), and bumps the build number to 2.

cyvcf2 supports Python 3.14 upstream (0.33.0 ships `cp314` wheels on PyPI), but the bioconda channel only has `py310`–`py313` builds because the conda-forge default pinning does not yet enable 3.14 on linux/osx. This mirrors the approach used for `pysam` (#64731) and `pyfastx` (#62077).

`numpy` is pinned to the oldest numpy-2 release per Python (numpy-2's forward-compatible ABI), which satisfies the recipe's existing `numpy >=2.0.0` build requirement:

| Python | numpy |
|---|---|
| 3.10–3.12 | 2.0 |
| 3.13 | 2.1 |
| 3.14 | 2.3 |

`conda render` produces all five variants (`py310`–`py314`) with no dependency conflicts.