### PR TITLE
Add vicmag 0.1.0

### DIFF
--- a/recipes/vicmag/build.sh
+++ b/recipes/vicmag/build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euo pipefail
+
+mkdir -p "${PREFIX}/bin"
+
+cp vicmag.py "${PREFIX}/bin/vicmag"
+
+if ! head -n 1 "${PREFIX}/bin/vicmag" | grep -q "^#!"; then
+    tmpfile=$(mktemp)
+    echo "#!/usr/bin/env python" > "${tmpfile}"
+    cat "${PREFIX}/bin/vicmag" >> "${tmpfile}"
+    mv "${tmpfile}" "${PREFIX}/bin/vicmag"
+fi
+
+chmod +x "${PREFIX}/bin/vicmag"

--- a/recipes/vicmag/meta.yaml
+++ b/recipes/vicmag/meta.yaml
@@ -1,0 +1,45 @@
+{% set name = "vicmag" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/TsudaYusuke/VicMAG/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 8e148cc7c072be06c6fae0065cb132d6fd71b2b102d16192ba1826674e93a858
+
+build:
+  noarch: python
+  number: 0
+
+requirements:
+  host:
+    - python >=3.8
+
+  run:
+    - python >=3.8
+    - pandas
+    - numpy
+    - matplotlib-base
+    - biopython
+    - biotite
+    - pillow
+
+test:
+  commands:
+    - vicmag --help
+
+about:
+  home: https://github.com/TsudaYusuke/VicMAG
+  license: MIT
+  license_file: LICENSE
+  summary: A visualization tool for circular metagenome-assembled genomes
+  description: |
+    VicMAG is a visualization tool for circular metagenome-assembled genomes
+    focusing on virulence genes, antimicrobial resistance genes, plasmids,
+    and viral regions.
+
+extra:
+  recipe-maintainers:
+    - TsudaYusuke

--- a/recipes/vicmag/meta.yaml
+++ b/recipes/vicmag/meta.yaml
@@ -17,10 +17,10 @@ build:
 
 requirements:
   host:
-    - python >=3.8
+    - python
 
   run:
-    - python >=3.8
+    - python
     - pandas
     - numpy
     - matplotlib-base

--- a/recipes/vicmag/meta.yaml
+++ b/recipes/vicmag/meta.yaml
@@ -12,6 +12,8 @@ source:
 build:
   noarch: python
   number: 0
+  run_exports:
+    - {{ pin_subpackage(name|lower, max_pin="x.x") }}
 
 requirements:
   host:


### PR DESCRIPTION
This PR adds VicMAG 0.1.0.

VicMAG is a Python-based visualization tool for circular metagenome-assembled genomes, focusing on virulence genes, antimicrobial resistance genes, plasmids, and viral regions.

The recipe installs the command-line script as `vicmag` and tests the CLI with:

`vicmag --help`