### PR TITLE
bwa-mem3: build with clang (build 1)

### DIFF
--- a/recipes/bwa-mem3/meta.yaml
+++ b/recipes/bwa-mem3/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: e6c2e479037e4ab5ede1835d3914ffc9347f6bb729e87fc5e4260f0dcb09bffe
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage('bwa-mem3', max_pin="x") }}
 
@@ -18,8 +18,13 @@ requirements:
   build:
     - make
     - cmake
-    - {{ compiler('c') }}
-    - {{ compiler('cxx') }}
+    # Build with clang (not the default gcc): bwa-mem3 is ~16% faster on x86
+    # and ~6% on ARM when compiled with clang than with g++ (see the upstream
+    # docs/src/best-practices/build.md). clang uses the LLVM OpenMP runtime
+    # (llvm-openmp), so the OpenMP host/run deps below are llvm-openmp on all
+    # platforms rather than libgomp on Linux.
+    - {{ compiler('clang') }}
+    - {{ compiler('clangxx') }}
     - {{ stdlib('c') }}
   host:
     - zlib
@@ -29,14 +34,12 @@ requirements:
     - htslib >=1.21,<2
     - libsais >=2.10.4,<3
     - sse2neon ==1.9.1  # [aarch64 or arm64]
-    - llvm-openmp  # [osx]
-    - libgomp      # [linux]
+    - llvm-openmp
   run:
     - mimalloc >=3.3,<4  # [osx]
     - htslib >=1.21,<2
     - libsais >=2.10.4,<3
-    - llvm-openmp  # [osx]
-    - libgomp      # [linux]
+    - llvm-openmp
 
 test:
   commands:


### PR DESCRIPTION
Builds `bwa-mem3` with **clang** instead of the default gcc.

### Why

bwa-mem3 is materially faster when compiled with clang than with g++ — roughly **16% lower wall + CPU on x86 (AVX2)** and **~6% on ARM** on WGS workloads (see the upstream build guide: https://bwa-mem3.readthedocs.io, `docs/src/best-practices/build.md`). Since the recipe already builds a single multi-tier binary, moving the linux build from gcc to clang carries the gain to the Bioconda package with no interface change.

### Changes

- Compiler: `{{ compiler('c') }}` / `{{ compiler('cxx') }}` → `{{ compiler('clang') }}` / `{{ compiler('clangxx') }}` (macOS was already clang; this switches linux).
- OpenMP runtime: `libgomp` (linux) → `llvm-openmp` on all platforms, in both `host` and `run`, since clang uses the LLVM OpenMP runtime.
- Build number bumped 0 → 1 (rebuild of the published 0.6.0).

`build.sh` is unchanged — it already passes `CC`/`CXX` through from the activated compiler.

### Notes for reviewers

Happy to revert to the default gcc toolchain if a clang-on-linux build is undesirable here — the change is isolated to the compiler + OpenMP deps. Flagging one thing to watch in CI: the OpenMP runtime is now `llvm-openmp` while the `libsais` host dep may be built against `libgomp`; if that interop causes issues I'll adjust.
