### PR TITLE
Add pyspoars 0.1.3

### DIFF
--- a/recipes/pyspoars/build.sh
+++ b/recipes/pyspoars/build.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+# spoars-py is the pyo3/maturin package. It is a member of the spoars workspace
+# and depends on the parent `spoars` crate by path, so build from within its
+# subdirectory of the source tree.
+cd spoars-py
+
+# The extension is built abi3 (pyo3 abi3-py310). Allow building the abi3 wheel
+# with a Python interpreter newer than the abi3 floor across the bioconda matrix.
+export PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1
+
+# Build the cargo dependency graph from the committed (workspace) Cargo.lock
+# (--locked) so the wheel pins the exact crate versions the project tests
+# against. pip (PEP 517) forwards this to maturin via MATURIN_PEP517_ARGS.
+export MATURIN_PEP517_ARGS="--locked"
+
+${PYTHON} -m pip install . --no-deps --no-build-isolation -vv
+
+# Capture the verbatim license text of every Cargo dependency into a bundle that
+# ships with the package (see meta.yaml license_file). Run after the build so
+# the crate sources are already fetched into CARGO_HOME.
+cargo-bundle-licenses --format yaml --output THIRDPARTY.yml

--- a/recipes/pyspoars/build.sh
+++ b/recipes/pyspoars/build.sh
@@ -2,6 +2,23 @@
 
 set -euxo pipefail
 
+# conda-build post-processes the maturin-built Rust extension by calling
+# `otool -l` on it to rewrite rpaths; conda-forge's cctools/llvm otool crashes
+# (SIGABRT) parsing the Mach-O headers of Rust .so files. Swap in the system
+# Xcode otool/install_name_tool, which parse them correctly. macOS only.
+# See https://github.com/conda/conda-build/issues/4392#issuecomment-1370281802
+if [[ "${target_platform:-}" == osx-* ]]; then
+  for toolname in otool install_name_tool; do
+    sys_tool="$(xcrun --find "${toolname}" 2>/dev/null || echo "/Library/Developer/CommandLineTools/usr/bin/${toolname}")"
+    for tool in "${BUILD_PREFIX}/bin/"*apple*-"${toolname}" "${BUILD_PREFIX}/bin/llvm-${toolname}"; do
+      if [[ -f "${tool}" && ! -e "${tool}.bak" ]]; then
+        mv "${tool}" "${tool}.bak"
+        ln -sf "${sys_tool}" "${tool}"
+      fi
+    done
+  done
+fi
+
 # spoars-py is the pyo3/maturin package. It is a member of the spoars workspace
 # and depends on the parent `spoars` crate by path, so build from within its
 # subdirectory of the source tree.

--- a/recipes/pyspoars/meta.yaml
+++ b/recipes/pyspoars/meta.yaml
@@ -1,0 +1,76 @@
+{% set name = "pyspoars" %}
+{% set version = "0.1.3" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  # Full-repo tarball: the Python package (spoars-py) is a member of the spoars
+  # workspace and depends on the parent `spoars` crate by path, so a maturin
+  # sdist of spoars-py alone would miss it. Build from the release source
+  # archive of the whole repository instead.
+  url: https://github.com/fg-labs/spoars/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: c720b2c23897872812c3b0196698edfb48bf02c1d950ad05ecd30eff92c86978
+
+build:
+  number: 0
+  run_exports:
+    # 0.x: API is not yet stable, so pin downstream consumers to the minor.
+    - {{ pin_subpackage('pyspoars', max_pin="x.x") }}
+  skip: True  # [py < 310]
+  # Build steps live in build.sh (bioconda is unix-only). spoars-py depends on
+  # the parent `spoars` crate by path, so the build cds into it.
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ stdlib('c') }}
+    - {{ compiler('rust') }}
+    # Bundles the verbatim license text of the Rust crate dependencies (see
+    # build.sh and the THIRDPARTY.yml entry in license_file below).
+    - cargo-bundle-licenses
+  host:
+    - python
+    - pip
+    - maturin >=1.5,<2
+  run:
+    - python
+
+test:
+  imports:
+    - spoars
+  requires:
+    - pip
+  commands:
+    - pip check
+    # Exercise the compiled pyo3 extension, not just the import machinery.
+    - python -c "import spoars; g = spoars.poa(['ACGTACGT', 'ACGTTCGT', 'ACGTACGT']); assert g.consensus() == 'ACGTACGT'"
+
+about:
+  home: https://github.com/fg-labs/spoars
+  license: MIT
+  license_family: MIT
+  license_file:
+    - LICENSE
+    # Attribution for the upstream spoa algorithm/library that spoars
+    # reimplements (no spoa source is shipped or linked; carried for provenance).
+    - THIRD-PARTY.md
+    # Verbatim license text of the Rust crate closure, generated at build time
+    # by cargo-bundle-licenses (see build.sh).
+    - spoars-py/THIRDPARTY.yml
+  summary: Python bindings for spoars — partial order alignment consensus and MSA
+  description: |
+    Python bindings for spoars, a memory-safe, SIMD-accelerated native-Rust
+    reimplementation of the C++ spoa partial order alignment library. Provides
+    consensus, multiple sequence alignment, and GFA/DOT graph output from a
+    simple `poa()` convenience call or an incremental `Poa` builder.
+  dev_url: https://github.com/fg-labs/spoars
+  doc_url: https://github.com/fg-labs/spoars/blob/v{{ version }}/spoars-py/README.md
+
+extra:
+  recipe-maintainers:
+    - nh13
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64


### PR DESCRIPTION
Adds a recipe for **pyspoars** — the Python bindings for [spoars](https://github.com/fg-labs/spoars), a memory-safe, SIMD-accelerated native-Rust reimplementation of the C++ spoa partial order alignment library. Provides consensus, MSA, and GFA/DOT graph output.

- Upstream: https://github.com/fg-labs/spoars (v0.1.3, MIT)
- Built with maturin/pyo3 (abi3); imports as `spoars` (the standalone CLI is submitted separately as `spoars`, mirroring the `spoa`/`pyspoa` split).
- Third-party crate licenses bundled via `cargo-bundle-licenses` into `THIRDPARTY.yml`.