### PR TITLE
Add synth-saxs v0.1.6

### DIFF
--- a/recipes/synth-saxs/meta.yaml
+++ b/recipes/synth-saxs/meta.yaml
@@ -1,0 +1,45 @@
+{% set name = "synth-saxs" %}
+{% set version = "0.1.6" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name | replace("-", "_") }}-{{ version }}.tar.gz
+  sha256: 3e3f638a11f794f710409e355a6a6d6d619d824f0f0c1e7ff7e34d1d0aa10bf6
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x") }}
+
+requirements:
+  host:
+    - python >=3.10
+    - pip
+    - setuptools
+  run:
+    - python >=3.10
+    - numpy >=1.26.4
+    - biotite >=0.35.0
+    - scipy >=1.7.0
+
+test:
+  imports:
+    - synth_saxs
+
+about:
+  home: https://github.com/elkins/synth-saxs
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: Education-focused SAXS profile simulation from protein coordinates
+  doc_url: https://github.com/elkins/synth-saxs
+  dev_url: https://github.com/elkins/synth-saxs
+
+extra:
+  recipe-maintainers:
+    - elkins


### PR DESCRIPTION
synth-saxs is a lightweight Python library for simulating Small-Angle X-ray Scattering (SAXS) profiles from protein coordinates.
Add synth-saxs recipe for v0.1.6. Includes new interactive tutorials and memory optimizations.