### PR TITLE
Add bammmotif2

### DIFF
--- a/recipes/bammmotif2/build.sh
+++ b/recipes/bammmotif2/build.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+# Upstream v2.0 has CMakeLists.txt formatted as a single long line, so a
+# normal multi-line patch is fragile. Keep these conda-specific edits here.
+sed -i.bak \
+  -e 's/cmake_minimum_required (VERSION 2.8.11 FATAL_ERROR)/cmake_minimum_required (VERSION 3.5 FATAL_ERROR)/' \
+  -e 's/set (Boost_USE_STATIC_LIBS ON CACHE BOOL "use static libraries from Boost")/set (Boost_USE_STATIC_LIBS OFF CACHE BOOL "use shared libraries from Boost")/' \
+  -e 's/include_directories (${Boost_INCLUDEDIR})/include_directories (${Boost_INCLUDE_DIRS})/' \
+  -e 's/set (CMAKE_CXX_FLAGS "-std=c++11 -Wall")/set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall")/' \
+  CMakeLists.txt
+
+# Fail early if any expected replacement did not happen.
+grep -q 'cmake_minimum_required (VERSION 3.5 FATAL_ERROR)' CMakeLists.txt
+grep -q 'Boost_USE_STATIC_LIBS OFF' CMakeLists.txt
+grep -q 'Boost_INCLUDE_DIRS' CMakeLists.txt
+grep -q 'CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall"' CMakeLists.txt
+
+mkdir -p build
+cd build
+
+cmake \
+  ${CMAKE_ARGS} \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+  ..
+
+make -j"${CPU_COUNT}"
+make install
+
+test -x "${PREFIX}/bin/BaMMmotif"
+test -x "${PREFIX}/bin/BaMMScan"
+test -x "${PREFIX}/bin/FDR"

--- a/recipes/bammmotif2/meta.yaml
+++ b/recipes/bammmotif2/meta.yaml
@@ -13,10 +13,13 @@ source:
 build:
   number: 0
   skip: true  # [win]
+  run_exports:
+    - {{ pin_subpackage('bammmotif2', max_pin="x.x") }}
 
 requirements:
   build:
     - {{ compiler('cxx') }}
+    - {{ stdlib('c') }}
     - cmake
     - make  # [unix]
   host:

--- a/recipes/bammmotif2/meta.yaml
+++ b/recipes/bammmotif2/meta.yaml
@@ -1,0 +1,49 @@
+{% set name = "bammmotif2" %}
+{% set version = "2.0.0" %}
+{% set tag = "v2.0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/soedinglab/BaMMmotif2/archive/refs/tags/{{ tag }}.tar.gz
+  sha256: a9c72631c37b2b142203a06530c3c251905a27d9a9aa1d7067c7b80062466b10
+
+build:
+  number: 0
+  skip: true  # [win]
+
+requirements:
+  build:
+    - {{ compiler('cxx') }}
+    - cmake
+    - make  # [unix]
+  host:
+    - boost-cpp
+  run:
+    - boost-cpp
+
+test:
+  commands:
+    - test -x "${PREFIX}/bin/BaMMmotif"
+    - test -x "${PREFIX}/bin/BaMMScan"
+    - test -x "${PREFIX}/bin/FDR"
+    - BaMMmotif --help > bammmotif.help 2>&1 || true
+    - test -s bammmotif.help
+    - grep -Eiq "SYNOPSIS:|BaMMmotif OUTDIR|OPTIONS:" bammmotif.help
+
+about:
+  home: https://github.com/soedinglab/BaMMmotif2
+  summary: Bayesian Markov Model motif discovery tool version 2
+  description: |
+    BaMMmotif2 is a command-line tool for de novo discovery of enriched motifs
+    modelled by higher-order Bayesian Markov models. This Bioconda recipe
+    packages the core C++ command-line tools only and does not add R plotting
+    dependencies.
+  license: GPL-3.0-or-later
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - ubercomrade


### PR DESCRIPTION
This PR adds a Bioconda recipe for BaMMmotif2 v2.0.

BaMMmotif2 is a bioinformatics command-line tool for de novo motif discovery using higher-order Bayesian Markov models. This recipe packages the core C++ command-line tools:

* `BaMMmotif`
* `BaMMScan`
* `FDR`

The recipe intentionally does not add the optional R plotting/logo dependencies. The goal of this package is to provide the core motif discovery and scanning algorithms for command-line use and for downstream Python wrappers.

## Build notes

The upstream v2.0 `CMakeLists.txt` requires a few small conda-specific compatibility adjustments during the build:

* update `cmake_minimum_required(VERSION 2.8.11)` to `cmake_minimum_required(VERSION 3.5)`, because current CMake versions no longer support compatibility with CMake versions older than 3.5;
* use shared Boost from conda-forge instead of static Boost;
* use `Boost_INCLUDE_DIRS`;
* preserve conda-build `CXXFLAGS` instead of overwriting `CMAKE_CXX_FLAGS`.

These substitutions are applied in `build.sh` with `sed` because the upstream v2.0 `CMakeLists.txt` is formatted as a single long line, which makes a normal multi-line patch fragile.

The changes are limited to build-system compatibility and should not affect the BaMMmotif2 algorithms.

I can open an upstream PR for the CMake compatibility changes if preferred; for this recipe they are kept minimal and limited to conda build-system compatibility.

## run_exports

The recipe includes:

```yaml
build:
  run_exports:
    - {{ pin_subpackage('bammmotif2', max_pin="x.x") }}
```

I used `max_pin="x.x"` conservatively because BaMMmotif2 provides command-line tools rather than a library API, and downstream recipes are most likely to depend on the CLI behavior and output formats. A minor-version change could plausibly introduce CLI or output-format changes that affect downstream wrappers or workflows.

## Tests

The recipe includes smoke tests that verify the installed executables are present:

* `BaMMmotif`
* `BaMMScan`
* `FDR`

The test also captures `BaMMmotif --help` output and checks for expected usage/help text.

`BaMMmotif --help` prints the help text but returns a non-zero exit code because it first reports missing required positional arguments, so the test validates the output rather than relying on the exit status.

## Local validation

I tested the recipe locally with:

```bash
conda build recipes/bammmotif2 -c conda-forge -c bioconda
bioconda-utils lint --packages bammmotif2 recipes config.yml
bioconda-utils build --docker --mulled-test --packages bammmotif2 recipes config.yml
```

The Docker/mulled test passed locally.