### PR TITLE
Install rsem-generate-ngvector in rsem package

### DIFF
--- a/recipes/rsem/build.sh
+++ b/recipes/rsem/build.sh
@@ -40,7 +40,7 @@ for n in ${PREFIX}/bin/rsem-*; do
 	mv -v "$n" perl-build
     fi
 done
-mv rsem-control-fdr rsem-run-ebseq perl-build
+mv rsem-control-fdr rsem-generate-ngvector rsem-run-ebseq perl-build
 cp -rf ${RECIPE_DIR}/Build.PL perl-build
 cd perl-build
 # now run perl install

--- a/recipes/rsem/meta.yaml
+++ b/recipes/rsem/meta.yaml
@@ -13,7 +13,7 @@ source:
     - 02_fix_makefile.patch  # de-vendor samtools and allow overriding *FLAGS
 
 build:
-  number: 12
+  number: 13
   rpaths:
     - lib/R/lib/
     - lib/
@@ -44,6 +44,7 @@ test:
     - rsem-prepare-reference 2>&1 | grep reference_name > /dev/null
     - rsem-for-ebseq-find-DE 2>&1 | grep Usage > /dev/null
     - rsem-bam2wig foo bar foobar 2>&1 | grep "Failed to open file" > /dev/null
+    - test -x ${PREFIX}/bin/rsem-generate-ngvector
     - which rsem-for-ebseq-calculate-clustering-info  # [not aarch64]
     - test -x ${PREFIX}/bin/rsem-for-ebseq-calculate-clustering-info  # [aarch64]
 

--- a/recipes/rsem/meta.yaml
+++ b/recipes/rsem/meta.yaml
@@ -24,6 +24,7 @@ requirements:
   build:
     - make
     - {{ compiler('cxx') }}
+    - {{ stdlib('c') }}
   host:
     - perl
     - perl-module-build


### PR DESCRIPTION
## Summary

- install `rsem-generate-ngvector` through the recipe's existing Perl script path
- bump the RSEM recipe build number from 12 to 13
- add an executable package test for the missing command

RSEM v1.3.3 includes `rsem-generate-ngvector`, but its upstream Makefile does not install the top-level script. The recipe already routes `rsem-control-fdr` and `rsem-run-ebseq` through `Module::Build`; this change includes the missing script in that same flow.

The currently published Linux build 12 contains the two neighboring Perl commands but not `bin/rsem-generate-ngvector`, reproducing the reported packaging gap.

## Validation

- `git diff --check`
- `bash -n recipes/rsem/build.sh` with Git Bash
- parsed the recipe after replacing Jinja expressions with placeholders and asserted build number 13 plus the new executable test
- inspected the published Linux build 12 archive and confirmed that `rsem-generate-ngvector` is absent

A full `bioconda-utils` lint/build was not run locally because the current environment does not provide Conda or `bioconda-utils`; repository CI remains the authoritative build check.

Closes #48601.

This patch was prepared with automated assistance and deterministically reviewed; the contributor remains responsible for the submitted change.
