### PR TITLE
Update plannotate to 2.0.0

### DIFF
--- a/recipes/plannotate/build.sh
+++ b/recipes/plannotate/build.sh
@@ -1,7 +1,3 @@
 #!/bin/bash
 set -ex
 $PYTHON -m pip install . --no-deps --ignore-installed -vv
-
-# Install databases
-bpath=$(python -c "import sys; print(sys.path[-1])")
-mv BLAST_dbs "$bpath"/plannotate/data/

--- a/recipes/plannotate/meta.yaml
+++ b/recipes/plannotate/meta.yaml
@@ -1,23 +1,18 @@
 {% set name = "plannotate" %}
-{% set version = "1.2.5" %}
-{% set sha256 = "9219c4bfaf423f124737ec532709a1a9650df9f0b4b8da387a7c2cb970565740" %}
+{% set version = "2.0.0" %}
+{% set sha256 = "c0b83e6895cca4895143d5e05704f9e99c9da71389a9575b2e6f2bc913b3d4d6" %}
 
 package:
   name: {{ name }}
   version: {{ version }}
 
 source:
-  - url: https://github.com/mmcguffi/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-    sha256: {{ sha256 }}
-  - url: https://github.com/mmcguffi/{{ name }}/releases/download/v{{ version }}/BLAST_dbs.tar.gz
-    sha256: 34c7bacb1c73bd75129e16990653f73b3eba7e3cdb3816a55d3989a7601f2137
-    folder: BLAST_dbs
+  url: https://github.com/mmcguffi/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: {{ sha256 }}
 
 build:
   number: 0
   noarch: python
-  entry_points:
-    - plannotate = plannotate.pLannotate:main
   run_exports:
     - {{ pin_subpackage('plannotate', max_pin="x") }}
 
@@ -28,20 +23,17 @@ requirements:
     - setuptools
   run:
     - python >=3.10
-    - click
-    - curl
-    - numpy >=1.23,<2
-    - biopython >=1.78
+    - biopython >=1.81
+    - numpy >=1.23
+    - pandas >=1.5,<3
+    - pyyaml >=6
+    - rich >=13
+    - typer >=0.12
     - blast >=2.10.1
     - diamond >=2.0.13
-    - pandas >=1.3.5,<3
-    - ripgrep >=13.0.0
-    - tabulate >=0.8.9
-    - trnascan-se >=2.0.7
-    - streamlit >=1.36,<1.42
-    - altair =4.2.2
-    - bokeh =2.4.3
-    - protobuf >=3.20.3
+    - infernal >=1.1.4
+    - bokeh >=3.4,<4
+    - tabulate >=0.9
 
 test:
   commands:


### PR DESCRIPTION
## Description

Updates the `plannotate` recipe to 2.0.0.

This is a structural change, not just a version bump: 2.0.0 moved the
annotation databases out of the conda package entirely. They are no
longer bundled at build time via a second `source:` entry — they're
downloaded on demand at runtime via `plannotate setupdb`. The old
`BLAST_dbs.tar.gz` release asset no longer exists (2.0.0 ships
`plannotate-databases-v2.tar.gz` instead, resolved dynamically by the
installed package's own version), so the previous recipe would 404
trying to fetch it.

Changes:
- Drop the second `source:` entry and the `build.sh` step that moved
  `BLAST_dbs` into `site-packages`.
- Fix the entry point: `plannotate.main:main` (was
  `plannotate.pLannotate:main`, stale from before an internal
  refactor).
- Update `run:` requirements to the leaner 2.0.0 core dependencies
  (`biopython`, `numpy`, `pandas`, `pyyaml`, `rich`, `typer`) plus the
  external search tools (`blast`, `diamond`, `infernal`). `infernal`
  was previously missing from the recipe entirely even though Rfam
  search requires it. Kept `bokeh` so `--html` output works out of the
  box, matching prior behavior.
- Dropped `streamlit`/`altair`/`protobuf`/`click`/`curl`/`ripgrep`/
  `trnascan-se`, which are no longer runtime requirements of the core
  CLI in 2.0.0 (the web app is now an optional `server` extra of the
  PyPI-style install, not part of the base CLI).

## Checklist

- [x] Bumped version and sha256 for the new release
- [x] Updated entry point and run requirements to match 2.0.0
- [x] `bioconda-utils` lint/build (will run in CI on this PR)

<!--
Note to reviewer: I maintain this package (mmcguffi) and authored this
PR by hand since bioconda's autobump bot can't handle the source
restructuring here (the old release asset it was tracking no longer
exists).
-->