### PR TITLE
Add phads recipe

### DIFF
--- a/recipes/phads/build.sh
+++ b/recipes/phads/build.sh
@@ -1,8 +1,38 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
-${PYTHON} -m pip install . --no-deps --no-build-isolation -vv
+echo "PWD=${PWD}"
+echo "PREFIX=${PREFIX}"
+echo "PYTHON=${PYTHON}"
+ls -la
+
+"${PYTHON}" --version
+"${PYTHON}" -m pip --version
+
+test -f phads.py
+test -d scripts
+test -d database
+
+if [[ -f pyproject.toml ]]; then
+	"${PYTHON}" -m pip install . --no-deps --no-build-isolation -vv
+else
+	site_packages=$("${PYTHON}" -c 'import sysconfig; print(sysconfig.get_path("purelib"))')
+	mkdir -p "${site_packages}" "${PREFIX}/bin"
+	cp phads.py "${site_packages}/phads.py"
+fi
+
+if [[ ! -x "${PREFIX}/bin/phads" ]]; then
+	mkdir -p "${PREFIX}/bin"
+	cat > "${PREFIX}/bin/phads" <<'EOF'
+#!/bin/sh
+exec python -m phads "$@"
+EOF
+	chmod +x "${PREFIX}/bin/phads"
+fi
 
 mkdir -p "${PREFIX}/share/phads"
 cp -R scripts "${PREFIX}/share/phads/"
 cp -R database "${PREFIX}/share/phads/"
+
+test -f "${PREFIX}/share/phads/scripts/predict_residue_pool_gate.py"
+test -d "${PREFIX}/share/phads/database"

--- a/recipes/phads/build.sh
+++ b/recipes/phads/build.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+${PYTHON} -m pip install . --no-deps --no-build-isolation -vv
+
+mkdir -p "${PREFIX}/share/phads"
+cp -R scripts "${PREFIX}/share/phads/"
+cp -R database "${PREFIX}/share/phads/"

--- a/recipes/phads/build.sh
+++ b/recipes/phads/build.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-set -euxo pipefail
-
-${PYTHON} -m pip install . --no-deps --no-build-isolation -vv
-
-mkdir -p "${PREFIX}/share/phads"
-cp -R scripts "${PREFIX}/share/phads/"
-cp -R database "${PREFIX}/share/phads/"

--- a/recipes/phads/meta.yaml
+++ b/recipes/phads/meta.yaml
@@ -14,7 +14,6 @@ build:
   noarch: python
   run_exports:
     - {{ pin_subpackage("phads", max_pin="x.x") }}
-  script: bash ${RECIPE_DIR}/build.sh
   entry_points:
     - phads = phads:main
 

--- a/recipes/phads/meta.yaml
+++ b/recipes/phads/meta.yaml
@@ -19,6 +19,8 @@ build:
     - phads = phads:main
 
 requirements:
+  build:
+    - bash
   host:
     - python >=3.10
     - pip

--- a/recipes/phads/meta.yaml
+++ b/recipes/phads/meta.yaml
@@ -12,7 +12,6 @@ source:
 build:
   number: 0
   noarch: python
-  skip: true  # [py<310]
   run_exports:
     - {{ pin_subpackage("phads", max_pin="x.x") }}
   script: bash ${RECIPE_DIR}/build.sh

--- a/recipes/phads/meta.yaml
+++ b/recipes/phads/meta.yaml
@@ -1,0 +1,60 @@
+{% set name = "phads" %}
+{% set version = "0.6.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/George-nsn/PhADS/archive/refs/tags/PhADS--V0.6.0.tar.gz
+  sha256: c967cf847d9cef98279235e4f7e880682cbee0a6dc39275c6d89a155fc6b7917
+  license: Apache-2.0
+
+build:
+  number: 0
+  skip: true  # [win]
+  script: bash ${RECIPE_DIR}/build.sh
+  entry_points:
+    - phads = phads:main
+
+requirements:
+  host:
+    - python >=3.10
+    - pip
+    - setuptools >=68
+    - wheel
+  run:
+    - python >=3.10
+    - biopython
+    - foldseek
+    - hmmer
+    - huggingface_hub
+    - numpy
+    - onnxruntime
+    - pandas
+    - pyrodigal
+    - pyrodigal-gv
+    - pytorch
+    - sentencepiece
+    - tqdm
+    - transformers
+
+test:
+  commands:
+    - phads --help
+    - test -d ${PREFIX}/share/phads/database
+    - test -f ${PREFIX}/share/phads/scripts/predict_residue_pool_gate.py
+
+about:
+  home: https://github.com/George-nsn/PhADS
+  summary: PHADS-style anti-defense protein inference pipeline
+  description: |
+    PHADS provides a command-line anti-defense protein inference pipeline using
+    residue-level ESM2 and ProtT5 embeddings, HMM features, prototype inference,
+    optional Foldseek structure search, and bundled PHADS databases.
+  license: Apache-2.0
+  license_file: LICENSE
+
+extra:
+  identifiers:
+    - biotools:phads

--- a/recipes/phads/meta.yaml
+++ b/recipes/phads/meta.yaml
@@ -14,8 +14,6 @@ build:
   noarch: python
   run_exports:
     - {{ pin_subpackage("phads", max_pin="x.x") }}
-  entry_points:
-    - phads = phads:main
 
 requirements:
   build:

--- a/recipes/phads/meta.yaml
+++ b/recipes/phads/meta.yaml
@@ -6,14 +6,15 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/George-nsn/PhADS/archive/refs/tags/PhADS--V0.6.0.tar.gz
+  url: https://github.com/George-nsn/PhADS/archive/refs/tags/PhADS--V{{ version }}.tar.gz
   sha256: c967cf847d9cef98279235e4f7e880682cbee0a6dc39275c6d89a155fc6b7917
 
 build:
   number: 0
   noarch: python
+  skip: true  # [py<310]
   run_exports:
-    - {{ pin_subpackage('phads', max_pin='x') }}
+    - {{ pin_subpackage("phads", max_pin="x.x") }}
   script: bash ${RECIPE_DIR}/build.sh
   entry_points:
     - phads = phads:main

--- a/recipes/phads/meta.yaml
+++ b/recipes/phads/meta.yaml
@@ -8,7 +8,6 @@ package:
 source:
   url: https://github.com/George-nsn/PhADS/archive/refs/tags/PhADS--V0.6.0.tar.gz
   sha256: c967cf847d9cef98279235e4f7e880682cbee0a6dc39275c6d89a155fc6b7917
-  license: Apache-2.0
 
 build:
   number: 0

--- a/recipes/phads/meta.yaml
+++ b/recipes/phads/meta.yaml
@@ -11,7 +11,9 @@ source:
 
 build:
   number: 0
-  skip: true  # [win]
+  noarch: python
+  run_exports:
+    - {{ pin_subpackage('phads', max_pin='x') }}
   script: bash ${RECIPE_DIR}/build.sh
   entry_points:
     - phads = phads:main


### PR DESCRIPTION
This PR adds a new Bioconda recipe for `phads`.

PHADS is a command-line bioinformatics pipeline for anti-defense protein prediction. It supports protein and DNA FASTA inputs and provides multiple inference modes, including prototype-based deep prediction, nearest-instance prediction, HMM-only annotation, and optional Foldseek-based structure search.

The package combines residue-level ESM2 and ProtT5 embeddings, HMM-derived evolutionary features, and a PHADS-style prototype inference model. The recipe installs the `phads` command-line entry point and copies the bundled PHADS resources into `$PREFIX/share/phads`, including:

- `scripts/`
- `database/`
- HMM profiles
- PHADS model files
- annotation tables
- Foldseek database files

The command-line tool automatically locates these resources from the conda installation prefix.

### Recipe details

- Package name: `phads`
- Version: `0.6.0`
- Upstream source: https://github.com/George-nsn/PhADS
- License: Apache-2.0
- Main executable: `phads`
- Main test command: `phads --help`

### Biological relevance

PHADS is intended for biological sequence and structure analysis, specifically prediction and annotation of anti-defense related protein families. It uses HMMER, Foldseek, protein language model embeddings, and curated PHADS model/database resources.

### Tests

The recipe includes tests to verify that:

- the `phads` command is available
- `phads --help` runs successfully
- bundled resource directories are installed under `$PREFIX/share/phads`
- the prediction helper script is available after installation

### Notes on run_exports

No `run_exports` section is added because this recipe provides an end-user command-line application rather than a library intended to be linked against or imported by downstream conda packages. Downstream ABI/API pinning is therefore not applicable.

### Checklist

- [x] I have read the Bioconda recipe guidelines.
- [x] This package is relevant to biological sciences.
- [x] The recipe uses a tagged upstream source archive.
- [x] The source archive sha256 is specified.
- [x] The license is specified.
- [x] Basic command-line tests are included.