### PR TITLE
harmonypy 2.0.0: bump build number to rebuild missing Python versions

### DIFF
--- a/recipes/harmonypy/meta.yaml
+++ b/recipes/harmonypy/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: "98c18954781aec9a82aaec3cde3764d89fd2ef93e84ece6724bc0f25b37244ed"
 
 build:
-  number: 0
+  number: 1
   script: "{{ PYTHON }} -m pip install . --no-deps --no-build-isolation --no-cache-dir -vvv"
   run_exports:
     - {{ pin_subpackage(name, max_pin="x.x") }}

--- a/recipes/harmonypy/meta.yaml
+++ b/recipes/harmonypy/meta.yaml
@@ -11,6 +11,7 @@ source:
 
 build:
   number: 1
+  skip: True  # [py < 39]
   script: "{{ PYTHON }} -m pip install . --no-deps --no-build-isolation --no-cache-dir -vvv"
   run_exports:
     - {{ pin_subpackage(name, max_pin="x.x") }}
@@ -24,14 +25,14 @@ requirements:
     - ninja
   host:
     - pip
-    - python >=3.9
+    - python
     - armadillo
     - scikit-build-core >=0.10
     - nanobind >=2.0
     - libopenblas  # [linux]
   run:
     - numpy
-    - python >=3.9
+    - python
     - libopenblas  # [linux]
 
 test:


### PR DESCRIPTION
## Summary

Fixes #66713.

Only `py314` builds were published for `harmonypy` 2.0.0. The original autobump PR (#64868) and subsequent rebuild attempt both produced only a single Python variant. Root cause: using `python >=3.9` in host/run requirements prevents conda-build from enumerating the `[python, is_python_min]` zip_keys group from conda-forge-pinning, causing the variant solver to fall back to just the running Python version.

Fix: use bare `python` (no version pin) in host/run requirements, matching the pattern used by other scikit-build-core/nanobind recipes (e.g. hictkpy) that correctly build for all pinned variants. A `skip: True  # [py < 39]` guard preserves the minimum Python 3.9 requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)