### PR TITLE
Add pmotools package

### DIFF
--- a/recipes/pmotools/meta.yaml
+++ b/recipes/pmotools/meta.yaml
@@ -1,0 +1,50 @@
+{% set version = "1.1.0" %}
+
+package:
+  name: pmotools
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/p/pmotools/pmotools-{{ version }}.tar.gz
+  sha256: 84f0064eabaa9f470677641264216ede0ee9528a91ce67f11948654cc0edce93
+
+build:
+  entry_points:
+    - pmotools-python = pmotools.cli:main
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python >=3.11
+    - uv-build >=0.8.11,<0.9.0
+    - pip
+  run:
+    - python >=3.11
+    - pandas >=2.2.2
+    - biopython >=1.83
+    - jsonschema >=4.23.0
+    - pre-commit
+    - openpyxl >=3.1.5
+
+test:
+  imports:
+    - pmotools
+  commands:
+    - pip check
+    - pmotools-python --help
+  requires:
+    - pip
+    - python
+
+about:
+  home: https://pypi.org/project/pmotools/
+  summary: Tools for building and analyzing PMO files
+  license: GPL-3.0-only
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - kathrynmurie
+    - nickjhathaway

--- a/recipes/pmotools/meta.yaml
+++ b/recipes/pmotools/meta.yaml
@@ -14,7 +14,8 @@ build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
-
+  run_exports:
+    - {{ pin_subpackage('pmotools', max_pin="x") }}
 requirements:
   host:
     - python >=3.11

--- a/recipes/pmotools/meta.yaml
+++ b/recipes/pmotools/meta.yaml
@@ -9,8 +9,6 @@ source:
   sha256: 84f0064eabaa9f470677641264216ede0ee9528a91ce67f11948654cc0edce93
 
 build:
-  entry_points:
-    - pmotools-python = pmotools.cli:main
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
@@ -41,7 +39,14 @@ test:
 
 about:
   home: https://pypi.org/project/pmotools/
-  summary: Tools for building and analyzing PMO files
+  dev_url: https://github.com/PlasmoGenEpi/pmotools
+  summary: Tools for creating and manipulating Portable Microhaplotype Object (PMO) files.
+  description: >
+    pmotools provides utilities for creating, validating, manipulating, and
+    converting Portable Microhaplotype Object (PMO) files. PMO is a JSON-based
+    standard for storing phased targeted sequencing (microhaplotype) data and
+    associated metadata, enabling interoperable analysis, data sharing, and
+    reproducible workflows across targeted sequencing applications.
   license: GPL-3.0-only
   license_file: LICENSE
 


### PR DESCRIPTION
This PR adds the Python package pmotools.

The package is available on PyPI:
https://pypi.org/project/pmotools/

Source:
https://github.com/PlasmoGenEpi/pmotools