### PR TITLE
pyensembl: rebuild for datacache >=1.4.0

### DIFF
--- a/recipes/pyensembl/meta.yaml
+++ b/recipes/pyensembl/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vvv --no-deps --no-build-isolation --no-cache-dir
   entry_points:
     - pyensembl = pyensembl.shell:run
@@ -29,7 +29,7 @@ requirements:
     - typechecks >=0.0.2
     - numpy >=2.0.0
     - pandas >=0.15
-    - datacache >=1.1.4
+    - datacache >=1.4.0,<2.0
     - memoized-property >=1.0.2
     - six >=1.9.0
     - gtfparse >=2.5.0


### PR DESCRIPTION
Rebuild of `pyensembl` 2.6.7 (build 0 → 1) to correct its `datacache` run requirement.

pyensembl requires `datacache >=1.4.0,<2.0` (per its PyPI metadata for 2.6.7), but the recipe pinned `datacache >=1.1.4` — which let the solver resolve to conda-forge's older datacache (it was stuck at 1.1.5). conda-forge `datacache` was just updated to 1.5.0 (conda-forge/datacache-feedstock#10), so the correct floor is now satisfiable.

Changes:
- `run:` → `datacache >=1.4.0,<2.0` (was `>=1.1.4`)
- `build: number: 1` (rebuild, no version change)