### PR TITLE
Add shellinford 0.4.1

### DIFF
--- a/recipes/shellinford/meta.yaml
+++ b/recipes/shellinford/meta.yaml
@@ -1,0 +1,47 @@
+{% set name = "shellinford" %}
+{% set version = "0.4.1" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: c19f125a9d22d9676dbec64c0490ddd2d95d2449363052ddc2f4a588a52b04b3
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --no-cache-dir -vvv
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x.x") }}
+
+requirements:
+  build:
+    - {{ compiler('cxx') }}
+    - {{ stdlib('c') }}
+  host:
+    - python
+    - pip
+    - setuptools
+  run:
+    - python
+
+test:
+  imports:
+    - shellinford
+
+about:
+  home: https://github.com/ikegami-yukino/shellinford-python
+  summary: Wavelet Matrix/Tree succinct data structure for full text search
+  description: |
+    Python binding for the shellinford C++ library, providing an FM-index
+    built on a wavelet matrix/tree succinct data structure for full text
+    search.
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE
+  dev_url: https://github.com/ikegami-yukino/shellinford-python
+
+extra:
+  recipe-maintainers:
+    - jonasscheid


### PR DESCRIPTION
Adds `shellinford` 0.4.1, a Python binding for the shellinford C++ library (FM-index over a wavelet matrix/tree).

Needed as a dependency of `vaxrank`, which is in turn required by `pVACtools`.

### Notes
- Compiled recipe (C++ extension); the sdist ships a pre-generated SWIG wrapper, so no SWIG is needed at build time — only a C++ compiler.
- The 2014-era wrapper was verified to compile and run on both Python 3.11 and 3.13, so no python cap is applied.

### Test plan
- [x] Builds locally with `conda-build` (linux-64)
- [x] `import shellinford` and a round-trip `FMIndex` build/search return the expected hit
- [ ] Bioconda CI

---

### Dependency chain (pVACtools)

This PR is one of a set adding [pVACtools](https://github.com/griffithlab/pVACtools) to bioconda. pVACtools was not previously packaged; it needs four new dependencies and two repaired recipes. Suggested merge order:

| # | PR | Recipe | |
|---|----|--------|-|
| 1 | #67034 | `shellinford` 0.4.1 | new (C++ ext) |
| 2 | #67035 | `mhctools` 1.9.0 | new |
| 3 | #67036 | `isovar` 1.4.24 | new |
| 4 | #67037 | `pdfkit` 1.0.0 | fix — published builds are py2.7–3.6 only |
| 5 | #67038 | `mhcnuggets` 2.4.1 build 1 | fix — pins `python =3.6`; breaks under Keras 3 |
| 6 | #67039 | `vaxrank` 1.4.0 | new — needs 1–4 |
| 7 | #67040 | `pvactools` 7.0.1 | new — needs 5–6 |

PRs 1–5 are independent and can be reviewed and merged in any order. 6 and 7 are drafts until their dependencies land in the channel.
