### PR TITLE
Add variantstring package

### DIFF
--- a/recipes/r-variantstring/build.sh
+++ b/recipes/r-variantstring/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+${R} CMD INSTALL --build .

--- a/recipes/r-variantstring/meta.yaml
+++ b/recipes/r-variantstring/meta.yaml
@@ -1,0 +1,46 @@
+{% set version = "1.8.7" %}
+
+package:
+  name: r-variantstring
+  version: {{ version }}
+
+source:
+  url: https://github.com/mrc-ide/variantstring/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 89280cfc46e2e7871f654a8f84b713e0e7aed06d6ad99ca3534c8dea8a9b9907
+
+build:
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+  run_exports:
+    - {{ pin_subpackage("r-variantstring", max_pin="x") }}
+
+requirements:
+  host:
+    - r-base
+    - r-remotes
+    - r-dplyr
+    - r-stringr
+
+  run:
+    - r-base
+    - r-dplyr
+    - r-stringr
+
+test:
+  commands:
+    - $R -e "library('variantstring')"
+
+about:
+  home: https://github.com/mrc-ide/variantstring
+  dev_url: https://github.com/mrc-ide/variantstring
+  summary: Functions for working with variant string format
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - kathrynmurie
+    - bobverity


### PR DESCRIPTION
This pull request adds a Bioconda recipe for the R package variantstring.

variantstring provides functions for working with genetic information encoded in variant string format, including methods for comparing and manipulating variant strings.

Package information

Source: https://github.com/mrc-ide/variantstring
Version: 1.8.7
License: MIT

The recipe packages the current GitHub release as a noarch R package and includes a basic installation test by loading the package.