### PR TITLE
Add bioformats2raw

### DIFF
--- a/recipes/bioformats2raw/meta.yaml
+++ b/recipes/bioformats2raw/meta.yaml
@@ -1,0 +1,47 @@
+{% set version = "0.12.1" %}
+
+package:
+  name: bioformats2raw
+  version: {{ version }}
+
+source:
+  url: https://github.com/glencoesoftware/bioformats2raw/releases/download/v{{ version }}/bioformats2raw-{{ version }}.zip
+  sha256: 51fbbf04a83c2042b707fce016ad0c8260d37194ff8fe7d986d53f4ebee116a6
+
+build:
+  number: 0
+  noarch: generic
+  run_exports:
+    - {{ pin_subpackage('bioformats2raw', max_pin="x") }}
+  script:
+    - mkdir -p "$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM/bin" "$PREFIX/bin"
+    - cp -R lib "$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM/"
+    - install -m 755 bin/bioformats2raw "$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM/bin/bioformats2raw"
+    - ln -s "../share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM/bin/bioformats2raw" "$PREFIX/bin/bioformats2raw"
+
+requirements:
+  run:
+    - openjdk >=11
+
+test:
+  commands:
+    - bioformats2raw --version 2>&1 | grep -F "Version = {{ version }}"
+    - bioformats2raw --help
+    - bioformats2raw "test&sizeX=16&sizeY=16.fake" output.zarr --resolutions 1
+    - test -d output.zarr
+
+about:
+  home: https://github.com/glencoesoftware/bioformats2raw
+  summary: Bio-Formats image file format to OME-NGFF format converter
+  description: |
+    bioformats2raw converts image file formats supported by Bio-Formats into
+    a Zarr structure compatible with the OME-NGFF specification.
+  license: GPL-2.0-only
+  license_file: LICENSE.txt
+  doc_url: https://github.com/glencoesoftware/bioformats2raw/blob/v{{ version }}/README.md
+  dev_url: https://github.com/glencoesoftware/bioformats2raw
+
+extra:
+  recipe-maintainers:
+    - Darlokt
+    - Tom-TBT

--- a/recipes/bioformats2raw/meta.yaml
+++ b/recipes/bioformats2raw/meta.yaml
@@ -29,6 +29,7 @@ test:
     - bioformats2raw --help
     - bioformats2raw "test&sizeX=16&sizeY=16.fake" output.zarr --resolutions 1
     - test -d output.zarr
+    - rm -rf output.zarr
 
 about:
   home: https://github.com/glencoesoftware/bioformats2raw

--- a/recipes/bioformats2raw/meta.yaml
+++ b/recipes/bioformats2raw/meta.yaml
@@ -12,7 +12,7 @@ build:
   number: 0
   noarch: generic
   run_exports:
-    - {{ pin_subpackage('bioformats2raw', max_pin="x") }}
+    - {{ pin_subpackage('bioformats2raw', max_pin="x.x") }}
   script:
     - mkdir -p "$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM/bin" "$PREFIX/bin"
     - cp -R lib "$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM/"
@@ -21,7 +21,7 @@ build:
 
 requirements:
   run:
-    - openjdk >=11
+    - openjdk >=11,<26
 
 test:
   commands:
@@ -45,3 +45,6 @@ extra:
   recipe-maintainers:
     - Darlokt
     - Tom-TBT
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64


### PR DESCRIPTION
# Adds a recipe for bioformats2raw 0.12.1, a Bio-Formats image file format to OME-NGFF converter.

bioformats2raw converts image file formats supported by Bio-Formats into a Zarr structure compatible with the OME-NGFF specification.

## Info

Source: official GitHub release archive (bioformats2raw-0.12.1.zip), GPL-2.0-only, license_file included.
Upstream: https://github.com/glencoesoftware/bioformats2raw.
Build: Installs the prebuilt distribution and provides platform-specific launchers. Requires OpenJDK >=11 at runtime.
Tests: bioformats2raw --version, bioformats2raw --help, and conversion of a small fake image to an output Zarr directory.

This PR adds a new recipe.
AGPL/GPL/Apache licenses include a license_file.

## Checklist

- [x] Title of this PR is meaningful: `Adding bioformats2raw`.
- [x] License file is packaged.
- [x] Source is from the official source.
- [x] Build number is 0.
- [x] An official release archive is used rather than a repository.
- [x] GitHub users listed in the maintainer section have confirmed they are willing to be listed.
