### PR TITLE
Rebuild ms2rescore to pick up ms2pip 4.1.2

### DIFF
--- a/recipes/ms2rescore/meta.yaml
+++ b/recipes/ms2rescore/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   noarch: python
   run_exports:
     - {{ pin_subpackage(name, max_pin="x.x") }}


### PR DESCRIPTION
Build-number bump so the biocontainer resolves against the newly published ms2pip 4.1.2, giving numpy 2 / pyopenms 3.5.0 instead of the old numpy-1 stack.