### PR TITLE
Add adapterremoval 3.0.1

### DIFF
--- a/recipes/adapterremoval/0001-quick-exit.patch
+++ b/recipes/adapterremoval/0001-quick-exit.patch
@@ -1,0 +1,21 @@
+--- a/src/main.cpp
++++ b/src/main.cpp
+@@ -9,7 +9,7 @@
+ #include "reports.hpp"    // for print_terminal_postamble, print_terminal_...
+ #include "userconfig.hpp" // for ar_command, userconfig, ar_command::demul...
+ #include "version.hpp"    // for version
+-#include <cstdlib>        // for abort, size_t, quick_exit
++#include <cstdlib>        // for abort, size_t, _Exit
+ #include <exception>      // for set_terminate
+ #include <filesystem>     // for filesystem_error
+ #include <ios>            // for ios_base
+@@ -51,7 +51,8 @@ terminate_on_failure(std::string_view message)
+     // function is called by std::terminate, so cannot rethrow exceptions
+   }
+ 
+-  std::quick_exit(1);
++  // used since not all targets have `quick_exit` and no handlers are registered
++  std::_Exit(1);
+ }
+ 
+ [[noreturn]] void

--- a/recipes/adapterremoval/adapterremoval2/build.sh
+++ b/recipes/adapterremoval/adapterremoval2/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib"
+export CPPFLAGS="${CPPFLAGS} -I${PREFIX}/include"
+export CXXFLAGS="${CXXFLAGS} -O3"
+
+sed -i.bak -e 's/install -d/mkdir -p/' Makefile
+rm -f *.bak
+
+make
+make install PREFIX="${PREFIX}"

--- a/recipes/adapterremoval/adapterremoval2/meta.yaml
+++ b/recipes/adapterremoval/adapterremoval2/meta.yaml
@@ -23,8 +23,6 @@ requirements:
   host:
     - zlib
     - bzip2
-    - wget
-    - perl
 
 test:
   commands:

--- a/recipes/adapterremoval/adapterremoval2/meta.yaml
+++ b/recipes/adapterremoval/adapterremoval2/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 2
+  number: 3
   run_exports:
     - {{ pin_subpackage('adapterremoval', max_pin="x") }}
 
@@ -18,6 +18,7 @@ requirements:
   build:
     - make
     - {{ compiler('cxx') }}
+    - {{ stdlib('c') }}
     - pkg-config
   host:
     - zlib

--- a/recipes/adapterremoval/adapterremoval2/meta.yaml
+++ b/recipes/adapterremoval/adapterremoval2/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "3.0.1" %}
-{% set sha256 = "52bef5e9ad5de76a6bd0a1522ad621e95efec0cc23602900bd65a154f96a1f6e" %}
+{% set version = "2.3.4" %}
+{% set sha256 = "a4433a45b73ead907aede22ed0c7ea6fbc080f6de6ed7bc00f52173dfb309aa1" %}
 
 package:
   name: adapterremoval
@@ -10,39 +10,37 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 2
   run_exports:
     - {{ pin_subpackage('adapterremoval', max_pin="x") }}
 
 requirements:
   build:
-    - meson >=0.56.0
-    - ninja >=1.10
-    - pkg-config
-    - python >=3.7 # To convert HTML templates to cpp and for tests
-    - sphinx # To build man-page (can be disabled)
+    - make
     - {{ compiler('cxx') }}
-    - {{ stdlib('c') }}
+    - pkg-config
   host:
-    - libdeflate >=1.7
-    - isa-l >=2.30
-  run:
-    - libdeflate >=1.7
-    - isa-l >=2.30
+    - zlib
+    - bzip2
+    - wget
+    - perl
 
 test:
   commands:
-    - adapterremoval3 --help
+    - AdapterRemoval -h
 
 about:
   home: "https://github.com/MikkelSchubert/adapterremoval"
   license: "GPL-3.0-or-later"
   license_family: GPL3
   license_file: LICENSE
-  summary: "The AdapterRemoval v3 tool for merging, clipping, and QC'ing reads"
+  summary: "The AdapterRemoval v2 tool for merging and clipping reads."
   dev_url: "https://github.com/MikkelSchubert/adapterremoval"
 
 extra:
   additional-platforms:
     - linux-aarch64
     - osx-arm64
+  identifiers:
+    - biotools:adapterremoval
+    - usegalaxy-eu:adapter_removal

--- a/recipes/adapterremoval/build.sh
+++ b/recipes/adapterremoval/build.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
+set -euo pipefail
 
-export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib"
-export CPPFLAGS="${CPPFLAGS} -I${PREFIX}/include"
-export CXXFLAGS="${CXXFLAGS} -O3"
+# Conda attempts to set a lower hardening level without unsetting the define,
+# while AdapterRemoval sets -D_FORTIFY_SOURCE=3 by default. This fixes the
+# build, silences warnings, and preserves the higher hardening level
+export CPPFLAGS="-U_FORTIFY_SOURCE ${CPPFLAGS} -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3"
 
-sed -i.bak -e 's/install -d/mkdir -p/' Makefile
-rm -f *.bak
-
-make
-make install PREFIX="${PREFIX}"
+meson setup "build" --prefix="${PREFIX}" 
+meson compile -C "build" adapterremoval3
+meson install -C "build"

--- a/recipes/adapterremoval/build.sh
+++ b/recipes/adapterremoval/build.sh
@@ -6,6 +6,9 @@ set -euo pipefail
 # build, silences warnings, and preserves the higher hardening level
 export CPPFLAGS="-U_FORTIFY_SOURCE ${CPPFLAGS} -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3"
 
+# Required to build documentation with sphinx
+export LC_ALL="en_US.UTF-8"
+
 meson setup "build" --prefix="${PREFIX}" 
 meson compile -C "build" adapterremoval3
 meson install -C "build"

--- a/recipes/adapterremoval/meta.yaml
+++ b/recipes/adapterremoval/meta.yaml
@@ -29,9 +29,6 @@ requirements:
   host:
     - libdeflate >=1.7
     - isa-l >=2.30
-  run:
-    - libdeflate >=1.7
-    - isa-l >=2.30
 
 test:
   commands:

--- a/recipes/adapterremoval/meta.yaml
+++ b/recipes/adapterremoval/meta.yaml
@@ -8,6 +8,9 @@ package:
 source:
   url: https://github.com/MikkelSchubert/adapterremoval/archive/v{{ version }}.tar.gz
   sha256: {{ sha256 }}
+  patches:
+    # https://github.com/MikkelSchubert/adapterremoval/pull/371
+    - 0001-quick-exit.patch
 
 build:
   number: 0


### PR DESCRIPTION
This PR adds AdapterRemoval v3.0.1 based on the existing recipe for v2.

This PR replaces the automatic PR #65082, which won't work due the changes to both build-time and runtime requirements in v3.

AdapterRemoval 2 is still supported for the sake of old workflows, and will receive bug fixes if needed, though I am unlikely to add any new features. It was unclear to me if the approach taken in this PR made the most sense, or if I should add a separate `adapterremoval3` recipe: AdapterRemoval v3 breaks backwards compatibility in a number of ways, and the executable is intentionally named to allow both v2 (`AdapterRemoval`) and v3 (`adapterremoval3`) to coexist