### PR TITLE
add bipangolin 0.5

### DIFF
--- a/recipes/bipangolin/build.sh
+++ b/recipes/bipangolin/build.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+${PYTHON} -m pip install . -vv --no-deps --no-build-isolation

--- a/recipes/bipangolin/build.sh
+++ b/recipes/bipangolin/build.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-set -euo pipefail
-
-${PYTHON} -m pip install . -vv --no-deps --no-build-isolation

--- a/recipes/bipangolin/meta.yaml
+++ b/recipes/bipangolin/meta.yaml
@@ -1,0 +1,47 @@
+{% set name = "bipangolin" %}
+{% set version = "0.5.0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/b/bipangolin/bipangolin-{{ version }}.tar.gz
+  sha256: 627c2d1387b4717db725ea5bd82f26c8bdc5696608a8b71e7d97507b51c044d2
+
+build:
+  noarch: python
+  number: 0
+  entry_points:
+    - bipangolin = bipangolin.cli:main
+  script: bash build.sh
+
+requirements:
+  host:
+    - python >=3.9
+    - pip
+    - hatchling
+  run:
+    - python >=3.9
+    - numpy >=1.20
+    - pyfastx >=2.0
+    - pytorch >=2.0
+
+test:
+  commands:
+    - bipangolin --help
+    - python -c "import bipangolin; print(bipangolin.__version__)"
+    - python -c "from bipangolin import BiPangolinRunner; print('ok')"
+
+about:
+  home: https://github.com/Delayed-Gitification/biPangolin
+  summary: Per-base donor/acceptor splice site predictions from Pangolin representations
+  license: GPL-3.0-only
+  license_file:
+    - LICENSE
+    - THIRD_PARTY_NOTICES.md
+  dev_url: https://github.com/Delayed-Gitification/biPangolin
+
+extra:
+  recipe-maintainers:
+    - ogw

--- a/recipes/bipangolin/meta.yaml
+++ b/recipes/bipangolin/meta.yaml
@@ -15,6 +15,8 @@ build:
   entry_points:
     - bipangolin = bipangolin.cli:main
   script: bash build.sh
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x.x") }}
 
 requirements:
   host:

--- a/recipes/bipangolin/meta.yaml
+++ b/recipes/bipangolin/meta.yaml
@@ -14,7 +14,7 @@ build:
   number: 0
   entry_points:
     - bipangolin = bipangolin.cli:main
-  script: bash build.sh
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   run_exports:
     - {{ pin_subpackage(name, max_pin="x.x") }}
 


### PR DESCRIPTION
Adds bipangolin 0.5.0 to Bioconda.

- noarch Python package
- source pinned to the PyPI sdist
- `run_exports` added with `pin_subpackage(name, max_pin="x.x")`
- offline smoke tests only
- runtime deps: python, numpy, pyfastx, pytorch