### PR TITLE
Add FreqEstimationModel

### DIFF
--- a/recipes/r-freqestimationmodel/bld.bat
+++ b/recipes/r-freqestimationmodel/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . --no-build-vignettes %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-freqestimationmodel/bld.bat
+++ b/recipes/r-freqestimationmodel/bld.bat
@@ -1,2 +1,0 @@
-"%R%" CMD INSTALL --build . --no-build-vignettes %R_ARGS%
-IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-freqestimationmodel/build.sh
+++ b/recipes/r-freqestimationmodel/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 export DISABLE_AUTOBREW=1
-${R} CMD INSTALL --build . --no-build-vignettes ${R_ARGS}
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-freqestimationmodel/build.sh
+++ b/recipes/r-freqestimationmodel/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . --no-build-vignettes ${R_ARGS}

--- a/recipes/r-freqestimationmodel/meta.yaml
+++ b/recipes/r-freqestimationmodel/meta.yaml
@@ -14,6 +14,8 @@ build:
   rpaths:
     - lib/R/lib/
     - lib/
+  run_exports:
+    - {{ pin_subpackage('r-freqestimationmodel', max_pin="x.x") }}
 
 requirements:
   host:

--- a/recipes/r-freqestimationmodel/meta.yaml
+++ b/recipes/r-freqestimationmodel/meta.yaml
@@ -1,0 +1,44 @@
+{% set version = "0.1.0" %}
+
+package:
+  name: r-freqestimationmodel
+  version: {{ version }}
+
+source:
+  url: https://github.com/kathrynmurie/FreqEstimationModel/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: a9544922cb5b27d546ccdce2934449601ea55b0509682fb60669fc242ab4ecb2
+
+build:
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  host:
+    - r-base
+    - r-foreach
+    - r-domc
+    - r-rngtools
+  run:
+    - r-base
+    - r-foreach
+    - r-domc
+    - r-rngtools
+
+test:
+  commands:
+    - $R -e "library('FreqEstimationModel')"  # [not win]
+    - "\"%R%\" -e \"library('FreqEstimationModel')\""  # [win]
+
+about:
+  home: https://github.com/aimeertaylor/FreqEstimationModel
+  summary: Multi-SNP haplotype frequency estimation
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - kathrynmurie
+    - aimeertaylor


### PR DESCRIPTION
This pull request adds a Bioconda recipe for the R package **FreqEstimationModel**.

`FreqEstimationModel` provides methods for estimating multi-SNP haplotype frequencies from genetic data.

**Package information**

* Source (temporary): https://github.com/kathrynmurie/FreqEstimationModel
* Original repository: https://github.com/aimeertaylor/FreqEstimationModel
* Version: 0.1.0
* License: MIT

The recipe currently builds from a tagged release in my fork because I made a small number of metadata improvements (DESCRIPTION and LICENSE) to support packaging while the upstream maintainer is unavailable. A pull request will be submitted to the upstream repository, and once those changes are merged, the recipe source will be updated to use the original repository. I know the author of the package, they are on vacation at the moment, but when they are back I will sort merging the fork. I am trying to publish a pipeline that uses this package with nf-core and would ideally not wait until they get back from vacation.
