### PR TITLE
Update hmmer BLAS provider compatibility

### DIFF
--- a/recipes/hmmer/meta.yaml
+++ b/recipes/hmmer/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: ca70d94fd0cf271bd7063423aabb116d42de533117343a9b27a65c17ff06fbf3
 
 build:
-  number: 4
+  number: 5
   run_exports:
     # commands/options have been removed or replaced between minor versions
     - {{ pin_subpackage('hmmer', max_pin="x.x") }}
@@ -19,6 +19,7 @@ requirements:
   build:
     - make
     - {{ compiler('c') }}
+    - {{ stdlib('c') }}
     - autoconf
     - automake
     - libtool
@@ -26,11 +27,14 @@ requirements:
     - gnuconfig
   host:
     - gsl
+    - libblas * *_netlib
     - openmpi
   run:
     - openmpi
 
 test:
+  requires:
+    - libblas * *_netlib
   commands:
     - alimask -h 2>&1 | grep "HMMER 3\." > /dev/null
     - hmmalign -h 2>&1 | grep "HMMER 3\." > /dev/null
@@ -43,6 +47,9 @@ test:
     - hmmsim -h 2>&1 | grep "HMMER 3\." > /dev/null
     - hmmstat -h 2>&1 | grep "HMMER 3\." > /dev/null
     - jackhmmer -h 2>&1 | grep "HMMER 3\." > /dev/null
+    - 'printf ">query_protein\nMKTIIALSYIFCLVFADYKDDDDK\n" > query.fa'
+    - 'printf ">matching_target\nMKTIIALSYIFCLVFADYKDDDDK\n>unrelated_target\nGAVLKVLTTGLPALISWIKRKRQQ\n" > targets.fa'
+    - jackhmmer --noali -N 1 query.fa targets.fa 2>&1 | grep "matching_target" > /dev/null
     - phmmer -h 2>&1 | grep "HMMER 3\." > /dev/null
     - nhmmer -h 2>&1 | grep "HMMER 3\." > /dev/null
     - nhmmscan -h 2>&1 | grep "HMMER 3\." > /dev/null


### PR DESCRIPTION
Closes #56856

The current HMMER build links directly to `libopenblas.so.0`, so it fails when another valid BLAS provider is selected. This rebuild pins Netlib in the host environment to link against the generic BLAS ABI while leaving the runtime provider selectable through `libblas` run exports.

Changes:

- bump the HMMER build number
- build and test with the Netlib BLAS variant
- add a self-contained functional `jackhmmer` search with tiny protein inputs

Local validation:

- `conda render` completed successfully
- the HMMER 3.4 package built and its complete test section passed
- a clean install of the local package with `libblas=*=*netlib` contained no OpenBLAS package
- `readelf` showed no `libopenblas.so.0` dependency and the functional search exited successfully