### PR TITLE
Update r-cellosaurus to 0.8.4

### DIFF
--- a/recipes/r-cellosaurus/meta.yaml
+++ b/recipes/r-cellosaurus/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.8.2" %}
+{% set version = "0.8.4" %}
 {% set github = "https://github.com/acidgenomics/r-cellosaurus" %}
 
 package:
@@ -7,11 +7,11 @@ package:
 
 source:
   url: "{{ github }}/archive/v{{ version }}.tar.gz"
-  sha256: 83d730b19dfe21ca7447d8eaf674b991010300918bb17dad70f25458617b33a3
+  sha256: dfd91fb4b506eb49d1a9498a19c9fbc3311bdbaa9aa7659e2eacb3b966f58742
 
 build:
   noarch: generic
-  number: 1
+  number: 0
   run_exports:
     - {{ pin_subpackage('r-cellosaurus', max_pin="x.x") }}
 
@@ -20,30 +20,30 @@ requirements:
     # Depends:
     - r-base
     # Imports:
-    - bioconductor-biocgenerics >=0.46.0
-    - bioconductor-iranges >=2.34.0
-    - bioconductor-s4vectors >=0.38.0
-    - r-acidbase >=0.7.0
+    - bioconductor-biocgenerics >=0.48.0
+    - bioconductor-iranges >=2.36.0
+    - bioconductor-s4vectors >=0.40.0
+    - r-acidbase >=0.7.3
     - r-acidcli >=0.3.0
-    - r-acidgenerics >=0.7.1
-    - r-acidplyr >=0.4.2
-    - r-goalie >=0.7.1
-    - r-pipette >=0.14.0
-    - r-syntactic >=0.7.0
+    - r-acidgenerics >=0.7.6
+    - r-acidplyr >=0.5.3
+    - r-goalie >=0.7.7
+    - r-pipette >=0.15.2
+    - r-syntactic >=0.7.1
   run:
     # Depends:
     - r-base
     # Imports:
-    - bioconductor-biocgenerics >=0.46.0
-    - bioconductor-iranges >=2.34.0
-    - bioconductor-s4vectors >=0.38.0
-    - r-acidbase >=0.7.0
+    - bioconductor-biocgenerics >=0.48.0
+    - bioconductor-iranges >=2.36.0
+    - bioconductor-s4vectors >=0.40.0
+    - r-acidbase >=0.7.3
     - r-acidcli >=0.3.0
-    - r-acidgenerics >=0.7.1
-    - r-acidplyr >=0.4.2
-    - r-goalie >=0.7.1
-    - r-pipette >=0.14.0
-    - r-syntactic >=0.7.0
+    - r-acidgenerics >=0.7.6
+    - r-acidplyr >=0.5.3
+    - r-goalie >=0.7.7
+    - r-pipette >=0.15.2
+    - r-syntactic >=0.7.1
 
 test:
   commands:
@@ -52,9 +52,9 @@ test:
 about:
   home: https://r.acidgenomics.com/packages/cellosaurus/
   dev_url: "{{ github }}"
-  license: AGPL-3.0
-  license_file: LICENSE
-  license_family: GPL
+  license: Apache-2.0
+  license_file: LICENSE.md
+  license_family: APACHE
   summary: Cellosaurus identifier mapping toolkit.
 
 extra:


### PR DESCRIPTION
- Update r-cellosaurus 0.8.2 → 0.8.4
- License: Apache-2.0 (LICENSE.md present in tarball)
- Update dep pins per DESCRIPTION