### PR TITLE
Add r-acidtest 0.9.2

### DIFF
--- a/recipes/r-acidtest/build.sh
+++ b/recipes/r-acidtest/build.sh
@@ -1,0 +1,1 @@
+$R CMD INSTALL --build .

--- a/recipes/r-acidtest/meta.yaml
+++ b/recipes/r-acidtest/meta.yaml
@@ -1,0 +1,39 @@
+{% set version = "0.9.2" %}
+{% set github = "https://github.com/acidgenomics/r-acidtest" %}
+
+package:
+  name: r-acidtest
+  version: "{{ version }}"
+
+source:
+  url: "{{ github }}/archive/v{{ version }}.tar.gz"
+  sha256: 82db661faa40d82d1aba446cc10f87a1c75c15771d98ace6a0bcd4d0def7bb2a
+
+build:
+  number: 0
+  noarch: generic
+  run_exports:
+    - {{ pin_subpackage('r-acidtest', max_pin="x.x") }}
+
+requirements:
+  host:
+    - r-base
+  run:
+    - r-base
+
+test:
+  commands:
+    - $R -e "library('AcidTest')"
+
+about:
+  home: https://r.acidgenomics.com/packages/acidtest/
+  dev_url: "{{ github }}"
+  license: Apache-2.0
+  license_file: LICENSE.md
+  license_family: APACHE
+  summary: Reference data for Acid Genomics unit tests.
+
+extra:
+  recipe-maintainers:
+    - acidgenomics
+    - mjsteinbaugh


### PR DESCRIPTION
New recipe for AcidTest 0.9.2.

- noarch: generic
- License: Apache-2.0