### PR TITLE
Update strainify 1.3.0

### DIFF
--- a/recipes/strainify/build.sh
+++ b/recipes/strainify/build.sh
@@ -1,16 +1,23 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# bioconda build script for Strainify
+set -euo pipefail
 
-SHARE_DIR=$PREFIX/share/$PKG_NAME
-mkdir -p $SHARE_DIR
-mkdir -p $PREFIX/bin
+SHARE="$PREFIX/share/strainify"
+mkdir -p "$SHARE" "$PREFIX/bin"
 
-# Copy repo to share
-cp -r . $SHARE_DIR/
+# Copy pipeline assets. VERSION is included so the launcher's `--version`
+# reports the real version instead of falling back to "unknown".
+# (helpers/, environment.yml and recipes/ are intentionally NOT bundled.)
+cp -r main.nf nextflow.config VERSION conf modules subworkflows bin "$SHARE/"
 
-# Ensure internal scripts are executable
-chmod +x $SHARE_DIR/strainify
-chmod +x $SHARE_DIR/*.py
-chmod +x $SHARE_DIR/*.sh
+# Bundle the example dataset so `-profile test` works from a conda install.
+# Guarded so the build still succeeds if example/ is ever absent. Remove this
+# line if you'd rather keep test data out of the package (e.g. for Bioconda).
+[ -d example ] && cp -r example "$SHARE/"
 
-# Create the global wrapper
-ln -s $SHARE_DIR/strainify $PREFIX/bin/strainify
+# The exec bit on the bundled bin/ scripts may not survive packaging; restore it.
+find "$SHARE/bin" -type f -exec chmod +x {} +
+
+# Install the CLI launcher onto PATH. It resolves the pipeline dir via the
+# $PREFIX/share/strainify fallback, so it works from a conda install.
+install -m 0755 strainify "$PREFIX/bin/strainify"

--- a/recipes/strainify/meta.yaml
+++ b/recipes/strainify/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "strainify" %}
-{% set version = "1.2.0" %}
+{% set version = "1.3.0" %}
 
 package:
   name: "{{ name|lower }}"
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/treangenlab/Strainify/archive/refs/tags/V{{ version }}.tar.gz
-  sha256: df29c2645992a4add6f28bf66e65c6fb261a514825c26783a553522fe67341f2
+  sha256: 1deb2b7c5e4df8060915db29ce851426c7876bed346514089fbe8cb0426e9f3f
 
 build:
   number: 0

--- a/recipes/strainify/meta.yaml
+++ b/recipes/strainify/meta.yaml
@@ -15,6 +15,8 @@ source:
 build:
   number: 0
   noarch: generic
+  run_exports:
+    - {{ pin_subpackage('strainify', max_pin="x") }}
   # Do NOT add a `script:` here. conda-build automatically runs the co-located
   # build.sh for Unix/noarch builds; naming it explicitly breaks the path.
 

--- a/recipes/strainify/meta.yaml
+++ b/recipes/strainify/meta.yaml
@@ -1,82 +1,91 @@
-{% set name = "strainify" %}
 {% set version = "1.3.0" %}
+# Keep `version` in sync with the repo's VERSION file (without the leading "V")
+# and with the git tag that source.url points at (V{{ version }}).
 
 package:
-  name: "{{ name|lower }}"
-  version: "{{ version }}"
+  name: strainify
+  version: {{ version }}
 
 source:
   url: https://github.com/treangenlab/Strainify/archive/refs/tags/V{{ version }}.tar.gz
+  # Fill in after you push the tag:
+  #   wget -qO- https://github.com/treangenlab/Strainify/archive/refs/tags/V{{ version }}.tar.gz | sha256sum
   sha256: 1deb2b7c5e4df8060915db29ce851426c7876bed346514089fbe8cb0426e9f3f
 
 build:
   number: 0
   noarch: generic
-  run_exports:
-    - {{ pin_subpackage(name, max_pin="x") }}
+  # Do NOT add a `script:` here. conda-build automatically runs the co-located
+  # build.sh for Unix/noarch builds; naming it explicitly breaks the path.
 
 requirements:
   run:
-    - python >=3.12
-
-    # Workflow / CLI
-    - snakemake >=9.3
-    - typer >=0.15
-    - pyyaml >=6.0
+    # The launcher is a bash script
+    - bash
+    # Workflow engine
+    - nextflow >=26.04
+    # Python runtime
+    - python >=3.10,<3.13   # 3.13 removed stdlib 'cgi' that the MAGNET stack imports
+    - biopython >=1.85
     - pandas >=2.2
     - numpy >=2.2
+    - pysam >=0.23
+    - scipy >=1.15
+    - scikit-learn >=1.6
+    - cvxpy >=1.6
+    - clarabel >=0.10
+    - ecos >=2.0
+    - osqp >=1.0
+    - scs >=3.2
+    - joblib >=1.5
     - psutil >=7.0
-    - biopython >=1.85
+    - threadpoolctl >=3.6
+    - tqdm >=4.67
     - pulp >=2.8
     - coincbc
-
+    - pyyaml >=6.0
     # Bioinformatics tools
-    - bcftools >=1.21
+    - bwa >=0.7.18
     - samtools >=1.21
     - htslib >=1.21
-    - bwa >=0.7.18
+    - bcftools >=1.21
+    - parsnp >=2.1.4
+    - harvesttools >=1.2
+    - wgatools >=1.1.0
     - fastani >=1.34
     - fasttree >=2.1.11
-    - harvesttools >=1.2  # [x86_64]
     - mash >=2.3
-    - parsnp >=2.1.4
     - phipack >=1.1
-    - pyspoa >=0.2.1
     - raxml >=8.2.13
-    - wgatools >=1.1.0
     - parallel
-
-    # Optional Utilities
-    - configargparse >=1.7.1
-    - jinja2 >=3.1
-    - jsonschema >=4.23
-    - tabulate >=0.9
-    - tqdm >=4.67
-    - gitpython >=3.1
-
-    # Converted from PIP to Conda
-    - clarabel >=0.10.0
-    - cvxpy >=1.6.5
-    - ecos >=2.0.14
-    - git-filter-repo >=2.47.0
-    - joblib >=1.5.0
-    - osqp >=1.0.4
-    - pysam >=0.23.0
-    - scikit-learn >=1.6.1
-    - scipy >=1.15.3
-    - scs >=3.2.7
-    - threadpoolctl >=3.6.0
+    # Prefilter (MAGNET)
+    - ete3 >=3.1.3          # magnet.py does `from ete3 import NCBITaxa` at import time -- HARD dep
+    - minimap2              # MAGNET ONT mode (-m ont); drop only if you drop ONT support
+    - ncbi-datasets-cli   # ONLY if you enable MAGNET's NCBI genome-download mode;
+    #                       # the bring-your-own-genomes filter-run path never calls it
 
 test:
   commands:
-    - "strainify --help || test $? -eq 1" 
+    - strainify --help
+    - test -f "$PREFIX/share/strainify/main.nf"
+    - test -f "$PREFIX/share/strainify/VERSION"
 
 about:
   home: https://github.com/treangenlab/Strainify
   license: MIT
   license_file: LICENSE
-  summary: "Strain-level abundance analysis tool for short-read metagenomics"
+  summary: Strain-level abundance analysis tool for short-read metagenomics
+  description: |
+    Strainify is an accurate strain-level abundance analysis tool for short-read
+    metagenomics. It uses whole-genome alignments (Parsnp) to identify variant
+    sites, maps metagenomic reads to a reference, and estimates strain abundances
+    via a maximum likelihood model. It is designed to perform well on complex microbial
+    communities and at low sequencing depths, where strain-resolved signal is
+    sparse and closely related strains are easily confused.
+  doc_url: https://github.com/treangenlab/Strainify/blob/master/README.md
+  dev_url: https://github.com/treangenlab/Strainify
 
 extra:
   recipe-maintainers:
+    # Replace with the GitHub handle(s) of the maintainer(s) (lint requires this).
     - rossie-luo


### PR DESCRIPTION
Supersedes #66731. The autobump bot bumped the old Snakemake-based recipe to 1.3.0; this replaces it with the corrected recipe for the Nextflow rewrite — adds nextflow, ete3, minimap2; drops the Snakemake-era deps and git-filter-repo; updates build.sh to stage the Nextflow pipeline.
