### PR TITLE
Pin pytorch and transformers for deeptaxa-rrna

### DIFF
--- a/recipes/deeptaxa-rrna/meta.yaml
+++ b/recipes/deeptaxa-rrna/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage(name, max_pin="x") }}
   script:
@@ -30,9 +30,9 @@ requirements:
     - wheel
   run:
     - python >=3.10
-    - pytorch
+    - pytorch >=2.4
     - numpy
-    - transformers
+    - transformers >=4.28
     - pandas
     - tqdm
     - scikit-learn


### PR DESCRIPTION
The `deeptaxa-rrna` run requirements left `pytorch` and `transformers` unpinned, so a conda solve can resolve a torch (e.g. 1.12) that is too old for the package, which uses `torch.load(weights_only=...)` and `torch.amp.GradScaler`. This pins `pytorch >=2.4` and `transformers >=4.28` to match the package's requirements and bumps the build number. I am the recipe maintainer (@ahmedmoustafa).