### PR TITLE
Add cellpheno-nis

### DIFF
--- a/recipes/cellpheno-nis/build.sh
+++ b/recipes/cellpheno-nis/build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euo pipefail
+
+# Build the NIS C++/LibTorch/OpenCV/CUDA executable against the conda environment.
+# find_package(Torch)/find_package(OpenCV) resolve from $PREFIX via CMAKE_PREFIX_PATH.
+cd cpp
+mkdir -p build && cd build
+cmake .. \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_PREFIX_PATH="${PREFIX}" \
+    -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+    -DCMAKE_CUDA_COMPILER="${CUDA_HOME:-${PREFIX}}/bin/nvcc"
+cmake --build . -j "${CPU_COUNT:-2}"
+
+# Upstream names the binary `main`; install under an unambiguous name so it can
+# live on the global PATH.
+install -d "${PREFIX}/bin"
+install -m 0755 main "${PREFIX}/bin/cellpheno-nis"

--- a/recipes/cellpheno-nis/conda_build_config.yaml
+++ b/recipes/cellpheno-nis/conda_build_config.yaml
@@ -1,5 +1,0 @@
-# CUDA version to build the CUDA-enabled libtorch link against. Locally validated with
-# 12.9; when submitting to bioconda, align this with a cuda-version their CI supports
-# (their global pinning / CUDA migration).
-cuda_version:
-  - "12.9"

--- a/recipes/cellpheno-nis/conda_build_config.yaml
+++ b/recipes/cellpheno-nis/conda_build_config.yaml
@@ -1,0 +1,7 @@
+# Select the CUDA compiler for {{ compiler('cuda') }}. Without cuda_compiler_version
+# defined, the jinja renders as "None" and dependency parsing fails. 12.9 matches a
+# conda-forge libtorch CUDA variant (cuda129) validated locally.
+cuda_compiler:
+  - cuda-nvcc
+cuda_compiler_version:
+  - "12.9"

--- a/recipes/cellpheno-nis/conda_build_config.yaml
+++ b/recipes/cellpheno-nis/conda_build_config.yaml
@@ -1,0 +1,5 @@
+# CUDA version to build the CUDA-enabled libtorch link against. Locally validated with
+# 12.9; when submitting to bioconda, align this with a cuda-version their CI supports
+# (their global pinning / CUDA migration).
+cuda_version:
+  - "12.9"

--- a/recipes/cellpheno-nis/meta.yaml
+++ b/recipes/cellpheno-nis/meta.yaml
@@ -19,6 +19,7 @@ build:
 requirements:
   build:
     - {{ compiler('cxx') }}
+    - {{ stdlib('c') }}
     # CUDA-enabled libtorch's CMake config (Caffe2) calls enable_language(CUDA) and
     # needs nvcc even though NIS has no custom .cu kernels.
     - {{ compiler('cuda') }}

--- a/recipes/cellpheno-nis/meta.yaml
+++ b/recipes/cellpheno-nis/meta.yaml
@@ -26,9 +26,9 @@ requirements:
     - cmake >=3.18
     - make
   host:
-    - cuda-version {{ cuda_version }}
     # libtorch provides the C++ LibTorch libs + the Torch/Caffe2 CMake config that
-    # cpp/CMakeLists.txt resolves via CMAKE_PREFIX_PATH=$PREFIX.
+    # cpp/CMakeLists.txt resolves via CMAKE_PREFIX_PATH=$PREFIX. The CUDA version is
+    # taken from the CUDA-enabled libtorch variant + {{ compiler('cuda') }} pinning.
     - libtorch
     - libopencv
     # libtorch_cuda.so references NCCL symbols (e.g. ncclAlltoAll) at link time.

--- a/recipes/cellpheno-nis/meta.yaml
+++ b/recipes/cellpheno-nis/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "cellpheno-nis" %}
-{% set version = "1.0.2" %}
+{% set version = "1.0.3" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/Chrisa142857/Lightsheet_microscopy_image_3D_nuclei_instance_segmentation/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 17256f15241c1e68479bd1d02475df142a41c6c2e3e302ddcfbbcd0441c46e74
+  sha256: 031a8bb96e3171abb277e7b5fb81f3f77691c30a55c83f3d1cacd8bdf1381a39
 
 build:
   number: 0

--- a/recipes/cellpheno-nis/meta.yaml
+++ b/recipes/cellpheno-nis/meta.yaml
@@ -1,0 +1,54 @@
+{% set name = "cellpheno-nis" %}
+{% set version = "1.0.1" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/Chrisa142857/Lightsheet_microscopy_image_3D_nuclei_instance_segmentation/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 3dd18c3acb5f69064c74480edc07068c200e4645582693eee02a3db2a5765e86
+
+build:
+  number: 0
+  # Linux/GPU only: the tool links CUDA-enabled LibTorch and has no macOS/Windows target.
+  skip: True  # [not linux]
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x.x") }}
+
+requirements:
+  build:
+    - {{ compiler('cxx') }}
+    # CUDA-enabled libtorch's CMake config (Caffe2) calls enable_language(CUDA) and
+    # needs nvcc even though NIS has no custom .cu kernels.
+    - {{ compiler('cuda') }}
+    - cmake >=3.18
+    - make
+  host:
+    - cuda-version {{ cuda_version }}
+    # libtorch provides the C++ LibTorch libs + the Torch/Caffe2 CMake config that
+    # cpp/CMakeLists.txt resolves via CMAKE_PREFIX_PATH=$PREFIX.
+    - libtorch
+    - libopencv
+    # libtorch_cuda.so references NCCL symbols (e.g. ncclAlltoAll) at link time.
+    - nccl
+  run:
+    - libtorch
+    - libopencv
+
+test:
+  commands:
+    # Installed as `cellpheno-nis` (upstream binary is generically named `main`,
+    # which must not go on the global PATH).
+    - cellpheno-nis --help
+
+about:
+  home: https://github.com/Chrisa142857/Lightsheet_microscopy_image_3D_nuclei_instance_segmentation
+  license: MIT
+  license_file: LICENSE
+  summary: Whole-brain 3D nuclei instance segmentation for light-sheet microscopy (C++/LibTorch/CUDA)
+  dev_url: https://github.com/Chrisa142857/Lightsheet_microscopy_image_3D_nuclei_instance_segmentation
+
+extra:
+  recipe-maintainers:
+    - Chrisa142857

--- a/recipes/cellpheno-nis/meta.yaml
+++ b/recipes/cellpheno-nis/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "cellpheno-nis" %}
-{% set version = "1.0.1" %}
+{% set version = "1.0.2" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/Chrisa142857/Lightsheet_microscopy_image_3D_nuclei_instance_segmentation/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 3dd18c3acb5f69064c74480edc07068c200e4645582693eee02a3db2a5765e86
+  sha256: 17256f15241c1e68479bd1d02475df142a41c6c2e3e302ddcfbbcd0441c46e74
 
 build:
   number: 0


### PR DESCRIPTION
Adds `cellpheno-nis` — a C++/LibTorch/CUDA executable for whole-brain 3D nuclei **instance** segmentation of light-sheet microscopy (LSFM).

- **Upstream:** https://github.com/Chrisa142857/Lightsheet_microscopy_image_3D_nuclei_instance_segmentation (I'm the author)
- **Source:** pinned to the `v1.0.1` release tarball + sha256
- **License:** MIT

### Notes for reviewers
This is a **GPU / CUDA** package (like a few existing pytorch-dependent recipes):

- It builds a C++ binary that links CUDA-enabled `libtorch` + `libopencv`. It has **no custom `.cu` kernels**, but CUDA-enabled libtorch's CMake config (`Caffe2Config`) calls `enable_language(CUDA)`, so the recipe needs `{{ compiler('cuda') }}`.
- `libtorch_cuda.so` references NCCL symbols, so `nccl` is a host dependency.
- The upstream binary is generically named `main`; `build.sh` installs it as `cellpheno-nis` so it doesn't collide on PATH.
- `conda_build_config.yaml` pins a CUDA version — happy to align it with whatever your CUDA CI/pinning expects; guidance welcome.
- I locally confirmed the sources compile cleanly against conda-forge `libtorch` 2.12.

This will back an nf-core module (nf-core/modules#12179); a reviewer there suggested publishing on bioconda rather than shipping a build-from-source Dockerfile.

##### Please edit this to add/remove reviewers/labels as needed. Thanks for reviewing!