### PR TITLE
Update fastaguard to 0.6.0

### DIFF
--- a/recipes/fastaguard/meta.yaml
+++ b/recipes/fastaguard/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "fastaguard" %}
-{% set version = "0.5.0" %}
+{% set version = "0.6.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/ehsanestaji/FastaGuard/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: b3de60c83cb570bb90e894c262effe4092101b1655e5c64023445078ee2c5971
+  sha256: b57e967ccaa03ef5e70c14b96247a644750d8bd492360633988f2f53fe84184b
 
 build:
   number: 0


### PR DESCRIPTION
Update `fastaguard` from `0.5.0` to `0.6.0`.

This release adopts conventional process exit codes for workflow compatibility. QC decisions remain available through JSON and TSV reports.

Release: https://github.com/ehsanestaji/FastaGuard/releases/tag/v0.6.0
SHA256: `b57e967ccaa03ef5e70c14b96247a644750d8bd492360633988f2f53fe84184b`