### PR TITLE
Add ngs45

### DIFF
--- a/recipes/ngs45/meta.yaml
+++ b/recipes/ngs45/meta.yaml
@@ -1,0 +1,73 @@
+{% set name = "ngs45" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/maidinhvn/ngs45/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 53c6817e7ef633c31db9b2fc22868454c355462ca8ea5943e37b5c4df4d52a09
+
+build:
+  noarch: python
+  number: 0
+  run_exports:
+    - {{ pin_subpackage('ngs45', max_pin="x.x") }}
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  entry_points:
+    - ngs45 = ngs45.cli:main
+
+requirements:
+  host:
+    - python {{ python_min }}
+    - pip
+    - setuptools >=64
+    - wheel
+  run:
+    - python >={{ python_min }}
+    - biopython >=1.79
+    # external tools invoked via subprocess (the package itself is pure-Python)
+    - bowtie2
+    - spades
+    - seqkit
+    - blast
+    - barrnap
+    - itsx
+    - infernal
+    - bwa
+    - samtools
+    - bcftools
+    # cutadapt >=5.0 requires dnaio >=1.2.3, which has no py310 build;
+    # test env is pinned to python_min (3.10), so cap cutadapt (S0 trim only).
+    - cutadapt <5.0
+
+test:
+  imports:
+    - ngs45
+  requires:
+    - pip
+    - python {{ python_min }}
+  commands:
+    - pip check
+    - ngs45 --version
+
+about:
+  home: https://github.com/maidinhvn/ngs45
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: "Recover the 45S nrDNA transcribed unit from Illumina short reads"
+  description: |
+    ngs45 recovers the 45S nrDNA transcribed unit (18S-ITS1-5.8S-ITS2-26S) and
+    ITS barcode from Illumina short reads: it baits rDNA reads against a conserved
+    45S seed, assembles them with SPAdes, resolves a single repeat unit, trims to
+    the mature 18S/26S boundaries with Rfam SSU/LSU covariance models, annotates
+    the ITS regions, and reports intragenomic ribotype heterozygosity (a
+    hybridisation / allopolyploidy signal). Short-read counterpart of easy45 (HiFi).
+  dev_url: https://github.com/maidinhvn/ngs45
+  doc_url: https://github.com/maidinhvn/ngs45/tree/main/docs
+
+extra:
+  recipe-maintainers:
+    - maidinhvn


### PR DESCRIPTION
Adds a recipe for **ngs45** — recovery of the 45S nrDNA transcribed unit
(18S–ITS1–5.8S–ITS2–26S) and ITS barcode from Illumina short reads.

The pipeline baits rDNA reads against a conserved 45S seed (bowtie2), assembles
them (SPAdes), resolves a single repeat unit, trims to the mature 18S/26S
boundaries with Rfam SSU/LSU covariance models (infernal), annotates the ITS
regions (ITSx), and reports intragenomic ribotype heterozygosity.

- Pure-Python package (biopython); all heavy tools are existing bioconda run
  dependencies: bowtie2, spades, seqkit, blast, barrnap, itsx, infernal, bwa,
  samtools, bcftools, cutadapt.
- `noarch: python`, single entry point `ngs45`.
- Source: GitHub release v0.1.0 (https://github.com/maidinhvn/ngs45).
- Short-read counterpart of easy45 (PacBio HiFi).


----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
