### PR TITLE
Add mdl-repeat

### DIFF
--- a/recipes/mdl-repeat/build.sh
+++ b/recipes/mdl-repeat/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -ex
+
+# The Makefile defaults CC to literal `gcc`, which does not exist in the conda/bioconda
+# build environment (only the activated cross-compiler $CC = x86_64-conda-linux-gnu-gcc).
+# PORTABLE=1 drops -march=native so the binary is safe across CPUs/containers.
+make PORTABLE=1 CC="${CC:-gcc}" -j "${CPU_COUNT}"
+
+mkdir -p "$PREFIX/bin"
+[ -x bin/mdl-repeat ] || { echo "mdl-repeat binary not produced" >&2; exit 1; }
+install -m 0755 bin/mdl-repeat "$PREFIX/bin/mdl-repeat"

--- a/recipes/mdl-repeat/meta.yaml
+++ b/recipes/mdl-repeat/meta.yaml
@@ -1,0 +1,42 @@
+{% set name = "mdl-repeat" %}
+{% set version = "1.0.1" %}
+
+# mdl-repeat is PUBLIC at github.com/unavailable-2374/mdl-repeat, GPL-3.0, tagged v1.0.1
+# (rmblastn resolved from $RMBLASTN_BIN/PATH). Build verified from main. Ready to submit.
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/unavailable-2374/mdl-repeat/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 160f23e50961e71100adebba051498d17383873a392ae1be52e417f538e9966f
+
+build:
+  number: 0
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x") }}
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ stdlib('c') }}
+    - make
+
+test:
+  commands:
+    - mdl-repeat --help 2>&1 | head -1 || mdl-repeat 2>&1 | head -1
+
+about:
+  home: https://github.com/unavailable-2374/mdl-repeat
+  license: GPL-3.0-or-later
+  license_family: GPL
+  license_file: LICENSE
+  summary: "De novo repeat discovery via the Minimum Description Length (MDL) principle."
+  description: |
+    mdl-repeat performs de novo repeat-family discovery on genomic FASTA using the MDL
+    principle. It is the broad-spectrum de novo track of the Pan_TE pipeline.
+
+extra:
+  recipe-maintainers:
+    - unavailable-2374


### PR DESCRIPTION
Adds `mdl-repeat`, a C de-novo repeat-family discovery tool (MDL principle), used as a detection track of the Pan_TE pan-genome TE annotation pipeline.

- Source: https://github.com/unavailable-2374/mdl-repeat (v1.0.1, GPL-3.0-or-later)

Split out from #66613 per maintainer request to submit new recipes separately.