### PR TITLE
Add pam_scanning 1.0.0

### DIFF
--- a/recipes/pam_scanning/meta.yaml
+++ b/recipes/pam_scanning/meta.yaml
@@ -1,0 +1,57 @@
+{% set name = "pam_scanning" %}
+{% set version = "1.0.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/dangerisom/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: d413775fccab8a830fbb10dcf335033c0b84080917cd0e007abc6ddaf92fe1e3
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  entry_points:
+    - pam-scan = pam_scanning.cli:main
+    - pam-scan-gui = pam_scanning.gui:main
+    - pam-scan-fetch-cds = pam_scanning.fetch_cds:main
+
+requirements:
+  host:
+    - python >=3.8
+    - pip
+    - setuptools >=64
+  run:
+    - python >=3.8
+    - openpyxl
+    - matplotlib-base
+    - blast
+
+test:
+  imports:
+    - pam_scanning
+  commands:
+    - pam-scan --help
+    - pam-scan-fetch-cds --help
+
+about:
+  home: https://github.com/dangerisom/pam_scanning
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: Design CRISPR guides and primers for ORF-wide chimera (PAM) scanning.
+  description: |
+    pam_scanning designs CRISPR guides and cloning primers for ORF-wide chimera
+    (PAM) scanning. Given an open reading frame and its flanking sequence, it
+    locates PAM sites, silences them where required, evaluates guide specificity
+    by BLAST against a reference genome, selects optimal guides per insertion
+    site, and emits primer orders, plate layouts, and QC reports. A graphical
+    interface and a UniProt-to-CDS fetcher are included.
+  dev_url: https://github.com/dangerisom/pam_scanning
+  doc_url: https://github.com/dangerisom/pam_scanning/blob/master/docs/pipeline.md
+
+extra:
+  recipe-maintainers:
+    - dangerisom

--- a/recipes/pam_scanning/meta.yaml
+++ b/recipes/pam_scanning/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pam_scanning" %}
-{% set version = "1.0.0" %}
+{% set version = "1.0.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/dangerisom/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: d413775fccab8a830fbb10dcf335033c0b84080917cd0e007abc6ddaf92fe1e3
+  sha256: 85d9bbc8c84ae266027946566c55a5275f88f53e0d74800a0593e4ecaefa44f6
 
 build:
   noarch: python

--- a/recipes/pam_scanning/meta.yaml
+++ b/recipes/pam_scanning/meta.yaml
@@ -13,6 +13,8 @@ build:
   noarch: python
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x") }}
   entry_points:
     - pam-scan = pam_scanning.cli:main
     - pam-scan-gui = pam_scanning.gui:main

--- a/recipes/pam_scanning/meta.yaml
+++ b/recipes/pam_scanning/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/dangerisom/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  url: https://github.com/isomlab/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
   sha256: 85d9bbc8c84ae266027946566c55a5275f88f53e0d74800a0593e4ecaefa44f6
 
 build:
@@ -28,7 +28,8 @@ requirements:
   run:
     - python >=3.8
     - openpyxl
-    - matplotlib-base
+    # >=3.4 for Colormap.with_extremes, used in plots.py
+    - matplotlib-base >=3.4
     - blast
 
 test:
@@ -39,7 +40,7 @@ test:
     - pam-scan-fetch-cds --help
 
 about:
-  home: https://github.com/dangerisom/pam_scanning
+  home: https://github.com/isomlab/pam_scanning
   license: MIT
   license_family: MIT
   license_file: LICENSE
@@ -51,8 +52,8 @@ about:
     by BLAST against a reference genome, selects optimal guides per insertion
     site, and emits primer orders, plate layouts, and QC reports. A graphical
     interface and a UniProt-to-CDS fetcher are included.
-  dev_url: https://github.com/dangerisom/pam_scanning
-  doc_url: https://github.com/dangerisom/pam_scanning/blob/master/docs/pipeline.md
+  dev_url: https://github.com/isomlab/pam_scanning
+  doc_url: https://github.com/isomlab/pam_scanning/blob/main/docs/pipeline.md
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Adds `pam_scanning` 1.0.0 — a tool for designing CRISPR guides and cloning primers for ORF-wide chimera (PAM) scanning.

Given an open reading frame and its flanking sequence, it locates PAM sites, silences them where required, evaluates guide specificity by BLAST against a reference genome, selects optimal guides per insertion site, and emits primer orders, plate layouts, and QC reports. Ships a CLI (`pam-scan`), a Tk GUI (`pam-scan-gui`), and a UniProt-to-CDS fetcher (`pam-scan-fetch-cds`).

Source: https://github.com/dangerisom/pam_scanning (MIT)
Release: https://github.com/dangerisom/pam_scanning/releases/tag/v1.0.0

`noarch: python`. Runtime deps: `openpyxl`, `matplotlib-base`, and `blast` (the pipeline shells out to `blastn`/`makeblastdb`).

I am the package author and have added myself as recipe maintainer.