### PR TITLE
Update finaletoolkit to 1.0.0

### DIFF
--- a/recipes/finaletoolkit/meta.yaml
+++ b/recipes/finaletoolkit/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "finaletoolkit" %}
-{% set version = "0.11.1" %}
+{% set version = "1.0.0" %}
 {% set loess_version = "2.1.2" %}
 {% set plotbin_version = "3.1.7" %}
 
@@ -9,7 +9,7 @@ package:
 
 source:
   - url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-    sha256: eeb23f50fad1666b66aa2d22c16075c9c06d4788506792367d16794d8f9b9893
+    sha256: bb5494ffa465c314ff7e4f623cf904a50ef85ed7d8df28796f462ed85d6a6cc9
   - url: https://files.pythonhosted.org/packages/a7/91/676f1839b94259e30ed85c962be6009c819e61b3fd29c64b34c0894e69b4/loess-{{ loess_version }}-py3-none-any.whl
     sha256: 105f12daa0fdff5185855ae57c2d3f25420fb30b475ae3f4078843a5c61699b9
   - url: https://files.pythonhosted.org/packages/1e/00/6b6b084717523a3bba465c42b7309849c9ee580d64f2baccf972bc3d462d/plotbin-{{ plotbin_version }}-py3-none-any.whl
@@ -28,11 +28,11 @@ build:
 
 requirements:
   host:
-    - python >=3.9,<3.13
+    - python >=3.10,<3.13
     - setuptools >=61.0
     - pip
   run:
-    - python >=3.9,<3.13
+    - python >=3.10,<3.13
     - numpy
     - pysam
     - pybigwig
@@ -43,6 +43,7 @@ requirements:
     - pandas
     - statsmodels
     - matplotlib-base
+    - rich-click >=1.8
 
 test:
   imports:
@@ -66,3 +67,4 @@ about:
 extra:
   recipe-maintainers:
     - Kudostoy0u
+    - jamesli124


### PR DESCRIPTION
Updates `finaletoolkit` to 1.0.0.

This supersedes #67223, which is stalled on a failing **Linux Tests** check. That failure is caused by a missing runtime dependency: 1.0.0's CLI was refactored to use `rich-click` (`finaletoolkit/cli/main_cli.py` does `import rich_click as click`), so the recipe's `finaletoolkit --help` test errors with `ModuleNotFoundError: No module named 'rich_click'`. This PR carries the same 1.0.0 update plus `rich-click >=1.8` in the run requirements to fix it.

Opened by a FinaleToolkit maintainer (epifluidlab). #67223 can be closed in favor of this.

---

* [x] This PR adds a new recipe / updates an existing recipe.
* [x] `bioconda-utils` linting passes.
