### PR TITLE
Update r-panther 0.5.1 → 0.5.2

### DIFF
--- a/recipes/r-panther/meta.yaml
+++ b/recipes/r-panther/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.5.1" %}
+{% set version = "0.5.2" %}
 {% set github = "https://github.com/acidgenomics/r-panther" %}
 
 package:
@@ -7,7 +7,7 @@ package:
 
 source:
   url: "{{ github }}/archive/v{{ version }}.tar.gz"
-  sha256: fcdf235ad05020b17f9a4ab3ecd0a56d45ab279479b72550d047c7d3cdca51b7
+  sha256: 4f2ff0c2f303ba711a9d8b16f8aef1868bd50b09c0f136bef8699e939321153b
 
 build:
   number: 0
@@ -24,13 +24,13 @@ requirements:
     - bioconductor-iranges >=2.34.0
     - bioconductor-s4vectors >=0.38.0
     - r-acidbase >=0.7.0
-    - r-acidcli >=0.3.0
-    - r-acidgenerics >=0.7.3
-    - r-acidgenomes >=0.6.0
-    - r-acidplyr >=0.5.0
-    - r-goalie >=0.7.3
-    - r-pipette >=0.14.1
-    - r-syntactic >=0.7.0
+    - r-acidcli >=0.3.3
+    - r-acidgenerics >=0.7.6
+    - r-acidgenomes >=0.7.5
+    - r-acidplyr >=0.5.5
+    - r-goalie >=0.7.8
+    - r-pipette >=0.16.1
+    - r-syntactic >=0.8.1
   run:
     # Depends:
     - r-base
@@ -39,13 +39,13 @@ requirements:
     - bioconductor-iranges >=2.34.0
     - bioconductor-s4vectors >=0.38.0
     - r-acidbase >=0.7.0
-    - r-acidcli >=0.3.0
-    - r-acidgenerics >=0.7.3
-    - r-acidgenomes >=0.6.0
-    - r-acidplyr >=0.5.0
-    - r-goalie >=0.7.3
-    - r-pipette >=0.14.1
-    - r-syntactic >=0.7.0
+    - r-acidcli >=0.3.3
+    - r-acidgenerics >=0.7.6
+    - r-acidgenomes >=0.7.5
+    - r-acidplyr >=0.5.5
+    - r-goalie >=0.7.8
+    - r-pipette >=0.16.1
+    - r-syntactic >=0.8.1
 
 test:
   commands:
@@ -54,9 +54,9 @@ test:
 about:
   home: https://r.acidgenomics.com/packages/panther/
   dev_url: "{{ github }}"
-  license: AGPL-3.0
-  license_file: LICENSE
-  license_family: GPL
+  license: Apache-2.0
+  license_file: LICENSE.md
+  license_family: APACHE
   summary: PANTHER database annotations.
 
 extra:


### PR DESCRIPTION
## Changes

- Bump version 0.5.1 → 0.5.2
- Fix license: AGPL-3 → Apache-2.0 (upstream relicensed; recipe now uses `license_file: LICENSE.md`)
- Update dependency pins

Supersedes autobump PR #66499.