### PR TITLE
Add spoars 0.1.3

### DIFF
--- a/recipes/spoars/build.sh
+++ b/recipes/spoars/build.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -euo pipefail
+
+export RUST_BACKTRACE=1
+
+# Capture the verbatim license text of every Cargo dependency into a bundle that
+# ships with the package (see meta.yaml license_file).
+cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
+
+# --locked builds from the committed Cargo.lock for a reproducible dependency
+# graph; --no-track skips writing the install receipt into ${PREFIX}. The
+# default `cli` feature is enabled, which pulls needletail's vendored C
+# compression (zstd/lzma); it is compiled statically into the binary by ${CC},
+# so no host libraries are required.
+cargo install --no-track --locked --verbose --root "${PREFIX}" --path .

--- a/recipes/spoars/meta.yaml
+++ b/recipes/spoars/meta.yaml
@@ -1,0 +1,57 @@
+{% set name = "spoars" %}
+{% set version = "0.1.3" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/fg-labs/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: c720b2c23897872812c3b0196698edfb48bf02c1d950ad05ecd30eff92c86978
+
+build:
+  number: 0
+  run_exports:
+    # 0.x: the CLI/behaviour is not yet stable, so pin downstream consumers to
+    # the minor version.
+    - {{ pin_subpackage("spoars", max_pin="x.x") }}
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ stdlib('c') }}
+    - {{ compiler('rust') }}
+    - cargo-bundle-licenses
+
+test:
+  commands:
+    - spoars --help
+
+about:
+  home: https://github.com/fg-labs/spoars
+  license: MIT
+  license_family: MIT
+  license_file:
+    - LICENSE
+    # Attribution for the upstream spoa algorithm/library that spoars
+    # reimplements. spoars ships no spoa source and does not link it (see the
+    # file itself); carried for provenance.
+    - THIRD-PARTY.md
+    # Verbatim license text of the Rust crate closure, generated at build time
+    # by cargo-bundle-licenses (see build.sh).
+    - THIRDPARTY.yml
+  summary: Faithful native-Rust reimplementation of the spoa partial order alignment library
+  description: |
+    spoars is a memory-safe, SIMD-accelerated native-Rust reimplementation of
+    the C++ spoa (partial order alignment) library. It produces bit-identical
+    consensus, multiple-sequence-alignment, and alignment output across SSE4.1 /
+    AVX2 / NEON via runtime CPU dispatch.
+  dev_url: https://github.com/fg-labs/spoars
+  doc_url: https://github.com/fg-labs/spoars/blob/v{{ version }}/README.md
+
+extra:
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64
+  recipe-maintainers:
+    - nh13


### PR DESCRIPTION
Adds a recipe for **spoars** — a faithful, memory-safe, SIMD-accelerated native-Rust reimplementation of the C++ [spoa](https://github.com/rvaser/spoa) partial order alignment library. It produces bit-identical consensus / MSA / alignment output across SSE4.1 / AVX2 / NEON via runtime CPU dispatch.

- Upstream: https://github.com/fg-labs/spoars (v0.1.3, MIT)
- Rust CLI built with `cargo install --locked --no-track`; third-party crate licenses bundled via `cargo-bundle-licenses` into `THIRDPARTY.yml` (listed in `license_file` alongside `LICENSE`).
- The Python bindings are submitted separately as `pyspoars`.