### PR TITLE
Add mhctools 1.9.0

### DIFF
--- a/recipes/mhctools/meta.yaml
+++ b/recipes/mhctools/meta.yaml
@@ -1,0 +1,57 @@
+{% set name = "mhctools" %}
+{% set version = "1.9.0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 543931571dc5784faa9769acec3ef00054b42ec568dfdb3e3ba87660f7988c0e
+
+build:
+  number: 0
+  noarch: python
+  entry_points:
+    - mhctools = mhctools.cli.script:main
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --no-cache-dir -vvv
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x") }}
+
+requirements:
+  host:
+    - python >=3.9
+    - pip
+    - setuptools
+  run:
+    - python >=3.9
+    - numpy >=1.7
+    - pandas >=0.13.1
+    - varcode >=0.5.9
+    - pyensembl >=1.0.3
+    - sercol >=0.0.2
+    - mhcflurry >=2.0.0
+    - mhcnames >=0.3.2
+
+test:
+  imports:
+    - mhctools
+    - mhctools.cli
+  commands:
+    - mhctools --help
+
+about:
+  home: https://github.com/openvax/mhctools
+  summary: Python interface to running command-line and web-based MHC binding predictors
+  description: |
+    mhctools provides a uniform Python interface to a variety of MHC binding
+    prediction tools, including NetMHC, NetMHCpan, NetMHCIIpan, MHCflurry and
+    the IEDB web servers.
+  license: Apache-2.0
+  license_family: APACHE
+  license_file: LICENSE
+  dev_url: https://github.com/openvax/mhctools
+
+extra:
+  recipe-maintainers:
+    - jonasscheid

--- a/recipes/mhctools/meta.yaml
+++ b/recipes/mhctools/meta.yaml
@@ -20,11 +20,11 @@ build:
 
 requirements:
   host:
-    - python >=3.9
+    - python
     - pip
     - setuptools
   run:
-    - python >=3.9
+    - python
     - numpy >=1.7
     - pandas >=0.13.1
     - varcode >=0.5.9


### PR DESCRIPTION
Adds `mhctools` 1.9.0, a uniform Python interface to MHC binding predictors (NetMHC family, MHCflurry, IEDB web servers).

Needed as a dependency of `vaxrank`, which is in turn required by `pVACtools`.

All of its runtime dependencies (`varcode`, `pyensembl`, `sercol`, `mhcflurry`, `mhcnames`) are already in bioconda.

### Test plan
- [x] Builds locally with `conda-build`
- [x] `import mhctools`, `import mhctools.cli`, and `mhctools --help` all succeed
- [ ] Bioconda CI

---

### Dependency chain (pVACtools)

This PR is one of a set adding [pVACtools](https://github.com/griffithlab/pVACtools) to bioconda. pVACtools was not previously packaged; it needs four new dependencies and two repaired recipes. Suggested merge order:

| # | PR | Recipe | |
|---|----|--------|-|
| 1 | #67034 | `shellinford` 0.4.1 | new (C++ ext) |
| 2 | #67035 | `mhctools` 1.9.0 | new |
| 3 | #67036 | `isovar` 1.4.24 | new |
| 4 | #67037 | `pdfkit` 1.0.0 | fix — published builds are py2.7–3.6 only |
| 5 | #67038 | `mhcnuggets` 2.4.1 build 1 | fix — pins `python =3.6`; breaks under Keras 3 |
| 6 | #67039 | `vaxrank` 1.4.0 | new — needs 1–4 |
| 7 | #67040 | `pvactools` 7.0.1 | new — needs 5–6 |

PRs 1–5 are independent and can be reviewed and merged in any order. 6 and 7 are drafts until their dependencies land in the channel.
