### PR TITLE
Update cgmlst-dists-py to 0.1.5

### DIFF
--- a/recipes/cgmlst-dists-py/meta.yaml
+++ b/recipes/cgmlst-dists-py/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "cgmlst-dists-py" %}
-{% set version = "0.1.3" %}
-{% set sha256 = "7275e6287092d116c575389b6dfed34dfecf02258c595921ec202e895e380a16" %}
+{% set version = "0.1.5" %}
+{% set sha256 = "78c43c53a4572d7a9cbd9ff401ddf8f8833af35cfc0168aeb5ba0b913d44a746" %}
 {% set user = "genpat-it" %}
 
 package:
@@ -39,5 +39,7 @@ about:
   dev_url: "https://github.com/{{ user }}/{{ name }}"
 
 extra:
+  recipe-maintainers:
+    - andreaderuvo
   skip-lints:
     - should_be_noarch_python


### PR DESCRIPTION
Version bump of `cgmlst-dists-py` from 0.1.3 to 0.1.5.

Upstream changes since 0.1.3 (see the project [CHANGELOG](https://github.com/genpat-it/cgmlst-dists-py/blob/main/CHANGELOG.md)):

- **0.1.5**: up-front memory feasibility check that aborts before the distance computation when the N×N matrix won't fit in RAM (with `--force` to override); `--stdout` no longer materializes the whole matrix as strings (fixes a `MemoryError` on large datasets) and now writes logs to stderr; short option aliases for all flags.
- **0.1.4**: fix a startup crash when the tool runs as a non-root user (numba cache directory).

Recipe changes:
- `version` 0.1.3 → 0.1.5
- updated `sha256` for the new source tarball
- added `recipe-maintainers` (was missing)

Runtime dependencies are unchanged.

---

- [x] This PR bumps an existing recipe to a new version.
- [x] The tests pass locally (`--version` reports 0.1.5; `-h` works).