### PR TITLE
Update `last` version from 1651 to 1652

### DIFF
--- a/recipes/last/build.sh
+++ b/recipes/last/build.sh
@@ -4,6 +4,14 @@ export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib"
 export CPPFLAGS="${CPPFLAGS} -I${PREFIX}/include"
 export CXXFLAGS="${CXXFLAGS} -O3 -pthread -I${PREFIX}/include"
 
+# macOS specific flags to prevent compilation conflicts
+if [[ `uname -s` == "Darwin" ]]; then
+    export MACOSX_DEPLOYMENT_TARGET=11.3
+    export MACOSX_SDK_VERSION=11.3
+    export CFLAGS="${CFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
+    export CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
+fi
+
 ARCH=$(uname -m)
 
 case ${ARCH} in

--- a/recipes/last/meta.yaml
+++ b/recipes/last/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "LAST" %}
-{% set version = "1651" %}
+{% set version = "1652" %}
 
 package:
   name: {{ name|lower }}

--- a/recipes/last/meta.yaml
+++ b/recipes/last/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://gitlab.com/mcfrith/last/-/archive/{{ version }}/last-{{ version }}.tar.gz
-  sha256: 788b362a83214958cb3b64376e524efbbc45faf03ea098a7c5b90df6e8f54531
+  sha256: cd21b0124e9d1594ac13b7e5a7325e23bd48009ed36dca34493b583e4d46f060
 
 build:
   number: 0


### PR DESCRIPTION
This is a minor update fixes the `blasttab+` output format in `maf-convert` when the input was produced with `last-split`.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
