### PR TITLE
rebuild dnaio for other python versions

### DIFF
--- a/recipes/dnaio/meta.yaml
+++ b/recipes/dnaio/meta.yaml
@@ -1,12 +1,11 @@
-{% set name = "dnaio" %}
 {% set version = "1.2.3" %}
 
 package:
-  name: {{ name }}
+  name: dnaio
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/d/dnaio/dnaio-{{ version }}.tar.gz
   sha256: aad456d9f6272339958b2c5af32fd64d77a50aca12e394e7a143b4129d49b0b9
 
 build:

--- a/recipes/dnaio/meta.yaml
+++ b/recipes/dnaio/meta.yaml
@@ -1,30 +1,31 @@
+{% set name = "dnaio" %}
 {% set version = "1.2.3" %}
 
 package:
-  name: dnaio
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://files.pythonhosted.org/packages/ca/23/1afaeadecfe4712769db4b609ca4aeb4246f6a47a9ab39801cb6a5aa8c2e/dnaio-1.2.3.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: aad456d9f6272339958b2c5af32fd64d77a50aca12e394e7a143b4129d49b0b9
 
 build:
-  number: 0
-  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+  number: 1
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   run_exports:
     - {{ pin_subpackage('dnaio', max_pin="x") }}
-
 
 requirements:
   build:
     - {{ compiler('c') }}
+    - {{ stdlib('c') }}
   host:
     - pip
-    - python >=3.9
+    - python
     - cython
     - setuptools-scm
   run:
-    - python >=3.9
+    - python
     - xopen >=1.4.0
 
 test:


### PR DESCRIPTION
`dnaio 1.2.3` is currently only available for `python 3.13`. This may cause [problems](https://github.com/bioconda/bioconda-recipes/pull/66848#issuecomment-4866994037).

* remove `>=3.9` to build for all python versions
* change source url: resolves to same server; the pypi URL seems more common
* script is just the default script
* `{{ stdlib('c') }}` is a new pin

local `bioconda-utils build --docker --mulled-test --packages dnaio` was successful and produced packages for python 3.{10,11,12,13,14}

After this, we can also try bumping the version to 1.2.4 - there is a stale autobump PR somewhere 

---

ping @marcelm (recipe maintainer)