### PR TITLE
Update r-eggnog to 0.3.2

### DIFF
--- a/recipes/r-eggnog/meta.yaml
+++ b/recipes/r-eggnog/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.3.1" %}
+{% set version = "0.3.2" %}
 {% set github = "https://github.com/acidgenomics/r-eggnog" %}
 
 package:
@@ -7,7 +7,7 @@ package:
 
 source:
   url: "{{ github }}/archive/v{{ version }}.tar.gz"
-  sha256: e3804574ef575467f294f42197ddf31066b8d407387dcbb68e23f9228de017a4
+  sha256: 6cfba92caa93c751adde10134d7f3568a7fadfb86b953b5a97baceebe23d9c99
 
 build:
   number: 0
@@ -25,7 +25,7 @@ requirements:
     - bioconductor-s4vectors >=0.38.0
     - r-acidbase >=0.7.1
     - r-goalie >=0.7.3
-    - r-pipette >=0.14.1
+    - r-pipette >=0.16.1
   run:
     # Depends:
     - r-base
@@ -35,7 +35,7 @@ requirements:
     - bioconductor-s4vectors >=0.38.0
     - r-acidbase >=0.7.1
     - r-goalie >=0.7.3
-    - r-pipette >=0.14.1
+    - r-pipette >=0.16.1
 
 test:
   commands:
@@ -44,9 +44,9 @@ test:
 about:
   home: https://r.acidgenomics.com/packages/eggnog/
   dev_url: "{{ github }}"
-  license: AGPL-3.0
-  license_file: LICENSE
-  license_family: GPL
+  license: Apache-2.0
+  license_file: LICENSE.md
+  license_family: APACHE
   summary: EggNOG database annotations.
 
 extra:


### PR DESCRIPTION
Supersedes #66508 (autobump).

Changes:
- Bump version 0.3.1 → 0.3.2
- Fix license: AGPL-3 → Apache-2.0 (upstream relicensed; `license_file: LICENSE.md`)
- Update dep pins: r-acidbase ≥0.7.1, r-goalie ≥0.7.3, r-pipette ≥0.16.1

Autobump PR #66508 will be closed as superseded.