### PR TITLE
Update amalgkit to 0.16.31

### DIFF
--- a/recipes/amalgkit/meta.yaml
+++ b/recipes/amalgkit/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "amalgkit" %}
-{% set version = "0.16.25" %}
-{% set python_min = "3.9" %}
+{% set version = "0.16.30" %}
+{% set python_min = "3.11" %}
 
 package:
   name: "{{ name|lower }}"
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://github.com/kfuku52/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 3d6de6110673ce9dfe821ee42c530a38f02d4fa8b12ee360f9d98d02b8666a44
+  sha256: 69bd8708407c4d50925373f815a4f735a4a962dc936460b6f059b2854b7b1abd
 
 build:
   number: 0
@@ -21,19 +21,19 @@ requirements:
   host:
     - python {{ python_min }}
     - pip
-    - setuptools
+    - setuptools >=77.0.3
     - wheel
 
   run:
     - python >={{ python_min }}
-    - biopython
-    - matplotlib-base
-    - numpy
-    - pandas
-    - scikit-learn
-    - scipy
-    - statsmodels
-    - ete4
+    - biopython >=1.81
+    - defusedxml >=0.7.1
+    - matplotlib-base >=3.7.5
+    - numpy >=1.24.4
+    - pandas >=2.0.3
+    - scikit-learn >=1.3.2
+    - scipy >=1.10.1
+    - statsmodels >=0.14
     - seqkit
     - sra-tools >=3
     - fastp
@@ -41,6 +41,7 @@ requirements:
 
 test:
   commands:
+    - amalgkit --version
     - amalgkit --help
     - amalgkit help finalize
     - amalgkit dataset --list

--- a/recipes/amalgkit/meta.yaml
+++ b/recipes/amalgkit/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "amalgkit" %}
-{% set version = "0.16.30" %}
+{% set version = "0.16.31" %}
 {% set python_min = "3.11" %}
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://github.com/kfuku52/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 69bd8708407c4d50925373f815a4f735a4a962dc936460b6f059b2854b7b1abd
+  sha256: 4f56a0085c7902025f941381bc3580d94735932e29a10c53313a791496e363eb
 
 build:
   number: 0


### PR DESCRIPTION
## Changes

- Update AMALGKIT from 0.16.25 to 0.16.31 and pin the published tag archive by SHA256.
- Raise the minimum Python version to 3.11 to match upstream metadata.
- Require a PEP 517/PEP 639-capable setuptools in the host environment.
- Remove the retired `ete4` runtime dependency, add `defusedxml`, and align Python dependency floors with upstream.
- Add an explicit CLI version smoke test.

## Why

AMALGKIT 0.16.31 replaces its limited ETE taxonomy usage with a native backend, modernizes its Python packaging, and hardens ENA URL normalization. The existing Bioconda recipe still described the pre-migration dependency graph and Python support range.

## Impact

The package remains `noarch: python`. New 0.16.31 environments require Python 3.11 or newer; environments constrained to older Python versions can continue resolving earlier AMALGKIT builds.

## Root cause

The Bioconda recipe was last updated for 0.16.25, before the upstream taxonomy and packaging changes.

## Checks

- Verified the GitHub tag archive SHA256: `4f56a0085c7902025f941381bc3580d94735932e29a10c53313a791496e363eb`.
- `bioconda-utils 4.4.1 lint recipes config.yml --packages amalgkit` passes.
- A Linux x86_64 `conda build` completed successfully and passed the import and CLI recipe tests; the noarch test environment resolved with Python 3.14.
- Upstream Tests, CodeQL, Dependency Graph, and release workflows completed successfully for the tagged commit.
