### PR TITLE
Update python-minibwa to 0.1.3

### DIFF
--- a/recipes/python-minibwa/meta.yaml
+++ b/recipes/python-minibwa/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "python-minibwa" %}
-{% set version = "0.1.0" %}
+{% set version = "0.1.3" %}
 
 package:
   name: {{ name }}
@@ -11,10 +11,10 @@ source:
   # minibwa C source. A maturin sdist of minibwa-py alone would miss those, so
   # the recipe builds from the release source archive of the whole workspace.
   url: https://github.com/fg-labs/minibwa-bindings/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 6d506c604b7f81ee05e4aae8c666b609f99868f437119fc0fad61bb216f5edf3
+  sha256: 4310e6ef5443ad73794874e6a4943458490216f3871a66c8678a85dff60353cf
 
 build:
-  number: 1
+  number: 0
   run_exports:
     # 0.x: API is not yet stable, so pin downstream consumers to the minor.
     - {{ pin_subpackage('python-minibwa', max_pin="x.x") }}


### PR DESCRIPTION
Bumps **python-minibwa** 0.1.0 → 0.1.3 (version + sha256; build number reset to 0).

Upstream [fg-labs/minibwa-bindings](https://github.com/fg-labs/minibwa-bindings) v0.1.3 brings `minibwa-py` into the workspace so its version tracks the crate in lockstep — this is the first release to actually publish the wheel to PyPI. `build.sh` and the vendored-license files are unchanged and remain valid against the new tarball.