### PR TITLE
Update aviary to v0.13.1

### DIFF
--- a/recipes/aviary/meta.yaml
+++ b/recipes/aviary/meta.yaml
@@ -1,6 +1,6 @@
-{% set version = "0.13.0" %}
+{% set version = "0.13.1" %}
 {% set name = "aviary" %}
-{% set sha256 = "c7fc48fec5211b93c45f010d260879be59dfed39b7a9a929e839bb3c916c10e1" %}
+{% set sha256 = "c24c40359dd3b966a94ed5116d52be8750e84e702718248852409de8283202ec" %}
 
 package:
   name: {{ name }}


### PR DESCRIPTION
Update `aviary` v0.13.0 to v0.13.1.

Patch release repairing database downloads (`aviary configure --download`) and pixi 0.71+ compatibility:
- `download_databases` no longer requires read inputs
- eggNOG, Metabuli GTDB, and CheckM2 download URLs/commands fixed
- `pixi.toml` migrated to rich platforms (min `pixi >=0.71`)

