### PR TITLE
motus: update to 4.1.0

### DIFF
--- a/recipes/motus/meta.yaml
+++ b/recipes/motus/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "4.0.4" %}
-{% set sha256 = "e42f671f0dd46ac5606bc8c68a93ffdd09bfb90e8eb12e4b22269c320d0adc52" %}
+{% set version = "4.1.0" %}
+{% set sha256 = "1607bc6a2cdd7bf7c119fcea9120133b6f196e5f8ac1fbf4bc36ba60ebd8ccb7" %}
 
 package:
   name: motus
@@ -21,14 +21,14 @@ requirements:
     - pip
     - setuptools
   run:
-    - bwa >=0.7.19
+    - bwa >=0.7.18
     - vsearch >=2.30.4
     - python >=3.12
     - biopython >=1.8.5
     - pysam >=0.23.3
     - polars >=1.32.2
     - rapidfuzz >=3.13.0
-    - tqdm >=4.67.3
+    - tqdm
     - fetchmgs >=2.1.2
 
 test:

--- a/recipes/uniqsketch/meta.yaml
+++ b/recipes/uniqsketch/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "uniqsketch" %}
-{% set version = "1.3.0" %}
+{% set version = "1.4.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/amazon-science/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 29e1df5d16168b29c00a0d7575236ae17517a4eb2e0eaf6091a3a07b9d147a99
+  sha256: ea53d1bf8e6d44b8b544c5babb4e4e77d72aeb6c8a075bf297c2ddd2a27546e0
 
 build:
   number: 0


### PR DESCRIPTION
## Summary
Update motus to version 4.1.0

## Changes
- Update version from 4.0.4 to 4.1.0
- Update SHA256 hash from new PyPI release
- Fix dependencies to match pyproject.toml (bwa >=0.7.18, tqdm without version constraint)

## Release Notes

https://github.com/motu-tool/mOTUs/releases/tag/v4.1.0

Key improvements in 4.1.0:
- data access via motus-api
- including of new genomic data
- Standardized TAXONOMY field naming across commands
