### PR TITLE
Fix MoGAAAP recipe

### DIFF
--- a/recipes/mogaaap/meta.yaml
+++ b/recipes/mogaaap/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - poetry-core >=1.0.0
   run:
     - apptainer >=1.3
-    - click =8.0
+    - click =8
     - python =3.11
     - pyyaml =6.0
     - psutil =7.0

--- a/recipes/mogaaap/meta.yaml
+++ b/recipes/mogaaap/meta.yaml
@@ -24,7 +24,10 @@ requirements:
     - poetry-core >=1.0.0
   run:
     - apptainer >=1.3
+    - click =8.0
     - python =3.11
+    - pyyaml =6.0
+    - psutil =7.0
     - snakemake >=8.0.0
 
 test:

--- a/recipes/mogaaap/meta.yaml
+++ b/recipes/mogaaap/meta.yaml
@@ -11,7 +11,7 @@ build:
   script: python -m pip install --no-deps --ignore-installed . -vvv
   run_exports:
     - {{ pin_subpackage('mogaaap', max_pin="x") }}
-  number: 0
+  number: 1
 
 source:
   - url: https://github.com/dirkjanvw/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz


### PR DESCRIPTION
Because `pip` for `mogaaap` recipe has `--no-deps` specified to have the dependencies handled by conda, the dependencies should be specified in the recipe. This was not done previously, so adding with this PR.