### PR TITLE
Update macrel 1.6.0

### DIFF
--- a/recipes/macrel/meta.yaml
+++ b/recipes/macrel/meta.yaml
@@ -34,7 +34,7 @@ requirements:
     - pandas
     - scikit-learn
     - requests
-    - onnxruntime <=1.25.1
+    - onnxruntime <1.26
     - tzlocal
     - pyrodigal >=0.7.3
   

--- a/recipes/macrel/meta.yaml
+++ b/recipes/macrel/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   noarch: python
-  number: 1
+  number: 2
   entry_points:
     - macrel= macrel.main:main
   script: python -m pip install --disable-pip-version-check --no-cache-dir --ignore-installed --no-deps -vv .
@@ -23,6 +23,7 @@ requirements:
   host:
     - python
     - pip
+    - setuptools
   run:
     - python
     - atomicwrites
@@ -33,7 +34,7 @@ requirements:
     - pandas
     - scikit-learn
     - requests
-    - onnxruntime
+    - onnxruntime <=1.25.1
     - tzlocal
     - pyrodigal >=0.7.3
   


### PR DESCRIPTION
Onnxruntime 1.26 and 1.27 have a regression that breaks macrel: https://github.com/microsoft/onnxruntime/issues/28557

Older versions work and presumably newer versions will eventually incorporate the regression fix, but, for the moment, avoid 1.26 and newer.

----
### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
