### PR TITLE
Add look4ltrs

### DIFF
--- a/recipes/look4ltrs/build.sh
+++ b/recipes/look4ltrs/build.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -ex
+
+# CMake build of the look4ltrs target (C++17 + OpenMP).
+cmake -S . -B build_conda \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX="$PREFIX"
+cmake --build build_conda --target look4ltrs -j "${CPU_COUNT}"
+
+mkdir -p "$PREFIX/bin"
+LB="$(find . -name look4ltrs -type f -perm -u+x | head -1)"
+[ -n "$LB" ] || { echo "look4ltrs binary not produced" >&2; exit 1; }
+install -m 0755 "$LB" "$PREFIX/bin/look4ltrs"
+
+# Ship the LTR-library builder used by the Pan_TE pipeline at the path it expects
+# (Pan_TE resolves it as <pan_te_share>/../submodule/Look4LTRs/build_ltr_library.py;
+# installing a copy here lets a standalone look4ltrs install also carry it).
+if [ -f build_ltr_library.py ]; then
+    mkdir -p "$PREFIX/share/Look4LTRs"
+    install -m 0644 build_ltr_library.py "$PREFIX/share/Look4LTRs/build_ltr_library.py"
+fi

--- a/recipes/look4ltrs/meta.yaml
+++ b/recipes/look4ltrs/meta.yaml
@@ -14,7 +14,7 @@ source:
 
 build:
   number: 0
-  skip: True  # [osx]   # CMakeLists requires GCC (rejects Clang); uses OpenMP + a GCC-specific -O0 workaround
+  skip: True  # [osx]
   run_exports:
     - {{ pin_subpackage(name, max_pin="x") }}
 

--- a/recipes/look4ltrs/meta.yaml
+++ b/recipes/look4ltrs/meta.yaml
@@ -1,0 +1,49 @@
+{% set name = "look4ltrs" %}
+{% set version = "1.0.0" %}
+
+# Look4LTRs is PUBLIC at github.com/unavailable-2374/Look4LTRs, AGPL-1.0, tagged v1.0.0
+# (includes the GCC>=11.4 -O0 miscompilation fix). Build verified from main. Ready to submit.
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/unavailable-2374/Look4LTRs/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 2c5bb2184229de680805aaf7cea06838c89091f00c6b37d6dea6c43ec71ed316
+
+build:
+  number: 0
+  skip: True  # [osx]   # CMakeLists requires GCC (rejects Clang); uses OpenMP + a GCC-specific -O0 workaround
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x") }}
+
+requirements:
+  build:
+    - {{ compiler('cxx') }}
+    - {{ stdlib('c') }}
+    - cmake
+    - make
+  host:
+    - zlib
+  run:
+    - python >=3.8        # build_ltr_library.py helper ships with this tool (used by pan_te)
+    - biopython
+
+test:
+  commands:
+    - look4ltrs --help 2>&1 | head -1 || look4ltrs 2>&1 | head -1
+
+about:
+  home: https://github.com/unavailable-2374/Look4LTRs
+  license: AGPL-1.0-only
+  license_family: AGPL
+  license_file: LICENSE
+  summary: "LTR retrotransposon detection (Look4LTRs), C++17 + OpenMP."
+  description: |
+    Look4LTRs detects LTR retrotransposons from genomic FASTA. Used as the
+    LTR-detection track of the Pan_TE pan-genome TE annotation pipeline.
+
+extra:
+  recipe-maintainers:
+    - unavailable-2374


### PR DESCRIPTION
Adds `look4ltrs`, a C++17/OpenMP LTR-retrotransposon detector, used as the LTR-detection track of the Pan_TE pan-genome TE annotation pipeline.

- Source: https://github.com/unavailable-2374/Look4LTRs (v1.0.0, AGPL-1.0)
- Linux-only (`skip: True # [osx]`): CMakeLists requires GCC + OpenMP and a GCC-specific -O0 workaround; rejects Clang.

Split out from #66613 per maintainer request to submit new recipes separately.