### PR TITLE
Update r-acidgenerics to 0.7.11

### DIFF
--- a/recipes/r-acidgenerics/meta.yaml
+++ b/recipes/r-acidgenerics/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.7.10" %}
+{% set version = "0.7.11" %}
 {% set github = "https://github.com/acidgenomics/r-acidgenerics" %}
 
 package:
@@ -7,7 +7,7 @@ package:
 
 source:
   url: "{{ github }}/archive/v{{ version }}.tar.gz"
-  sha256: 2abc95a86bdb0ac4594aca0a942ccea37f17370c9add6c592e2f9af8b5b9031b
+  sha256: 54dbc1ea95d6228715a045a8778d26caabd97d2b8882c5dba1443ea059fe41f2
 
 build:
   number: 0
@@ -28,9 +28,9 @@ test:
 about:
   home: https://r.acidgenomics.com/packages/acidgenerics/
   dev_url: "{{ github }}"
-  license: AGPL-3.0
-  license_file: LICENSE
-  license_family: GPL
+  license: Apache-2.0
+  license_file: LICENSE.md
+  license_family: APACHE
   summary: S4 generic functions for Acid Genomics packages.
 
 extra:


### PR DESCRIPTION
- Version: 0.7.10 → 0.7.11
- License: AGPL-3.0 → Apache-2.0
- license_file: LICENSE → LICENSE.md
- license_family: GPL → APACHE