### PR TITLE
Add vaxrank 1.4.0

### DIFF
--- a/recipes/vaxrank/drop-removed-jinja2-autoescape-extension.patch
+++ b/recipes/vaxrank/drop-removed-jinja2-autoescape-extension.patch
@@ -1,0 +1,15 @@
+Jinja2 3.0 removed the `jinja2.ext.autoescape` extension; autoescaping has been
+a core Environment keyword since Jinja2 2.9. The Environment below already
+passes `autoescape=False` explicitly, so loading the extension is redundant and
+raises AttributeError on modern Jinja2.
+
+--- a/vaxrank/report.py
++++ b/vaxrank/report.py
+@@ -36,7 +36,6 @@
+ 
+ JINJA_ENVIRONMENT = jinja2.Environment(
+     loader=jinja2.FileSystemLoader(os.path.dirname(__file__)),
+-    extensions=['jinja2.ext.autoescape'],
+     autoescape=False,
+     trim_blocks=True,
+     lstrip_blocks=True,

--- a/recipes/vaxrank/lazy-pdfkit-import.patch
+++ b/recipes/vaxrank/lazy-pdfkit-import.patch
@@ -1,0 +1,28 @@
+pdfkit is only needed to render the optional `--output-pdf-report` output, and
+it drives the external wkhtmltopdf binary, which is not packaged for osx. A
+module-level import therefore makes vaxrank uninstallable on platforms where
+PDF output could never have worked anyway. Import it lazily instead, mirroring
+how the neighbouring xvfbwrapper import is already handled.
+
+--- a/vaxrank/report.py
++++ b/vaxrank/report.py
+@@ -24,7 +24,6 @@
+ from astropy.io import ascii as asc
+ import jinja2
+ import pandas as pd
+-import pdfkit
+ import requests
+ import roman
+ from varcode import load_vcf_fast
+@@ -397,6 +396,11 @@
+ def make_pdf_report(
+         template_data,
+         pdf_report_path):
++    # Imported lazily: pdfkit drives the wkhtmltopdf binary, which is not
++    # available on every platform. PDF output is one of several optional
++    # report formats, so importing vaxrank must not require it.
++    import pdfkit
++
+     with tempfile.NamedTemporaryFile(mode='w', suffix='.html') as f:
+         _make_report(template_data, f, 'templates/template.html')
+         f.flush()

--- a/recipes/vaxrank/meta.yaml
+++ b/recipes/vaxrank/meta.yaml
@@ -1,0 +1,71 @@
+{% set name = "vaxrank" %}
+{% set version = "1.4.0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 0a287076eae0542a26fd0131848b230c803714de3ff5ba14d9add0e8d7c99be7
+  patches:
+    - drop-removed-jinja2-autoescape-extension.patch
+
+build:
+  number: 0
+  noarch: python
+  entry_points:
+    - vaxrank = vaxrank.cli:main
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --no-cache-dir -vvv
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x") }}
+
+requirements:
+  host:
+    - python >=3.9
+    - pip
+    - setuptools
+  run:
+    - python >=3.9
+    - six
+    - numpy >=1.14.0
+    - pandas
+    - pyensembl >=1.5.0
+    - varcode >=0.5.9
+    - isovar >=1.1.1
+    - mhctools >=1.5.0
+    - roman
+    - jinja2
+    - pdfkit
+    - pypandoc
+    - shellinford >=0.3.4
+    - xlrd
+    - xlsxwriter
+    - xvfbwrapper
+    - future >=0.16.0
+    - astropy
+    # vaxrank.cli imports pkg_resources at runtime
+    - setuptools <82
+
+test:
+  imports:
+    - vaxrank
+    - vaxrank.manufacturability
+  commands:
+    - vaxrank --help
+
+about:
+  home: https://github.com/openvax/vaxrank
+  summary: Ranked vaccine peptides for personalized cancer immunotherapy
+  description: |
+    Vaxrank selects mutated peptides for therapeutic personalized cancer
+    vaccines, ranking candidates by a combination of predicted MHC binding
+    affinity, RNA expression support and manufacturability.
+  license: Apache-2.0
+  license_family: APACHE
+  license_file: LICENSE
+  dev_url: https://github.com/openvax/vaxrank
+
+extra:
+  recipe-maintainers:
+    - jonasscheid

--- a/recipes/vaxrank/meta.yaml
+++ b/recipes/vaxrank/meta.yaml
@@ -10,6 +10,7 @@ source:
   sha256: 0a287076eae0542a26fd0131848b230c803714de3ff5ba14d9add0e8d7c99be7
   patches:
     - drop-removed-jinja2-autoescape-extension.patch
+    - lazy-pdfkit-import.patch
 
 build:
   number: 0
@@ -36,7 +37,11 @@ requirements:
     - mhctools >=1.5.0
     - roman
     - jinja2
-    - pdfkit
+    # pdfkit is intentionally not a dependency: it is only used for the
+    # optional --output-pdf-report format and drives the wkhtmltopdf binary,
+    # which is not packaged for osx. It is imported lazily (see
+    # lazy-pdfkit-import.patch). Install conda-forge::python-pdfkit alongside
+    # vaxrank to enable PDF reports.
     - pypandoc
     - shellinford >=0.3.4
     - xlrd

--- a/recipes/vaxrank/meta.yaml
+++ b/recipes/vaxrank/meta.yaml
@@ -36,7 +36,7 @@ requirements:
     - mhctools >=1.5.0
     - roman
     - jinja2
-    - pdfkit
+    - python-pdfkit
     - pypandoc
     - shellinford >=0.3.4
     - xlrd


### PR DESCRIPTION
Adds `vaxrank` 1.4.0, which selects and ranks mutated peptides for personalized cancer vaccines.

Required by `pVACtools`, which uses `vaxrank.manufacturability` to compute manufacturability metrics.

All four dependencies are now merged and on the channel, so this is ready for review.

### Why 1.4.0 and not the latest (3.1.8)

`pVACtools` 7.0.1 declares `vaxrank>=1.1.0`, but every `vaxrank >= 1.7.0` requires `numpy>=2.0`, and 1.6.1 requires `pandas>=2.1.4`. Both conflict with pVACtools' own `numpy==1.26.4` / `pandas<2.1.0` pins. `vaxrank 1.4.0` is the newest version that is actually co-installable, and is also what pip's resolver selects for `pip install pvactools==7.0.1`.

### Patches

**`drop-removed-jinja2-autoescape-extension.patch`** removes `extensions=['jinja2.ext.autoescape']` from the report `Environment`. Jinja2 3.0 removed that extension — autoescaping became a core `Environment` keyword back in 2.9 — so `vaxrank --help` died on import with `AttributeError: module 'jinja2.ext' has no attribute 'autoescape'`. The call already passes `autoescape=False` explicitly, so dropping the extension is a no-op. Preferable to pinning `jinja2 <3`, which would drag `markupsafe <2.1` along with it.

**`lazy-pdfkit-import.patch`** moves `import pdfkit` from module scope into `make_pdf_report()`.

`pdfkit` now lives in conda-forge as `python-pdfkit`, which requires the `wkhtmltopdf` binary. `wkhtmltopdf` has no osx build:

```
$ CONDA_SUBDIR=osx-64 mamba create --dry-run -c conda-forge -c bioconda python-pdfkit
  - nothing provides wkhtmltopdf needed by python-pdfkit-0.6.1-py_0
```

Since `vaxrank` is `noarch`, a hard dependency on `python-pdfkit` would make it uninstallable on osx while enabling nothing there (PDF rendering was never possible on osx). `pdfkit` is used in exactly one function, backing the optional `--output-pdf-report` flag — one of four output formats. The lazy import mirrors how upstream already handles the adjacent `xvfbwrapper` import. Users who want PDF reports install `conda-forge::python-pdfkit`, as documented in the recipe.

`setuptools <82` is an explicit run dependency because `vaxrank.cli` imports `pkg_resources` at module level.

### Test plan
- [x] Builds locally with `conda-build`
- [x] `import vaxrank`, `import vaxrank.manufacturability`, `vaxrank --help` all succeed
- [x] Verified in an environment with `pdfkit` absent: `vaxrank.report` imports, `make_pdf_report()` raises `ImportError` only when called, manufacturability scoring returns correct values
- [ ] Bioconda CI

---

### Dependency chain (pVACtools)

This PR is one of a set adding [pVACtools](https://github.com/griffithlab/pVACtools) to bioconda.

| # | PR | Recipe | Status |
|---|----|--------|--------|
| 1 | #67034 | `shellinford` 0.4.1 | merged |
| 2 | #67035 | `mhctools` 1.9.0 | merged |
| 3 | #67036 | `isovar` 1.4.24 | merged |
| 4 | #67038 | `mhcnuggets` 2.4.1 build 1 | merged |
| 5 | #67039 | `vaxrank` 1.4.0 | needs 1–4 |
| 6 | #67040 | `pvactools` 7.0.1 | needs 4–5 |

#67037 (`pdfkit`) was closed: pdfkit lives in conda-forge as `python-pdfkit`. `vaxrank` now imports it lazily instead of depending on it — see #67039.
