### PR TITLE
Update mosdepth: bump build number for htslib 1.24 rebuild

### DIFF
--- a/recipes/mosdepth/meta.yaml
+++ b/recipes/mosdepth/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: abac67de4547dc5642efd46846044d6b3536d2ca3443b4ca172446edf82eeb42
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage(name, max_pin="x.x") }}
 


### PR DESCRIPTION
Rebuild `mosdepth 0.3.14` against `htslib 1.24`. See https://github.com/brentp/mosdepth/issues/271

### Summary
* `mosdepth 0.3.14` build 0 was pinned to `htslib <1.24.0a0`.
* When environment solvers (Conda / Pixi) upgrade `htslib` or `samtools` to `1.24`, the solver falls back to legacy `mosdepth 0.3.3` (which lacks the upper `htslib` pin).
* `mosdepth 0.3.3` has known CRAM slice decoding bugs.
* Bumping `build.number` to `1` triggers a rebuild of `mosdepth 0.3.14` against `htslib 1.24`.

### Checklist
- [x] Recipe updated: `recipes/mosdepth/meta.yaml`
- [x] Build number bumped from 0 to 1
