### PR TITLE
Update r-goalie to 0.7.10

### DIFF
--- a/recipes/r-goalie/meta.yaml
+++ b/recipes/r-goalie/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.7.8" %}
+{% set version = "0.7.10" %}
 {% set github = "https://github.com/acidgenomics/r-goalie" %}
 
 package:
@@ -7,8 +7,8 @@ package:
 
 source:
   url: "{{ github }}/archive/v{{ version }}.tar.gz"
-  sha256: 7f92b652c452f19fb122532e991d842588772dcbd74e22fbddbb3630606f004f
-  
+  sha256: 2bf03a0208744d447ee7a9549fe195aceb518f69f4b9559e526eb9b6d94a5fd7
+
 build:
   number: 0
   noarch: generic
@@ -28,9 +28,9 @@ test:
 about:
   home: https://r.acidgenomics.com/packages/goalie/
   dev_url: "{{ github }}"
-  license: AGPL-3
-  license_file: LICENSE
-  license_family: GPL
+  license: Apache-2.0
+  license_file: LICENSE.md
+  license_family: APACHE
   summary: Assertive check functions for defensive R programming.
 
 extra:


### PR DESCRIPTION
- Version: 0.7.8 → 0.7.10
- License: AGPL-3 → Apache-2.0
- license_file: LICENSE → LICENSE.md
- license_family: GPL → APACHE

Supersedes bot PR #66494 (`bump/r_goalie`) which has the wrong license.