### PR TITLE
update version number

### DIFF
--- a/recipes/telescope/meta.yaml
+++ b/recipes/telescope/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "telescope" %}
-{% set version = "1.0.4" %}
+{% set version = "1.0.4.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/hanalysis/telescope/archive/v{{ version }}.tar.gz
-  sha256: 02d4466223ad5898c0891078269fb798047885d7f8489e6e84f6d73b07566e83
+  sha256: 49423bcd5a6fb59aa2258d0641baedac870e9f52fcdfb2121b45497a59c8facc
 #  patches:
 #   - 0001-Fix-setup.py.patch
 


### PR DESCRIPTION
In the last telescope recipe update, I forgot to change the version number in the __version.py in telescope, this is just a correction to that.