### PR TITLE
fastga: install ANOtoBED, BEDtoANO, ANOstat, ANOshow, FastKS

### DIFF
--- a/recipes/fastga/build.sh
+++ b/recipes/fastga/build.sh
@@ -10,4 +10,5 @@ install -v -m 0755 FastGA \
     FAtoGDB GIXmake ALNtoPAF ALNtoPSL \
     GDBshow GDBstat GIXshow ALNshow ALNplot \
     GDBtoFA GIXrm GIXcp GIXmv ALNchain ALNreset PAFtoALN PAFtoPSL \
-    ONEview $PREFIX/bin
+    ONEview FastKS \
+    ANOtoBED BEDtoANO ANOstat ANOshow $PREFIX/bin

--- a/recipes/fastga/meta.yaml
+++ b/recipes/fastga/meta.yaml
@@ -14,6 +14,7 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
+    - {{ stdlib('c') }}
     - make
   host:
     - zlib  

--- a/recipes/fastga/meta.yaml
+++ b/recipes/fastga/meta.yaml
@@ -7,7 +7,7 @@ source:
   sha256: c12e8f54ff69f76e872a8878a5a2e68c4a7bce18f91e246d2e06b21871477a0e
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage('fastga', max_pin="x") }}
 
@@ -41,6 +41,11 @@ test:
     - PAFtoALN 2>&1 | grep Usage
     - PAFtoPSL 2>&1 | grep Usage
     - ONEview
+    - FastKS 2>&1 | grep Usage
+    - ANOtoBED 2>&1 | grep Usage
+    - BEDtoANO 2>&1 | grep Usage
+    - ANOstat 2>&1 | grep Usage
+    - ANOshow 2>&1 | grep Usage
 
 about:
   home: https://github.com/thegenemyers/FASTGA


### PR DESCRIPTION
This adds the five binaries that FASTGA's `Makefile` already builds at `v1.5`
(they are in the `ALL` target, so `make` compiles them today) but that
`build.sh` does not install:

- **ANOtoBED**, **BEDtoANO**, **ANOstat**, **ANOshow** — the documented `.1ano`
  annotation toolset (see the FASTGA README command list). `ANOtoBED` in
  particular is needed by downstream tools that convert FASTGA/FasTAN
  annotation output to BED.
- **FastKS** — the standalone adaptamer k-mer table builder (has its own
  `Usage`).

No source/version bump and no patch are required — the tools are already
compiled by the existing `make` invocation; this only adds them to the
`install` list and adds `2>&1 | grep Usage` test commands. Build number bumped
`0 -> 1`.

`ONEalnTEST` is intentionally **not** installed: it is the ONElib/alncode API
demonstration program referenced by the README ("see the make command for
ONEalnTEST"), not a user-facing command.

---
##### Checklist
- [x] Recipe builds the added binaries (already in `ALL`).
- [x] `build.number` bumped.
- [x] Tests added for each new command.
- [ ] (maintainer) `@BiocondaBot please add label` if appropriate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
