### PR TITLE
Update r-wormbase 0.5.0 → 0.5.1

### DIFF
--- a/recipes/r-wormbase/meta.yaml
+++ b/recipes/r-wormbase/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.5.0" %}
+{% set version = "0.5.1" %}
 {% set github = "https://github.com/acidgenomics/r-wormbase" %}
 
 package:
@@ -7,10 +7,10 @@ package:
 
 source:
   url: "{{ github }}/archive/v{{ version }}.tar.gz"
-  sha256: dce59a925b8fa24c4de87747e303333eb0a9f79a0f0dde130d8f242cb17809a7
+  sha256: ed44bc627e53fd4bac5217c330d9a2d70a63095fc27dc2508e2bdf8d162f5c18
 
 build:
-  number: 1
+  number: 0
   noarch: generic
   run_exports:
     - {{ pin_subpackage('r-wormbase', max_pin="x.x") }}
@@ -28,7 +28,7 @@ requirements:
     - r-acidgenerics >=0.6.13
     - r-acidplyr >=0.4.3
     - r-goalie >=0.7.0
-    - r-pipette >=0.14.0
+    - r-pipette >=0.16.1
     - r-syntactic >=0.6.7
     # Suggests:
     - r-httr2 >=0.2.3
@@ -44,7 +44,7 @@ requirements:
     - r-acidgenerics >=0.6.13
     - r-acidplyr >=0.4.3
     - r-goalie >=0.7.0
-    - r-pipette >=0.14.0
+    - r-pipette >=0.16.1
     - r-syntactic >=0.6.7
     # Suggests:
     - r-httr2 >=0.2.3
@@ -56,9 +56,9 @@ test:
 about:
   home: https://r.acidgenomics.com/packages/wormbase/
   dev_url: "{{ github }}"
-  license: AGPL-3.0
-  license_file: LICENSE
-  license_family: GPL
+  license: Apache-2.0
+  license_file: LICENSE.md
+  license_family: APACHE
   summary: Fetch Caenorhabditis elegans genome annotations from WormBase.
 
 extra:


### PR DESCRIPTION
Update r-wormbase from 0.5.0 to 0.5.1.

Also fixes:
- License: AGPL-3 → Apache-2.0 (upstream relicensed)
- `license_file`: LICENSE → LICENSE.md (Apache-2.0 packages use LICENSE.md)
- Updated dependency pins

Supersedes autobump PR #66501.