### PR TITLE
clair3: update to 2.0.2

### DIFF
--- a/recipes/clair3/build.sh
+++ b/recipes/clair3/build.sh
@@ -45,11 +45,32 @@ if [ "$OS" = "Darwin" ]; then
     export LDFLAGS
 fi
 
-make CC=${CC} CXX=${CXX} PREFIX=${PREFIX} CC_PATH=${CC}
+make libhts.a libclair3.so CC=${CC} CXX=${CXX} PREFIX=${PREFIX} CC_PATH=${CC}
 cp libclair3*.so $PREFIX/bin
-if [ -f longphase ]; then
-    cp longphase $PREFIX/bin
-fi
 
-mkdir -p $PREFIX/bin/models
+# ---- Bundle pre-trained models -------------------------------------------
+# All Clair3 models are pre-packaged into a single archive so the build only
+# needs ONE download instead of many small per-file requests. It unpacks to
+# ${PREFIX}/bin/models/<model>/{pileup.pt,full_alignment.pt}.
+# Override CLAIR3_MODELS_URL to use a mirror, or set it to "" to skip bundling.
+# Individual / additional models can be downloaded by users from:
+#   https://www.bio8.cs.hku.hk/clair3/clair3_models_pytorch/
+#   https://www.bio8.cs.hku.hk/clair3/clair3_models_rerio_pytorch/
+CLAIR3_MODELS_URL="${CLAIR3_MODELS_URL-https://www.bio8.cs.hku.hk/clair3/bioconda/clair3_models_v2.0.2.tar.gz}"
+CLAIR3_MODELS_SHA256="${CLAIR3_MODELS_SHA256-27c7ea0777134567861e1f305a368d89a199332a1118a4f70df8bfebdbe1306b}"
+
+mkdir -p "$PREFIX/bin/models"
+if [ -n "$CLAIR3_MODELS_URL" ]; then
+    echo "Downloading bundled Clair3 models from ${CLAIR3_MODELS_URL}"
+    curl -fSL -o clair3_models.tar.gz "$CLAIR3_MODELS_URL"
+    if [ -n "$CLAIR3_MODELS_SHA256" ]; then
+        actual=$( { sha256sum clair3_models.tar.gz 2>/dev/null || shasum -a 256 clair3_models.tar.gz; } | awk '{print $1}' )
+        if [ "$actual" != "$CLAIR3_MODELS_SHA256" ]; then
+            echo "ERROR: model archive sha256 mismatch (expected ${CLAIR3_MODELS_SHA256}, got ${actual})" >&2
+            exit 1
+        fi
+    fi
+    tar xzf clair3_models.tar.gz -C "$PREFIX/bin/"
+    rm -f clair3_models.tar.gz
+fi
 

--- a/recipes/clair3/meta.yaml
+++ b/recipes/clair3/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "clair3" %}
-{% set version = "2.0.1" %}
+{% set version = "2.0.2" %}
 {% set pypy_version = "3.11-v7.3.20" %}
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   - url: https://github.com/HKU-BAL/Clair3/archive/refs/tags/v{{ version }}.tar.gz
-    sha256: cf95fa2fa81f31e2231446aa21abc4642b1f810274858a98b17acd010be5ef7c
+    sha256: 144afb25e96c984c1d2aeb7dcf4f09412e47fc479922023ce20c5f9b0d473c66
 
 {% if linux and x86_64 %}
   - url: https://downloads.python.org/pypy/pypy{{ pypy_version }}-linux64.tar.bz2
@@ -54,7 +54,7 @@ requirements:
     - libcurl
     - openssl
     - libdeflate
-    - longphase  # [linux]
+    - longphase
   run:
     - python 3.11.*
     - pytorch-cpu  # [linux]
@@ -70,11 +70,11 @@ requirements:
     - parallel >=20191122
     - openssl
     - cffi <2
-    - longphase  # [linux]
+    - longphase
 
 test:
   commands:
-    - longphase --version  # [linux]
+    - longphase --version
     - which run_clair3.sh
     - run_clair3.sh -v
 


### PR DESCRIPTION
Clair3 repo updates:
- Always emit a valid, indexed VCF/gVCF when no variants are found ([Issue#447](https://github.com/HKU-BAL/Clair3/issues/447)).
- Fail early with clear guidance, instead of crashing, when a move-table `*_with_mv` model is run without `--enable_dwell_time` ([Issue#437](https://github.com/HKU-BAL/Clair3/issues/437)).

Recipe repo updates:
- Use the longphase conda package on all platforms (longphase now supports linux-aarch64) instead of compiling it at build time ([PR#64876](https://github.com/bioconda/bioconda-recipes/pull/64876)). 
- Re-bundle pre-trained models (single pre-packaged archive extracted to \${PREFIX}/bin/models/), restoring bundled models removed since v2.0.0 ([Issue#446](https://github.com/HKU-BAL/Clair3/issues/446)). 