### PR TITLE
r-acidcli 0.3.2: rebuild for r-base 4.5 migration

### DIFF
--- a/recipes/r-acidcli/meta.yaml
+++ b/recipes/r-acidcli/meta.yaml
@@ -10,10 +10,10 @@ source:
   sha256: 6cb99c5cb6054069db1f2c072b9f8df30b6375bb1d2bc9291e6a3221776d96e5
 
 build:
-  number: 0
+  number: 1
   noarch: generic
   run_exports:
-    - {{ pin_subpackage('r-acidcli', max_pin="x.x") }}
+    - {{ pin_subpackage("r-acidcli", max_pin="x.x") }}
 
 requirements:
   host:
@@ -35,7 +35,7 @@ requirements:
 
 test:
   commands:
-    - $R -e "library('AcidCLI')"
+    - $R -e "library("AcidCLI")"
 
 about:
   home: https://r.acidgenomics.com/packages/acidcli/


### PR DESCRIPTION
Build number bump to trigger a rebuild against bioconda's new global pin `r_base: 4.5.*`.

r-acidcli depends on r-goalie; land #66490 (r-goalie 0.7.9 fix) first so this picks up an r45 build of r-goalie. Once this lands, r-acidbase (#66491 / #66484) can satisfy its full dependency closure against r-base 4.5.

Part of the r-base 4.5 migration for the Acid Genomics R stack.