### PR TITLE
Add unum-bio 0.1.1

### DIFF
--- a/recipes/unum-bio/build.sh
+++ b/recipes/unum-bio/build.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+# rust-htslib 1.0.1 forces the `bindgen` feature on hts-sys, which runs bindgen
+# at build time; point clang-sys at the conda libclang so it is found.
+export LIBCLANG_PATH="${BUILD_PREFIX}/lib"
+
+# hts-sys builds a bundled htslib from source and generates its FFI bindings
+# with bindgen; point the C preprocessor/linker and bindgen's clang at the conda
+# prefix so the bundled build finds the host libs (zlib, bzip2, xz, openssl,
+# libcurl) and headers.
+export CPPFLAGS="${CPPFLAGS} -I${PREFIX}/include"
+export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib"
+# flate2's zlib-ng backend (libz-ng-sys) compiles vendored C; modern clang makes
+# implicit function declarations an error, so relax that for the vendored build.
+export CFLAGS="${CFLAGS} -O3 -Wno-deprecated-declarations -Wno-implicit-function-declaration"
+export BINDGEN_EXTRA_CLANG_ARGS="${CPPFLAGS} ${CFLAGS} ${LDFLAGS}"
+
+# On macOS, undefined symbols (openssl/libcurl) are resolved at load time.
+if [[ "$(uname)" == "Darwin" ]]; then
+  export RUSTFLAGS="-C link-arg=-undefined -C link-arg=dynamic_lookup"
+fi
+
+# Bundle the verbatim license text of every Cargo dependency (bioconda
+# requirement for Rust recipes). Run before the build so it resolves the
+# workspace crate graph.
+cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
+
+# unum is a Cargo workspace; the binary lives in crates/unum. Build against the
+# committed Cargo.lock (--locked) so the pinned crate versions are used.
+export RUST_BACKTRACE=1
+cargo install --no-track --locked --verbose --path crates/unum --root "${PREFIX}"

--- a/recipes/unum-bio/meta.yaml
+++ b/recipes/unum-bio/meta.yaml
@@ -1,0 +1,75 @@
+{% set name = "unum-bio" %}
+{% set version = "0.1.1" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  # Upstream repo and the installed binary are both named `unum`; the conda
+  # package is `unum-bio` because `unum` is already taken on conda-forge.
+  url: https://github.com/fg-labs/unum/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: f926a183987307195801fb26ca2b0bf3db2e9916b8df8156181ee82b53374471
+
+build:
+  number: 0
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x.x") }}
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('rust') }}
+    - {{ stdlib("c") }}
+    # Bundles the verbatim license text of the Rust crate closure into
+    # THIRDPARTY.yml (see build.sh and the license_file entry below).
+    - cargo-bundle-licenses
+    - pkg-config
+    - make
+    # libz-ng-sys (flate2's zlib-ng backend) builds via cmake.
+    - cmake
+    # libclang for the bindgen step in hts-sys (rust-htslib). Pinned <22
+    # because hts-sys's bundled bindgen (0.69) does not support clang 22 yet.
+    - clangdev <22
+  host:
+    # hts-sys builds a bundled htslib from source, which links these.
+    - zlib
+    - bzip2
+    - xz
+    - openssl
+    - libcurl
+  run:
+    - openssl
+
+test:
+  commands:
+    - unum --version | grep {{ version }}
+    - unum --help
+
+about:
+  home: "https://github.com/fg-labs/unum"
+  license: MIT
+  license_family: MIT
+  license_file:
+    - LICENSE
+    # Verbatim license text of the Rust crate closure, generated at build time
+    # by cargo-bundle-licenses (see build.sh).
+    - THIRDPARTY.yml
+  summary: "e pluribus unum: a pure-Rust HLA/KIR genotyper (a port of T1K)."
+  description: |
+    unum is a pure-Rust HLA/KIR genotyper — a port of T1K that rebuilds its
+    k-mer-based genotyping pipeline (k-mer filtering, banded alignment, and EM
+    genotyping) in Rust with no C++ dependency. It provides subcommands to build
+    reference FASTAs from an IPD-IMGT/HLA or IPD-KIR database, extract candidate
+    reads from FASTQ or BAM/CRAM input, and call genotypes. Installs as the
+    `unum` command (the conda package is named `unum-bio` to avoid a name
+    collision with the unrelated `unum` package on conda-forge).
+  dev_url: "https://github.com/fg-labs/unum"
+  doc_url: "https://github.com/fg-labs/unum/blob/v{{ version }}/README.md"
+
+extra:
+  recipe-maintainers:
+    - nh13
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64


### PR DESCRIPTION
Adds a recipe for **unum** — a pure-Rust HLA/KIR genotyper, a port of [T1K](https://github.com/mourisl/T1K) that rebuilds its k-mer-based genotyping pipeline (k-mer filtering, banded alignment, EM genotyping) in Rust with no C++ dependency.

- Upstream: https://github.com/fg-labs/unum (v0.1.1, MIT)
- Cargo workspace; builds the `crates/unum` binary. `unum-core` uses `rust-htslib` (hts-sys builds a bundled htslib), so the recipe carries htslib's C deps (openssl/curl/zlib/bzip2/xz) + `clangdev` for bindgen — modeled on the `perbase` recipe.
- Third-party crate licenses bundled via `cargo-bundle-licenses` into `THIRDPARTY.yml`.
- Platforms: linux-64, osx-64, plus additional-platforms linux-aarch64 and osx-arm64.
