### PR TITLE
Add scanexitron recipe

### DIFF
--- a/recipes/scanexitron/meta.yaml
+++ b/recipes/scanexitron/meta.yaml
@@ -27,6 +27,8 @@ requirements:
     - python >=3.10,<3.13
     - pyfaidx >=0.7
     - numpy >=1.21
+    - htseq >=2.0
+    - typer >=0.12
     # External bioinformatics tools (install from bioconda):
     - samtools
     - bedtools

--- a/recipes/scanexitron/meta.yaml
+++ b/recipes/scanexitron/meta.yaml
@@ -21,9 +21,8 @@ build:
 requirements:
   host:
     - python >=3.10,<3.13
+    - hatchling
     - pip
-    - setuptools >=68
-    - wheel
   run:
     - python >=3.10,<3.13
     - pyfaidx >=0.7

--- a/recipes/scanexitron/meta.yaml
+++ b/recipes/scanexitron/meta.yaml
@@ -1,0 +1,60 @@
+{% set name = "scanexitron" %}
+{% set version = "1.4.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 3c8f43ce3ab0bb7170c03d58ade9408e77f7ac744cffd54666ea977bb6b8ac85
+
+build:
+  number: 0
+  noarch: python
+  run_exports:
+    - {{ pin_subpackage('scanexitron', max_pin="x") }}
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  entry_points:
+    - scanexitron = scanexitron.cli:main
+
+requirements:
+  host:
+    - python >=3.10,<3.13
+    - pip
+    - setuptools >=68
+    - wheel
+  run:
+    - python >=3.10,<3.13
+    - pyfaidx >=0.7
+    - numpy >=1.21
+    # External bioinformatics tools (install from bioconda):
+    - samtools
+    - bedtools
+    - regtools =0.5.0
+
+test:
+  imports:
+    - scanexitron
+    - scanexitron.core
+    - scanexitron.vcf
+    - scanexitron.cli
+  commands:
+    - scanexitron --version
+    - scanexitron convert --help
+
+about:
+  home: https://github.com/ylab-hi/ScanExitron
+  license: MIT
+  license_file: LICENSE
+  summary: A computational workflow for exitron splicing identification from RNA-Seq data
+  description: |
+    ScanExitron detects exitron splicing events from RNA-Seq BAM/CRAM alignment
+    files. It uses regtools to call and annotate junctions, bedtools to intersect
+    them with CDS annotations, and computes per-exitron PSO/PSI statistics.
+  doc_url: https://github.com/ylab-hi/ScanExitron
+  dev_url: https://github.com/ylab-hi/ScanExitron
+
+extra:
+  recipe-maintainers:
+    - dolittle007


### PR DESCRIPTION
## Description

Adds a new recipe for [ScanExitron](https://github.com/ylab-hi/ScanExitron), a computational workflow for exitron splicing identification from RNA-Seq data. It uses `regtools` to call and annotate junctions, `bedtools` to intersect them with CDS annotations, and computes per-exitron PSO/PSI statistics.

- PyPI release: https://pypi.org/project/scanexitron/1.4.0/
- Runtime depends on `samtools`, `bedtools`, and `regtools` (all pulled from bioconda).

## Checklist

- [x] I have read the [guidelines for noarch builds](https://bioconda.github.io/contributor/guidelines.html#noarch-builds).
- [x] If this PR adds or updates a package, I have verified that this recipe would be built with a valid build number of 0.
- [x] I have verified that the license information for this recipe is correct.