### PR TITLE
Add nuclease Bioconda recipe

### DIFF
--- a/recipes/nuclease/meta.yaml
+++ b/recipes/nuclease/meta.yaml
@@ -1,0 +1,53 @@
+{% set name = "nuclease" %}
+{% set version = "0.6.0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/nrminor/nuclease/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 7ec51f05cb1f13327e63eea77cf83d8cfbb474cb71f4bc86aecc971b2a817f15
+
+build:
+  number: 0
+  run_exports:
+    - {{ pin_subpackage('nuclease', max_pin="x.x") }}
+  script:
+    - export CARGO_INCREMENTAL=0
+    - cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
+    - cargo install -v --locked --no-track --root $PREFIX --path . --bin nuclease
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('rust') }}
+    - {{ stdlib('c') }}
+    - cargo-bundle-licenses
+    - pkg-config
+
+test:
+  commands:
+    - nuclease --version
+    - nuclease --help
+
+about:
+  home: https://github.com/nrminor/nuclease
+  license: MIT
+  license_file:
+    - LICENSE
+    - THIRDPARTY.yml
+  summary: Streaming FASTQ preprocessor for trimming, merging, filtering, and more.
+  description: |
+    nuclease is a fast and resource-frugal sequencing read preprocessor. It streams
+    local or ENA FASTQ through a processing plan and emits cleaned FASTQ/FASTA for
+    downstream tools.
+  dev_url: https://github.com/nrminor/nuclease
+  doc_url: https://github.com/nrminor/nuclease/blob/v{{ version }}/README.md
+
+extra:
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64
+  recipe-maintainers:
+    - nrminor


### PR DESCRIPTION
This PR adds a Bioconda recipe for `nuclease`, a streaming FASTQ preprocessor for sequencing reads. The package installs the command-line executable as `nuclease`.

The recipe builds from the GitHub `v0.6.0` source tag using the checked-in `Cargo.lock` via `cargo install --locked` and bundles third-party Rust dependency licenses with `cargo-bundle-licenses`. It also preserves the standard portable CPU-target behavior expected for conda packages.

The following validation passed locally before I opened this PR:

```sh
pixi exec -c conda-forge -c bioconda -s bioconda-utils \
  bioconda-utils lint --packages nuclease recipes config.yml
```

Thanks in advance for the review.