### PR TITLE
Add m6aformer 0.1.2

### DIFF
--- a/recipes/m6aformer/meta.yaml
+++ b/recipes/m6aformer/meta.yaml
@@ -15,6 +15,8 @@ build:
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:
     - m6aformer = m6aformer.cli:app
+  run_exports:
+    - {{ pin_subpackage(name|lower, max_pin="x.x") }}
 
 requirements:
   host:

--- a/recipes/m6aformer/meta.yaml
+++ b/recipes/m6aformer/meta.yaml
@@ -1,0 +1,65 @@
+{% set name = "m6aformer" %}
+{% set version = "0.1.2" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/m/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 7d886315e75edfed5beeaff9c87916accdf63fc2a348c9bed34664609391cf82
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  entry_points:
+    - m6aformer = m6aformer.cli:app
+
+requirements:
+  host:
+    - python >=3.10
+    - pip
+    - setuptools >=77.0.3
+    - wheel
+  run:
+    - python >=3.10
+    - numpy >=1.21
+    - pandas >=1.3
+    - pytorch >=2.0
+    - typer >=0.9
+    - rich >=13.0
+    - tqdm >=4.65
+    - requests >=2.28
+    - fastapi >=0.100
+    - uvicorn >=0.23
+    - jinja2 >=3.1
+    - python-multipart >=0.0.6
+    - matplotlib-base >=3.6
+
+test:
+  imports:
+    - m6aformer
+    - m6aformer.cli
+    - m6aformer.weights
+  commands:
+    - m6aformer --version
+    - python -c "from m6aformer.weights import list_available_models; models = list_available_models(); assert len(models) == 4; assert all(m.source == 'bundled' for m in models)"
+    - python -c "from m6aformer import M6AFormer; m = M6AFormer.from_pretrained('all_201', device='cpu', allow_download=False); assert m.window_size == 201"
+
+about:
+  home: https://github.com/zhixinniu/M6AFormer
+  summary: Deep learning toolkit for m6A site prediction.
+  description: |
+    M6AFormer is a Python toolkit for transcriptome-wide
+    N6-methyladenosine (m6A) site prediction using a hybrid CNN and
+    lightweight Transformer architecture. It provides a Python API, a CLI,
+    a local web UI, and bundled pretrained checkpoints.
+  license: MIT
+  license_file: LICENSE
+  doc_url: https://github.com/zhixinniu/M6AFormer#readme
+  dev_url: https://github.com/zhixinniu/M6AFormer
+
+extra:
+  recipe-maintainers:
+    - zhixinniu


### PR DESCRIPTION
This PR adds `m6aformer`, a Python toolkit for transcriptome-wide N6-methyladenosine (m6A) site prediction.

  M6AFormer provides a Python API, CLI, bundled pretrained checkpoints, and an optional local web UI for scoring candidate m6A sites from FASTA input. The package is directly relevant to epitranscriptomics and RNA modification analysis.

  Recipe notes:

  - New recipe for `m6aformer` version `0.1.2`
  - Pure Python package, marked as `noarch: python`
  - Source is the PyPI sdist with sha256 checksum
  - Includes bundled pretrained model weights from the upstream package
  - Tests cover package import, CLI version command, bundled model discovery, and loading a bundled checkpoint
  - Runtime dependencies include the CLI and local web UI stack

  I read the Bioconda recipe guidelines and checked that this package is relevant to biological sciences.
