### PR TITLE
Update verifybamid2 to 2.0.3

### DIFF
--- a/recipes/verifybamid2/build.sh
+++ b/recipes/verifybamid2/build.sh
@@ -21,10 +21,21 @@ case $(uname -m) in
 	;;
 esac
 
+CONFIG_ARGS=()
 if [[ `uname -s` == "Darwin" ]]; then
-	export CONFIG_ARGS="-DCMAKE_FIND_FRAMEWORK=NEVER -DCMAKE_FIND_APPBUNDLE=NEVER"
-else
-	export CONFIG_ARGS=""
+	CONFIG_ARGS+=(-DCMAKE_FIND_FRAMEWORK=NEVER -DCMAKE_FIND_APPBUNDLE=NEVER)
+	# Force CMake to archive static libraries with the conda cctools ar/ranlib
+	# rather than the compiler-bundled llvm tools. The llvm-ranlib in the osx
+	# build environment is broken (it aborts trying to load @rpath/libLLVM.*.dylib),
+	# which breaks archiving of the C++-only libVcf library. cctools ranlib works
+	# fine -- it is what CMAKE_RANLIB already resolves to for the mixed-language
+	# libstatgen, which archives successfully. Guarded so that if the conda
+	# toolchain ever stops exporting AR/RANLIB we fall back to CMake's defaults
+	# rather than failing under `set -u`.
+	if [[ -n "${AR:-}" && -n "${RANLIB:-}" ]]; then
+		CONFIG_ARGS+=(-DCMAKE_C_COMPILER_AR="${AR}" -DCMAKE_CXX_COMPILER_AR="${AR}")
+		CONFIG_ARGS+=(-DCMAKE_C_COMPILER_RANLIB="${RANLIB}" -DCMAKE_CXX_COMPILER_RANLIB="${RANLIB}")
+	fi
 fi
 
 sed -i.bak "s|2.0.1|${PKG_VERSION}|" main.cpp
@@ -34,7 +45,7 @@ cmake -S . -B build -G Ninja -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
 	-DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER="${CXX}" \
 	-DCMAKE_CXX_FLAGS="${CXXFLAGS}" \
 	-Wno-dev -Wno-deprecated --no-warn-unused-cli \
-	"${CONFIG_ARGS}"
+	"${CONFIG_ARGS[@]+"${CONFIG_ARGS[@]}"}"
 
 ninja -C build -j"${CPU_COUNT}"
 

--- a/recipes/verifybamid2/meta.yaml
+++ b/recipes/verifybamid2/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "verifybamid2" %}
-{% set version = "2.0.2" %}
-{% set sha256 = "bccd0d9c8f0bb80986ab73b22656c82919635453a50420001a0d7376f487820c" %}
+{% set version = "2.0.3" %}
+{% set sha256 = "ac0189793e85eb1982f7ce7e801957b540d85caa3d7de07dcbca3f9f819e0ea6" %}
 
 package:
   name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://github.com/Griffan/VerifyBamID/archive/refs/tags/V{{ version }}.tar.gz
+  url: https://github.com/Griffan/VerifyBamID/archive/refs/tags/v{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:


### PR DESCRIPTION
New upstream release bundling recent VerifyBamID2 work: https://github.com/Griffan/VerifyBamID/releases/tag/v2.0.3

The release tag case changed from V2.0.2 to v2.0.3, so the source URL is updated to use a lowercase v.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
