### PR TITLE
Add isovar 1.4.24

### DIFF
--- a/recipes/isovar/meta.yaml
+++ b/recipes/isovar/meta.yaml
@@ -27,11 +27,11 @@ build:
 
 requirements:
   host:
-    - python >=3.9
+    - python
     - pip
     - setuptools >=64
   run:
-    - python >=3.9
+    - python
     - pyensembl >=1.5.0
     - varcode >=0.9.0
     - pandas >=0.23.0

--- a/recipes/isovar/meta.yaml
+++ b/recipes/isovar/meta.yaml
@@ -1,0 +1,62 @@
+{% set name = "isovar" %}
+{% set version = "1.4.24" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: c526771a64df8c7f96b463dcade4bea873fd5852b3189e719c92bdf1a4669ddf
+
+build:
+  number: 0
+  noarch: python
+  entry_points:
+    - isovar = isovar.cli.isovar_main:run
+    - isovar-protein-sequences = isovar.cli.isovar_protein_sequences:run
+    - isovar-translations = isovar.cli.isovar_translations:run
+    - isovar-reference-contexts = isovar.cli.isovar_reference_contexts:run
+    - isovar-allele-reads = isovar.cli.isovar_allele_reads:run
+    - isovar-allele-counts = isovar.cli.isovar_allele_counts:run
+    - isovar-variant-reads = isovar.cli.isovar_variant_reads:run
+    - isovar-variant-sequences = isovar.cli.isovar_variant_sequences:run
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --no-cache-dir -vvv
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x") }}
+
+requirements:
+  host:
+    - python >=3.9
+    - pip
+    - setuptools >=64
+  run:
+    - python >=3.9
+    - pyensembl >=1.5.0
+    - varcode >=0.9.0
+    - pandas >=0.23.0
+    - pysam >=0.15.2
+    - psutil
+
+test:
+  imports:
+    - isovar
+    - isovar.cli
+  commands:
+    - isovar --help
+
+about:
+  home: https://github.com/openvax/isovar
+  summary: Determine mutant protein sequences from RNA using assembly around variants
+  description: |
+    Isovar assembles RNA reads which support a variant to determine the mutant
+    protein sequence(s) that a tumour actually expresses, rather than relying
+    on a reference transcript annotation alone.
+  license: Apache-2.0
+  license_family: APACHE
+  license_file: LICENSE
+  dev_url: https://github.com/openvax/isovar
+
+extra:
+  recipe-maintainers:
+    - jonasscheid


### PR DESCRIPTION
Adds `isovar` 1.4.24, which assembles RNA reads supporting a variant to determine the mutant protein sequence a tumour actually expresses.

Needed as a dependency of `vaxrank`, which is in turn required by `pVACtools`.

All of its runtime dependencies (`pyensembl`, `varcode`, `pandas`, `pysam`, `psutil`) are already in bioconda.

### Test plan
- [x] Builds locally with `conda-build`
- [x] `import isovar`, `import isovar.cli`, and `isovar --help` all succeed
- [ ] Bioconda CI

---

### Dependency chain (pVACtools)

This PR is one of a set adding [pVACtools](https://github.com/griffithlab/pVACtools) to bioconda. pVACtools was not previously packaged; it needs four new dependencies and two repaired recipes. Suggested merge order:

| # | PR | Recipe | |
|---|----|--------|-|
| 1 | #67034 | `shellinford` 0.4.1 | new (C++ ext) |
| 2 | #67035 | `mhctools` 1.9.0 | new |
| 3 | #67036 | `isovar` 1.4.24 | new |
| 4 | #67037 | `pdfkit` 1.0.0 | fix — published builds are py2.7–3.6 only |
| 5 | #67038 | `mhcnuggets` 2.4.1 build 1 | fix — pins `python =3.6`; breaks under Keras 3 |
| 6 | #67039 | `vaxrank` 1.4.0 | new — needs 1–4 |
| 7 | #67040 | `pvactools` 7.0.1 | new — needs 5–6 |

PRs 1–5 are independent and can be reviewed and merged in any order. 6 and 7 are drafts until their dependencies land in the channel.
