### PR TITLE
r-acidbase 0.7.6: fix license_file (LICENSE -> LICENSE.md)

### DIFF
--- a/recipes/r-acidbase/meta.yaml
+++ b/recipes/r-acidbase/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.7.5" %}
+{% set version = "0.7.6" %}
 {% set github = "https://github.com/acidgenomics/r-acidbase" %}
 
 package:
@@ -7,7 +7,7 @@ package:
 
 source:
   url: "{{ github }}/archive/v{{ version }}.tar.gz"
-  sha256: a475c4fac1de259fbdd642301baf4a1e4a49c200ec0777753f45246afc53778b
+  sha256: 175c8d114dafb865fcc0ff05aabcc4aa75c96c998b28f3b1b6ea4cf5474056a9
 
 build:
   number: 0

--- a/recipes/r-acidbase/meta.yaml
+++ b/recipes/r-acidbase/meta.yaml
@@ -13,7 +13,7 @@ build:
   number: 0
   noarch: generic
   run_exports:
-    - {{ pin_subpackage('r-acidbase', max_pin="x.x") }}
+    - {{ pin_subpackage("r-acidbase", max_pin="x.x") }}
 
 requirements:
   host:
@@ -45,13 +45,13 @@ requirements:
 
 test:
   commands:
-    - $R -e "library('AcidBase')"
+    - $R -e "library("AcidBase")"
 
 about:
   home: https://r.acidgenomics.com/packages/acidbase/
   dev_url: "{{ github }}"
   license: AGPL-3.0
-  license_file: LICENSE
+  license_file: LICENSE.md
   license_family: GPL
   summary: Low-level base functions imported by Acid Genomics packages.
 


### PR DESCRIPTION
Fixes the build failure on #66484.

Two issues block this autobump PR:

1. **LICENSE rename** — upstream renamed `LICENSE` to `LICENSE.md` in v0.7.6. The recipe still declared `license_file: LICENSE`, causing a build abort before the solve even starts.

2. **r-base 4.5 dependency gap** — bioconda's global pin is now `r_base: 4.5.*`, but the Acid deps (`r-acidcli`, `r-acidgenerics`, `r-goalie`) have no r45 builds yet. Companion PRs #66490 (r-goalie fix), #66491 (r-acidgenerics rebuild), #66492 (r-acidcli rebuild) address that in dependency order.

This PR only fixes issue 1. Once the tier-1 r45 builds are live, CI on this PR should pass.