### PR TITLE
Update gtdbtk build number and add wget dependency

### DIFF
--- a/recipes/gtdbtk/meta.yaml
+++ b/recipes/gtdbtk/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 786493c1b89a83b73e6b77d82eb8d0e0e1f0df0e2540b1a6f2ba334b82b172cc
 
 build:
-  number: 0
+  number: 1
   noarch: python
   entry_points:
     - gtdbtk = gtdbtk.__main__:main
@@ -35,6 +35,7 @@ requirements:
     - tqdm >=4.35.0
     - pydantic >=1.9.2,<2
     - skani >=0.3.0
+    - wget
 
 test:
   imports:


### PR DESCRIPTION
heya, @aaronmussig and @pchaumeil,

thanks for maintaining a gtdbtk conda recipe for all!

someone brought to my attention today a failure when running the download-db shell script due to wget not being installed on their machine. So on the relatively rare situations where wget isn't already present, that can be an issue. 

i just stuck wget into the env yaml here, which is of course light, so probably a fine path, but you could also consider changing to curl instead of wget in the download script if you want to avoid another dependency. (curl is much more reliably present on virtually all unix-like systems)

cheers :)

**edit:** also just realized the current version of the download script gracefully exit if wget isn't there 👍  but still wouldn't hurt sticking wget in the env or swapping to curl in the script