### PR TITLE
Add python-minibwa 0.1.0

### DIFF
--- a/recipes/python-minibwa/build.sh
+++ b/recipes/python-minibwa/build.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+# minibwa-py is the pyo3/maturin package. It depends on the sibling `minibwa`
+# and `minibwa-sys` crates by path (and minibwa-sys vendors the minibwa C), so
+# build from within its subdirectory of the workspace source tree.
+cd minibwa-py
+
+# minibwa-sys generates its FFI via bindgen, whose clang-sys backend needs to
+# locate libclang.so at build time. The conda `clangdev` build dep installs it
+# under ${BUILD_PREFIX}/lib; point bindgen at it explicitly.
+export LIBCLANG_PATH="${BUILD_PREFIX}/lib"
+
+# minibwa-sys emits `cargo:rustc-link-lib=z`. On Linux rustc's link step does
+# not search the host prefix by default (it ignores conda's LDFLAGS), so `-lz`
+# fails to resolve; add ${PREFIX}/lib explicitly. On macOS we deliberately do
+# NOT add it: `-lz` then resolves against the system libSystem zlib, which
+# maturin leaves alone when bundling. Linking conda's libz.1.dylib instead
+# breaks maturin's wheel repair ("@rpath/libz.1.dylib could not be located").
+# (`pthread`/`m` resolve from the compiler sysroot on both platforms.)
+if [[ "$(uname)" != "Darwin" ]]; then
+  export RUSTFLAGS="${RUSTFLAGS:-} -L native=${PREFIX}/lib"
+fi
+
+# Build the cargo dependency graph from the committed Cargo.lock (`--locked`)
+# so the wheel pins the exact crate versions the project tests against, rather
+# than re-resolving at build time. maturin forwards this cargo flag, and pip
+# (PEP 517) forwards maturin args via MATURIN_PEP517_ARGS.
+export MATURIN_PEP517_ARGS="--locked"
+
+${PYTHON} -m pip install . --no-deps --no-build-isolation -vv

--- a/recipes/python-minibwa/meta.yaml
+++ b/recipes/python-minibwa/meta.yaml
@@ -1,0 +1,71 @@
+{% set name = "python-minibwa" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  # Full-repo tarball: the Python package (minibwa-py) depends on the sibling
+  # `minibwa`/`minibwa-sys` crates via path, and minibwa-sys vendors the
+  # minibwa C source. A maturin sdist of minibwa-py alone would miss those, so
+  # the recipe builds from the release source archive of the whole workspace.
+  url: https://github.com/fg-labs/minibwa-bindings/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 6d506c604b7f81ee05e4aae8c666b609f99868f437119fc0fad61bb216f5edf3
+
+build:
+  number: 0
+  run_exports:
+    # 0.x: API is not yet stable, so pin downstream consumers to the minor.
+    - {{ pin_subpackage('python-minibwa', max_pin="x.x") }}
+  # Skip Intel macOS: minibwa-sys's x86 SIMD runtime dispatch (ksw_extd2)
+  # references __cpu_model, which the macOS linker rejects as an illegal text
+  # relocation on x86_64-apple-darwin. Upstream ships no x86_64-darwin artifact
+  # either; supported targets are linux-64, linux-aarch64, and osx-arm64.
+  skip: True  # [py < 39 or (osx and x86_64)]
+  # Build steps live in build.sh (bioconda is unix-only). minibwa-py depends on
+  # the sibling `minibwa`/`minibwa-sys` crates by path, so the build cds into it.
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ stdlib('c') }}
+    - {{ compiler('rust') }}
+    # minibwa-sys runs bindgen at build time, which needs libclang.
+    - clangdev
+  host:
+    - python
+    - pip
+    - maturin >=1.5,<2
+    - zlib
+  run:
+    - python
+
+test:
+  imports:
+    - minibwa
+  commands:
+    # Exercise the compiled pyo3 extension, not just the import machinery.
+    - python -c "import minibwa; minibwa.Opts()"
+
+about:
+  home: https://github.com/fg-labs/minibwa-bindings
+  # The default build statically links libsais (Apache-2.0) and the vendored
+  # minibwa C (MIT) into the extension. The GPL bwtgen path is an opt-in Cargo
+  # feature (minibwa-sys `default = []`) and is NOT enabled here.
+  license: MIT AND Apache-2.0
+  license_family: MIT
+  license_file:
+    - LICENSE
+    - THIRD-PARTY.md
+    - minibwa-sys/vendor/minibwa/LICENSE.txt
+  summary: Python bindings for minibwa (Heng Li's lightweight bwa-mem successor)
+  dev_url: https://github.com/fg-labs/minibwa-bindings
+  doc_url: https://github.com/fg-labs/minibwa-bindings/blob/main/README.md
+
+extra:
+  recipe-maintainers:
+    - nh13
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64


### PR DESCRIPTION
Adds a recipe for **python-minibwa** — Python bindings (pyo3 + maturin) for [minibwa](https://github.com/lh3/minibwa), Heng Li's lightweight bwa-mem successor. Source: https://github.com/fg-labs/minibwa-bindings (PyPI: `minibwa`).

The conda package is named `python-minibwa` because the `minibwa` name is already taken by the lh3 C tool recipe; the Python import remains `import minibwa`.

### Notes for reviewers

- **Source is the full-repo tarball, not a maturin sdist.** `minibwa-py` depends on the sibling `minibwa`/`minibwa-sys` crates by path (and `minibwa-sys` vendors the minibwa C), so an sdist of the Python package alone would be unbuildable. The recipe builds from the workspace release archive and `cd minibwa-py`.
- **License is `MIT AND Apache-2.0`.** The default build statically links the vendored minibwa C (MIT, Dana-Farber) and libsais (Apache-2.0) into the extension; `license_file` ships `LICENSE`, `THIRD-PARTY.md`, and the vendored upstream notices. The GPL `bwtgen` path is an opt-in Cargo feature (`minibwa-sys` `default = []`) and is **not** enabled.
- **libsais is vendored rather than taken from conda-forge.** Unlike bwa-mem3 (#65470), `minibwa-sys`'s `build.rs` compiles `libsais.c`/`libsais64.c` inline via the `cc` crate with no env hook to substitute an external library, so unbundling would require an upstream `build.rs` change. The Apache-2.0 text is packaged.
- Build uses `--locked` (via `MATURIN_PEP517_ARGS`) against the committed `Cargo.lock`.
- `additional-platforms`: `linux-aarch64`, `osx-arm64` (matches the project's published wheel targets).

---

- [x] I am the original author / maintainer of this software (recipe-maintainer: `nh13`).

@BiocondaBot please add label
