### PR TITLE
Remove pip and setuptools from pyopenms run requirements

### DIFF
--- a/recipes/pyopenms/meta.yaml
+++ b/recipes/pyopenms/meta.yaml
@@ -18,7 +18,7 @@ source:
 {% endif %}
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage(name, max_pin="x") }}
 
@@ -50,8 +50,6 @@ requirements:
     - libopenms =={{ version }}
     - numpy >=2.0
     - pandas
-    - pip <25.3
-    - setuptools <81
     - matplotlib-base
 
 test:


### PR DESCRIPTION
Removes `pip` and `setuptools` from `pyopenms`'s **run** requirements so that 3.5.0 is selected by default again.

They are build-time deps only (pyopenms's Python code references none of `pip`/`setuptools`/`pkg_resources`, and it imports fine with both removed). As run deps with caps `<25.3`/`<81` they, together with the `libarrow =21` pin, force enough downgrades that solves prefer `pyopenms 3.4.1` over 3.5.0 (e.g. anything pulling in `ms2rescore`/`pyarrow`). The `host` caps are left untouched, so build behaviour is unchanged.

Verified locally (py3.12): builds green, `pip`/`setuptools` gone from `depends`, and the plain solve now picks 3.5.0 without downgrading them.

`libarrow =21` is left as-is: bumping it is unsolvable against `libopenms 3.5.0`'s `qt6-main` (krb5/icu/libxml2 conflicts) and would need a libopenms rebuild — separate concern, and not required here.
