### PR TITLE
minibwa: statically link vendored zlib-ng for faster gzip input

### DIFF
--- a/recipes/minibwa/build.sh
+++ b/recipes/minibwa/build.sh
@@ -4,15 +4,49 @@ set -xe
 
 mkdir -p "${PREFIX}/bin" "${PREFIX}/lib" "${PREFIX}/include"
 
+# Build the vendored zlib-ng (fetched as the `_zlib_ng` source) in ZLIB_COMPAT
+# mode: a static, drop-in libz.a + zlib.h with a faster inflate. Static so the
+# speedup is baked in without adding a runtime dependency or a track_features
+# anchor.
+DEPS="${SRC_DIR}/_deps"
+mkdir -p "${DEPS}"
+cmake -S "${SRC_DIR}/_zlib_ng" -B "${SRC_DIR}/_zlib_ng/build" -G Ninja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX="${DEPS}" \
+    -DZLIB_COMPAT=ON \
+    -DBUILD_SHARED_LIBS=OFF \
+    -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+    -DZLIB_ENABLE_TESTS=OFF \
+    -DWITH_GTEST=OFF
+cmake --build "${SRC_DIR}/_zlib_ng/build" --parallel "${CPU_COUNT}"
+cmake --install "${SRC_DIR}/_zlib_ng/build"
+
+# zlib-ng may install into lib or lib64 depending on the platform.
+ZLIBNG_LIBDIR="${DEPS}/lib"
+[ -f "${DEPS}/lib64/libz.a" ] && ZLIBNG_LIBDIR="${DEPS}/lib64"
+
+# The bundled SSE->NEON shim (s2n-lite.h) reinterprets uint32x4_t results
+# through signed int32x4_t intrinsics, which GCC on aarch64 rejects. Permit
+# the conversion as GCC itself suggests (clang/macOS already accepts it).
+case "$(uname -m)" in
+    aarch64 | arm64)
+        export CFLAGS="${CFLAGS} -flax-vector-conversions"
+        ;;
+esac
+
 # CC drives the Makefile's OpenMP auto-detection. The override-makefile.patch
 # lets the Makefile append its OpenMP/GPL/SSE4.2 flags on top of conda's
 # CFLAGS/CPPFLAGS rather than having them clobbered by the command line.
-# LIBS is left untouched so the Makefile keeps -lpthread -lz -lm.
+# CPPFLAGS points at the vendored zlib.h; LIBS replaces the Makefile's `-lz`
+# with the static zlib-ng archive so minibwa embeds the compat build rather
+# than linking the shared system zlib.
+export CPPFLAGS="-I${DEPS}/include ${CPPFLAGS}"
 make \
     CC="${CC}" \
     CFLAGS="${CFLAGS}" \
     CPPFLAGS="${CPPFLAGS}" \
     LDFLAGS="${LDFLAGS}" \
+    LIBS="-lpthread ${ZLIBNG_LIBDIR}/libz.a -lm" \
     -j"${CPU_COUNT}" \
     minibwa
 

--- a/recipes/minibwa/meta.yaml
+++ b/recipes/minibwa/meta.yaml
@@ -1,28 +1,42 @@
 {% set name = "minibwa" %}
 {% set version = "0.3" %}
+{% set zlibng_version = "2.3.3" %}
 
 package:
   name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://github.com/lh3/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: 85040b1b25caeee6304616c2bc081c313e0ff1a29006bb0295098b8ae51973de
-  patches:
-    - override-makefile.patch
+  - url: https://github.com/lh3/{{ name }}/archive/v{{ version }}.tar.gz
+    sha256: 85040b1b25caeee6304616c2bc081c313e0ff1a29006bb0295098b8ae51973de
+    patches:
+      - override-makefile.patch
+  # zlib-ng built in ZLIB_COMPAT mode is a drop-in libz with a much faster
+  # inflate. minibwa's gzip read path (kseq gzread) is single-threaded, so at
+  # high thread counts one inflate stream bottlenecks the mappers; statically
+  # linking zlib-ng lifts that ceiling (~7% faster at 96 threads on Graviton4).
+  # Vendored + static because the conda-forge `zlib-ng-compat` track_features
+  # anchor is not on the main channel; cf. the salmon recipe, which does the
+  # same. Declared as a second source so the build stays hermetic (no network).
+  - url: https://github.com/zlib-ng/zlib-ng/archive/refs/tags/{{ zlibng_version }}.tar.gz
+    sha256: f9c65aa9c852eb8255b636fd9f07ce1c406f061ec19a2e7d508b318ca0c907d1
+    folder: _zlib_ng
 
 build:
-  number: 1
+  number: 2
   run_exports:
     - {{ pin_subpackage(name, max_pin="x.x") }}
 
 requirements:
   build:
     - make
+    - cmake
+    - ninja
     - {{ compiler('c') }}
     - {{ stdlib("c") }}
   host:
-    - zlib
+    # zlib-ng is vendored and statically linked in build.sh (see source above),
+    # so no `zlib` here.
     - llvm-openmp  # [osx]
   run:
     - llvm-openmp  # [osx]


### PR DESCRIPTION
minibwa reads gzipped FASTQ through a single-threaded `kseq`/`gzread` path. At high thread counts one inflate stream becomes the bottleneck that starves the mappers. This builds zlib-ng in `ZLIB_COMPAT` mode (a drop-in `libz`/`zlib.h` with a much faster inflate) and statically links it in place of the stock `-lz`, with no source changes to minibwa.

Why vendored + static rather than a dependency: the conda-forge `zlib-ng-compat` package (the `track_features` anchor that swaps the system zlib) is not on the main channel, so it can't be used as a bioconda dependency. The plain `zlib-ng` package only ships the `zng_`-prefixed API, not a drop-in `libz`. Vendoring zlib-ng in compat mode is the same approach the `salmon` recipe uses. zlib-ng is declared as a second `source:` entry (pinned by sha256) so the build stays hermetic — no network fetch in `build.sh`.

Validation (on `linux-aarch64`, Graviton4):
- Built with `bioconda-utils build`; the binary statically embeds zlib-ng (no dynamic `libz`).
- Produces byte-identical SAM output vs the stock-zlib build (md5-identical over a 200k-read set).
- ~7% faster at 96 threads on a 20M read-pair hg38 alignment (40.7s vs 43.5s, 3 runs each, ±<0.4s); the gap scales with thread count (tied at 16/32t, 1.3% at 64t, 7.0% at 96t), confirming the inflate bottleneck. Measured on the v0.1 binary; the gzip I/O path is unchanged in v0.2.

Build number bumped to 1 (recipe change, same version).
