### PR TITLE
Add cs-tagger

### DIFF
--- a/recipes/cs-tagger/build.sh
+++ b/recipes/cs-tagger/build.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+export CARGO_PROFILE_RELEASE_STRIP=symbols
+export CARGO_PROFILE_RELEASE_LTO=fat
+
+# Tell bindgen where to find libclang
+export LIBCLANG_PATH="${BUILD_PREFIX}/lib"
+
+# The Cargo project lives in the nested cs-tagger/ directory of the source tree.
+cd cs-tagger
+
+# Vendor all dependencies locally so we can patch them.
+mkdir -p .cargo
+cargo vendor vendor/ > .cargo/config.toml
+
+# rust-htslib 1.0.0 hardcodes features = ["bindgen"] on hts-sys in its
+# [dependencies.hts-sys] section. This forces runtime bindgen which produces
+# opaque struct bindings in conda's cross-compilation environment because
+# the sysroot lacks standard C headers. Patch it out so hts-sys uses its
+# pre-built bindings instead.
+sed -i 's/features = \["bindgen"\]/features = []/' \
+    vendor/rust-htslib/Cargo.toml
+
+# Fix pre-built bindings type mismatches between bindgen output and
+# what rust-htslib expects:
+# 1. size_t should be usize (not c_ulong/u64) to match rust-htslib usage
+# 2. bam1_core_t.isize should be isize_ to match rust-htslib field access
+BINDINGS=vendor/hts-sys/linux_prebuilt_bindings.rs
+sed -i 's/pub type size_t = ::std::os::raw::c_ulong;/pub type size_t = usize;/' "$BINDINGS"
+sed -i 's/pub isize:/pub isize_:/' "$BINDINGS"
+sed -i 's/stringify!(isize)/stringify!(isize_)/' "$BINDINGS"
+
+# Update checksums for all patched files so cargo accepts the modified vendor tree.
+for f in vendor/rust-htslib/Cargo.toml "$BINDINGS"; do
+    sha=$(sha256sum "$f" | cut -d' ' -f1)
+    base=$(basename "$f")
+    dir=$(dirname "$f")
+    sed -i "s|\"${base}\":\"[a-f0-9]*\"|\"${base}\":\"${sha}\"|" \
+        "${dir}/.cargo-checksum.json"
+done
+
+# Build from vendored deps
+cargo install --no-track --root "$PREFIX" --path .
+
+cargo-bundle-licenses --format yaml --output "${SRC_DIR}/cs-tagger/THIRDPARTY.yml"

--- a/recipes/cs-tagger/meta.yaml
+++ b/recipes/cs-tagger/meta.yaml
@@ -1,0 +1,57 @@
+{% set name = "cs-tagger" %}
+{% set version = "0.3.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/jiangyun-fun/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: bd3b3753e21d7077f2cfe118bbd9dde142cbf1611f26bebd65edbd516c5d4586
+
+build:
+  number: 0
+  skip: True  # [not linux]
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x") }}
+
+requirements:
+  build:
+    - {{ stdlib('c') }}
+    - {{ compiler('c') }}
+    - {{ compiler('rust') }}
+    - clangdev
+    - cmake
+    - make
+    - pkg-config
+    - cargo-bundle-licenses
+  host:
+    - zlib
+    - bzip2
+    - xz
+    - openssl
+    - libcurl
+
+test:
+  commands:
+    - cs-tagger --help
+    - cs-tagger --version
+
+about:
+  home: https://github.com/jiangyun-fun/cs-tagger
+  license: MIT
+  license_family: MIT
+  license_file:
+    - LICENSE
+    - cs-tagger/THIRDPARTY.yml
+  summary: "Generate minimap2-like CS tags for BAM files."
+  description: |
+    CS tags encode the alignment between query and reference sequences in a
+    compact string representation. cs-tagger computes CS tags from an existing
+    BAM alignment and a reference FASTA, then writes them as auxiliary tags
+    into the output BAM.
+  dev_url: https://github.com/jiangyun-fun/cs-tagger
+
+extra:
+  recipe-maintainers:
+    - jiangyun-fun


### PR DESCRIPTION
## New recipe: **cs-tagger** v0.3.0

`cs-tagger` (renamed from `cs-tag`) is a Rust CLI that generates minimap2-like **CS tags** for BAM files — it computes the compact query/reference alignment string from an existing BAM alignment plus a reference FASTA and writes it as an auxiliary tag into the output BAM.

- **Upstream:** https://github.com/jiangyun-fun/cs-tagger
- **License:** MIT
- **Tests:** `cs-tagger --help`, `cs-tagger --version`
- **Maintainer:** @jiangyun-fun

> Note: this supersedes #66467, which added the same tool under its previous name `cs-tag`. The upstream project was renamed to `cs-tagger` (repo + Cargo package + binary) and re-released as v0.3.0; this PR tracks the new name.

### Build notes
cs-tagger depends on `rust-htslib` 1.0.0, which forces the `bindgen` feature on `hts-sys`. Running bindgen at build time produces opaque struct bindings under conda's cross-compilation sysroot, so `build.sh`:

1. `cargo vendor`s the dependency tree,
2. patches `vendor/rust-htslib/Cargo.toml` to drop the `bindgen` feature so `hts-sys` uses its **pre-built bindings**,
3. fixes two type mismatches in those pre-built bindings (`size_t` → `usize`; the `bam1_core_t.isize` field rename) and refreshes the vendored `.cargo-checksum.json`,
4. builds with `cargo install` and bundles third-party licenses via `cargo-bundle-licenses`.

This is the same recipe that built successfully on conda-forge staged-recipes (and as `cs-tag` in #66467, where all checks were green).

Scoped to **Linux** (`skip: not linux`) because the pre-built bindings path is Linux-specific; macOS support can follow.

Checklist:
- [x] Package not already in bioconda
- [x] License and third-party licenses bundled