### PR TITLE
Rebuild bcftools 1.24 against htslib 1.24

### DIFF
--- a/recipes/bcftools/meta.yaml
+++ b/recipes/bcftools/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage("bcftools", max_pin="x") }}
 


### PR DESCRIPTION
*(Posted by Claude, an AI assistant, on behalf of @jmchilton.)*

`bcftools` 1.24 was built against **htslib 1.23.1** on linux-64, linux-aarch64, and osx-arm64. Only osx-64 picked up htslib 1.24. Verified against the live `repodata.json`:

| subdir | build | declared htslib dep |
|---|---|---|
| linux-64 | `h487d631_0` | `htslib >=1.23.1,<1.24.0a0` :x: |
| linux-aarch64 | `hd65497c_0` | `htslib >=1.23.1,<1.24.0a0` :x: |
| osx-arm64 | `hf623529_0` | `htslib >=1.23.1,<1.24.0a0` :x: |
| osx-64 | `h59c2e17_0` | `htslib >=1.24,<1.25.0a0` :white_check_mark: |

This is the situation jmarshall and eseiler identified in #67046 — the 1.24 PRs' CI solved their host envs before htslib 1.24 finished uploading. eseiler suggested a build number bump there; it appears it was never opened, so here it is.

### Why it matters

bcftools and htslib are released in lockstep, so those three binaries are compiled against mismatched headers — per jmarshall in #67046 they are likely missing an htslib 1.24 fix to `bgzf_read_small()`.

Separately, htslib's `run_exports` pins `x.x`, so anything built against htslib 1.24 requires `htslib >=1.24,<1.25`, which no linux/ARM bcftools satisfies. That makes any recipe with `htslib` in `host:` and `bcftools` in `run:` unsatisfiable on those three platforms (this is how it surfaced, in #67152) — or, if its bcftools dep is unpinned, silently resolve to a pre-1.10 bcftools, which declares no htslib dependency at all.

### Why a bare build-number bump suffices

- `host:` lists `htslib` unpinned and `build.sh` uses `--with-htslib=system`, so a rebuild solves to htslib 1.24 and `run_exports` stamps `htslib >=1.24,<1.25.0a0` on every subdir.
- bcftools 1.24 demonstrably compiles against htslib 1.24 — osx-64 `h59c2e17_0` already did it and passed this recipe's tests.
- osx-64 cannot regress; it re-solves to the same htslib 1.24.
- htslib 1.24 has been in repodata since 2026-07-09, so the original race cannot recur.

`samtools` needs no rebuild — 1.24 already links htslib 1.24 on all four platforms.
