### PR TITLE
blacklist kalign3

### DIFF
--- a/build-fail-blacklist
+++ b/build-fail-blacklist
@@ -53,6 +53,7 @@ recipes/epydoc
 recipes/esmre
 recipes/forked-path
 recipes/justbackoff
+recipes/kalign3
 recipes/kid
 recipes/myriad
 recipes/nose-capturestderr


### PR DESCRIPTION
Migrated to conda-forge. Currently breaks nightlies because it has no `meta.yaml`.