### PR TITLE
Add sam-subsampler

### DIFF
--- a/recipes/sam-subsampler/build.sh
+++ b/recipes/sam-subsampler/build.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# build.sh for sam-subsampler — Rust crate with a native C dep (rust-htslib →
+# hts-sys). rust-htslib 1.0.1 hardcodes `features = ["bindgen"]` on hts-sys,
+# which produces opaque struct bindings under conda's cross-compile sysroot
+# (the sysroot lacks standard C headers). Same workaround as cs-tagger: vendor
+# all deps, drop the bindgen feature so hts-sys uses its pre-built bindings,
+# fix the type mismatches in those pre-built bindings, refresh checksums.
+#
+# Patches verified against rust-htslib 1.0.1 + hts-sys 2.2.0:
+#   - rust-htslib/Cargo.toml still has `features = ["bindgen"]`
+#   - linux_prebuilt_bindings.rs still has `pub type size_t = c_ulong`,
+#     `pub isize:` (keyword as field name), and `stringify!(isize)`
+#   - rust-htslib 1.0.1 accesses the field as `core.isize_` (bam/record.rs)
+set -euxo pipefail
+
+export CARGO_PROFILE_RELEASE_STRIP=symbols
+export CARGO_PROFILE_RELEASE_LTO=fat
+
+# Let bindgen find libclang at build time.
+export LIBCLANG_PATH="${BUILD_PREFIX}/lib"
+
+# Cargo.toml is at the archive root (rattler-build flattens the single top-level
+# folder into $SRC_DIR), so --path . and no `cd`. Vendor deps so we can patch them.
+mkdir -p .cargo
+cargo vendor vendor/ > .cargo/config.toml
+
+# Drop the forced bindgen feature so hts-sys falls back to its pre-built bindings.
+sed -i 's/features = \["bindgen"\]/features = []/' \
+    vendor/rust-htslib/Cargo.toml
+
+# Fix type mismatches in the pre-built bindings (bindgen output vs what
+# rust-htslib expects):
+# 1. size_t should be usize (not c_ulong/u64) to match rust-htslib usage.
+# 2. `isize` is a Rust keyword and cannot be a field name; rust-htslib accesses
+#    it as `isize_`, so rename the field and its #[derive] stringify!() site.
+BINDINGS=vendor/hts-sys/linux_prebuilt_bindings.rs
+sed -i 's/pub type size_t = ::std::os::raw::c_ulong;/pub type size_t = usize;/' "$BINDINGS"
+sed -i 's/pub isize:/pub isize_:/' "$BINDINGS"
+sed -i 's/stringify!(isize)/stringify!(isize_)/' "$BINDINGS"
+
+# Refresh checksums for every patched file (cargo verifies vendored integrity).
+for f in vendor/rust-htslib/Cargo.toml "$BINDINGS"; do
+    sha=$(sha256sum "$f" | cut -d' ' -f1)
+    base=$(basename "$f")
+    dir=$(dirname "$f")
+    sed -i "s|\"${base}\":\"[a-f0-9]*\"|\"${base}\":\"${sha}\"|" \
+        "${dir}/.cargo-checksum.json"
+done
+
+# Build from the vendored tree. Versions are pinned by `cargo vendor`, so the
+# shipped Cargo.lock is honored without --locked.
+cargo install --no-track --root "$PREFIX" --path .
+
+# Bundle third-party licenses (listed under about.license_file).
+cargo-bundle-licenses --format yaml --output "${SRC_DIR}/THIRDPARTY.yml"

--- a/recipes/sam-subsampler/meta.yaml
+++ b/recipes/sam-subsampler/meta.yaml
@@ -1,0 +1,69 @@
+{% set name = "sam-subsampler" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/jiangyun-fun/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 0a8b89136f9e6121785defc06dafe7717c10d84af25dbf6dc6c3ea12ed97546c
+  # LICENSE ships in the v0.1.0 archive (no second source needed).
+
+build:
+  number: 0
+  skip: True  # [not linux]
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x") }}
+  # The binary statically links zlib/bzip2/lzma/libdeflate (hts-sys pulls the
+  # -sys crates, which build them from vendored source). Confirmed via `ldd`:
+  # only libc/libm/libgcc_s/librt/libpthread appear. Suppress the bogus run deps
+  # auto-derived from the host libs. conda-build types this as a plain list and
+  # filters by spec prefix (the exported dep name) — it MUST live under `build:`,
+  # not `requirements:`.
+  ignore_run_exports:
+    - bzip2
+    - libdeflate
+    - liblzma
+    - libzlib
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('rust') }}
+    - clangdev
+    - cmake
+    - make
+    - pkg-config
+    - cargo-bundle-licenses
+  host:
+    - zlib
+    - bzip2
+    - xz
+    - libdeflate
+
+test:
+  commands:
+    - sam-subsampler --help
+    - sam-subsampler --version
+
+about:
+  home: https://github.com/jiangyun-fun/sam-subsampler
+  license: MIT
+  license_family: MIT
+  license_file:
+    - LICENSE
+    - THIRDPARTY.yml
+  summary: "Two-pass BAM/CRAM subsampler that tags a randomly chosen subset of reads in place."
+  description: |
+    sam-subsampler subsamples reads from a BAM/CRAM/SAM file by per-reference
+    count and tags the selected reads in place (it does not filter). Unlike
+    samtools view -s, it samples unique qnames per reference and tags every
+    record of a selected read (mate, supplementary) with a custom BAM aux tag.
+  dev_url: https://github.com/jiangyun-fun/sam-subsampler
+
+extra:
+  recipe-maintainers:
+    - jiangyun-fun
+  skip-lints:
+    - compiler_needs_stdlib_c


### PR DESCRIPTION
Adds **sam-subsampler** 0.1.0 — a two-pass BAM/CRAM subsampler that tags a randomly chosen subset of reads **in place** (it does not filter; the output is the full file with a BAM aux tag added to the selected subset).

**Why bioconda:** bioinformatics — BAM/CRAM/SAM subsampling via `rust-htslib`.

**Notes**
- linux-only (native `hts-sys` + bindgen; `build.sh` vendors deps, drops the forced `bindgen` feature, patches the prebuilt bindings — same pattern as `cs-tagger`).
- static binary → `ignore_run_exports` drops the bogus `zlib`/`bzip2`/`liblzma`/`libdeflate` run deps.
- `skip-lints: [compiler_needs_stdlib_c]` (standard workaround; conda-build can't resolve `stdlib('c')` in this env).
- Source: https://github.com/jiangyun-fun/sam-subsampler (v0.1.0 tag).
- Also published to crates.io: https://crates.io/crates/sam-subsampler

Built and verified locally with conda-build (green; `sam-subsampler --help` / `--version` exit 0; `ldd` confirms static linking).