### PR TITLE
Update lofreq: pin `bcftools >=1.22` to fix `concat` segfault

### DIFF
--- a/recipes/lofreq/meta.yaml
+++ b/recipes/lofreq/meta.yaml
@@ -11,7 +11,7 @@ source:
     - 0001-patches
 
 build:
-  number: 15
+  number: 16
   run_exports:
     - {{ pin_subpackage('lofreq', max_pin='x') }}
 
@@ -19,6 +19,7 @@ requirements:
   build:
     - make
     - {{ compiler('c') }}
+    - {{ stdlib('c') }}
     - autoconf
     - automake
     - libtool
@@ -32,7 +33,7 @@ requirements:
   run:
     - python
     - samtools
-    - bcftools
+    - bcftools >=1.22
     - gsl
 
 test:


### PR DESCRIPTION
### What / why

`lofreq`'s `bcftools` run dependency is unpinned, so build 15 resolves to **bcftools 1.21**. bcftools 1.21 **segfaults** in `bcftools concat -a` when an input VCF contains only a header and no records — a regression in 1.21, fixed in 1.22 (upstream: samtools/bcftools#2286).

`lofreq call-parallel` splits the reference into regions, calls variants per region, and merges the per-region VCFs with exactly `bcftools concat -a` (`src/scripts/lofreq2_call_pparallel.py`, `concat_vcf_files`). Any region with no called variants produces a header-only VCF, so on sparse / low-coverage / partially-covered inputs the merge step crashes and the whole run dies with a segfault and no informative error.

`lofreq` calls `bcftools` from `PATH`, so shipping `bcftools >=1.22` fixes it with no change to `lofreq` itself.

### Change

- `requirements/run`: `bcftools` → `bcftools >=1.22`
- `build/number`: 15 → 16

### Verification

All commands run against the **currently shipped** container `quay.io/biocontainers/lofreq:2.1.5--py310h4966b78_15`, which bundles bcftools 1.21:

```console
$ docker run --rm quay.io/biocontainers/lofreq:2.1.5--py310h4966b78_15 bcftools --version
bcftools 1.21
Using htslib 1.21
```

**Setup** — three header-only VCFs (no records), reproducing what `lofreq call-parallel` produces for regions with no called variants:

```bash
for n in 0 1 2; do
  printf '##fileformat=VCFv4.2\n##contig=<ID=NC_045512.2,length=29903>\n#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n' > $n.vcf
  bgzip $n.vcf && bcftools index -t $n.vcf.gz
done

$ zcat 0.vcf.gz
##fileformat=VCFv4.2
##contig=<ID=NC_045512.2,length=29903>
#CHROM  POS  ID  REF  ALT  QUAL  FILTER  INFO
```

**The failing operation** — the exact command `lofreq` runs to merge per-region VCFs
(`src/scripts/lofreq2_call_pparallel.py`, `concat_vcf_files`: `['bcftools', 'concat', '-a', '-O', 'z', '-o', out]`),
run against each bcftools release with the same three inputs:

```console
# bcftools 1.20
$ bcftools concat -a -O z -o concat.vcf.gz 0.vcf.gz 1.vcf.gz 2.vcf.gz
Checking the headers and starting positions of 3 files
exit code: 0            # 0 records in output — OK

# bcftools 1.21   (bundled in lofreq 2.1.5 build 15)
$ bcftools concat -a -O z -o concat.vcf.gz 0.vcf.gz 1.vcf.gz 2.vcf.gz
Checking the headers and starting positions of 3 files
Segmentation fault
exit code: 139         # SIGSEGV

# bcftools 1.22
$ bcftools concat -a -O z -o concat.vcf.gz 0.vcf.gz 1.vcf.gz 2.vcf.gz
Checking the headers and starting positions of 3 files
exit code: 0            # 0 records in output — OK
```

**Result matrix** (same inputs, same command):

| bcftools | `concat -a` on header-only VCFs | notes |
|---|---|---|
| 1.20 | ✅ exit 0 | 0 records emitted, no crash |
| **1.21** | ❌ **exit 139 (SIGSEGV)** | the version shipped in `lofreq` build 15 |
| 1.22 | ✅ exit 0 | 0 records emitted, no crash |

So the segfault is a regression isolated to **bcftools 1.21** (upstream samtools/bcftools#2286, fixed in 1.22), and it is exactly the version the unpinned recipe currently resolves to. Pinning `bcftools >=1.22` moves the build off the one broken release; since `lofreq` calls `bcftools` from `PATH`, no `lofreq` code change is required.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>

