### PR TITLE
Update amplirust to 0.3.0 (fix aarch64 build)

### DIFF
--- a/recipes/amplirust/build.sh
+++ b/recipes/amplirust/build.sh
@@ -1,8 +1,18 @@
 #!/bin/bash
 set -ex
 
-# Build with cargo
-RUST_BACKTRACE=1 cargo install --no-track --locked --root "${PREFIX}" --path .
+# sassy's SIMD needs AVX2 on x86-64 (x86-64-v3). aarch64/arm64 use NEON, which
+# the conda toolchain enables by default, so they need no override. The previous
+# aarch64/arm64 values were target *triples*, not CPU names; rustc rejected them
+# and dropped NEON, which tripped ensure_simd's AVX2/NEON compile_error.
+case $(uname -m) in
+    x86_64)
+        export RUSTFLAGS="-C target-cpu=x86-64-v3"
+        ;;
+esac
 
 # Bundle third-party licenses
 cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
+
+# Build with cargo
+RUST_BACKTRACE=1 cargo install --no-track --locked --root "${PREFIX}" --path .

--- a/recipes/amplirust/meta.yaml
+++ b/recipes/amplirust/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "amplirust" %}
-{% set version = "0.2.0" %}
+{% set version = "0.3.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/erdikilic/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
-  sha256: 04b92cb2744fe6bc9414d93d5e5e1100f5661f613d2c5fa64690a658ae039e85
+  sha256: a65ec18e54f63ef28a4291973b952516f0341750e7d3b5837b672edc10e87303
 
 build:
   number: 0
@@ -35,7 +35,7 @@ about:
   license_file:
     - LICENSE
     - THIRDPARTY.yml
-  summary: In-silico PCR primer matching and product extraction tool
+  summary: "In-silico PCR primer matching and product extraction tool."
   description: |
     Amplirust is a high-performance in-silico PCR tool written in Rust that
     performs primer matching and PCR product extraction from FASTA sequences.
@@ -44,5 +44,10 @@ about:
   dev_url: https://github.com/erdikilic/amplirust
 
 extra:
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64
   recipe-maintainers:
     - erdikilic
+  skip-lints:
+    - compiler_needs_stdlib_c

--- a/recipes/amplirust/meta.yaml
+++ b/recipes/amplirust/meta.yaml
@@ -18,6 +18,7 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - {{ stdlib('c') }}
     - {{ compiler('rust') }}
     - cargo-bundle-licenses
     - cmake
@@ -49,5 +50,3 @@ extra:
     - osx-arm64
   recipe-maintainers:
     - erdikilic
-  skip-lints:
-    - compiler_needs_stdlib_c


### PR DESCRIPTION
Updates **amplirust** to 0.3.0 and fixes the aarch64/arm64 build.

Supersedes the autobump PR #62973, which fails the ARM build. Root cause: `build.sh`
set `RUSTFLAGS="-C target-cpu=aarch64-unknown-linux-gnu"` (and `...=aarch64-apple-darwin`)
— those are target **triples**, not CPU names, so `rustc` rejects them and drops the
default NEON feature. amplirust depends on `sassy`, whose `ensure_simd` then aborts the
build with a `compile_error!` because neither AVX2 (x86-64) nor NEON (aarch64) is enabled.

Fix: keep `-C target-cpu=x86-64-v3` for x86_64 (needed for sassy's AVX2), and apply no
override on aarch64/arm64 so the conda toolchain's default NEON is used. This mirrors the
`sassy` recipe and the pending `whittle` recipe, both of which build cleanly on ARM this way.

- [x] This PR updates an existing recipe (version bump + build fix).
