### PR TITLE
Update nwkit to 0.27.0

### DIFF
--- a/recipes/nwkit/meta.yaml
+++ b/recipes/nwkit/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "nwkit" %}
-{% set version = "0.21.1" %}
+{% set version = "0.27.0" %}
 
 package:
   name: "{{ name|lower }}"
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/kfuku52/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 16a7026eec1e29fc65fc96932ccc6e8dd83733e644d388920ede7e4ff7c3bfca
+  sha256: 3d147b3c6471a481ff97658057e72d5eb6f865fdd5c3c18a4188d612d040ca2f
 
 build:
   number: 0
@@ -18,28 +18,35 @@ build:
 
 requirements:
   host:
-    - python >=3.9
+    - python >=3.10
     - pip
-    - setuptools
+    - setuptools >=77.0.3
     - wheel
   run:
-    - python >=3.9
-    - ete4 >=4.3.0
+    - python >=3.10
+    - ete4 >=4.4.0
     - biopython
     - pandas
     - requests
     - numpy
+    - scipy
+    - matplotlib-base
 
 test:
   commands:
     - nwkit --help
+    - nwkit --version
+    - python -m nwkit --version
+    - printf '(A:1,B:1);' | nwkit validate --fail-on-issue yes > /dev/null
   imports:
     - nwkit
 
 about:
   home: "https://github.com/kfuku52/nwkit"
-  license: "BSD-3-Clause"
-  license_file: LICENSE
+  license: "MIT"
+  license_file:
+    - LICENSE
+    - THIRD_PARTY_NOTICES
   summary: "Tools for processing newick trees"
 
 extra:


### PR DESCRIPTION
Updates NWKIT from 0.21.1 to 0.27.0 and synchronizes the recipe with the current upstream package metadata.

Changes beyond the version/hash bump:
- raises Python to >=3.10 and setuptools to >=77.0.3
- raises ete4 to >=4.4.0
- adds scipy and matplotlib-base runtime dependencies
- updates the license to MIT and ships THIRD_PARTY_NOTICES
- adds version, module entry point, and functional validate smoke tests

Dependency status:
- conda-forge/ete4-feedstock#13 has been merged
- ete4 4.4.0 packages are published for Linux and macOS on conda-forge

Supersedes #67192, whose automatic bump changes only the version and source hash and therefore retains stale dependency and license metadata.

Local validation:
- bioconda-utils lint: all checks OK
- bioconda-utils Docker build: success
- recipe tests passed with Python 3.14 and ete4 4.4.0 (CLI help/version, module entry point, validate smoke test, and import).