### PR TITLE
Add r-canek recipe

### DIFF
--- a/recipes/r-canek/LICENSE
+++ b/recipes/r-canek/LICENSE
@@ -1,0 +1,21 @@
+# MIT License
+
+Copyright (c) 2019 Martin Loza
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/recipes/r-canek/build.sh
+++ b/recipes/r-canek/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+$R CMD INSTALL --build .

--- a/recipes/r-canek/meta.yaml
+++ b/recipes/r-canek/meta.yaml
@@ -1,0 +1,49 @@
+{% set version = "0.2.5" %}
+
+package:
+  name: r-canek
+  version: '{{ version }}'
+
+source:
+  url: https://cran.r-project.org/src/contrib/Canek_{{ version }}.tar.gz
+  sha256: 5e7f5e030baa324f82a494e155d28ce8d18f760c3103e4d2f9d3d8ff306c3fc7
+
+build:
+  number: 0
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  host:
+    - r-base
+    - r-fnn
+    - bioconductor-bluster
+    - r-fpc
+    - r-igraph
+    - r-irlba
+    - r-matrixstats
+    - r-numbers
+  run:
+    - r-base
+    - r-fnn
+    - bioconductor-bluster
+    - r-fpc
+    - r-igraph
+    - r-irlba
+    - r-matrixstats
+    - r-numbers
+
+test:
+  commands:
+    - $R -e "library('Canek')"
+
+about:
+  home: https://martinloza.github.io/Canek/
+  license: MIT
+  license_file: LICENSE
+  summary: 'Non-linear/linear hybrid method for batch-effect correction that uses Mutual Nearest Neighbors (MNNs) to identify similar cells between datasets. Reference: Loza M. et al. (NAR Genomics and Bioinformatics, 2020) <doi:10.1093/nargab/lqac022>.'
+
+extra:
+  recipe-maintainers:
+    - MartinLoza

--- a/recipes/r-canek/meta.yaml
+++ b/recipes/r-canek/meta.yaml
@@ -10,6 +10,7 @@ source:
 
 build:
   number: 0
+  noarch: generic
   rpaths:
     - lib/R/lib/
     - lib/

--- a/recipes/r-canek/meta.yaml
+++ b/recipes/r-canek/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.2.5" %}
+{% set version = "0.3.1" %}
 
 package:
   name: r-canek
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://cran.r-project.org/src/contrib/Canek_{{ version }}.tar.gz
-  sha256: 5e7f5e030baa324f82a494e155d28ce8d18f760c3103e4d2f9d3d8ff306c3fc7
+  sha256: 6c6fdf3a6cc3259254dcaab38a2deeeaa245410ac10871948da41b07444794be
 
 build:
   number: 0

--- a/recipes/r-canek/meta.yaml
+++ b/recipes/r-canek/meta.yaml
@@ -11,6 +11,8 @@ source:
 build:
   number: 0
   noarch: generic
+  run_exports:
+    - '{{ pin_subpackage("r-canek", max_pin="x.x") }}'
   rpaths:
     - lib/R/lib/
     - lib/
@@ -43,7 +45,8 @@ about:
   home: https://martinloza.github.io/Canek/
   license: MIT
   license_file: LICENSE
-  summary: 'Non-linear/linear hybrid method for batch-effect correction that uses Mutual Nearest Neighbors (MNNs) to identify similar cells between datasets. Reference: Loza M. et al. (NAR Genomics and Bioinformatics, 2020) <doi:10.1093/nargab/lqac022>.'
+  summary: 'Batch Correction of Single Cell Transcriptome Data'
+  description: 'Non-linear/linear hybrid method for batch-effect correction that uses Mutual Nearest Neighbors (MNNs) to identify similar cells between datasets. Reference: Loza M. et al. (NAR Genomics and Bioinformatics, 2020) <doi:10.1093/nargab/lqac022>.'
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Add r-canek to bioconda-recipes

Recipe for [Canek](https://martinloza.github.io/Canek/), an R package for batch-effect
correction of single-cell transcriptome data (MNN-based hybrid method; Loza et al.,
*NAR Genomics and Bioinformatics*, 2020, <doi:10.1093/nargab/lqac022>).

Submitted to bioconda because Canek depends on Bioconductor
package `bluster`, which has no conda-forge feedstock.
