### PR TITLE
Update ms2pip to 4.1.2

### DIFF
--- a/recipes/ms2pip/meta.yaml
+++ b/recipes/ms2pip/meta.yaml
@@ -69,5 +69,9 @@ extra:
     - CompOmics
     - RalfG
   additional-platforms:
-    - linux-aarch64
+    # linux-aarch64 temporarily dropped: on aarch64, importing xgboost in a clean
+    # environment fails with "libgomp.so.1: cannot allocate memory in static TLS
+    # block". The same libxgboost 2.1.4 / pyarrow 24 / libgomp 15.2.0 versions are
+    # resolved on linux-64, where the import succeeds, so this is an aarch64-specific
+    # dependency issue rather than an ms2pip problem. Restore once it is fixed upstream.
     - osx-arm64

--- a/recipes/ms2pip/meta.yaml
+++ b/recipes/ms2pip/meta.yaml
@@ -1,6 +1,6 @@
-{% set version = "4.1.0" %}
+{% set version = "4.1.2" %}
 {% set name = "ms2pip" %}
-{% set sha256 = "0bf6a2161c28bf99b0c25945f524b1373e0b8d8f53f526ff3d134a68bef2c84f" %}
+{% set sha256 = "beadaf4a703d99885ea49d7b2411752c2a4d7f5abf266878ed254c22b869b015" %}
 
 package:
   name: "{{ name|lower }}"
@@ -11,8 +11,8 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 2
-  skip: True  # [osx and x86_64]
+  number: 0
+  skip: True  # [(osx and x86_64) or py < 310]
   run_exports:
     - {{ pin_subpackage(name, max_pin="x.x") }}
   entry_points:
@@ -29,6 +29,7 @@ requirements:
     - cython
     - numpy >=2.0
     - pip
+    - setuptools
     - python
   run:
     - python
@@ -37,7 +38,7 @@ requirements:
     - pyarrow
     - pyteomics >=3.5,<5
     - tomlkit >=0.5,<1
-    - sqlalchemy >=1.3,<2
+    - sqlalchemy >=1.4,<3
     - click >=7,<9
     - xgboost >=1.3,<3
     - lxml >=4

--- a/recipes/ms2pip/meta.yaml
+++ b/recipes/ms2pip/meta.yaml
@@ -69,9 +69,4 @@ extra:
     - CompOmics
     - RalfG
   additional-platforms:
-    # linux-aarch64 temporarily dropped: on aarch64, importing xgboost in a clean
-    # environment fails with "libgomp.so.1: cannot allocate memory in static TLS
-    # block". The same libxgboost 2.1.4 / pyarrow 24 / libgomp 15.2.0 versions are
-    # resolved on linux-64, where the import succeeds, so this is an aarch64-specific
-    # dependency issue rather than an ms2pip problem. Restore once it is fixed upstream.
     - osx-arm64

--- a/recipes/ms2pip/meta.yaml
+++ b/recipes/ms2pip/meta.yaml
@@ -25,6 +25,7 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
+    - {{ stdlib('c') }}
   host:
     - cython
     - numpy >=2.0


### PR DESCRIPTION
Updates `ms2pip` 4.1.0 → 4.1.2. Supersedes #61768.

`ms2pip 4.1.0` pins `sqlalchemy <2`, which conflicts with `ms2rescore >=3.2` (`sqlalchemy >=2`) and forces the numpy-1 build of ms2pip, dragging the whole stack down to `pyopenms 3.3.0`. Upstream relaxed this in 4.1.1 (CompOmics/ms2pip#249).

Beyond #61768, this needed:
- py313 `ms2rescore-rs`, added in #67073 (merged);
- `setuptools` in `host` (PEP 517 backend, else py313 fails with `Cannot import 'setuptools.build_meta'`);
- keep `- python` unpinned (an explicit spec suppresses the python variant → everything builds `py314`); floor via `skip: # [py < 310]`;
- `{{ stdlib('c') }}` for the `compiler_needs_stdlib_c` lint;
- `sqlalchemy >=1.4,<3` to match upstream.

`linux-aarch64` dropped: importing xgboost there fails with `libgomp.so.1: cannot allocate memory in static TLS block` (aarch64 dependency issue, not this recipe). `osx-arm64` retained.

Verified locally on py312/py313. sha256 checked against PyPI.
