### PR TITLE
Add python-ferro-hgvs 0.7.1

### DIFF
--- a/recipes/python-ferro-hgvs/build.sh
+++ b/recipes/python-ferro-hgvs/build.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+# The extension is built abi3 (pyo3 abi3-py310). Allow building the abi3 wheel
+# with a Python interpreter newer than the abi3 floor across the bioconda matrix.
+export PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1
+
+# Build the cargo dependency graph from the sdist's committed Cargo.lock
+# (--locked) so the wheel pins the exact crate versions upstream tests against.
+# pip (PEP 517) forwards this to maturin via MATURIN_PEP517_ARGS. The maturin
+# feature set (`python`) is declared in pyproject.toml [tool.maturin] and needs
+# no extra system libraries (pyo3 only).
+export MATURIN_PEP517_ARGS="--locked"
+
+${PYTHON} -m pip install . --no-deps --no-build-isolation -vv
+
+# Capture the verbatim license text of every Cargo dependency into a bundle that
+# ships with the package (see meta.yaml license_file). Run after the build so
+# the crate sources are already fetched into CARGO_HOME.
+cargo-bundle-licenses --format yaml --output THIRDPARTY.yml

--- a/recipes/python-ferro-hgvs/meta.yaml
+++ b/recipes/python-ferro-hgvs/meta.yaml
@@ -1,0 +1,67 @@
+{% set name = "python-ferro-hgvs" %}
+{% set version = "0.7.1" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  # maturin sdist from PyPI (contains the full Rust source + pyproject). The
+  # standalone Rust CLI is packaged separately on bioconda as `ferro-hgvs`.
+  url: https://pypi.org/packages/source/f/ferro-hgvs/ferro_hgvs-{{ version }}.tar.gz
+  sha256: 71c6fbca26028b73ace5ac906e9c1799c0c5038197ca0c2c27f7687b5225b081
+
+build:
+  number: 0
+  run_exports:
+    # 0.x: API is not yet stable, so pin downstream consumers to the minor.
+    - {{ pin_subpackage('python-ferro-hgvs', max_pin="x.x") }}
+  skip: True  # [py < 310]
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ stdlib('c') }}
+    - {{ compiler('rust') }}
+    # Bundles the verbatim license text of the Rust crate dependencies (see
+    # build.sh and the THIRDPARTY.yml entry in license_file below).
+    - cargo-bundle-licenses
+  host:
+    - python
+    - pip
+    - maturin >=1.5,<2
+  run:
+    - python
+
+test:
+  imports:
+    - ferro_hgvs
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/fulcrumgenomics/ferro-hgvs
+  license: MIT
+  license_family: MIT
+  license_file:
+    - LICENSE
+    # Verbatim license text of the Rust crate closure, generated at build time
+    # by cargo-bundle-licenses (see build.sh).
+    - THIRDPARTY.yml
+  summary: Python bindings for ferro-hgvs — an HGVS variant parser and normalizer
+  description: |
+    Python bindings for ferro-hgvs, a fast HGVS (Human Genome Variation Society)
+    sequence-variant parser and normalizer written in Rust. The standalone
+    command-line tool is available on bioconda as `ferro-hgvs`.
+  dev_url: https://github.com/fulcrumgenomics/ferro-hgvs
+  doc_url: https://github.com/fulcrumgenomics/ferro-hgvs/blob/v{{ version }}/README.md
+
+extra:
+  recipe-maintainers:
+    - nh13
+    - tfenne
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64


### PR DESCRIPTION
Adds a recipe for **python-ferro-hgvs** — the Python bindings for [ferro-hgvs](https://github.com/fulcrumgenomics/ferro-hgvs), a fast HGVS sequence-variant parser and normalizer written in Rust.

- Upstream: https://github.com/fulcrumgenomics/ferro-hgvs (v0.7.1, MIT)
- Built from the PyPI maturin sdist; imports as `ferro_hgvs`. The standalone Rust CLI already exists on bioconda as `ferro-hgvs`; this packages the Python extension separately.
- Third-party crate licenses bundled via `cargo-bundle-licenses` into `THIRDPARTY.yml`.