### PR TITLE
Add impaqt

### DIFF
--- a/recipes/impaqt/build.sh
+++ b/recipes/impaqt/build.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -euxo pipefail
+
+# conda-build sets CC/CXX to the conda toolchain, PREFIX to the install root,
+# CPU_COUNT to the available cores, PKG_CONFIG_PATH to $PREFIX/lib/pkgconfig (so the
+# host bamtools is found), and CMAKE_ARGS to the conda toolchain file + cross-compile
+# settings (required for osx-arm64 / linux-aarch64). Use the conda-provided bamtools
+# and skip the unit tests (and thus GoogleTest) so the build needs no network.
+cmake -S . -B build ${CMAKE_ARGS} \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+    -DUSE_SYSTEM_BAMTOOLS=ON \
+    -DIMPAQT_BUILD_TESTS=OFF
+
+cmake --build build -j"${CPU_COUNT}"
+cmake --install build

--- a/recipes/impaqt/meta.yaml
+++ b/recipes/impaqt/meta.yaml
@@ -1,0 +1,52 @@
+{% set name = "impaqt" %}
+{% set version = "1.2.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/bnjenner/impaqt/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 0d86c0b629cf798030f34d499eb574500bd029d2e1b25d73156efd18e4666c87
+
+build:
+  number: 0
+  skip: true  # [win]
+  run_exports:
+    - {{ pin_subpackage("impaqt", max_pin="x") }}
+
+requirements:
+  build:
+    - {{ compiler('cxx') }}
+    - {{ stdlib('c') }}
+    - cmake >=3.18
+    - make
+    - pkg-config
+  host:
+    - zlib
+    - bamtools
+  run:
+    # zlib and bamtools are normally pinned automatically via their run_exports;
+    # listed here for clarity.
+    - bamtools
+
+test:
+  commands:
+    - impaqt --help
+
+about:
+  home: https://github.com/bnjenner/impaqt
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: "Identifies Multiple Peaks and Quantifies Transcripts (TAGseq / 3' mRNA-seq)"
+  description: |
+    IMPAQT identifies and quantifies transcripts and isoforms with distinct 3'
+    ends from TAGseq and 3' mRNA-seq data by clustering read ends (DBSCAN). It
+    emits a GTF of identified transcripts and, optionally, a gene-level counts
+    table when given a reference annotation.
+  dev_url: https://github.com/bnjenner/impaqt
+
+extra:
+  recipe-maintainers:
+    - bnjenner


### PR DESCRIPTION
Add impaqt — identifies and quantifies isoforms with distinct 3' ends  from TAGseq / 3' mRNA-seq data (DBSCAN on read ends). New recipe.

- Source: GitHub release v1.2.0 (sha256 pinned)
- Builds against conda's bamtools; zlib host dep; tests run `impaqt --help`
- MIT licensed; leaf CLI application