### PR TITLE
Fix funtaxfinder metadata

### DIFF
--- a/recipes/funtaxfinder/meta.yaml
+++ b/recipes/funtaxfinder/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   run_exports:
     - {{ pin_subpackage(name, max_pin="x.x") }}
@@ -36,9 +36,9 @@ test:
     - funtaxfinder --version
 
 about:
-  home: https://github.com/YOUR_GITHUB_USERNAME/funtaxfinder
-  dev_url: https://github.com/YOUR_GITHUB_USERNAME/funtaxfinder
-  doc_url: https://github.com/YOUR_GITHUB_USERNAME/funtaxfinder#readme
+  home: https://github.com/Zhoufengwu/funtaxfinder
+  dev_url: https://github.com/Zhoufengwu/funtaxfinder
+  doc_url: https://github.com/Zhoufengwu/funtaxfinder#readme
   license: MIT
   license_file: LICENSE
   summary: Screen functional microbial ASVs from PICRUSt2 KO predictions


### PR DESCRIPTION
This PR fixes the homepage, development URL, documentation URL, and maintainer metadata for funtaxfinder.

The source version remains 0.1.0, so the build number is incremented from 0 to 1.