### PR TITLE
Rebuild ms2rescore-rs for Python 3.13

### DIFF
--- a/recipes/ms2rescore-rs/meta.yaml
+++ b/recipes/ms2rescore-rs/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   skip: True  # [py < 37 or (osx and x86_64)]
   run_exports:
     - {{ pin_subpackage(name|lower, max_pin="x.x") }}

--- a/recipes/ms2rescore-rs/meta.yaml
+++ b/recipes/ms2rescore-rs/meta.yaml
@@ -19,6 +19,7 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
+    - {{ stdlib('c') }}
     - {{ compiler('cxx') }}
     - {{ compiler('rust') }}
     - make


### PR DESCRIPTION
Rebuilds `ms2rescore-rs` 0.4.3 so that Python 3.13 artifacts are published.

### Why

`ms2rescore-rs` was last built on 2025-09-30 and exists only for py38–py312 — there is no py313 build on any subdir:

```
conda create --dry-run -c conda-forge -c bioconda python=3.13 ms2rescore-rs
  -> LibMambaUnsatisfiableError
conda create --dry-run -c conda-forge -c bioconda python=3.12 ms2rescore-rs
  -> ok (0.4.3)
```

This blocks #61768 (`ms2pip` 4.1.2), which run-depends on `ms2rescore-rs >=0.4,<2`. Because that is a *run* dependency, the compile succeeds and the failure surfaces in conda-build's `_test_env` solve. @RalfG already identified this in https://github.com/bioconda/bioconda-recipes/pull/61768#issuecomment-3816802489.

Upstream already publishes `cp313` wheels for 0.4.3, and the recipe's only skip is `py < 37 or (osx and x86_64)`, so a build-number bump is all that's required to produce the missing artifacts.

### Changes

* `build.number: 0 -> 1` — publish py313 artifacts.
* Add `{{ stdlib('c') }}` — required by the `compiler_needs_stdlib_c` lint, which this recipe did not previously satisfy (it only surfaces once the recipe is touched).

### Verified locally

Built in `quay.io/bioconda/bioconda-utils-build-env-cos7:latest` (linux-64), using bioconda's own `conda_build_config.yaml`:

```
conda build --python 3.13 -m bioconda_utils-conda_build_config.yaml recipes/ms2rescore-rs
  -> ms2rescore-rs-0.4.3-py313h9b6b6b8_1.conda   (import ms2rescore_rs + pip check pass)
conda build --python 3.12 recipes/ms2rescore-rs
  -> ms2rescore-rs-0.4.3-py312h3fd9d12_1.conda   (import ms2rescore_rs + pip check pass)
```

### Follow-up

A subsequent PR will update `ms2pip` to 4.1.2 (superseding #61768). Beyond the missing py313 artifact, #61768 needs two further fixes, both verified locally:

1. It changes `- python` to `- python >=3.10,<4` in `host`/`run`. For a compiled package this suppresses conda-build's python variant, so `--python 3.12` and `--python 3.13` both produce `ms2pip-4.1.2-py314...`. The `>=3.10` floor is better expressed as `skip: True  # [py < 310]`.
2. `requirements: host:` is missing `setuptools`, which ms2pip's `pyproject.toml` declares as a PEP 517 backend requirement. On py313 the build fails with `BackendUnavailable: Cannot import 'setuptools.build_meta'`.

Landing `ms2pip` 4.1.2 matters downstream: 4.1.0 constrains `sqlalchemy <2`, while `ms2rescore >=3.2.0` requires `sqlalchemy >=2`. The solver escapes that only via the older `ms2pip 4.1.0` build `_0`, which pins `numpy <2` and `pandas <2` — dragging the whole ms2rescore stack to numpy 1.26 / pandas 1.5.3 / py311, and therefore to `pyopenms 3.3.0` (since `pyopenms >=3.4` requires `numpy >=2.0`). Upstream fixed this in ms2pip 4.1.1 (CompOmics/ms2pip#249).
