### PR TITLE
Update bismark to 3.1.0

### DIFF
--- a/recipes/bismark/meta.yaml
+++ b/recipes/bismark/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.0.0" %}
+{% set version = "3.1.0" %}
 
 package:
   name: bismark
@@ -7,7 +7,7 @@ package:
 source:
   # Rust GA tag (distinct from the Perl `v*` tags).
   url: https://github.com/FelixKrueger/Bismark/archive/refs/tags/bismark-rust-v{{ version }}.tar.gz
-  sha256: da04c2dccd234877d61bc217afa39474eba4aca56f34fc3752ef3bc891c11636
+  sha256: 638d7b068031b23fca9c3b3ca5a6b0db675a4da9d48975420fa642b584b5e411
 
 build:
   number: 0
@@ -31,7 +31,7 @@ requirements:
 
 test:
   commands:
-    - bismark --version | grep -q "3.0.0"
+    - bismark --version | grep -q "${PKG_VERSION}"
     - bismark --help > /dev/null
     - for t in deduplicate_bismark bismark_methylation_extractor bismark2bedGraph coverage2cytosine bismark_genome_preparation bam2nuc NOMe_filtering filter_non_conversion methylation_consistency bismark2report bismark2summary ; do $t --version > /dev/null ; done
 


### PR DESCRIPTION
Bumps `bismark` to 3.1.0.

Supersedes the autobump PR #67142, which failed CI (Linux + ARM) because the `test:` section pins the version literally (`bismark --version | grep -q "3.0.0"`) — a line the autobump bot doesn't rewrite, so the 3.1.0 binary (which reports `v3.1.0`) makes the assertion exit 1. The build itself is fine; only the stale test assertion failed.

This PR:
- sets `version = "3.1.0"` and updates the source `sha256` (identical to the autobump's, independently verified against the GitHub tag tarball);
- **makes the version test agnostic** — `grep -q "${PKG_VERSION}"` — so future autobumps won't trip the same wire.

I'm a listed recipe-maintainer (`FelixKrueger`). Upstream 3.1.0 is released (crates.io `bismark` 3.1.0, GHCR `:3.1.0`/`:latest`, tag `bismark-rust-v3.1.0`).

---
- [x] I have read the [guidelines](https://bioconda.github.io/contributor/index.html) for bioconda recipes.
- [x] This PR only affects a single recipe (`recipes/bismark`).