### PR TITLE
Add jq as a direct run dependency of bioconductor-data-packages

### DIFF
--- a/recipes/bioconductor-data-packages/meta.yaml
+++ b/recipes/bioconductor-data-packages/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: '20260207'
 source:
 build:
-  number: 0
+  number: 1
   noarch: generic
   run_exports:
     - {{ pin_subpackage("bioconductor-data-packages", max_pin=None) }}
@@ -12,9 +12,11 @@ requirements:
     - r-base
     - curl
     - yq
+    - jq
 test:
   commands:
     - yq --help
+    - jq --help
 about:
   home: "https://github.com/bioconda/bioconda-utils"
   license: 'MIT'


### PR DESCRIPTION
## Summary

`installBiocDataPackage.sh`, the post-link script this package installs, shells out directly to `yq` to parse `dataURLs.json`, and `yq` (the Python jq-wrapper) shells out to the `jq` binary. `yq`'s own conda-forge recipe does not declare `jq` as a runtime dependency ([conda-forge/yq-feedstock#41](https://github.com/conda-forge/yq-feedstock/issues/41)), so on minimal images without `jq` preinstalled, the post-link script fails silently and the Bioconductor data package being installed (e.g. `GenomeInfoDbData`) never actually gets installed, leading to a runtime error like:

```
Error: package or namespace load failed for 'GenomeInfoDb':
 there is no package called 'GenomeInfoDbData'
```

This was hit building containers via Wave from an `environment.yml` containing `bioconductor-tximeta` (nf-core/modules#12362); the prebuilt bioconda-built containers are unaffected because bioconda's own build environment happens to have `jq` present already.

## Fix

Add `jq` directly to this recipe's `run` requirements, since this recipe's own script is what actually invokes it. This removes the reliance on `yq`'s transitive dependency manifest being correct, and fixes the issue immediately rather than waiting on the upstream `yq` fix (which would also require every existing build depending on `yq` to be rebuilt).

Build number bumped to 1 since no version change.