### PR TITLE
Add r-scarhrd 0.1.1

### DIFF
--- a/recipes/r-scarhrd/build.sh
+++ b/recipes/r-scarhrd/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-scarhrd/meta.yaml
+++ b/recipes/r-scarhrd/meta.yaml
@@ -1,0 +1,47 @@
+{% set version = "0.1.1" %}
+{% set github_commit = "c98f8bc42ed0810393a98677d415114360616725" %}
+
+package:
+  name: r-scarhrd
+  version: {{ version }}
+
+source:
+  url: https://github.com/sztup/scarHRD/archive/{{ github_commit }}.tar.gz
+  sha256: 608b984eef261c07db61ce75c40c40587bf49e91009e7388426f67b65c00c7ee
+
+build:
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+  run_exports:
+    - {{ pin_subpackage("r-scarhrd", max_pin="x.x") }}
+
+requirements:
+  host:
+    - r-base >=3.5.0
+    - r-data.table >=1.10
+    - r-sequenza >=2.1.2
+  run:
+    - r-base >=3.5.0
+    - r-data.table >=1.10
+    - r-sequenza >=2.1.2
+
+test:
+  commands:
+    - $R -e "library('scarHRD')"
+
+about:
+  home: https://github.com/sztup/scarHRD
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: Estimating genomic scar signatures (LST, TAI, LOH) and homologous recombination deficiency from WXS or WGS data.
+  dev_url: https://github.com/sztup/scarHRD
+
+extra:
+  recipe-maintainers:
+    - pinin4fjords
+  identifiers:
+    - doi:10.1038/s41523-018-0066-6

--- a/recipes/r-scarhrd/meta.yaml
+++ b/recipes/r-scarhrd/meta.yaml
@@ -23,10 +23,12 @@ requirements:
     - r-base >=3.5.0
     - r-data.table >=1.10
     - r-sequenza >=2.1.2
+    - jq
   run:
     - r-base >=3.5.0
     - r-data.table >=1.10
     - r-sequenza >=2.1.2
+    - jq
 
 test:
   commands:

--- a/recipes/r-scarhrd/meta.yaml
+++ b/recipes/r-scarhrd/meta.yaml
@@ -23,12 +23,10 @@ requirements:
     - r-base >=3.5.0
     - r-data.table >=1.10
     - r-sequenza >=2.1.2
-    - jq
   run:
     - r-base >=3.5.0
     - r-data.table >=1.10
     - r-sequenza >=2.1.2
-    - jq
 
 test:
   commands:


### PR DESCRIPTION
Adds a recipe for [scarHRD](https://github.com/sztup/scarHRD) 0.1.1, an R package that estimates genomic scar signatures (LST, TAI, LOH) and homologous recombination deficiency from WXS/WGS data (Sztupinszki et al., npj Breast Cancer 2018, doi:10.1038/s41523-018-0066-6).

The package is GitHub-only (not on CRAN/Bioconductor) and has no upstream tags/releases, so the source points at the commit corresponding to version 0.1.1 (`c98f8bc`). It is pure R (`noarch: generic`). Dependencies mirror its `DESCRIPTION`/`NAMESPACE`: `r-data.table` and `r-sequenza`, both available on the conda-forge/bioconda channels.

---

Please read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

- [x] This PR adds a new recipe.
- [x] AUTOMATED TESTS: This PR contains automated tests (the `test:` block runs `library('scarHRD')`).
- [x] The recipe includes a `run_exports` section, so downstream packages are guaranteed compatibility.