### PR TITLE
Add gxfkit recipe

### DIFF
--- a/recipes/gxfkit/build.sh
+++ b/recipes/gxfkit/build.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
+cargo install --locked --no-track --root "${PREFIX}" --path crates/gxfkit

--- a/recipes/gxfkit/meta.yaml
+++ b/recipes/gxfkit/meta.yaml
@@ -11,11 +11,14 @@ source:
 
 build:
   number: 0
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x.x") }}
 
 requirements:
   build:
     - {{ compiler('rust') }}
     - {{ compiler('c') }}
+    - {{ stdlib('c') }}
     - cargo-bundle-licenses
 
 test:

--- a/recipes/gxfkit/meta.yaml
+++ b/recipes/gxfkit/meta.yaml
@@ -1,0 +1,36 @@
+{% set name = "gxfkit" %}
+{% set version = "0.0.1" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/benngaihk/gxfkit/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: b5cc0313f02ca4e31f6d223c6a551e9b753705da0f7f186a98869ec3ed819ed5
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - {{ compiler('rust') }}
+    - {{ compiler('c') }}
+    - cargo-bundle-licenses
+
+test:
+  commands:
+    - gxfkit version
+    - gxfkit gff2gtf --help
+
+about:
+  home: https://github.com/benngaihk/gxfkit
+  license: MIT
+  license_file:
+    - LICENSE
+    - THIRDPARTY.yml
+  summary: Fast Rust reimplementation of AGAT GFF/GTF operations
+
+extra:
+  recipe-maintainers:
+    - benngaihk


### PR DESCRIPTION
Add a Bioconda recipe for gxfkit v0.0.1.

gxfkit is a fast Rust implementation of AGAT-style GFF/GTF operations. The first release focuses on the `gff2gtf` command.

Recipe notes:
- Source: public GitHub tag `v0.0.1`
- License: MIT, with `cargo-bundle-licenses` output included as `THIRDPARTY.yml`
- Tests: `gxfkit version` and `gxfkit gff2gtf --help`

Local checks performed:
- `bash -n recipes/gxfkit/build.sh`
- `git diff --check`
- verified source archive sha256 against the recipe
