### PR TITLE
Add samtools 1.8

### DIFF
--- a/recipes/samtools/1.8/build.sh
+++ b/recipes/samtools/1.8/build.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+sed -i.bak 's/^CPPFLAGS =$//g' Makefile
+sed -i.bak 's/^LDFLAGS  =$//g' Makefile
+
+sed -i.bak 's/^CPPFLAGS =$//g' htslib-$PKG_VERSION/Makefile
+sed -i.bak 's/^LDFLAGS  =$//g' htslib-$PKG_VERSION/Makefile
+
+# varfilter.py in install fails because we don't install Python
+sed -i.bak 's#misc/varfilter.py##g' Makefile
+
+# Remove rdynamic which can cause build issues on OSX
+# https://sourceforge.net/p/samtools/mailman/message/34699333/
+sed -i.bak 's/ -rdynamic//g' Makefile
+sed -i.bak 's/ -rdynamic//g' htslib-$PKG_VERSION/configure
+
+export CPPFLAGS="${CPPFLAGS} -I$PREFIX/include"
+export LDFLAGS="${LDFLAGS} -L$PREFIX/lib"
+# -fcommon: pre-GCC-10 sources rely on common-symbol linking (default -fno-common breaks them)
+export CFLAGS="${CFLAGS} -O3 -I$PREFIX/include -Wno-deprecated-declarations -fcommon"
+
+cd htslib*
+./configure --prefix="$PREFIX" --enable-libcurl CFLAGS="${CFLAGS}" LDFLAGS="${LDFLAGS}"
+make
+cd ..
+# Problem with ncurses from default channel we now get in bioconda so skip tview
+# https://github.com/samtools/samtools/issues/577
+./configure --prefix="$PREFIX" --enable-libcurl --without-curses
+make install prefix="$PREFIX" LIBS+=-lcrypto LIBS+=-lcurl

--- a/recipes/samtools/1.8/meta.yaml
+++ b/recipes/samtools/1.8/meta.yaml
@@ -10,6 +10,7 @@ source:
 
 build:
   number: 6
+  skip: True  # [osx]
   run_exports:
     - {{ pin_subpackage("samtools", max_pin="x") }}
 
@@ -44,6 +45,5 @@ about:
 extra:
   additional-platforms:
     - linux-aarch64
-    - osx-arm64
   identifiers:
     - biotools:samtools

--- a/recipes/samtools/1.8/meta.yaml
+++ b/recipes/samtools/1.8/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   number: 6
-  skip: True  # [osx]
+  skip: True  # [osx and x86_64]
   run_exports:
     - {{ pin_subpackage("samtools", max_pin="x") }}
 
@@ -45,5 +45,6 @@ about:
 extra:
   additional-platforms:
     - linux-aarch64
+    - osx-arm64
   identifiers:
     - biotools:samtools

--- a/recipes/samtools/1.8/meta.yaml
+++ b/recipes/samtools/1.8/meta.yaml
@@ -1,0 +1,49 @@
+{% set version = "1.8" %}
+
+package:
+  name: samtools
+  version: {{ version }}
+
+source:
+  url: https://github.com/samtools/samtools/releases/download/{{ version }}/samtools-{{ version }}.tar.bz2
+  sha256: c942bc1d9b85fd1b05ea79c5afd2805d489cd36b2c2d8517462682a4d779be16
+
+build:
+  number: 6
+  run_exports:
+    - {{ pin_subpackage("samtools", max_pin="x") }}
+
+requirements:
+  build:
+    - make
+    - {{ compiler('c') }}
+    - {{ stdlib('c') }}
+  host:
+    # ncurses not compatible with samtools, see note in build.sh
+    #- ncurses
+    - bzip2
+    - curl
+    - openssl  # [not osx]
+    - xz
+    - zlib
+  run:
+    - curl
+    - openssl  # [not osx]
+
+test:
+  commands:
+    - samtools --help
+
+about:
+  home: "https://github.com/samtools/samtools"
+  license: MIT
+  license_family: MIT
+  summary: "Tools for dealing with SAM, BAM and CRAM files."
+  dev_url: "https://github.com/samtools/samtools"
+
+extra:
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64
+  identifiers:
+    - biotools:samtools


### PR DESCRIPTION
Adds a version-pinned recipe for the legacy samtools 1.8 release under `recipes/samtools/1.8/`, following the existing `recipes/samtools/1.6/` subdirectory pattern.

- Builds the htslib bundled in the samtools source tarball (no dependency on the standalone `htslib` package).
- Compiles with `-fcommon` so the pre-GCC-10 sources link cleanly under modern toolchains.
- Builds on `linux-64`, `linux-aarch64`, and `osx-arm64`. Only `osx-64` is skipped, where the bundled htslib-1.8 configure fails to compile and link under the current toolchain.

Companion to #67220 (samtools 1.7); kept as a separate PR so each version builds as its own node and tests in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)