### PR TITLE
Update pdfkit to 1.0.0 and rebuild as noarch

### DIFF
--- a/build-fail-blacklist
+++ b/build-fail-blacklist
@@ -56,7 +56,6 @@ recipes/justbackoff
 recipes/kid
 recipes/myriad
 recipes/nose-capturestderr
-recipes/pdfkit
 recipes/perl-pcap
 recipes/perl-getopt-argvfile
 recipes/perl-probe-perl

--- a/recipes/pdfkit/meta.yaml
+++ b/recipes/pdfkit/meta.yaml
@@ -1,29 +1,49 @@
-package:
-  name: pdfkit
-  version: "0.6.1"
+{% set name = "pdfkit" %}
+{% set version = "1.0.0" %}
 
-build:
-  noarch: python
-  number: 0
-  script: {{ PYTHON }} -m pip install . --ignore-installed --no-deps -vv
+package:
+  name: {{ name }}
+  version: {{ version }}
 
 source:
-  url: https://files.pythonhosted.org/packages/a1/98/6988328f72fe3be4cbfcb6cbfc3066a00bf111ca7821a83dd0ce56e2cf57/pdfkit-0.6.1.tar.gz
-  sha256: ef1da35b78d534197e7ce4a604a4a190e9aa769e56634957535f3479a50d8cd1
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 992f821e1e18fc8a0e701ecae24b51a2d598296a180caee0a24c0af181da02a9
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --no-cache-dir -vvv
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x") }}
 
 requirements:
   host:
+    - python >=3.9
     - pip
-    - python
+    - setuptools
   run:
-    - wkhtmltopdf
-    - python
+    - python >=3.9
+    # wkhtmltopdf is the external renderer pdfkit shells out to. It is not a
+    # python dependency (upstream declares none) and is only packaged for
+    # linux-64, so depending on it here would make this noarch package
+    # uninstallable on osx. Install it alongside pdfkit to render PDFs.
 
 test:
   imports:
     - pdfkit
 
 about:
-  home: https://pypi.python.org/pypi/pdfkit
-  license: MIT License
-  summary: 'Wkhtmltopdf python wrapper to convert html to pdf using the webkit rendering engine and qt'
+  home: https://github.com/JazzCore/python-pdfkit
+  summary: Wkhtmltopdf python wrapper to convert html to pdf using the webkit rendering engine and qt
+  description: |
+    Python wrapper around the wkhtmltopdf command line tool, used to convert
+    HTML documents into PDF files. The wkhtmltopdf executable must be
+    available on PATH at run time.
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  dev_url: https://github.com/JazzCore/python-pdfkit
+
+extra:
+  recipe-maintainers:
+    - jonasscheid


### PR DESCRIPTION
Updates `pdfkit` 0.6.1 → 1.0.0 and rebuilds it as a genuinely noarch package.

### Why

The recipe already declared `noarch: python`, but the only artifacts ever published were `py2.7` / `py3.4` / `py3.5` / `py3.6` builds. As a result `pdfkit` cannot be resolved on any currently supported Python:

```
pdfkit [0.5.0|0.6.1] would require python [=2.7|>=2.7,<2.8.0a0] ...
pdfkit 0.5.0 would require python =3.4 ...
```

This surfaced while packaging `vaxrank` (a `pVACtools` dependency), which depends on `pdfkit`.

### Dropping the `wkhtmltopdf` run dependency

`wkhtmltopdf` is packaged only for `linux-64` (bioconda) and `linux-64`/`win-64` (conda-forge). A `noarch` package that hard-depends on it is therefore uninstallable on osx.

It is not a Python dependency — upstream `pdfkit` declares none — but an external binary invoked through `subprocess`, and only when actually rendering a PDF. Importing and using the library's API does not require it. It is now documented in the recipe and in `about.description` instead. Users who need to render PDFs install `wkhtmltopdf` alongside.

### Test plan
- [x] Builds locally with `conda-build`
- [x] `import pdfkit` succeeds on Python 3.11
- [ ] Bioconda CI

---

### Dependency chain (pVACtools)

This PR is one of a set adding [pVACtools](https://github.com/griffithlab/pVACtools) to bioconda. pVACtools was not previously packaged; it needs four new dependencies and two repaired recipes. Suggested merge order:

| # | PR | Recipe | |
|---|----|--------|-|
| 1 | #67034 | `shellinford` 0.4.1 | new (C++ ext) |
| 2 | #67035 | `mhctools` 1.9.0 | new |
| 3 | #67036 | `isovar` 1.4.24 | new |
| 4 | #67037 | `pdfkit` 1.0.0 | fix — published builds are py2.7–3.6 only |
| 5 | #67038 | `mhcnuggets` 2.4.1 build 1 | fix — pins `python =3.6`; breaks under Keras 3 |
| 6 | #67039 | `vaxrank` 1.4.0 | new — needs 1–4 |
| 7 | #67040 | `pvactools` 7.0.1 | new — needs 5–6 |

PRs 1–5 are independent and can be reviewed and merged in any order. 6 and 7 are drafts until their dependencies land in the channel.
