### PR TITLE
Add cs-tag

### DIFF
--- a/recipes/cs-tag/build.sh
+++ b/recipes/cs-tag/build.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+export CARGO_PROFILE_RELEASE_STRIP=symbols
+export CARGO_PROFILE_RELEASE_LTO=fat
+
+# Tell bindgen where to find libclang
+export LIBCLANG_PATH="${BUILD_PREFIX}/lib"
+
+# The Cargo project lives in the nested cs-tag/ directory of the source tree.
+cd cs-tag
+
+# Vendor all dependencies locally so we can patch them.
+mkdir -p .cargo
+cargo vendor vendor/ > .cargo/config.toml
+
+# rust-htslib 1.0.0 hardcodes features = ["bindgen"] on hts-sys in its
+# [dependencies.hts-sys] section. This forces runtime bindgen which produces
+# opaque struct bindings in conda's cross-compilation environment because
+# the sysroot lacks standard C headers. Patch it out so hts-sys uses its
+# pre-built bindings instead.
+sed -i 's/features = \["bindgen"\]/features = []/' \
+    vendor/rust-htslib/Cargo.toml
+
+# Fix pre-built bindings type mismatches between bindgen output and
+# what rust-htslib expects:
+# 1. size_t should be usize (not c_ulong/u64) to match rust-htslib usage
+# 2. bam1_core_t.isize should be isize_ to match rust-htslib field access
+BINDINGS=vendor/hts-sys/linux_prebuilt_bindings.rs
+sed -i 's/pub type size_t = ::std::os::raw::c_ulong;/pub type size_t = usize;/' "$BINDINGS"
+sed -i 's/pub isize:/pub isize_:/' "$BINDINGS"
+sed -i 's/stringify!(isize)/stringify!(isize_)/' "$BINDINGS"
+
+# Update checksums for all patched files so cargo accepts the modified vendor tree.
+for f in vendor/rust-htslib/Cargo.toml "$BINDINGS"; do
+    sha=$(sha256sum "$f" | cut -d' ' -f1)
+    base=$(basename "$f")
+    dir=$(dirname "$f")
+    sed -i "s|\"${base}\":\"[a-f0-9]*\"|\"${base}\":\"${sha}\"|" \
+        "${dir}/.cargo-checksum.json"
+done
+
+# Build from vendored deps
+cargo install --no-track --root "$PREFIX" --path .
+
+cargo-bundle-licenses --format yaml --output "${SRC_DIR}/cs-tag/THIRDPARTY.yml"

--- a/recipes/cs-tag/meta.yaml
+++ b/recipes/cs-tag/meta.yaml
@@ -17,6 +17,7 @@ build:
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - {{ compiler('rust') }}
     - clangdev

--- a/recipes/cs-tag/meta.yaml
+++ b/recipes/cs-tag/meta.yaml
@@ -1,0 +1,56 @@
+{% set name = "cs-tag" %}
+{% set version = "0.2.2" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/jiangyun-fun/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: cb2bd6bc6d3714f6f6d4815e3ce282d6ceeef025ac7fe73807b8a2b8e2d206fe
+
+build:
+  number: 0
+  skip: True  # [not linux]
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x") }}
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('rust') }}
+    - clangdev
+    - cmake
+    - make
+    - pkg-config
+    - cargo-bundle-licenses
+  host:
+    - zlib
+    - bzip2
+    - xz
+    - openssl
+    - libcurl
+
+test:
+  commands:
+    - cs-tag --help
+    - cs-tag --version
+
+about:
+  home: https://github.com/jiangyun-fun/cs-tag
+  license: MIT
+  license_family: MIT
+  license_file:
+    - LICENSE
+    - cs-tag/THIRDPARTY.yml
+  summary: "Generate minimap2-like CS tags for BAM files."
+  description: |
+    CS tags encode the alignment between query and reference sequences in a
+    compact string representation. cs-tag computes CS tags from an existing
+    BAM alignment and a reference FASTA, then writes them as auxiliary tags
+    into the output BAM.
+  dev_url: https://github.com/jiangyun-fun/cs-tag
+
+extra:
+  recipe-maintainers:
+    - jiangyun-fun


### PR DESCRIPTION
## New recipe: **cs-tag** v0.2.2

`cs-tag` is a Rust CLI that generates minimap2-like **CS tags** for BAM files — it computes the compact query/reference alignment string from an existing BAM alignment plus a reference FASTA and writes the result as an auxiliary tag into the output BAM.

- **Upstream:** https://github.com/jiangyun-fun/cs-tag
- **License:** MIT
- **Tests:** `cs-tag --help`, `cs-tag --version`
- **Maintainer:** @jiangyun-fun

### Build notes
cs-tag depends on `rust-htslib` 1.0.0, which forces the `bindgen` feature on `hts-sys`. Running bindgen at build time produces opaque struct bindings under conda's cross-compilation sysroot, so `build.sh`:

1. `cargo vendor`s the dependency tree,
2. patches `vendor/rust-htslib/Cargo.toml` to drop the `bindgen` feature so `hts-sys` uses its **pre-built bindings**,
3. fixes two type mismatches in those pre-built bindings (`size_t` → `usize`; the `bam1_core_t.isize` field rename) and refreshes the vendored `.cargo-checksum.json`,
4. builds with `cargo install` and bundles third-party licenses via `cargo-bundle-licenses`.

This is the same recipe already building successfully on conda-forge staged-recipes.

Scoped to **Linux** (`skip: not linux`) because the pre-built bindings path is Linux-specific; macOS support can follow in a follow-up PR.

Checklist:
- [x] Package not already in bioconda
- [x] Linter passes locally (`bioconda-utils` / recipe structure follows existing rust-htslib recipes: longshot, wgatools, var-agg)
- [x] License and third-party licenses bundled