### PR TITLE
Update panoptes-ui to 1.6.0

### DIFF
--- a/recipes/panoptes-ui/meta.yaml
+++ b/recipes/panoptes-ui/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "panoptes-ui" %}
-{% set version = "1.5.1" %}
+{% set version = "1.6.0" %}
 
 package:
   name: "{{ name|lower }}"
@@ -7,7 +7,7 @@ package:
 
 source:
   url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name|replace('-', '_') }}-{{ version }}.tar.gz"
-  sha256: e96e1f1eece16d2e7d12c5bc1f484968203daec7e8ea28e45859859c3f067732
+  sha256: 16f8a3138353e9dc350a69d2e4bac79dd8ba05ec506092cefc55b6eb3454fc61
 
 build:
   noarch: python
@@ -31,6 +31,10 @@ requirements:
     - flask >=1.1.1
     - humanfriendly >=4.18
     - marshmallow >=3.0.1
+    # PostgreSQL driver, so conda installs and the biocontainer can use
+    # PANOPTES_DB_URL=postgresql+psycopg2://... (panoptes 1.6.0 documents and
+    # CI-tests PostgreSQL support; the container use case needs it built in).
+    - psycopg2 >=2.9
     - python >=3.11
     - sqlalchemy >=1.3.7
 


### PR DESCRIPTION
Update `panoptes-ui` 1.5.1 → 1.6.0 (I'm the recipe maintainer and upstream maintainer).

Beyond the version bump, this adds **`psycopg2` to the run requirements**: panoptes-ui 1.6.0 documents and CI-tests PostgreSQL support via its `PANOPTES_DB_URL` environment variable ([panoptes-organization/panoptes#203](https://github.com/panoptes-organization/panoptes/issues/203)), and shipping the driver makes conda installs and — importantly — the biocontainer PostgreSQL-ready out of the box. Pointing the container at an external database is the main alternative to mounting volumes for the default SQLite file.

Upstream 1.6.0 is a docs/CI/packaging release on top of 1.5.1 (pure-Python Flask app, no other dependency changes). sha256 taken from the PyPI sdist and verified against a fresh download.

---

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
* [x] This PR is ready for review.