### PR TITLE
Update plannotate to 1.2.5

### DIFF
--- a/recipes/plannotate/meta.yaml
+++ b/recipes/plannotate/meta.yaml
@@ -23,11 +23,11 @@ build:
 
 requirements:
   host:
-    - python >=3.10,<3.14
+    - python >=3.10
     - pip
     - setuptools
   run:
-    - python >=3.10,<3.14
+    - python >=3.10
     - click
     - curl
     - numpy >=1.23,<2

--- a/recipes/plannotate/meta.yaml
+++ b/recipes/plannotate/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "plannotate" %}
 {% set version = "1.2.5" %}
-{% set sha256 = "5d9b557027730e4751cdd987da8d8c59847ea3ba39bb0c13450d9c06c042421e" %}
+{% set sha256 = "9219c4bfaf423f124737ec532709a1a9650df9f0b4b8da387a7c2cb970565740" %}
 
 package:
   name: {{ name }}

--- a/recipes/plannotate/meta.yaml
+++ b/recipes/plannotate/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "plannotate" %}
-{% set version = "1.2.4" %}
-{% set sha256 = "cf47f80bdfda558bef80df52dfb51d25ae902ad2d3c55af4d96356ab914fa0aa" %}
+{% set version = "1.2.5" %}
+{% set sha256 = "5d9b557027730e4751cdd987da8d8c59847ea3ba39bb0c13450d9c06c042421e" %}
 
 package:
   name: {{ name }}
@@ -9,7 +9,7 @@ package:
 source:
   - url: https://github.com/mmcguffi/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
     sha256: {{ sha256 }}
-  - url: https://github.com/mmcguffi/{{ name }}/releases/download/v1.2.0/BLAST_dbs.tar.gz
+  - url: https://github.com/mmcguffi/{{ name }}/releases/download/v{{ version }}/BLAST_dbs.tar.gz
     sha256: 34c7bacb1c73bd75129e16990653f73b3eba7e3cdb3816a55d3989a7601f2137
     folder: BLAST_dbs
 
@@ -23,25 +23,25 @@ build:
 
 requirements:
   host:
-    - python >=3.9,<3.13
+    - python >=3.10,<3.14
     - pip
     - setuptools
   run:
-    - python >=3.9,<3.13
+    - python >=3.10,<3.14
     - click
     - curl
-    - numpy
+    - numpy >=1.23,<2
     - biopython >=1.78
     - blast >=2.10.1
     - diamond >=2.0.13
-    - pandas >=1.3.5,<2.0.0
+    - pandas >=1.3.5,<3
     - ripgrep >=13.0.0
     - tabulate >=0.8.9
     - trnascan-se >=2.0.7
-    - streamlit =1.8.1
-    - altair =4.2.*
-    - bokeh =2.4.1
-    - protobuf =3.20.*
+    - streamlit >=1.36,<1.42
+    - altair =4.2.2
+    - bokeh =2.4.3
+    - protobuf >=3.20.3
 
 test:
   commands:


### PR DESCRIPTION
## What changed

- update pLannotate from 1.2.4 to 1.2.5
- use the versioned `BLAST_dbs.tar.gz` asset now attached to every pLannotate release
- update Python and Python-package constraints to match upstream `pyproject.toml`

## Why

The previous database source was permanently pinned to the `v1.2.0` release. Bioconda's autobump logic rejects a version update if any source URL is unchanged. Both recipe sources now use `v{{ version }}`, making future version-only releases eligible for automatic updates.

## Validation

- verified both SHA-256 checksums from the published `v1.2.5` sources
- `bioconda-utils lint recipes config.yml --packages plannotate --full-report`
- `bioconda-utils build recipes config.yml --packages plannotate --force --lint`
- local macOS ARM build and recipe test succeeded: `plannotate-1.2.5-pyhdfd78af_0.conda`
