### PR TITLE
Update sra-human-scrubber for linux-64

### DIFF
--- a/recipes/sra-human-scrubber/meta.yaml
+++ b/recipes/sra-human-scrubber/meta.yaml
@@ -13,8 +13,10 @@ source:
       - fix_scrub_path.patch
 
 build:
-  number: 0
-  noarch: generic
+  number: 1
+  skip: true  # [not linux or not x86_64]
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x") }}
 
 requirements:
   run:
@@ -32,5 +34,7 @@ about:
   summary: An SRA tool identifies and removes any significant human read, and outputs the edited (cleaned) fastq file for SRA submission.
 
 extra:
+  skip-lints:
+    - should_be_noarch_generic  # Package contains bundled x86_64 binaries
   recipe-maintainers:
     - rpetit3


### PR DESCRIPTION
## Summary

- remove the incorrect `noarch: generic` classification
- build `sra-human-scrubber` only for Linux x86_64
- bump the 2.2.1 build number and add the currently required `run_exports`
- document why the bundled binary makes the noarch lint inapplicable

Upstream tag 2.2.1 bundles `bin/aligns_to` as an ELF64 x86-64 executable (`e_machine=62`), which explains the reported ARM `Exec format error`.

## Validation

- `git diff --check`
- rendered the recipe with Jinja expressions replaced by placeholders and parsed the resulting YAML
- verified the selector truth table: Linux x86_64 builds; Linux non-x86_64 and macOS targets skip
- preserved the existing `scrub.sh -h` package smoke test

A full `bioconda-utils` lint/build was not run locally because the current environment does not provide Conda or `bioconda-utils`; repository CI remains the authoritative build check.

## Published noarch builds

The channel currently still labels four historical noarch artifacts as `main` (versions 1.0.2021_05_05, 2.0.0, 2.1.0, and 2.2.1). Those artifacts also bundle the architecture-specific executable, so non-x86_64 solvers could fall back to them after this recipe fix.

@rpetit3, could those historical noarch artifacts also be moved to `broken` or removed from the `main` label as part of the maintainer follow-up?

Addresses #65077.

This patch was prepared with automated assistance and deterministically reviewed; the contributor remains responsible for the submitted change.
