### PR TITLE
Update gxfkit to 0.0.2

### DIFF
--- a/recipes/gxfkit/meta.yaml
+++ b/recipes/gxfkit/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "gxfkit" %}
-{% set version = "0.0.1" %}
+{% set version = "0.0.2" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/benngaihk/gxfkit/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: b5cc0313f02ca4e31f6d223c6a551e9b753705da0f7f186a98869ec3ed819ed5
+  sha256: b60a0c96f4d70abea6a0a77f26e2fe8092aa4ab913936bb502f2561689c27020
 
 build:
   number: 0


### PR DESCRIPTION
Update gxfkit to v0.0.2.\n\nSource archive: https://github.com/benngaihk/gxfkit/archive/refs/tags/v0.0.2.tar.gz\nsha256: b60a0c96f4d70abea6a0a77f26e2fe8092aa4ab913936bb502f2561689c27020\n\nRelease: https://github.com/benngaihk/gxfkit/releases/tag/v0.0.2\n\nLocal checks in gxfkit repo:\n- python3 scripts/check-version-consistency.py --scope bioconda --expected-version 0.0.2 --check-remote-bioconda-sha256\n- python3 scripts/check-bioconda-recipe.py\n- bash scripts/test-bioconda-recipe.sh