### PR TITLE
Update teloscope to 0.1.5

### DIFF
--- a/recipes/teloscope/conda_build_config.yaml
+++ b/recipes/teloscope/conda_build_config.yaml
@@ -1,0 +1,9 @@
+# teloscope 0.1.5+ uses std::filesystem (canonical/parent_path in
+# src/main.cpp), which on macOS requires a 10.15+ deployment target. The
+# default osx-64 target is older, so bump it for the Intel macOS build
+# (osx-arm64 is already >= 11.0). See:
+# https://conda-forge.org/docs/maintainer/knowledge_base/#newer-c-features-with-old-sdk
+c_stdlib_version:            # [osx and x86_64]
+  - "10.15"                  # [osx and x86_64]
+MACOSX_DEPLOYMENT_TARGET:    # [osx and x86_64]
+  - "10.15"                  # [osx and x86_64]

--- a/recipes/teloscope/meta.yaml
+++ b/recipes/teloscope/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "teloscope" %}
-{% set version = "0.1.3" %}
+{% set version = "0.1.5" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/vgl-hub/teloscope/releases/download/v{{version}}/teloscope.v{{version}}-with_submodules.zip
-  sha256: 6c28d19f6bd5315689a239d0a8832e128755715f1608e0e74b5e38901e639bfa
+  sha256: a644271c88a6648d6f27c7db4e92efce6cab97e534de30aef5a4cc21cbf5261c
 
 build:
   number: 0
@@ -18,6 +18,7 @@ requirements:
   build:
     - make
     - {{ compiler('cxx') }}
+    - {{ stdlib('c') }}
   host:
     - zlib
     - openssl
@@ -30,7 +31,7 @@ about:
   home: https://github.com/vgl-hub/teloscope
   dev_url: https://github.com/vgl-hub/teloscope
   doc_url: "https://github.com/vgl-hub/teloscope/blob/v{{ version }}/README.md"
-  license_familiy: MIT
+  license_family: MIT
   license: MIT
   license_file: LICENSE
   summary: "A telomere annotation tools for genome assemblies."


### PR DESCRIPTION
Updates `teloscope` to 0.1.5.

This supersedes the failing auto-bump PR #67016. That PR's version and sha256 are correct, but its Lint check fails on `compiler_needs_stdlib_c`: the recipe requests a compiler but has no `stdlib`. The auto-bump bot only rewrites the version/sha lines, so it could not add the missing entry.

Changes here, on top of the current recipe:

- Add `{{ stdlib('c') }}` to `requirements.build` (fixes the lint failure that also gated the ARM build).
- Fix the `license_familiy` -> `license_family` typo.
- Bump to 0.1.5 with `sha256: a644271c88a6648d6f27c7db4e92efce6cab97e534de30aef5a4cc21cbf5261c`, verified against the released `teloscope.v0.1.5-with_submodules.zip`.

The teloscope release workflow has also been updated upstream so future releases attach all assets before publishing, keeping auto-bumps reliable.
