### PR TITLE
Add salmofreq

### DIFF
--- a/recipes/salmofreq/meta.yaml
+++ b/recipes/salmofreq/meta.yaml
@@ -13,7 +13,6 @@ build:
   number: 0
   noarch: python
   run_exports:
-    # 0.x.x semantic versioning -> pin to minor (x.x) per Bioconda guidelines.
     - {{ pin_subpackage("salmofreq", max_pin="x.x") }}
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
@@ -30,7 +29,6 @@ requirements:
     - pandas >=1.3
     - openpyxl >=3.0
     - blast
-    # GUI dependency (`salmofreq gui`); drop this line for a CLI-only package.
     - streamlit >=1.49
 
 test:

--- a/recipes/salmofreq/meta.yaml
+++ b/recipes/salmofreq/meta.yaml
@@ -1,0 +1,63 @@
+{% set name = "salmofreq" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/shaodongyan/SalmoFreq/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 5526f8d23988e4939f53f6e761e9799b0ea68a8f805c2311bf180b38e988348d
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  entry_points:
+    - salmofreq = salmofreq.cli:main
+
+requirements:
+  host:
+    - python >=3.9
+    - pip
+    - setuptools >=64
+    - wheel
+  run:
+    - python >=3.9
+    - pandas >=1.3
+    - openpyxl >=3.0
+    - blast
+    # GUI dependency (`salmofreq gui`); drop this line for a CLI-only package.
+    - streamlit >=1.49
+
+test:
+  imports:
+    - salmofreq
+    - salmofreq.core
+    - salmofreq.serotyper
+  commands:
+    - salmofreq --version
+    - salmofreq --help
+    - salmofreq run --help
+
+about:
+  home: https://github.com/shaodongyan/SalmoFreq
+  license: GPL-2.0-only
+  license_family: GPL2
+  license_file: LICENSE
+  summary: Serotype-resolved Salmonella virulence-factor gene frequencies
+  description: |
+    SalmoFreq is a command-line tool for calculating serotype-resolved gene
+    frequencies in Salmonella. It serotypes assembled genomes with a bundled
+    SeqSero2-derived k-mer serotyper (or a user-provided serotype table),
+    screens each genome for genes by BLAST against a bundled virulence-factor
+    gene database (or any user-defined gene set), and produces a
+    serotype-by-gene frequency matrix. SalmoFreq was developed at the State
+    Key Laboratory of Veterinary Public Health and Safety, China Agricultural
+    University, in collaboration with the China National Center for Food
+    Safety Risk Assessment (CFSA).
+  dev_url: https://github.com/shaodongyan/SalmoFreq
+
+extra:
+  recipe-maintainers:
+    - shaodongyan

--- a/recipes/salmofreq/meta.yaml
+++ b/recipes/salmofreq/meta.yaml
@@ -12,6 +12,9 @@ source:
 build:
   number: 0
   noarch: python
+  run_exports:
+    # 0.x.x semantic versioning -> pin to minor (x.x) per Bioconda guidelines.
+    - {{ pin_subpackage("salmofreq", max_pin="x.x") }}
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
     - salmofreq = salmofreq.cli:main


### PR DESCRIPTION
Adds salmofreq, a command-line tool for serotype-resolved Salmonella virulence-factor (and user-defined) gene-frequency 
  calculation. noarch: python; pulls BLAST+ from Bioconda as a runtime dependency. Source: the GitHub v0.1.0 release tag.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
