### PR TITLE
Update fastaguard to 0.5.0

### DIFF
--- a/recipes/fastaguard/meta.yaml
+++ b/recipes/fastaguard/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "fastaguard" %}
-{% set version = "0.3.0" %}
+{% set version = "0.5.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/ehsanestaji/FastaGuard/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 643d5d0107b6dc237f3be782a8463414880b95c45964397b773dac7e794e4fde
+  sha256: b3de60c83cb570bb90e894c262effe4092101b1655e5c64023445078ee2c5971
 
 build:
   number: 0


### PR DESCRIPTION
## Summary

Update `fastaguard` from `0.3.0` to `0.5.0`.

The v0.5.0 release includes the v0.4 preflight-readiness/compare-mode contract and adds the v0.5 submission-readiness gate:

- `--gate submission`
- `--submission-target generic|ncbi`
- updated JSON schema and finding catalog
- submission readiness fields in JSON, TSV, HTML, MultiQC, and compare outputs

## Source

- Release: https://github.com/ehsanestaji/FastaGuard/releases/tag/v0.5.0
- Source archive SHA256: `b3de60c83cb570bb90e894c262effe4092101b1655e5c64023445078ee2c5971`

This supersedes the earlier open `0.4.0` update because the current FastaGuard release line is now `0.5.0`.
