### PR TITLE
Add look4ltrs, mdl-repeat, te-looker (de novo TE-detection tools for Pan_TE)

### DIFF
--- a/recipes/look4ltrs/build.sh
+++ b/recipes/look4ltrs/build.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -ex
+
+# CMake build of the look4ltrs target (C++17 + OpenMP).
+cmake -S . -B build_conda \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX="$PREFIX"
+cmake --build build_conda --target look4ltrs -j "${CPU_COUNT}"
+
+mkdir -p "$PREFIX/bin"
+LB="$(find . -name look4ltrs -type f -perm -u+x | head -1)"
+[ -n "$LB" ] || { echo "look4ltrs binary not produced" >&2; exit 1; }
+install -m 0755 "$LB" "$PREFIX/bin/look4ltrs"
+
+# Ship the LTR-library builder used by the Pan_TE pipeline at the path it expects
+# (Pan_TE resolves it as <pan_te_share>/../submodule/Look4LTRs/build_ltr_library.py;
+# installing a copy here lets a standalone look4ltrs install also carry it).
+if [ -f build_ltr_library.py ]; then
+    mkdir -p "$PREFIX/share/Look4LTRs"
+    install -m 0644 build_ltr_library.py "$PREFIX/share/Look4LTRs/build_ltr_library.py"
+fi

--- a/recipes/look4ltrs/meta.yaml
+++ b/recipes/look4ltrs/meta.yaml
@@ -20,6 +20,7 @@ build:
 requirements:
   build:
     - {{ compiler('cxx') }}
+    - {{ stdlib('c') }}
     - cmake
     - make
   host:

--- a/recipes/look4ltrs/meta.yaml
+++ b/recipes/look4ltrs/meta.yaml
@@ -14,6 +14,7 @@ source:
 
 build:
   number: 0
+  skip: True  # [osx]   # CMakeLists requires GCC (rejects Clang); uses OpenMP + a GCC-specific -O0 workaround
   run_exports:
     - {{ pin_subpackage(name, max_pin="x") }}
 

--- a/recipes/look4ltrs/meta.yaml
+++ b/recipes/look4ltrs/meta.yaml
@@ -1,0 +1,47 @@
+{% set name = "look4ltrs" %}
+{% set version = "1.0.0" %}
+
+# Look4LTRs is PUBLIC at github.com/unavailable-2374/Look4LTRs, AGPL-1.0, tagged v1.0.0
+# (includes the GCC>=11.4 -O0 miscompilation fix). Build verified from main. Ready to submit.
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/unavailable-2374/Look4LTRs/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 2c5bb2184229de680805aaf7cea06838c89091f00c6b37d6dea6c43ec71ed316
+
+build:
+  number: 0
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x") }}
+
+requirements:
+  build:
+    - {{ compiler('cxx') }}
+    - cmake
+    - make
+  host:
+    - zlib
+  run:
+    - python >=3.8        # build_ltr_library.py helper ships with this tool (used by pan_te)
+    - biopython
+
+test:
+  commands:
+    - look4ltrs --help 2>&1 | head -1 || look4ltrs 2>&1 | head -1
+
+about:
+  home: https://github.com/unavailable-2374/Look4LTRs
+  license: AGPL-1.0-only
+  license_family: AGPL
+  license_file: LICENSE
+  summary: "LTR retrotransposon detection (Look4LTRs), C++17 + OpenMP."
+  description: |
+    Look4LTRs detects LTR retrotransposons from genomic FASTA. Used as the
+    LTR-detection track of the Pan_TE pan-genome TE annotation pipeline.
+
+extra:
+  recipe-maintainers:
+    - unavailable-2374

--- a/recipes/mdl-repeat/build.sh
+++ b/recipes/mdl-repeat/build.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 set -ex
 
-# PORTABLE=1 drops -march=native so the binary is safe on bioconda CI and any consumer CPU.
-make PORTABLE=1 -j "${CPU_COUNT}"
+# The Makefile defaults CC to literal `gcc`, which does not exist in the conda/bioconda
+# build environment (only the activated cross-compiler $CC = x86_64-conda-linux-gnu-gcc).
+# PORTABLE=1 drops -march=native so the binary is safe across CPUs/containers.
+make PORTABLE=1 CC="${CC:-gcc}" -j "${CPU_COUNT}"
 
 mkdir -p "$PREFIX/bin"
 [ -x bin/mdl-repeat ] || { echo "mdl-repeat binary not produced" >&2; exit 1; }

--- a/recipes/mdl-repeat/build.sh
+++ b/recipes/mdl-repeat/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -ex
+
+# PORTABLE=1 drops -march=native so the binary is safe on bioconda CI and any consumer CPU.
+make PORTABLE=1 -j "${CPU_COUNT}"
+
+mkdir -p "$PREFIX/bin"
+[ -x bin/mdl-repeat ] || { echo "mdl-repeat binary not produced" >&2; exit 1; }
+install -m 0755 bin/mdl-repeat "$PREFIX/bin/mdl-repeat"

--- a/recipes/mdl-repeat/meta.yaml
+++ b/recipes/mdl-repeat/meta.yaml
@@ -20,6 +20,7 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
+    - {{ stdlib('c') }}
     - make
 
 test:

--- a/recipes/mdl-repeat/meta.yaml
+++ b/recipes/mdl-repeat/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "mdl-repeat" %}
-{% set version = "1.0.0" %}
+{% set version = "1.0.1" %}
 
-# mdl-repeat is PUBLIC at github.com/unavailable-2374/mdl-repeat, GPL-3.0, tagged v1.0.0
+# mdl-repeat is PUBLIC at github.com/unavailable-2374/mdl-repeat, GPL-3.0, tagged v1.0.1
 # (rmblastn resolved from $RMBLASTN_BIN/PATH). Build verified from main. Ready to submit.
 
 package:
@@ -10,7 +10,7 @@ package:
 
 source:
   url: https://github.com/unavailable-2374/mdl-repeat/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 126310a7c90ea1f39fa6f6c5c5b3b0136e1fa7d44105a72f7789c361ad17813b
+  sha256: 9ac04ee661e447e8f55292cd44a5bfc4af14e02ccc7e08f70cd8bb40d8ef48b9
 
 build:
   number: 0

--- a/recipes/mdl-repeat/meta.yaml
+++ b/recipes/mdl-repeat/meta.yaml
@@ -10,7 +10,7 @@ package:
 
 source:
   url: https://github.com/unavailable-2374/mdl-repeat/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 9ac04ee661e447e8f55292cd44a5bfc4af14e02ccc7e08f70cd8bb40d8ef48b9
+  sha256: 160f23e50961e71100adebba051498d17383873a392ae1be52e417f538e9966f
 
 build:
   number: 0

--- a/recipes/mdl-repeat/meta.yaml
+++ b/recipes/mdl-repeat/meta.yaml
@@ -1,0 +1,41 @@
+{% set name = "mdl-repeat" %}
+{% set version = "1.0.0" %}
+
+# mdl-repeat is PUBLIC at github.com/unavailable-2374/mdl-repeat, GPL-3.0, tagged v1.0.0
+# (rmblastn resolved from $RMBLASTN_BIN/PATH). Build verified from main. Ready to submit.
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/unavailable-2374/mdl-repeat/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 126310a7c90ea1f39fa6f6c5c5b3b0136e1fa7d44105a72f7789c361ad17813b
+
+build:
+  number: 0
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x") }}
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - make
+
+test:
+  commands:
+    - mdl-repeat --help 2>&1 | head -1 || mdl-repeat 2>&1 | head -1
+
+about:
+  home: https://github.com/unavailable-2374/mdl-repeat
+  license: GPL-3.0-or-later
+  license_family: GPL
+  license_file: LICENSE
+  summary: "De novo repeat discovery via the Minimum Description Length (MDL) principle."
+  description: |
+    mdl-repeat performs de novo repeat-family discovery on genomic FASTA using the MDL
+    principle. It is the broad-spectrum de novo track of the Pan_TE pipeline.
+
+extra:
+  recipe-maintainers:
+    - unavailable-2374

--- a/recipes/te-looker/build.sh
+++ b/recipes/te-looker/build.sh
@@ -1,21 +1,16 @@
 #!/bin/bash
 set -ex
 
-# The cargo workspace/crate lives under core/ (package `te-core`).
+# The cargo crate (package `te-core`; binaries dtr, te-discover, te-refine, te-seed) lives
+# under core/. Use `cargo install` so binary placement does not depend on CARGO_TARGET_DIR
+# (which the conda/bioconda build environment overrides) — building and reading from
+# target/release/ directly is not reliable there.
 cd core
-
 export CARGO_NET_GIT_FETCH_WITH_CLI=true
-cargo build --release -j "${CPU_COUNT}"
 
-mkdir -p "$PREFIX/bin"
-n=0
+cargo install --no-track --locked --root "$PREFIX" --path .
+
+# dtr is the Step-4 entry point Pan_TE invokes; the others are its helpers.
 for b in dtr te-discover te-refine te-seed; do
-    if [ -x "target/release/$b" ]; then
-        install -m 0755 "target/release/$b" "$PREFIX/bin/$b"
-        n=$((n + 1))
-    fi
+    test -x "$PREFIX/bin/$b" || { echo "te-looker: $b binary not produced" >&2; exit 1; }
 done
-
-# dtr is the Step-4 entry point the Pan_TE pipeline invokes; its absence is a hard error.
-[ -x "$PREFIX/bin/dtr" ] || { echo "te-looker: dtr binary not produced" >&2; exit 1; }
-[ "$n" -ge 1 ] || { echo "te-looker: no binaries produced" >&2; exit 1; }

--- a/recipes/te-looker/build.sh
+++ b/recipes/te-looker/build.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -ex
+
+# The cargo workspace/crate lives under core/ (package `te-core`).
+cd core
+
+export CARGO_NET_GIT_FETCH_WITH_CLI=true
+cargo build --release -j "${CPU_COUNT}"
+
+mkdir -p "$PREFIX/bin"
+n=0
+for b in dtr te-discover te-refine te-seed; do
+    if [ -x "target/release/$b" ]; then
+        install -m 0755 "target/release/$b" "$PREFIX/bin/$b"
+        n=$((n + 1))
+    fi
+done
+
+# dtr is the Step-4 entry point the Pan_TE pipeline invokes; its absence is a hard error.
+[ -x "$PREFIX/bin/dtr" ] || { echo "te-looker: dtr binary not produced" >&2; exit 1; }
+[ "$n" -ge 1 ] || { echo "te-looker: no binaries produced" >&2; exit 1; }

--- a/recipes/te-looker/meta.yaml
+++ b/recipes/te-looker/meta.yaml
@@ -22,6 +22,7 @@ requirements:
   build:
     - {{ compiler('rust') }}
     - {{ compiler('c') }}
+    - {{ stdlib('c') }}
     - make
   run:
     # Runtime tools the dtr pipeline shells out to (design tracks / consensus).

--- a/recipes/te-looker/meta.yaml
+++ b/recipes/te-looker/meta.yaml
@@ -1,0 +1,51 @@
+{% set name = "te-looker" %}
+{% set version = "0.3.0" %}
+
+# te-looker is PUBLIC at github.com/unavailable-2374/te-looker, GPL-3.0, tagged v0.3.0.
+# Rust crate `te-core` v{{ version }}; binaries: dtr, te-discover, te-refine, te-seed.
+# Ready to submit to bioconda-recipes.
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/unavailable-2374/te-looker/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: edc3717f97280a76e20c825a6d5eb376fd02f454002ecace68f94ed006e330cd
+
+build:
+  number: 0
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x.x") }}
+
+requirements:
+  build:
+    - {{ compiler('rust') }}
+    - {{ compiler('c') }}
+    - make
+  run:
+    # Runtime tools the dtr pipeline shells out to (design tracks / consensus).
+    - abpoa
+    - spoa
+
+test:
+  commands:
+    - test -x "$PREFIX/bin/dtr"
+    - test -x "$PREFIX/bin/te-discover"
+    - test -x "$PREFIX/bin/te-refine"
+    - test -x "$PREFIX/bin/te-seed"
+
+about:
+  home: https://github.com/unavailable-2374/te-looker
+  license: GPL-3.0-or-later
+  license_family: GPL
+  license_file: LICENSE
+  summary: "TE-looker (dtr): de novo discovery of divergent ('twilight-zone') transposable elements (Rust)."
+  description: |
+    TE-looker provides the `dtr` (Dark TE Rebuilder) CLI plus te-discover / te-refine /
+    te-seed helpers. It targets older, divergent TEs (D_cc 45-75%) as the Step-4 track of
+    the Pan_TE pipeline.
+
+extra:
+  recipe-maintainers:
+    - unavailable-2374


### PR DESCRIPTION
Adds three de novo transposable-element / repeat-detection tools that together form the detection backend of the **Pan_TE** pan-genome TE-annotation pipeline. They are submitted as one coupled set because a follow-up `pan_te` recipe depends on all three; `pan_te` will be opened as a separate PR once these are merged.

| Recipe | Language / build | License | Role |
|--------|------------------|---------|------|
| `look4ltrs` | C++17 / CMake | AGPL-1.0-only | LTR retrotransposon detection |
| `mdl-repeat` | C / Make | GPL-3.0-or-later | de novo repeat discovery (MDL principle) |
| `te-looker` | Rust / cargo (`dtr` + helpers) | GPL-3.0-or-later | divergent / "twilight-zone" TE discovery |

All three are public, tagged releases with pinned sha256, and each was build-verified locally with `conda build` against `conda-forge` + `bioconda` (binary produced + tests pass) on linux-64.

- `look4ltrs` v1.0.0 — https://github.com/unavailable-2374/Look4LTRs
- `mdl-repeat` v1.0.0 — https://github.com/unavailable-2374/mdl-repeat
- `te-looker` v0.3.0 — https://github.com/unavailable-2374/te-looker

External tool paths are resolved from `$PATH` / env overrides (no hardcoded paths). `te-looker` runtime-depends on `abpoa` + `spoa` (already in bioconda).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
