### PR TITLE
r-goalie 0.7.9: fix license_file (LICENSE -> LICENSE.md)

### DIFF
--- a/recipes/r-goalie/meta.yaml
+++ b/recipes/r-goalie/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.7.8" %}
+{% set version = "0.7.9" %}
 {% set github = "https://github.com/acidgenomics/r-goalie" %}
 
 package:
@@ -7,7 +7,7 @@ package:
 
 source:
   url: "{{ github }}/archive/v{{ version }}.tar.gz"
-  sha256: 7f92b652c452f19fb122532e991d842588772dcbd74e22fbddbb3630606f004f
+  sha256: 301fd70218646e7e41f6e7a65ff66355e53ba9a98917a55874b7e81dbc1009f9
   
 build:
   number: 0

--- a/recipes/r-goalie/meta.yaml
+++ b/recipes/r-goalie/meta.yaml
@@ -13,7 +13,7 @@ build:
   number: 0
   noarch: generic
   run_exports:
-    - {{ pin_subpackage('r-goalie', max_pin="x.x") }}
+    - {{ pin_subpackage("r-goalie", max_pin="x.x") }}
 
 requirements:
   host:
@@ -23,13 +23,13 @@ requirements:
 
 test:
   commands:
-    - $R -e "library('goalie')"
+    - $R -e "library("goalie")"
 
 about:
   home: https://r.acidgenomics.com/packages/goalie/
   dev_url: "{{ github }}"
   license: AGPL-3
-  license_file: LICENSE
+  license_file: LICENSE.md
   license_family: GPL
   summary: Assertive check functions for defensive R programming.
 


### PR DESCRIPTION
Fixes the build failure on #66487.

Upstream renamed `LICENSE` to `LICENSE.md` in v0.7.9. The recipe still declared `license_file: LICENSE`, causing:

```
ValueError: License file given in about/license_file (/opt/recipe/LICENSE) does not exist in source root dir
```

This is a one-line fix to unblock the r-base 4.5 migration for the entire Acid Genomics R stack.