### PR TITLE
Fix nerpa-2.1.0

### DIFF
--- a/recipes/nerpa/build.sh
+++ b/recipes/nerpa/build.sh
@@ -41,3 +41,6 @@ cp -rf * ${SHARE_PATH}/
 
 ln -s ${SHARE_PATH}/nerpa.py ${PREFIX}/bin/nerpa.py
 ln -s ${SHARE_PATH}/nerpa.py ${PREFIX}/bin/nerpa
+
+mkdir -p "${SHARE_PATH}/external_tools/paras"
+cp paras_model/model.paras "${SHARE_PATH}/external_tools/paras/"

--- a/recipes/nerpa/meta.yaml
+++ b/recipes/nerpa/meta.yaml
@@ -7,13 +7,17 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/gurevichlab/nerpa/releases/download/{{ name|lower }}_{{ version }}/nerpa-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
-  patches:
-    - 0001-algorithm.patch
+  - url: https://github.com/gurevichlab/nerpa/releases/download/{{ name|lower }}_{{ version }}/nerpa-{{ version }}.tar.gz
+    sha256: {{ sha256 }}
+    patches:
+      - 0001-algorithm.patch
+
+  - url: https://zenodo.org/records/13165500/files/model.paras
+    sha256: 839b84d0f05766b2ab22aea5ab4a9de8e5dd7e29e94ed689ada172a8e8d8f387
+    folder: paras_model
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage(name|lower, max_pin="x") }}
 
@@ -37,7 +41,7 @@ requirements:
     - biopython
     - cairosvg
     - pulp
-    - scikit-learn >=1.2.0
+    - scikit-learn ==1.2.0
     - pandas >=1.5
     - polars >=0.19
     - pyarrow


### PR DESCRIPTION
This PR fixes the nerpa 2.1.0 Bioconda package.

The current recipe does not include the PARAS model required by nerpa at runtime. In the upstream installation procedure, this model is downloaded separately by install.sh, but this step is missing from the Bioconda recipe, making the installed package non-functional.

Changes
* Add the PARAS model from the corresponding Zenodo record as an additional source.
* Install the model to the location expected by the packaged nerpa installation.
* Pin scikit-learn to 1.2.0 for compatibility with the packaged model.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
