### PR TITLE
Update bwa-mem3 to build 1: statically link mimalloc on Linux

### DIFF
--- a/recipes/bwa-mem3/build.sh
+++ b/recipes/bwa-mem3/build.sh
@@ -65,16 +65,24 @@ else
   # bwa-mem3 calls shm_open/shm_unlink, which on conda's CentOS-7 sysroot
   # (glibc 2.17) live in librt. Newer Linux glibc (>= 2.34) folds them
   # into libc, so upstream CI on ubuntu-latest doesn't need this.
-  # Use conda-forge's mimalloc and htslib. conda-forge ships only the
-  # shared library form on Linux (no .a), so switch from the upstream
-  # Makefile's `-Wl,--whole-archive libmimalloc.a -Wl,--no-whole-archive`
-  # static linking to dynamic linking. mimalloc's docs note that placing
-  # `-lmimalloc` before `-lc` in link order is sufficient for malloc
-  # interposition via ELF symbol resolution order; the upstream LIBS
-  # variable already places $(MIMALLOC_LDFLAGS) before the implicit -lc.
+  #
+  # mimalloc: build and statically link the bundled ext/mimalloc submodule
+  # (the Makefile's default `-Wl,--whole-archive libmimalloc.a`) rather than
+  # dynamically linking conda-forge's libmimalloc.so. conda-forge's Linux
+  # libmimalloc.so exports only the mi_* API, NOT an overriding malloc/free
+  # (it is built without MI_OVERRIDE symbol interposition). Dynamically
+  # linking it therefore loads mimalloc but leaves every malloc/free on the
+  # system allocator -- `bwa-mem3 version` still prints a mimalloc version
+  # (mi_version() resolves), but the hot alignment path runs on glibc malloc,
+  # costing ~30% wall on multi-threaded WGS. The `-lmimalloc before -lc`
+  # interposition claimed by the old comment here only holds when the .so
+  # exports malloc, which conda-forge's does not. Static whole-archive of the
+  # bundled MI_OVERRIDE=ON libmimalloc.a is the only robust override on Linux,
+  # so we drop the MIMALLOC_LIB/MIMALLOC_LDFLAGS overrides and let the
+  # Makefile default build the vendored allocator. (macOS is unaffected: there
+  # conda's libmimalloc.dylib interposes via dyld __interpose regardless of
+  # symbol export, so the Darwin branch above keeps the conda-forge mimalloc.)
   MAKE_ARGS+=(
-    MIMALLOC_LIB="${PREFIX}/lib/libmimalloc.so"
-    MIMALLOC_LDFLAGS="-L${PREFIX}/lib -lmimalloc -Wl,-rpath,${PREFIX}/lib"
     HTS_LIB="${PREFIX}/lib/libhts.so"
     LIBS_EXTRA="-lrt -L${PREFIX}/lib -lsais -Wl,-rpath,${PREFIX}/lib"
   )

--- a/recipes/bwa-mem3/meta.yaml
+++ b/recipes/bwa-mem3/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 5e8bf61d13976a24508201374694f07efec789b6f3154ba8945ec8258bff07b1
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage('bwa-mem3', max_pin="x") }}
 
@@ -23,14 +23,16 @@ requirements:
     - {{ stdlib('c') }}
   host:
     - zlib
-    - mimalloc >=3.3,<4
+    # Linux statically links the bundled mimalloc (see build.sh); only macOS
+    # links the conda-forge mimalloc, whose dylib interposes malloc via dyld.
+    - mimalloc >=3.3,<4  # [osx]
     - htslib >=1.21,<2
     - libsais >=2.10.4,<3
     - sse2neon ==1.9.1  # [aarch64 or arm64]
     - llvm-openmp  # [osx]
     - libgomp      # [linux]
   run:
-    - mimalloc >=3.3,<4
+    - mimalloc >=3.3,<4  # [osx]
     - htslib >=1.21,<2
     - libsais >=2.10.4,<3
     - llvm-openmp  # [osx]
@@ -39,14 +41,25 @@ requirements:
 test:
   commands:
     - bwa-mem3 version
+    # Guard the Linux mimalloc regression: the bundled allocator is statically
+    # whole-archived, so the binary must NOT dynamically link libmimalloc. A
+    # dynamic libmimalloc.so link (conda-forge's) loads but does not override
+    # malloc, silently falling back to glibc. Fail the build if it reappears.
+    - 'if ldd "${PREFIX}/bin/bwa-mem3" | grep -q libmimalloc; then echo "FAIL - bwa-mem3 dynamically links libmimalloc (malloc override inert)"; exit 1; fi'  # [linux]
 
 about:
   home: "https://github.com/fg-labs/bwa-mem3"
-  license: "MIT AND Apache-2.0"
+  license: "MIT AND Apache-2.0 AND Zlib"
   license_family: MIT
   license_file:
     - LICENSE
     - ext/sse2neon/LICENSE
+    # mimalloc (MIT) is statically linked into the Linux binary (see build.sh);
+    # bundle its license. Harmless on macOS where it is dynamically linked.
+    - ext/mimalloc/LICENSE
+    # zlib-ng (Zlib) is statically linked on all platforms (vendored fast gzip
+    # reader); bundle its license and reflect Zlib in the SPDX expression above.
+    - ext/zlib-ng/LICENSE.md
   summary: "Short-read aligner derived from bwa-mem2 with correctness fixes, performance improvements, and methylation alignment."
   dev_url: "https://github.com/fg-labs/bwa-mem3"
   doc_url: "https://bwa-mem3.readthedocs.io"


### PR DESCRIPTION
### Fix inert mimalloc on Linux (bwa-mem3, build 1)

On Linux the recipe dynamically links conda-forge's `libmimalloc.so`, which exports only the `mi_*` API — **not** an overriding `malloc`/`free` (it is built without `MI_OVERRIDE` symbol interposition). The binary loads mimalloc (so `bwa-mem3 version` prints a mimalloc version via `mi_version()`) but every allocation falls through to glibc `malloc`, costing **~30% wall on multi-threaded WGS alignment**.

The old `build.sh` comment claimed `-lmimalloc` before `-lc` is sufficient for ELF interposition; that only holds when the `.so` exports `malloc`, which conda-forge's does not.

**Fix:** build and statically `--whole-archive` the bundled `MI_OVERRIDE=ON` `libmimalloc.a` (the upstream Makefile default) on Linux. macOS is unaffected — there `libmimalloc.dylib` interposes via dyld `__interpose` regardless of symbol export — so the Darwin branch keeps the conda-forge mimalloc, and `mimalloc` becomes an `# [osx]`-only requirement. An `ldd` test guard fails the build if a dynamic (inert) libmimalloc link regresses.

**Verified** on a c6a.4xlarge (AVX2), same v0.5.0 source built two ways, 1M read pairs vs hg38, `-t 16`, 3 reps:

| link | median wall | allocator |
|------|-------------|-----------|
| dynamic `-lmimalloc` (current) | 43.4 s | glibc (no mimalloc arenas under `MIMALLOC_SHOW_STATS=1`) |
| static whole-archive (this PR) | **34.0 s** | mimalloc (22 GiB arenas reserved) |

Alignments byte-identical between the two.

Source unchanged (same tarball / sha256); build number bumped `0 → 1`.

---
* [x] I have read the [guidelines](https://bioconda.github.io/contributor/index.html) for bioconda recipes.
* [x] This PR does not touch fewer than 10 recipes (it touches 1).
* [x] Tests pass locally.
