### PR TITLE
Update mumemto to v1.4.1

### DIFF
--- a/recipes/mumemto/build.sh
+++ b/recipes/mumemto/build.sh
@@ -15,6 +15,14 @@ mkdir -p "${PREFIX}/share/licenses/${PKG_NAME}"
 if [[ "$(uname -s)" == "Darwin" ]]; then
   export CONFIG_ARGS="-DCMAKE_FIND_FRAMEWORK=NEVER -DCMAKE_FIND_APPBUNDLE=NEVER"
   export CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
+  export DYLD_FALLBACK_LIBRARY_PATH="${BUILD_PREFIX}/lib:${PREFIX}/lib${DYLD_FALLBACK_LIBRARY_PATH:+:${DYLD_FALLBACK_LIBRARY_PATH}}"
+  # Use cctools ar/ranlib; llvm-ranlib-19 fails to load libLLVM on osx-64 CI.
+  if [[ -n "${AR:-}" ]]; then
+    export CMAKE_AR="${AR}"
+  fi
+  if [[ -n "${RANLIB:-}" ]]; then
+    export CMAKE_RANLIB="${RANLIB}"
+  fi
 else
   export CONFIG_ARGS=""
 fi
@@ -29,6 +37,8 @@ cmake -S "${SRC_DIR}" -B "${SRC_DIR}/build" \
   -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=FALSE \
   -Wno-dev -Wno-deprecated --no-warn-unused-cli \
   -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+  ${CMAKE_AR:+-DCMAKE_AR="${CMAKE_AR}"} \
+  ${CMAKE_RANLIB:+-DCMAKE_RANLIB="${CMAKE_RANLIB}"} \
   ${CONFIG_ARGS}
 
 cmake --build "${SRC_DIR}/build" --clean-first -j "${CPU_COUNT:-4}"

--- a/recipes/mumemto/build.sh
+++ b/recipes/mumemto/build.sh
@@ -27,11 +27,20 @@ else
   export CONFIG_ARGS=""
 fi
 
+INSTALL_ROOT="${SRC_DIR}/build/install"
+
 # Main project: CLI binaries + shared lib + CMake package (installed under build/install by top-level CMake).
+# Conda CMAKE_ARGS often passes -DCMAKE_INSTALL_LIBDIR=lib as a PATH. CMake then absolutizes it against
+# the source dir (→ $SRC_DIR/lib), so lib/cmake never land under INSTALL_ROOT and find_package(Mumemto)
+# fails when building the Python bindings. Force STRING-typed relative dirs after CMAKE_ARGS.
 cmake -S "${SRC_DIR}" -B "${SRC_DIR}/build" \
+  ${CMAKE_ARGS} \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_CXX_COMPILER="${CXX}" \
   -DCMAKE_CXX_FLAGS="${CXXFLAGS}" \
+  -DCMAKE_INSTALL_LIBDIR:STRING=lib \
+  -DCMAKE_INSTALL_BINDIR:STRING=bin \
+  -DCMAKE_INSTALL_INCLUDEDIR:STRING=include \
   -DCMAKE_INSTALL_RPATH="${PREFIX}/lib" \
   -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \
   -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=FALSE \
@@ -44,28 +53,39 @@ cmake -S "${SRC_DIR}" -B "${SRC_DIR}/build" \
 cmake --build "${SRC_DIR}/build" --clean-first -j "${CPU_COUNT:-4}"
 cmake --install "${SRC_DIR}/build"
 
-INSTALL_ROOT="${SRC_DIR}/build/install"
 if [[ ! -d "${INSTALL_ROOT}" ]]; then
   echo "Expected CMake install tree at ${INSTALL_ROOT}"
   exit 1
 fi
 
 # C/C++ SDK: shared library, headers, CMake package (Mumemto::mumemto, find_package).
+# Prefer INSTALL_ROOT; also accept $SRC_DIR/lib in case an absolute libdir slipped through.
 shopt -s nullglob
-libs=( "${INSTALL_ROOT}/lib"/libmumemto* )
-if (( ${#libs[@]} )); then
-  cp -a "${libs[@]}" "${PREFIX}/lib/"
-fi
+for libdir in "${INSTALL_ROOT}/lib" "${SRC_DIR}/lib"; do
+  libs=( "${libdir}"/libmumemto* )
+  if (( ${#libs[@]} )); then
+    cp -a "${libs[@]}" "${PREFIX}/lib/"
+  fi
+done
 shopt -u nullglob
 
-if [[ -d "${INSTALL_ROOT}/lib/cmake" ]]; then
-  mkdir -p "${PREFIX}/lib/cmake"
-  cp -a "${INSTALL_ROOT}/lib/cmake"/* "${PREFIX}/lib/cmake/"
-fi
+for cmakedir in "${INSTALL_ROOT}/lib/cmake" "${SRC_DIR}/lib/cmake"; do
+  if [[ -d "${cmakedir}/Mumemto" ]]; then
+    mkdir -p "${PREFIX}/lib/cmake"
+    cp -a "${cmakedir}"/* "${PREFIX}/lib/cmake/"
+  fi
+done
 
 if [[ -d "${INSTALL_ROOT}/include" ]]; then
   mkdir -p "${PREFIX}/include"
   cp -a "${INSTALL_ROOT}/include"/* "${PREFIX}/include/"
+fi
+
+if [[ ! -f "${PREFIX}/lib/cmake/Mumemto/MumemtoConfig.cmake" ]]; then
+  echo "MumemtoConfig.cmake was not installed into ${PREFIX}/lib/cmake/Mumemto" >&2
+  echo "Searched under ${INSTALL_ROOT}/lib and ${SRC_DIR}/lib:" >&2
+  find "${SRC_DIR}" -name 'MumemtoConfig.cmake' 2>/dev/null >&2 || true
+  exit 1
 fi
 
 # CLI tools (same layout as prior bioconda recipe).
@@ -80,6 +100,8 @@ install -v -m 0755 "${SRC_DIR}/mumemto/mumemto" "${PREFIX}/bin"
 cp -f "${SRC_DIR}/LICENSE" "${PREFIX}/share/licenses/${PKG_NAME}/"
 
 # Python: pybind11 extension + package __init__ (mum, mem, …); requires installed Mumemto CMake package in PREFIX.
+# scikit-build-core ignores CMAKE_INSTALL_PREFIX from CMAKE_ARGS; Mumemto_DIR is passed through for find_package.
+export CMAKE_ARGS="${CMAKE_ARGS} -DMumemto_DIR=${PREFIX}/lib/cmake/Mumemto"
 cd "${SRC_DIR}/python_bindings"
 "${PYTHON}" -m pip install . --no-deps --no-build-isolation -v
 cd "${SRC_DIR}"

--- a/recipes/mumemto/build.sh
+++ b/recipes/mumemto/build.sh
@@ -14,6 +14,7 @@ mkdir -p "${PREFIX}/share/licenses/${PKG_NAME}"
 
 if [[ "$(uname -s)" == "Darwin" ]]; then
   export CONFIG_ARGS="-DCMAKE_FIND_FRAMEWORK=NEVER -DCMAKE_FIND_APPBUNDLE=NEVER"
+  export CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
 else
   export CONFIG_ARGS=""
 fi

--- a/recipes/mumemto/build.sh
+++ b/recipes/mumemto/build.sh
@@ -16,13 +16,6 @@ if [[ "$(uname -s)" == "Darwin" ]]; then
   export CONFIG_ARGS="-DCMAKE_FIND_FRAMEWORK=NEVER -DCMAKE_FIND_APPBUNDLE=NEVER"
   export CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
   export DYLD_FALLBACK_LIBRARY_PATH="${BUILD_PREFIX}/lib:${PREFIX}/lib${DYLD_FALLBACK_LIBRARY_PATH:+:${DYLD_FALLBACK_LIBRARY_PATH}}"
-  # Use cctools ar/ranlib; llvm-ranlib-19 fails to load libLLVM on osx-64 CI.
-  if [[ -n "${AR:-}" ]]; then
-    export CMAKE_AR="${AR}"
-  fi
-  if [[ -n "${RANLIB:-}" ]]; then
-    export CMAKE_RANLIB="${RANLIB}"
-  fi
 else
   export CONFIG_ARGS=""
 fi
@@ -30,9 +23,10 @@ fi
 INSTALL_ROOT="${SRC_DIR}/build/install"
 
 # Main project: CLI binaries + shared lib + CMake package (installed under build/install by top-level CMake).
-# Conda CMAKE_ARGS often passes -DCMAKE_INSTALL_LIBDIR=lib as a PATH. CMake then absolutizes it against
-# the source dir (→ $SRC_DIR/lib), so lib/cmake never land under INSTALL_ROOT and find_package(Mumemto)
-# fails when building the Python bindings. Force STRING-typed relative dirs after CMAKE_ARGS.
+# Conda CMAKE_ARGS already sets absolute CMAKE_AR/RANLIB (cctools). Do not override those with bare
+# tool names — that breaks `ar` when linking libsdsl.a on CI ("Error running link command: no such file").
+# CMAKE_ARGS also passes -DCMAKE_INSTALL_LIBDIR=lib as a PATH; CMake absolutizes it against SRC_DIR,
+# so force STRING-typed relative install dirs after CMAKE_ARGS for find_package(Mumemto).
 cmake -S "${SRC_DIR}" -B "${SRC_DIR}/build" \
   ${CMAKE_ARGS} \
   -DCMAKE_BUILD_TYPE=Release \
@@ -46,8 +40,6 @@ cmake -S "${SRC_DIR}" -B "${SRC_DIR}/build" \
   -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=FALSE \
   -Wno-dev -Wno-deprecated --no-warn-unused-cli \
   -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
-  ${CMAKE_AR:+-DCMAKE_AR="${CMAKE_AR}"} \
-  ${CMAKE_RANLIB:+-DCMAKE_RANLIB="${CMAKE_RANLIB}"} \
   ${CONFIG_ARGS}
 
 cmake --build "${SRC_DIR}/build" --clean-first -j "${CPU_COUNT:-4}"

--- a/recipes/mumemto/conda_build_config.yaml
+++ b/recipes/mumemto/conda_build_config.yaml
@@ -4,3 +4,12 @@ c_compiler_version:  # [linux]
   - 12  # [linux]
 cxx_compiler_version:  # [linux]
   - 12  # [linux]
+
+# Bioconda still defaults osx-64 to 10.13, but host libs from conda-forge (libcxx,
+# zlib, …) are built for macOS 11.0+. Linking 10.13 against those produces
+# Mach-O version mismatches and can crash llvm-otool in conda-build post-
+# processing. Align with osx-arm64 / conda-forge.
+c_stdlib_version:  # [osx and x86_64]
+  - "11.0"  # [osx and x86_64]
+MACOSX_DEPLOYMENT_TARGET:  # [osx and x86_64]
+  - "11.0"  # [osx and x86_64]

--- a/recipes/mumemto/conda_build_config.yaml
+++ b/recipes/mumemto/conda_build_config.yaml
@@ -4,6 +4,3 @@ c_compiler_version:  # [linux]
   - 12  # [linux]
 cxx_compiler_version:  # [linux]
   - 12  # [linux]
-
-c_stdlib_version:  # [osx]
-  - "10.15"

--- a/recipes/mumemto/conda_build_config.yaml
+++ b/recipes/mumemto/conda_build_config.yaml
@@ -5,5 +5,5 @@ c_compiler_version:  # [linux]
 cxx_compiler_version:  # [linux]
   - 12  # [linux]
 
-MACOSX_DEPLOYMENT_TARGET:  # [osx]
+c_stdlib_version:  # [osx]
   - "10.15"

--- a/recipes/mumemto/conda_build_config.yaml
+++ b/recipes/mumemto/conda_build_config.yaml
@@ -4,3 +4,6 @@ c_compiler_version:  # [linux]
   - 12  # [linux]
 cxx_compiler_version:  # [linux]
   - 12  # [linux]
+
+MACOSX_DEPLOYMENT_TARGET:  # [osx]
+  - "10.15"

--- a/recipes/mumemto/meta.yaml
+++ b/recipes/mumemto/meta.yaml
@@ -20,6 +20,7 @@ build:
 requirements:
   build:
     - {{ compiler('cxx') }}
+    - {{ stdlib('c') }}
     - cmake
     - make
     - pkg-config
@@ -84,5 +85,3 @@ extra:
     - osx-arm64
   recipe-maintainers:
     - vikshiv
-  skip-lints:
-    - compiler_needs_stdlib_c

--- a/recipes/mumemto/meta.yaml
+++ b/recipes/mumemto/meta.yaml
@@ -10,7 +10,7 @@ source:
   # path: ..
   # Bioconda PR: replace `path` with release tarball after tagging, e.g.:
   url: https://github.com/vikshiv/mumemto/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 5df907e00156fbae9d4895ea0ab78c7c29354fc17645de22285624d8fa9bf283
+  sha256: b341fa36ee3c152860863bdf86c89507f705f76a7552134a9c383fb5668fe11a
 
 build:
   number: 0

--- a/recipes/mumemto/meta.yaml
+++ b/recipes/mumemto/meta.yaml
@@ -10,7 +10,7 @@ source:
   # path: ..
   # Bioconda PR: replace `path` with release tarball after tagging, e.g.:
   url: https://github.com/vikshiv/mumemto/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: b341fa36ee3c152860863bdf86c89507f705f76a7552134a9c383fb5668fe11a
+  sha256: 9e2db1c8483c460f6aad87298c88a201d1a9795e41e1ba01d5432d7bdeac2fc3
 
 build:
   number: 0

--- a/recipes/mumemto/meta.yaml
+++ b/recipes/mumemto/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "mumemto" %}
-{% set version = "1.4.0" %}
+{% set version = "1.4.1" %}
 
 package:
   name: {{ name }}
@@ -10,7 +10,7 @@ source:
   # path: ..
   # Bioconda PR: replace `path` with release tarball after tagging, e.g.:
   url: https://github.com/vikshiv/mumemto/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 0918a5556065e4a2d19446d6fac58288444c77109a250875d0dfa271f0e88aa5
+  sha256: 5df907e00156fbae9d4895ea0ab78c7c29354fc17645de22285624d8fa9bf283
 
 build:
   number: 0


### PR DESCRIPTION
Overrides the autobump do to a build issue in macosx (#67175)

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
