### PR TITLE
Add te-looker

### DIFF
--- a/recipes/te-looker/build.sh
+++ b/recipes/te-looker/build.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -ex
+
+# The cargo crate (package `te-core`; binaries dtr, te-discover, te-refine, te-seed) lives
+# under core/. Use `cargo install` so binary placement does not depend on CARGO_TARGET_DIR
+# (which the conda/bioconda build environment overrides) — building and reading from
+# target/release/ directly is not reliable there.
+cd core
+export CARGO_NET_GIT_FETCH_WITH_CLI=true
+
+cargo install --no-track --locked --root "$PREFIX" --path .
+
+# dtr is the Step-4 entry point Pan_TE invokes; the others are its helpers.
+for b in dtr te-discover te-refine te-seed; do
+    test -x "$PREFIX/bin/$b" || { echo "te-looker: $b binary not produced" >&2; exit 1; }
+done

--- a/recipes/te-looker/meta.yaml
+++ b/recipes/te-looker/meta.yaml
@@ -1,0 +1,52 @@
+{% set name = "te-looker" %}
+{% set version = "0.3.0" %}
+
+# te-looker is PUBLIC at github.com/unavailable-2374/te-looker, GPL-3.0, tagged v0.3.0.
+# Rust crate `te-core` v{{ version }}; binaries: dtr, te-discover, te-refine, te-seed.
+# Ready to submit to bioconda-recipes.
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/unavailable-2374/te-looker/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: edc3717f97280a76e20c825a6d5eb376fd02f454002ecace68f94ed006e330cd
+
+build:
+  number: 0
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x.x") }}
+
+requirements:
+  build:
+    - {{ compiler('rust') }}
+    - {{ compiler('c') }}
+    - {{ stdlib('c') }}
+    - make
+  run:
+    # Runtime tools the dtr pipeline shells out to (design tracks / consensus).
+    - abpoa
+    - spoa
+
+test:
+  commands:
+    - test -x "$PREFIX/bin/dtr"
+    - test -x "$PREFIX/bin/te-discover"
+    - test -x "$PREFIX/bin/te-refine"
+    - test -x "$PREFIX/bin/te-seed"
+
+about:
+  home: https://github.com/unavailable-2374/te-looker
+  license: GPL-3.0-or-later
+  license_family: GPL
+  license_file: LICENSE
+  summary: "TE-looker (dtr): de novo discovery of divergent ('twilight-zone') transposable elements (Rust)."
+  description: |
+    TE-looker provides the `dtr` (Dark TE Rebuilder) CLI plus te-discover / te-refine /
+    te-seed helpers. It targets older, divergent TEs (D_cc 45-75%) as the Step-4 track of
+    the Pan_TE pipeline.
+
+extra:
+  recipe-maintainers:
+    - unavailable-2374


### PR DESCRIPTION
Adds `te-looker` (`dtr` and helper binaries), a Rust de-novo TE-discovery tool used as a detection track of the Pan_TE pan-genome TE annotation pipeline.

- Source: https://github.com/unavailable-2374/te-looker (v0.3.0, GPL-3.0-or-later)

Split out from #66613 per maintainer request to submit new recipes separately.