### PR TITLE
Add whittle 0.1.1

### DIFF
--- a/recipes/whittle/meta.yaml
+++ b/recipes/whittle/meta.yaml
@@ -6,8 +6,8 @@ package:
   version: {{ version }}
 
 source:
-  url: https://static.crates.io/crates/{{ name }}/{{ name }}-{{ version }}.crate
-  sha256: dcb66d7994972bc7d16de9f9622e8e81bff065cd1723f3678226c47219391957
+  url: https://github.com/erdikilic/{{ name }}/archive/{{ version }}.tar.gz
+  sha256: 35f2c783c3ee1ea75f629d76d5bbd8297429ee28c53d5f9e7026f13d37c7ca88
 
 build:
   number: 0

--- a/recipes/whittle/meta.yaml
+++ b/recipes/whittle/meta.yaml
@@ -13,16 +13,20 @@ build:
   number: 0
   run_exports:
     - {{ pin_subpackage('whittle', max_pin="x.x") }}
-  # The crate ships a .cargo/config.toml that sets target-cpu=x86-64-v3, so
-  # `cargo install` from the source root produces an AVX2 build automatically
-  # (required by the sassy SIMD dependency). aarch64 uses NEON by default.
-  script: 'cargo install --no-track --locked --root "${PREFIX}" --path .'
+  # cargo-bundle-licenses collects the licenses of all vendored crates into
+  # THIRDPARTY.yml (bioconda Rust guideline; see about/license_file). The crate's
+  # bundled .cargo/config.toml sets target-cpu=x86-64-v3, so `cargo install`
+  # produces the AVX2 build sassy needs (aarch64 uses NEON by default).
+  script:
+    - 'cargo-bundle-licenses --format yaml --output THIRDPARTY.yml'
+    - 'cargo install --no-track --locked --root "${PREFIX}" --path .'
 
 requirements:
   build:
     - {{ compiler('rust') }}
     - {{ compiler('c') }}
     - {{ stdlib('c') }}
+    - cargo-bundle-licenses
     - cmake
     - make
 
@@ -35,7 +39,9 @@ about:
   home: https://github.com/erdikilic/whittle
   license: Apache-2.0
   license_family: APACHE
-  license_file: LICENSE
+  license_file:
+    - LICENSE
+    - THIRDPARTY.yml
   summary: Fast, tag-aware long-read (ONT/PacBio) trimmer for FASTQ and unaligned BAM
   description: |
     whittle trims Oxford Nanopore and PacBio long reads in FASTQ, gzipped

--- a/recipes/whittle/meta.yaml
+++ b/recipes/whittle/meta.yaml
@@ -1,0 +1,51 @@
+{% set name = "whittle" %}
+{% set version = "0.1.1" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://static.crates.io/crates/{{ name }}/{{ name }}-{{ version }}.crate
+  sha256: dcb66d7994972bc7d16de9f9622e8e81bff065cd1723f3678226c47219391957
+
+build:
+  number: 0
+  # The crate ships a .cargo/config.toml that sets target-cpu=x86-64-v3, so
+  # `cargo install` from the source root produces an AVX2 build automatically
+  # (required by the sassy SIMD dependency). aarch64 uses NEON by default.
+  script: 'cargo install --no-track --locked --root "${PREFIX}" --path .'
+
+requirements:
+  build:
+    - {{ compiler('rust') }}
+    - {{ compiler('c') }}
+    - cmake
+    - make
+
+test:
+  commands:
+    - whittle --version
+    - whittle --help
+
+about:
+  home: https://github.com/erdikilic/whittle
+  license: Apache-2.0
+  license_family: APACHE
+  license_file: LICENSE
+  summary: Fast, tag-aware long-read (ONT/PacBio) trimmer for FASTQ and unaligned BAM
+  description: |
+    whittle trims Oxford Nanopore and PacBio long reads in FASTQ, gzipped
+    FASTQ, and unaligned BAM. It keeps position-indexed tags (MM/ML/MN base
+    modifications, per-base kinetics, and ONT signal) in register through
+    every trim and split, so downstream modified-base and signal analyses
+    stay correct after trimming.
+  dev_url: https://github.com/erdikilic/whittle
+  doc_url: https://docs.rs/whittle
+
+extra:
+  recipe-maintainers:
+    - erdikilic
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64

--- a/recipes/whittle/meta.yaml
+++ b/recipes/whittle/meta.yaml
@@ -11,6 +11,8 @@ source:
 
 build:
   number: 0
+  run_exports:
+    - {{ pin_subpackage('whittle', max_pin="x.x") }}
   # The crate ships a .cargo/config.toml that sets target-cpu=x86-64-v3, so
   # `cargo install` from the source root produces an AVX2 build automatically
   # (required by the sassy SIMD dependency). aarch64 uses NEON by default.
@@ -20,6 +22,7 @@ requirements:
   build:
     - {{ compiler('rust') }}
     - {{ compiler('c') }}
+    - {{ stdlib('c') }}
     - cmake
     - make
 


### PR DESCRIPTION
Adds a recipe for **whittle** 0.1.1, a fast, tag-aware long-read (ONT/PacBio)
trimmer for FASTQ and unaligned BAM.

whittle trims Oxford Nanopore and PacBio long reads and keeps position-indexed
tags (`MM`/`ML`/`MN` base modifications, per-base kinetics, and ONT signal) in
register through every trim and split, so downstream modified-base and signal
analyses stay correct after trimming.

- Source: crates.io tarball (`whittle-0.1.1.crate`), Apache-2.0, `license_file` included.
- Upstream: https://github.com/erdikilic/whittle  (also on crates.io / docs.rs).
- Build: `cargo install` from the crate; the crate ships a `.cargo/config.toml`
  targeting `x86-64-v3` (AVX2) as required by its `sassy` SIMD dependency, mirroring
  the existing `sassy` recipe. The binary calls `ensure_simd()` at startup so it
  exits with a clear message on CPUs lacking AVX2. aarch64 uses NEON by default.
- Tests: `whittle --version` and `whittle --help`.

---

- [x] This PR adds a new recipe.
- [x] AGPL/GPL/Apache licenses include a `license_file`.
