### PR TITLE
bump cutadapt dependencies

### DIFF
--- a/recipes/cutadapt/meta.yaml
+++ b/recipes/cutadapt/meta.yaml
@@ -5,11 +5,11 @@ package:
   version: {{ version }}
 
 source:
-  url: https://files.pythonhosted.org/packages/25/0a/2b4007e4577dd3e19affdf7aa716ebf9642e224d68a9205b2081d42ed08a/cutadapt-5.2.tar.gz
+  url: https://pypi.org/packages/source/c/cutadapt/cutadapt-{{ version }}.tar.gz
   sha256: 2394deead42ecae5fe0fdf369e35f3e2afed770e14059582272779c2e8295d3c
 
 build:
-  number: 1
+  number: 2
   script: "{{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vvv"
   run_exports:
     - {{ pin_subpackage("cutadapt", max_pin="x") }}
@@ -17,6 +17,7 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
+    - {{ stdlib('c') }}
   host:
     - pip
     - python
@@ -25,7 +26,7 @@ requirements:
   run:
     - python
     - xopen >=1.6.0
-    - dnaio >=1.2.2
+    - dnaio >=1.2.3
 
 test:
   imports:


### PR DESCRIPTION
Upstream has `dnaio >= 1.2.3` as dependency: https://github.com/marcelm/cutadapt/blob/v5.2/pyproject.toml#L24

After #66857, `dnaio 1.2.3` should be available for all Python versions.

Also uses the shorter `pypi.org` link for the source that won't change in future version bumps. 

Ping @marcelm (recipe maintainer)