### PR TITLE
chore: use conda subdir notation for platform names

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -185,7 +185,7 @@ jobs:
       - name: Archive packages
         uses: actions/upload-artifact@v6
         with:
-          name: linux-packages
+          name: linux-64-packages
           path: |
             /tmp/artifacts
           compression-level: 0
@@ -284,7 +284,7 @@ jobs:
       - name: Archive packages
         uses: actions/upload-artifact@v6
         with:
-          name: osx-packages
+          name: osx-64-packages
           path: |
             /tmp/artifacts
           compression-level: 0


### PR DESCRIPTION
bioconda-utils mostly uses conda-subdir notation for platforms (and OCI or docker where interfacing with those), bioconda-recipes adheres to neither, adding a 4th notation to account for. Making this more consistent would make bioconda-utils less messy

prior to the multi-platform branch these artifact names had no consumers, afaik this will not break anything existing