### PR TITLE
Add viotucluster recipe

### DIFF
--- a/recipes/viotucluster/meta.yaml
+++ b/recipes/viotucluster/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "viotucluster" %}
-{% set version = "0.5.7.2" %}
-{% set sha256 = "7632215d98f08072a19c42e24aac41a45e3a235cc50bd2666c261d4911ce0408" %}
+{% set version = "0.6.0" %}
+{% set sha256 = "c52ce9bcae264bac85d009abefc300e9f7f863e104ace8ed2ca0dfa1a1d1f868" %}
 
 package:
   name: "{{ name|lower }}"

--- a/recipes/viotucluster/meta.yaml
+++ b/recipes/viotucluster/meta.yaml
@@ -12,7 +12,9 @@ source:
 
 build:
   number: 0
-  skip: true  # [not linux]
+  noarch: generic
+  run_exports:
+    - {{ pin_subpackage(name|lower, max_pin="x.x") }}
   script: "{{ PYTHON }} -m pip install . --no-deps --no-build-isolation --no-cache-dir -vvv"
   entry_points:
     - ViOTUcluster=ViOTUcluster.viotucluster_cli:main

--- a/recipes/viotucluster/meta.yaml
+++ b/recipes/viotucluster/meta.yaml
@@ -1,0 +1,66 @@
+{% set name = "viotucluster" %}
+{% set version = "0.5.7.2" %}
+{% set sha256 = "7632215d98f08072a19c42e24aac41a45e3a235cc50bd2666c261d4911ce0408" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: "https://github.com/liusihang/ViOTUcluster/archive/refs/tags/v{{ version }}.tar.gz"
+  sha256: "{{ sha256 }}"
+
+build:
+  number: 0
+  skip: true  # [not linux]
+  script: "{{ PYTHON }} -m pip install . --no-deps --no-build-isolation --no-cache-dir -vvv"
+  entry_points:
+    - ViOTUcluster=ViOTUcluster.viotucluster_cli:main
+    - ViOTUcluster_AllinOne=ViOTUcluster.viotucluster_allinone_cli:main
+
+requirements:
+  host:
+    - python >=3.10,<3.11
+    - pip
+    - setuptools
+  run:
+    - python >=3.10,<3.11
+    - biopython >=1.79
+    - pandas >=1.3
+    - numpy
+    - packaging
+    - fastp
+    - megahit
+    - spades
+    - viralverify
+    - virsorter =2.2.4
+    - genomad =1.8.0
+    - checkv =1.0.3
+    - drep =3.5.0
+    - vrhyme
+    - bwa
+    - sambamba
+    - coverm
+    - blast
+    - parallel
+
+test:
+  imports:
+    - ViOTUcluster
+  commands:
+    - ViOTUcluster --help
+    - ViOTUcluster_AllinOne --help
+    - python -c "import ViOTUcluster"
+
+about:
+  home: "https://github.com/liusihang/ViOTUcluster"
+  dev_url: "https://github.com/liusihang/ViOTUcluster"
+  doc_url: "https://github.com/liusihang/ViOTUcluster/blob/master/README.md"
+  license: "GPL-2.0-only"
+  license_family: "GPL"
+  license_file: "LICENSE"
+  summary: "High-speed all-in-one viromics analysis pipeline for metagenomic data."
+
+extra:
+  identifiers:
+    - doi:10.1002/imo2.70023


### PR DESCRIPTION
## Summary

Adds a first Bioconda recipe for `viotucluster` using upstream release `v0.6.0`.

## Scope

This recipe packages the validated default main workflow runtime:
- Python CLI package
- fastp
- megahit
- spades
- viralverify
- virsorter
- genomad
- checkv
- drep
- vrhyme
- bwa
- sambamba
- coverm
- blast
- parallel

It intentionally does **not** include the optional DRAM or iPhop stacks in the first package.

## Upstream source

- Upstream tag/release: `v0.6.0`
- Source tarball: `https://github.com/liusihang/ViOTUcluster/archive/refs/tags/v0.6.0.tar.gz`

## Notes

- The recipe is constrained to Linux because the validated runtime surface for ViOTUcluster is Linux.
- The upstream `0.6.0` line includes the Conda-install fixes, version pins for the validated database contract, fail-fast validation for incomplete VirSorter2 HMM assets, and README updates that make Bioconda/mamba the preferred install path.
