### PR TITLE
Removed the arm64 fix; added osx-arm64

### DIFF
--- a/recipes/minibwa/build.sh
+++ b/recipes/minibwa/build.sh
@@ -4,15 +4,6 @@ set -xe
 
 mkdir -p "${PREFIX}/bin" "${PREFIX}/lib" "${PREFIX}/include"
 
-# The bundled SSE->NEON shim (s2n-lite.h) reinterprets uint32x4_t results
-# through signed int32x4_t intrinsics, which GCC on aarch64 rejects. Permit
-# the conversion as GCC itself suggests (clang/macOS already accepts it).
-case "$(uname -m)" in
-    aarch64 | arm64)
-        export CFLAGS="${CFLAGS} -flax-vector-conversions"
-        ;;
-esac
-
 # CC drives the Makefile's OpenMP auto-detection. The override-makefile.patch
 # lets the Makefile append its OpenMP/GPL/SSE4.2 flags on top of conda's
 # CFLAGS/CPPFLAGS rather than having them clobbered by the command line.

--- a/recipes/minibwa/meta.yaml
+++ b/recipes/minibwa/meta.yaml
@@ -45,3 +45,4 @@ about:
 extra:
   additional-platforms:
     - linux-aarch64
+    - osx-arm64

--- a/recipes/minibwa/meta.yaml
+++ b/recipes/minibwa/meta.yaml
@@ -12,7 +12,7 @@ source:
     - override-makefile.patch
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage(name, max_pin="x.x") }}
 


### PR DESCRIPTION
The compiling error on arm64 has been fixed via lh3/minibwa@7e3b593. The extra test in build.sh is no longer needed. Also added osx-arm64 under additional-platforms.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
