### PR TITLE
r-acidgenerics 0.7.10: rebuild for r-base 4.5 migration

### DIFF
--- a/recipes/r-acidgenerics/meta.yaml
+++ b/recipes/r-acidgenerics/meta.yaml
@@ -10,10 +10,10 @@ source:
   sha256: 2abc95a86bdb0ac4594aca0a942ccea37f17370c9add6c592e2f9af8b5b9031b
 
 build:
-  number: 0
+  number: 1
   noarch: generic
   run_exports:
-    - {{ pin_subpackage('r-acidgenerics', max_pin="x.x") }}
+    - {{ pin_subpackage("r-acidgenerics", max_pin="x.x") }}
 
 requirements:
   host:
@@ -23,7 +23,7 @@ requirements:
 
 test:
   commands:
-    - $R -e "library('AcidGenerics')"
+    - $R -e "library("AcidGenerics")"
 
 about:
   home: https://r.acidgenomics.com/packages/acidgenerics/


### PR DESCRIPTION
Build number bump to trigger a rebuild against bioconda's new global pin `r_base: 4.5.*`.

r-acidgenerics has no Acid-internal deps so it is a tier-1 leaf in the rebuild order. Once this lands with an `r45hdfd78af_*` build, downstream packages (r-acidbase, r-pipette) can satisfy their dependency solves against r-base 4.5.

Part of the r-base 4.5 migration for the Acid Genomics R stack. See also: #66490 (r-goalie fix), #66491 (r-acidbase fix), #66492 (r-acidcli rebuild).