### PR TITLE
Add funtaxfinder 0.1.0

### DIFF
--- a/recipes/funtaxfinder/meta.yaml
+++ b/recipes/funtaxfinder/meta.yaml
@@ -9,10 +9,13 @@ source:
   url: https://github.com/Zhoufengwu/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
   sha256: b1c158722a2fac8fec6eeecd360f0380e5cad8d1552330dc32ad8ff489b92c70
 
+
 build:
   noarch: python
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x.x") }}
 
 requirements:
   host:

--- a/recipes/funtaxfinder/meta.yaml
+++ b/recipes/funtaxfinder/meta.yaml
@@ -1,0 +1,50 @@
+{% set name = "funtaxfinder" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/Zhoufengwu/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: b1c158722a2fac8fec6eeecd360f0380e5cad8d1552330dc32ad8ff489b92c70
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+
+requirements:
+  host:
+    - python >=3.10
+    - pip
+    - setuptools >=69
+    - wheel
+  run:
+    - python >=3.10
+    - pandas
+    - picrust2 >=2.6.3
+
+test:
+  imports:
+    - funtaxfinder
+  commands:
+    - funtaxfinder --help
+    - funtaxfinder --version
+
+about:
+  home: https://github.com/YOUR_GITHUB_USERNAME/funtaxfinder
+  dev_url: https://github.com/YOUR_GITHUB_USERNAME/funtaxfinder
+  doc_url: https://github.com/YOUR_GITHUB_USERNAME/funtaxfinder#readme
+  license: MIT
+  license_file: LICENSE
+  summary: Screen functional microbial ASVs from PICRUSt2 KO predictions
+  description: |
+    FunTaxFinder screens ASVs according to selected KEGG Orthology identifiers
+    from PICRUSt2 per-sequence prediction tables. It produces matched ASV
+    abundance tables, KO hit matrices, taxonomy annotations, optional
+    rank-specific subsets, and optional FAPROTAX cross-validation.
+
+extra:
+  recipe-maintainers:
+    - Zhoufengwu

--- a/recipes/funtaxfinder/run_test.sh
+++ b/recipes/funtaxfinder/run_test.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cat > asv_table.tsv <<'EOF'
+ASV_ID	Sample1	Sample2
+ASV1	10	0
+ASV2	0	5
+EOF
+
+cat > combined_KO_predicted.tsv <<'EOF'
+ASV_ID	K02586	K02588
+ASV1	1.5	0
+ASV2	0	2.0
+EOF
+
+funtaxfinder \
+    --asv-table asv_table.tsv \
+    --ko K02586 \
+    --ko-predicted combined_KO_predicted.tsv \
+    --outdir test_output
+
+test -s test_output/sub_asv_table.tsv
+test -s test_output/matched_asv_summary.tsv
+test -s test_output/run_summary.txt
+
+grep -q $'^ASV1\t' test_output/sub_asv_table.tsv
+
+if grep -q $'^ASV2\t' test_output/sub_asv_table.tsv; then
+    echo "ASV2 should not have matched K02586" >&2
+    exit 1
+fi


### PR DESCRIPTION
This PR adds FunTaxFinder 0.1.0.

FunTaxFinder is a Python command-line tool for screening functional microbial ASVs from PICRUSt2 ASV-by-KO prediction tables. It supports KO-based ASV screening, matched ASV abundance table extraction, taxonomy annotation, rank-based splitting, and optional FAPROTAX cross-validation.

The package is pure Python and is built as noarch.