### PR TITLE
Add AMULET 1.1

### DIFF
--- a/recipes/amulet/build.sh
+++ b/recipes/amulet/build.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -euo pipefail
+
+share_dir="${PREFIX}/share/amulet"
+mkdir -p "${PREFIX}/bin" "${share_dir}"
+
+install -m 0644 AMULET.py FragmentFileOverlapCounter.py peakoverlap.py \
+  human_autosomes.txt snATACOverlapCounter.jar "${share_dir}/"
+
+install -m 0755 AMULET.sh "${share_dir}/AMULET.sh"
+
+cat > "${PREFIX}/bin/amulet" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+
+share_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../share/amulet" && pwd)"
+
+if [[ "$#" -eq 0 ]]; then
+    echo "Usage: amulet [options] input.{bam,tsv,txt,tsv.gz,txt.gz} barcodemap chromosomelist repeatfilter outputdirectory"
+    exit 0
+fi
+
+exec "${share_dir}/AMULET.sh" "$@" "${share_dir}"
+EOF
+
+cat > "${PREFIX}/bin/amulet-fragment-overlap-counter" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+
+share_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../share/amulet" && pwd)"
+exec python "${share_dir}/FragmentFileOverlapCounter.py" "$@"
+EOF
+
+cat > "${PREFIX}/bin/amulet-multiplet-detection" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+
+share_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../share/amulet" && pwd)"
+exec python "${share_dir}/AMULET.py" "$@"
+EOF
+
+chmod 0755 \
+  "${PREFIX}/bin/amulet" \
+  "${PREFIX}/bin/amulet-fragment-overlap-counter" \
+  "${PREFIX}/bin/amulet-multiplet-detection"

--- a/recipes/amulet/meta.yaml
+++ b/recipes/amulet/meta.yaml
@@ -1,0 +1,54 @@
+{% set name = "amulet" %}
+{% set version = "1.1" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/UcarLab/AMULET/releases/download/v{{ version }}/AMULET-v{{ version }}.zip
+  sha256: 56bfc175f603054d1046b21fb714e951bfbbe8b5fdb779e4cade224b03a426b8
+  patches:
+    - numpy-1.24-compat.patch
+
+build:
+  number: 0
+  noarch: generic
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x.x") }}
+
+requirements:
+  run:
+    - python >=3
+    - numpy
+    - pandas
+    - scipy
+    - statsmodels
+    - openjdk >=8
+
+test:
+  commands:
+    - amulet 2>&1 | grep -q "Usage: amulet"
+    - amulet-fragment-overlap-counter --help
+    - amulet-multiplet-detection --help
+    - test -s "${PREFIX}/share/amulet/snATACOverlapCounter.jar"
+    - test -s "${PREFIX}/share/amulet/human_autosomes.txt"
+    - jar tf "${PREFIX}/share/amulet/snATACOverlapCounter.jar" | grep -q "org/jax/snatacoverlapcounter/OverlapCounter.class"
+
+about:
+  home: https://github.com/UcarLab/AMULET
+  dev_url: https://github.com/UcarLab/AMULET
+  license: GPL-3.0-only
+  license_file: LICENSE
+  summary: Detect multiplets in single-nucleus ATAC-seq data
+  description: |
+    AMULET (ATAC-seq MULtiplet Estimation Tool) is a count-based method for
+    detecting multiplets from single-nucleus ATAC-seq data. It supports
+    fragment-file input through Python and BAM input through the bundled Java
+    overlap counter.
+
+extra:
+  identifiers:
+    - doi:10.1186/s13059-021-02469-x
+  recipe-maintainers:
+    - qchiujunhao

--- a/recipes/amulet/meta.yaml
+++ b/recipes/amulet/meta.yaml
@@ -28,7 +28,7 @@ requirements:
 
 test:
   commands:
-    - amulet 2>&1 | grep -q "Usage: amulet"
+    - 'amulet 2>&1 | grep -q "Usage: amulet"'
     - amulet-fragment-overlap-counter --help
     - amulet-multiplet-detection --help
     - test -s "${PREFIX}/share/amulet/snATACOverlapCounter.jar"

--- a/recipes/amulet/numpy-1.24-compat.patch
+++ b/recipes/amulet/numpy-1.24-compat.patch
@@ -1,0 +1,24 @@
+diff --git a/AMULET.py b/AMULET.py
+--- a/AMULET.py
++++ b/AMULET.py
+@@ -102 +102 @@ def getDoublets(matrix, unionoverlaps, rcelliddict):
+-    return np.array(doublets_probas, dtype=np.object)
++    return np.array(doublets_probas, dtype=object)
+@@ -133 +133 @@ def getFilteredOverlaps(data, simplerepeats, expectedoverlap):
+-                counts = np.ones((len(starts), 2), dtype=np.object)
++                counts = np.ones((len(starts), 2), dtype=object)
+@@ -138 +138 @@ def getFilteredOverlaps(data, simplerepeats, expectedoverlap):
+-                counts2 = -1*np.ones((len(starts), 2), dtype=np.object)
++                counts2 = -1*np.ones((len(starts), 2), dtype=object)
+diff --git a/FragmentFileOverlapCounter.py b/FragmentFileOverlapCounter.py
+--- a/FragmentFileOverlapCounter.py
++++ b/FragmentFileOverlapCounter.py
+@@ -193 +193 @@ def writeOverlapSummary(filepath, overlapcounts, vreadspercell, readspercell):
+-    table = np.empty(shape=(len(overlapcounts),len(colnames)), dtype=np.object)
++    table = np.empty(shape=(len(overlapcounts),len(colnames)), dtype=object)
+diff --git a/peakoverlap.py b/peakoverlap.py
+--- a/peakoverlap.py
++++ b/peakoverlap.py
+@@ -358 +358 @@ def getUnionPeaks(datasets, chridx=0, startidx=1, endidx=2):
+-    return np.array(rv, dtype=np.object)
++    return np.array(rv, dtype=object)

--- a/recipes/amulet/run_test.sh
+++ b/recipes/amulet/run_test.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set -euo pipefail
+
+test_dir="amulet-fragment-workflow-test"
+rm -rf "${test_dir}"
+mkdir -p "${test_dir}/out"
+
+cat > "${test_dir}/cells.csv" <<'EOF'
+barcode,is__cell_barcode
+cellA,1
+cellB,1
+cellC,1
+EOF
+
+cat > "${test_dir}/chromosomes.txt" <<'EOF'
+chr1
+chr2
+EOF
+
+cat > "${test_dir}/repeats.bed" <<'EOF'
+chr9	1	2
+EOF
+
+cat > "${test_dir}/fragments.tsv" <<'EOF'
+chr1	100	150	cellA	1
+chr1	110	160	cellA	1
+chr1	120	170	cellA	1
+chr1	200	250	cellB	1
+chr1	210	260	cellB	1
+chr1	220	270	cellB	1
+chr1	300	350	cellC	1
+chr1	310	360	cellC	1
+chr1	320	370	cellC	1
+chr1	400	450	cellC	1
+chr1	410	460	cellC	1
+chr1	420	470	cellC	1
+chr2	1	10	cellA	1
+EOF
+
+amulet \
+  "${test_dir}/fragments.tsv" \
+  "${test_dir}/cells.csv" \
+  "${test_dir}/chromosomes.txt" \
+  "${test_dir}/repeats.bed" \
+  "${test_dir}/out"
+
+test "$(wc -l < "${test_dir}/out/Overlaps.txt")" -eq 5
+test "$(wc -l < "${test_dir}/out/OverlapSummary.txt")" -eq 4
+test "$(wc -l < "${test_dir}/out/MultipletProbabilities.txt")" -eq 4
+grep -q $'cellC\t6\t2\tcellC\t6' "${test_dir}/out/OverlapSummary.txt"
+grep -q $'Number of Cells\t3' "${test_dir}/out/MultipletSummary.txt"
+
+rm -rf "${test_dir}"


### PR DESCRIPTION
## Summary

- add a Bioconda recipe for the official AMULET 1.1 release
- install stable command wrappers for the fragment overlap counter, multiplet detection, and combined AMULET workflow
- retain the bundled BAM overlap-counter JAR and chromosome-list asset under `share/amulet`
- replace removed `numpy.object` aliases so the release works with current NumPy

AMULET is a count-based tool for identifying multiplets in single-nucleus ATAC-seq data. The recipe uses the immutable official release ZIP because that asset includes the BAM overlap-counter JAR referenced by the upstream documentation.

## Testing

- `bioconda-utils lint recipes config.yml --packages amulet` (`All checks OK`)
- installed-path command help tests
- deterministic offline fragment-file workflow covering overlap counting and multiplet detection
- JAR content and packaged chromosome-list checks
- PR CI passed on Linux, OSX-64, and ARM

The workflow smoke test passed with current NumPy 2.x and pandas 3.x.
