### PR TITLE
vcontact3-add-curl

### DIFF
--- a/recipes/vcontact3/meta.yaml
+++ b/recipes/vcontact3/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 702cdccf95c417558447e41a7a1214419a98780c900c29962ead9a08379acf2c
 
 build:
-  number: 0
+  number: 1
   noarch: python
   run_exports:
     - {{ pin_subpackage('vcontact3', max_pin='x') }}
@@ -31,6 +31,7 @@ requirements:
   run:
     - python >=3.10,<3.12
     - pip
+    - curl
     - numpy >=1.23.5,<2.0.0
     - pandas >=2.1.1
     - scikit-learn >=1.5.0


### PR DESCRIPTION
## Add `curl` as a runtime dependency for vcontact3

`vcontact3 prepare_databases` shells out to `curl` via Python's
subprocess module to download reference databases, but `curl` (the
CLI binary) is not declared as a `run:` dependency in this recipe.

Only `libcurl` (a transitive dependency of something else) is present
in the resulting environment — this is a C library, not the `curl`
command-line tool, and does not provide the `curl` executable.

This gap is masked on systems where the host OS happens to already
have `curl` installed (e.g. bare conda installs on Ubuntu CI runners),
but causes a hard failure inside isolated containers (Docker/
Singularity) built from this recipe, where no such binary exists:

    FileNotFoundError: [Errno 2] No such file or directory: 'curl'

Confirmed via:
- `conda list` on a freshly-built vcontact3 3.1.6 env shows only
  libcurl, no curl CLI package
- Docker container `quay.io/biocontainers/vcontact3:3.1.6--pyhdfd78af_0`
  fails with the above error when calling `prepare_databases`
- Failure log: https://github.com/nf-core/modules/actions/runs/26812632790/job/79051699520