### PR TITLE
Update nf-metro 0.7.2: add fonttools/jsonschema deps, update home URL

### DIFF
--- a/recipes/nf-metro/meta.yaml
+++ b/recipes/nf-metro/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 1
+  number: 2
   run_exports:
     - {{ pin_subpackage("nf-metro", max_pin="x") }}
 
@@ -28,6 +28,7 @@ requirements:
     - lark >=1.1
     - networkx >=3.0
     - pillow >=9.0
+    - fonttools >=4.0
     - jsonschema >=4.0
 
 test:
@@ -35,7 +36,7 @@ test:
     - nf-metro --help
 
 about:
-  home: https://github.com/pinin4fjords/nf-metro
+  home: https://github.com/seqeralabs/nf-metro
   summary: Metromap-style pipeline workflow components
   license: MIT
   license_file: LICENSE


### PR DESCRIPTION
## Summary

Patch build for nf-metro 0.7.2 (version already in master):

- **Add `fonttools >=4.0`** - enables the font subsetting feature (`font` extra in pyproject.toml)
- **Add `jsonschema >=4.0`** - enables the `nf-metro validate-svg` CLI command; imported lazily so absent before this
- **Update `home:` URL** to `https://github.com/seqeralabs/nf-metro` following org transfer from pinin4fjords
- **Bump build number** 1 → 2

Both new deps are available in conda-forge.