### PR TITLE
Update cnvkit to 0.9.14

### DIFF
--- a/recipes/cnvkit/meta.yaml
+++ b/recipes/cnvkit/meta.yaml
@@ -33,7 +33,7 @@ requirements:
   run:
     - python >=3.11
     - bioconductor-dnacopy
-    - bioframe
+    - bioframe >=0.8.0
     - biopython >=1.87
     - hypothesis
     - matplotlib-base >=3.10.7
@@ -46,6 +46,7 @@ requirements:
     - reportlab >=4.4.10
     - scikit-learn >=1.7.2
     - scipy >=1.16.3
+    - statsmodels >=0.14.6
 
 test:
   imports:

--- a/recipes/cnvkit/meta.yaml
+++ b/recipes/cnvkit/meta.yaml
@@ -33,6 +33,7 @@ requirements:
   run:
     - python >=3.11
     - bioconductor-dnacopy
+    - bioframe
     - biopython >=1.87
     - hypothesis
     - matplotlib-base >=3.10.7
@@ -41,6 +42,7 @@ requirements:
     - pandas >=2.3.3
     - pyfaidx >=0.8.1.3
     - pysam >=0.23.3
+    - r-base >=4.5.3
     - reportlab >=4.4.10
     - scikit-learn >=1.7.2
     - scipy >=1.16.3

--- a/recipes/cnvkit/meta.yaml
+++ b/recipes/cnvkit/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "cnvkit" %}
-{% set version = "0.9.13" %}
+{% set version = "0.9.14" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/etal/cnvkit/archive/v{{ version }}.tar.gz
-  sha256: a197acbfb4352fdb5f661adadc5c07f19eb4ede4c15fa50dde57aa52a8d91d67
+  sha256: 800cbdf0250e06f5e295f6d71be1707a550a18547b7d442e1df80252dce13e53
 
 build:
   noarch: python
@@ -27,25 +27,23 @@ build:
 
 requirements:
   host:
-    - python >=3.8
+    - python >=3.11
     - pip
     - setuptools
   run:
-    - python >=3.8
+    - python >=3.11
     - bioconductor-dnacopy
-    - biopython >=1.80
-    - matplotlib-base >=3.5.2
-    - networkx >=2.4
-    - numpy >=1.24.2
-    - pandas >=1.5.3
-    - pomegranate >=0.14.8,<=0.14.9
-    - pyfaidx >=0.7.1
-    - pysam >=0.20.0
-    - r-base >=3.4.1
-    - r-cghflasso
-    - reportlab >=3.6.12
-    - scikit-learn >=1.1.0
-    - scipy >=1.10.1
+    - biopython >=1.87
+    - hypothesis
+    - matplotlib-base >=3.10.7
+    - mypy
+    - numpy >=2.3.5
+    - pandas >=2.3.3
+    - pyfaidx >=0.8.1.3
+    - pysam >=0.23.3
+    - reportlab >=4.4.10
+    - scikit-learn >=1.7.2
+    - scipy >=1.16.3
 
 test:
   imports:


### PR DESCRIPTION
Update [`cnvkit`](https://bioconda.github.io/recipes/cnvkit/README.html): **0.9.13** &rarr; **0.9.14**

Supersedes https://github.com/bioconda/bioconda-recipes/pull/66831 to raise the minimum requirements and add missing dependencies

As of `cnvkit` v0.9.14, the minimum required `python` version is 3.11 & `biopython` 1.87. Also `pomegranate` isn't required anymore
