### PR TITLE
Add plastanno 2.0.0

### DIFF
--- a/recipes/plastanno/meta.yaml
+++ b/recipes/plastanno/meta.yaml
@@ -33,8 +33,7 @@ requirements:
     - exonerate
     - hmmer
     - aragorn
-  run_constrained:
-    - trnascan-se        # optional, only for the --trnascan source
+    - trnascan-se        # only used by the optional --trnascan tRNA source
 
 test:
   imports:

--- a/recipes/plastanno/meta.yaml
+++ b/recipes/plastanno/meta.yaml
@@ -1,0 +1,59 @@
+{% set name = "plastanno" %}
+{% set version = "2.0.0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/maidinhvn/plastanno/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 092762cdc9b93ef769566615ca1901ce41437200625fac413a07db1af886c77f
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  entry_points:
+    - plastanno = plastanno.cli:main
+
+requirements:
+  host:
+    - python >=3.9
+    - pip
+    - setuptools
+  run:
+    - python >=3.9
+    - biopython
+    - pandas
+    - matplotlib
+    - platformdirs
+    - blast
+    - exonerate
+    - hmmer
+    - aragorn
+  run_constrained:
+    - trnascan-se        # optional, only for the --trnascan source
+
+test:
+  imports:
+    - plastanno
+  commands:
+    - plastanno --help
+  # No real annotation run: that needs the 266 MB database, which bioconda CI does
+  # not download. Users fetch it post-install with `plastanno fetch-db`.
+
+about:
+  home: https://github.com/maidinhvn/plastanno
+  license: MIT
+  license_file: LICENSE
+  summary: "Dual-evidence, confidence-aware plastid genome (plastome) annotation pipeline"
+  description: |
+    Plastanno v2 annotates chloroplast genomes by merging two independent engines
+    (Exonerate protein2genome + profile HMMs) in a confidence-scored reconciliation
+    layer, flagging low-confidence loci for review. The reference database (~266 MB)
+    is downloaded separately via `plastanno fetch-db`.
+  dev_url: https://github.com/maidinhvn/plastanno
+
+extra:
+  recipe-maintainers:
+    - maidinhvn

--- a/recipes/plastanno/meta.yaml
+++ b/recipes/plastanno/meta.yaml
@@ -12,6 +12,8 @@ source:
 build:
   noarch: python
   number: 0
+  run_exports:
+    - {{ pin_subpackage("plastanno", max_pin="x") }}
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:
     - plastanno = plastanno.cli:main
@@ -25,7 +27,7 @@ requirements:
     - python >=3.9
     - biopython
     - pandas
-    - matplotlib
+    - matplotlib-base
     - platformdirs
     - blast
     - exonerate


### PR DESCRIPTION
New recipe for Plastanno v2 — a dual-evidence, confidence-aware chloroplast genome (plastome) annotation pipeline. noarch python; external tools (blast, exonerate, hmmer, aragorn) as run dependencies; the ~266 MB reference database is fetched post-install via `plastanno fetch-db` (not bundled). Tests cover import + `plastanno --help`.


