### PR TITLE
fungar: fix diamond dependency

### DIFF
--- a/recipes/fungar/meta.yaml
+++ b/recipes/fungar/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: bb041930f41c0a9d6c5de7557601193b3bb35bc92c3aa5ae9519e722f3ece93e
 
 build:
-  number: 0
+  number: 1
   noarch: generic
   run_exports:
     - {{ pin_subpackage(name, max_pin="x.x") }}
@@ -21,7 +21,7 @@ requirements:
   run:
     - python >=3.6
     - pandas
-    - diamond
+    - diamond >=2.1.24,<2.2
 
 test:
   commands:


### PR DESCRIPTION
## Description
This PR pins the `diamond` dependency to `<2.2` for the `fungar` package. 

## Reason for Change
The recent release of DIAMOND v2.2 introduced structural and breaking changes to output formats and command behavior. This caused the FUNGAR pipeline to crash silently or fail to parse files immediately after completing the R1 alignment step. Pinning the dependency ensures backward compatibility with DIAMOND v2.1.x, which functions correctly.

- [x] Fixed the `diamond` dependency pin in `meta.yaml`
- [x] Bumped the build number from `0` to `1`