### PR TITLE
esme: bump build number

### DIFF
--- a/recipes/esme/meta.yaml
+++ b/recipes/esme/meta.yaml
@@ -9,7 +9,7 @@
 {% set omb_version = "8.0b2" %}
 {% set vfd_gds_version = "1.0.2" %}
 {% set cuda_version = "12.6" %}
-{% set build = 0 %}
+{% set build = 1 %}
 
 # BUILD TRIGGER - manually change this for each MPI variant to force bioconda rebuild if needed
 {% set build_trigger = "psmpi" %}  # Change to: openmpi, mpich, psmpi or mvapich
@@ -413,5 +413,6 @@ extra:
     - compilers_must_be_in_build
     - folder_and_package_name_must_match
     - missing_tests  # tests are all a the top level
+    - build_number_needs_reset  # temporarily disable to get build numbers in sync
   additional-platforms:
     - linux-aarch64

--- a/recipes/esme/meta.yaml
+++ b/recipes/esme/meta.yaml
@@ -95,6 +95,7 @@ test:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - {{ compiler('fortran') }}
+    - {{ stdlib('c') }}
   commands:
     # PnetCDF test
     - export PATH=$PATH:${PREFIX}/bin
@@ -151,6 +152,7 @@ outputs:
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
         - {{ compiler('fortran') }}
+        - {{ stdlib('c') }}
         - make
         - m4
       host:
@@ -174,6 +176,7 @@ outputs:
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
         - {{ compiler('fortran') }}
+        - {{ stdlib('c') }}
         - cmake
         - make
         {% if mpi_name == "mvapich" %}
@@ -223,6 +226,7 @@ outputs:
         - automake
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
+        - {{ stdlib('c') }}
         - libtool
         - make
         - m4
@@ -254,6 +258,7 @@ outputs:
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
         - {{ compiler('fortran') }}
+        - {{ stdlib('c') }}
         - make
         - m4
       host:
@@ -286,6 +291,7 @@ outputs:
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
         - {{ compiler('fortran') }}
+        - {{ stdlib('c') }}
         - libtool
         - make
         - m4
@@ -322,6 +328,7 @@ outputs:
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
         - {{ compiler('fortran') }}
+        - {{ stdlib('c') }}
         - make
       host:
         - esme_hdf5_{{ mpi_pkg_suffix }}
@@ -360,6 +367,7 @@ outputs:
         - automake
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
+        - {{ stdlib('c') }}
         - libtool
         - make
       host:
@@ -404,5 +412,6 @@ extra:
     - version_constraints_missing_whitespace
     - compilers_must_be_in_build
     - folder_and_package_name_must_match
+    - missing_tests  # tests are all a the top level
   additional-platforms:
     - linux-aarch64

--- a/recipes/esme/meta.yaml
+++ b/recipes/esme/meta.yaml
@@ -9,7 +9,7 @@
 {% set omb_version = "8.0b2" %}
 {% set vfd_gds_version = "1.0.2" %}
 {% set cuda_version = "12.6" %}
-{% set build = 1 %}
+{% set build = 0 %}
 
 # BUILD TRIGGER - manually change this for each MPI variant to force bioconda rebuild if needed
 {% set build_trigger = "psmpi" %}  # Change to: openmpi, mpich, psmpi or mvapich

--- a/recipes/esme/meta.yaml
+++ b/recipes/esme/meta.yaml
@@ -9,7 +9,7 @@
 {% set omb_version = "8.0b2" %}
 {% set vfd_gds_version = "1.0.2" %}
 {% set cuda_version = "12.6" %}
-{% set build = 0 %}
+{% set build = 1 %}
 
 # BUILD TRIGGER - manually change this for each MPI variant to force bioconda rebuild if needed
 {% set build_trigger = "psmpi" %}  # Change to: openmpi, mpich, psmpi or mvapich


### PR DESCRIPTION
The nightly build is reporting a divergent build string for esme.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
