### PR TITLE
Rebuild mhcnuggets for python >=3.9 and cap keras <3

### DIFF
--- a/recipes/mhcnuggets/meta.yaml
+++ b/recipes/mhcnuggets/meta.yaml
@@ -12,14 +12,14 @@ source:
 build:
   number: 1
   noarch: python
-  script: "{{ PYTHON }} -m pip install . --no-deps --no-build-isolation --no-cache-dir -vvv"
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --no-cache-dir -vvv
   run_exports:
-    - {{ pin_subpackage(name|lower, max_pin="x") }}
+    - {{ pin_subpackage(name, max_pin="x") }}
 
 requirements:
   host:
     - pip
-    - python >=3.9
+    - python
     - setuptools
   run:
     # mhcnuggets calls the Keras 2 API (e.g. Adam(lr=...)), which Keras 3
@@ -27,7 +27,7 @@ requirements:
     - keras >=2.6,<3
     - numpy
     - pandas
-    - python >=3.9
+    - python
     - scikit-learn
     - scipy
     - tensorflow >=2.6,<2.16

--- a/recipes/mhcnuggets/meta.yaml
+++ b/recipes/mhcnuggets/meta.yaml
@@ -10,22 +10,27 @@ source:
   sha256: c0c853031b8cc0b8d7e08674500d4d5929c0720e4e0a2e421272437022f30406
 
 build:
-  number: 0
+  number: 1
   noarch: python
-  script: "{{ PYTHON }} -m pip install . -vv"
+  script: "{{ PYTHON }} -m pip install . --no-deps --no-build-isolation --no-cache-dir -vvv"
+  run_exports:
+    - {{ pin_subpackage(name|lower, max_pin="x") }}
 
 requirements:
   host:
     - pip
-    - python
+    - python >=3.9
+    - setuptools
   run:
-    - keras
+    # mhcnuggets calls the Keras 2 API (e.g. Adam(lr=...)), which Keras 3
+    # removed. tensorflow >=2.16 vendors Keras 3, so both are capped.
+    - keras >=2.6,<3
     - numpy
     - pandas
-    - python =3.6
+    - python >=3.9
     - scikit-learn
     - scipy
-    - tensorflow
+    - tensorflow >=2.6,<2.16
     - varcode
 
 test:


### PR DESCRIPTION
Rebuilds `mhcnuggets` 2.4.1 (build 0 → 1) so that it is installable and actually works.

### Why

Two independent problems made the published package unusable:

**1. It pins `python =3.6`.** Python 3.6 has been EOL since 2021, so the package cannot be installed into any currently supported environment. Now `python >=3.9`.

**2. It calls the Keras 2 API but depended on unbounded `keras`/`tensorflow`.** `mhcnuggets.src.models` tries `import keras` first and falls back to `tensorflow.keras`. Under Keras 3 the import *succeeds*, so the breakage is silent until prediction time:

```
ValueError: Argument(s) not recognized: {'lr': 0.001}
```

(Keras 3 removed the `lr=` alias for `learning_rate`.) Since TensorFlow ≥ 2.16 vendors Keras 3, both are now capped: `keras >=2.6,<3` and `tensorflow >=2.6,<2.16`.

Also switched the build script to the standard `pip install . --no-deps --no-build-isolation --no-cache-dir` and added `run_exports`.

### Verification

With `keras 2.15` / `tensorflow 2.15` on Python 3.11, prediction runs and gives sensible affinities — `GILGFVFTL` (a well-characterised strong HLA-A\*02:01 binder) scores 589 nM:

```
peptide,ic50
SIINFEKL,5600.06
GILGFVFTL,589.25
```

The same call under Keras 3 fails with the `ValueError` above.

### Test plan
- [x] Builds locally with `conda-build`
- [x] Import tests pass; `mhcnuggets.src.predict.predict` verified numerically
- [ ] Bioconda CI

---

### Dependency chain (pVACtools)

This PR is one of a set adding [pVACtools](https://github.com/griffithlab/pVACtools) to bioconda. pVACtools was not previously packaged; it needs four new dependencies and two repaired recipes. Suggested merge order:

| # | PR | Recipe | |
|---|----|--------|-|
| 1 | #67034 | `shellinford` 0.4.1 | new (C++ ext) |
| 2 | #67035 | `mhctools` 1.9.0 | new |
| 3 | #67036 | `isovar` 1.4.24 | new |
| 4 | #67037 | `pdfkit` 1.0.0 | fix — published builds are py2.7–3.6 only |
| 5 | #67038 | `mhcnuggets` 2.4.1 build 1 | fix — pins `python =3.6`; breaks under Keras 3 |
| 6 | #67039 | `vaxrank` 1.4.0 | new — needs 1–4 |
| 7 | #67040 | `pvactools` 7.0.1 | new — needs 5–6 |

PRs 1–5 are independent and can be reviewed and merged in any order. 6 and 7 are drafts until their dependencies land in the channel.
