### PR TITLE
Add markinp 0.1.0

### DIFF
--- a/recipes/markinp/meta.yaml
+++ b/recipes/markinp/meta.yaml
@@ -12,6 +12,8 @@ source:
 build:
   noarch: python
   number: 0
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x.x") }}
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:

--- a/recipes/markinp/meta.yaml
+++ b/recipes/markinp/meta.yaml
@@ -1,0 +1,52 @@
+{% set name = "markinp" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 9a0fc05c99a9f68d998e280b0ab92a9495ecd7ec2cceb146139ef624e96d8e3a
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python >=3.10
+    - pip
+    - hatchling
+  run:
+    - python >=3.10
+    - typer >=0.9
+
+test:
+  imports:
+    - markinp
+  commands:
+    - pip check
+    - markinp --help
+    - markinp --version
+  requires:
+    - pip
+
+about:
+  home: https://github.com/leonbzt/markinp
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: "Read, validate, and build Program MARK encounter-history (.inp) files."
+  description: |
+    markinp is an independent, unofficial command-line utility and Python
+    library for reading, validating, and building Program MARK encounter-history
+    (.inp) files. It performs file I/O and validation only and does not fit
+    models or compute statistics. It is not affiliated with or endorsed by the
+    authors of Program MARK or RMark.
+  dev_url: https://github.com/leonbzt/markinp
+
+extra:
+  recipe-maintainers:
+    - leonbzt


### PR DESCRIPTION
Adds a new recipe for **markinp** — a CLI / Python library to read, validate, and build Program MARK encounter-history (`.inp`) files. File I/O and validation only; no statistics.

- Home / source: https://github.com/leonbzt/markinp
- PyPI: https://pypi.org/project/markinp/0.1.0/
- License: MIT (packaged in the sdist and referenced via `license_file`)
- `noarch: python`; single runtime dependency (`typer`)

Checklist:
- [x] New recipe under `recipes/markinp/`
- [x] `sha256` matches the sdist published on PyPI
- [x] License file is packaged and referenced
- [x] Tests import the module, run `pip check`, and exercise the console entry point
- [x] I am the author/maintainer (recipe-maintainers: leonbzt)