### PR TITLE
Add pan_te 1.2.0

### DIFF
--- a/recipes/pan_te/build.sh
+++ b/recipes/pan_te/build.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -ex
+
+# The Look4LTRs helper is supplied at runtime by the look4ltrs dependency
+# ($PREFIX/share/Look4LTRs/build_ltr_library.py); no third-party source tree is
+# vendored into the Pan_TE package.
+SRC="$SRC_DIR/pan_te"
+PKG="$PREFIX/share/pan_te"
+
+mkdir -p "$PKG" "$PREFIX/bin"
+
+# --- 1. install the pipeline tree (scripts + python subpackages) into share/pan_te ---
+cp -r "$SRC/bin/." "$PKG/"
+
+# strip caches / logs / local tooling config / dev-only scaffolding that should never ship
+find "$PKG" -type d \( -name '__pycache__' -o -name '.claude' -o -name 'tests' \) \
+    -prune -exec rm -rf {} + 2>/dev/null || true
+find "$PKG" -type f \( -name '*.pyc' -o -name '*.log' -o -name '*.DONE' \) -delete 2>/dev/null || true
+rm -rf "$PKG/Refiner/cache" "$PKG/Refiner/checkpoints" "$PKG/Refiner_mdl/checkpoints" 2>/dev/null || true
+
+# ensure the script entry points are executable (cp usually preserves this, be explicit)
+for f in Pan_TE clean_seq_fast index LTR_detect build_mdl run_Classifier renameTE \
+         Combine_for_Two process_for_classify.py decode_gfa.pl; do
+    [ -e "$PKG/$f" ] && chmod 0755 "$PKG/$f" || true
+done
+
+# --- 2. PATH wrapper. A plain symlink would break Pan_TE: it uses
+#        os.path.dirname(os.path.abspath(__file__)) (NOT realpath), so the symlink target
+#        dir would be wrong. A wrapper that execs the real script keeps __file__ correct. ---
+cat > "$PREFIX/bin/Pan_TE" <<'EOF'
+#!/usr/bin/env bash
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+exec "$DIR/share/pan_te/Pan_TE" "$@"
+EOF
+chmod 0755 "$PREFIX/bin/Pan_TE"
+
+# --- 3. post-install data fetcher ---
+install -m 0755 "$RECIPE_DIR/pan_te-setup-data" "$PREFIX/bin/pan_te-setup-data"

--- a/recipes/pan_te/build.sh
+++ b/recipes/pan_te/build.sh
@@ -12,6 +12,11 @@ mkdir -p "$PKG" "$PREFIX/bin"
 # --- 1. install the pipeline tree (scripts + python subpackages) into share/pan_te ---
 cp -r "$SRC/bin/." "$PKG/"
 
+# --- 1b. install the current Chinese workflow/methods documentation ---
+install -d "$PKG/docx"
+install -m 0644 "$SRC/docx/PAN_TE_METHODS_ZH.docx" "$PKG/docx/PAN_TE_METHODS_ZH.docx"
+install -m 0644 "$SRC/docx/PAN_TE_METHODS_ZH.md" "$PKG/docx/PAN_TE_METHODS_ZH.md"
+
 # strip caches / logs / local tooling config / dev-only scaffolding that should never ship
 find "$PKG" -type d \( -name '__pycache__' -o -name '.claude' -o -name 'tests' \) \
     -prune -exec rm -rf {} + 2>/dev/null || true

--- a/recipes/pan_te/meta.yaml
+++ b/recipes/pan_te/meta.yaml
@@ -1,0 +1,85 @@
+{% set name = "pan_te" %}
+{% set version = "1.1.0" %}
+
+# Pan_TE receives executables and Look4LTRs' library-builder helper through runtime
+# dependencies. Non-redistributable data (Dfam libraries, ClassifyTE models) are NOT
+# shipped here; users run `pan_te-setup-data` after install.
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  - url: https://github.com/unavailable-2374/Pan_TE/archive/refs/tags/v{{ version }}.tar.gz
+    sha256: 5e3893d149754eda4b2db569374f1cdba38c23a4b5f6921e473a3222a5d5de4c
+    folder: pan_te
+
+build:
+  number: 0
+  noarch: generic
+  run_exports:
+    - {{ pin_subpackage('pan_te', max_pin="x") }}
+
+requirements:
+  run:
+    # --- interpreters / python libs ---
+    - python >=3.10
+    - perl
+    - biopython
+    - numpy
+    - scipy
+    - psutil
+    - gdown                       # pan_te-setup-data (ClassifyTE model fetch)
+    # --- custom Pan_TE tracks (the other recipes in this directory) ---
+    - look4ltrs
+    - mdl-repeat
+    - te-looker
+    - fastga
+    # --- sequence handling / MSA / consensus ---
+    - samtools
+    - bedtools
+    - cd-hit
+    - mafft
+    - abpoa
+    - spoa
+    # --- BLAST stack ---
+    - blast
+    - rmblast
+    # --- repeat masking / classification ---
+    - repeatmasker
+    - repeatmodeler
+    - trf
+    # --- profile HMM / k-mer / phylo / structural ---
+    - hmmer
+    - sourmash
+    - iqtree
+    - barrnap
+    - tesorter
+    # --- Perl modules (build_mdl) ---
+    - perl-parallel-forkmanager
+    - perl-log-log4perl
+
+test:
+  commands:
+    - Pan_TE --help 2>&1 | head -1
+    - pan_te-setup-data --help 2>&1 | head -1
+    - command -v dtr
+    - command -v look4ltrs
+    - command -v mdl-repeat
+
+about:
+  home: https://github.com/unavailable-2374/Pan_TE
+  license: GPL-3.0-or-later
+  license_family: GPL
+  license_file: pan_te/LICENSE
+  summary: "Pan-genome transposable-element annotation pipeline (LTR + mdl-repeat + TE-looker)."
+  description: |
+    Pan_TE combines three de novo TE-detection tracks (Look4LTRs for LTR retrotransposons,
+    mdl-repeat for broad-spectrum MDL repeat discovery, and TE-looker/dtr for divergent
+    'twilight-zone' TEs), deduplicates, and classifies via RepeatClassifier + ClassifyTE.
+    After install, run `pan_te-setup-data` to fetch the Dfam libraries and ClassifyTE models
+    (not redistributable via conda).
+
+extra:
+  recipe-maintainers:
+    - unavailable-2374

--- a/recipes/pan_te/meta.yaml
+++ b/recipes/pan_te/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pan_te" %}
-{% set version = "1.1.0" %}
+{% set version = "1.2.0" %}
 
 # Pan_TE receives executables and Look4LTRs' library-builder helper through runtime
 # dependencies. Non-redistributable data (Dfam libraries, ClassifyTE models) are NOT
@@ -11,7 +11,7 @@ package:
 
 source:
   - url: https://github.com/unavailable-2374/Pan_TE/archive/refs/tags/v{{ version }}.tar.gz
-    sha256: 5e3893d149754eda4b2db569374f1cdba38c23a4b5f6921e473a3222a5d5de4c
+    sha256: 661a7655ac4b5b00f6855f90e1e67eef5d88c80f4d0ea6eed1524c09e629ab71
     folder: pan_te
 
 build:
@@ -48,6 +48,7 @@ requirements:
     # --- repeat masking / classification ---
     - repeatmasker
     - repeatmodeler
+    - openjdk                     # ClassifyTE kanalyze (java) + feature collector (javac)
     - trf
     # --- profile HMM / k-mer / phylo / structural ---
     - hmmer
@@ -66,6 +67,8 @@ test:
     - command -v dtr
     - command -v look4ltrs
     - command -v mdl-repeat
+    - test -s "$PREFIX/share/pan_te/docx/PAN_TE_METHODS_ZH.docx"
+    - test -s "$PREFIX/share/pan_te/docx/PAN_TE_METHODS_ZH.md"
 
 about:
   home: https://github.com/unavailable-2374/Pan_TE

--- a/recipes/pan_te/pan_te-setup-data
+++ b/recipes/pan_te/pan_te-setup-data
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# pan_te-setup-data — fetch the data assets that cannot ship inside the conda package
+# (license / redistribution limits): the Dfam library used by RepeatMasker, and the
+# ClassifyTE code + trained models.
+#
+# This script performs REAL downloads. If a download fails it stops with the exact error
+# and a non-zero exit code — it never fabricates or stubs the data.
+#
+#   pan_te-setup-data --classifyte-dir <DIR>           # fetch ClassifyTE repo + models
+#   pan_te-setup-data --dfam-url <URL>                 # fetch a Dfam famdb partition for RepeatMasker
+#   pan_te-setup-data --dfam-list                      # show how to pick a Dfam partition
+#   pan_te-setup-data --classifyte-dir <DIR> --dfam-url <URL>   # both
+set -euo pipefail
+
+CLASSIFYTE_DIR=""
+DFAM_URL=""
+DFAM_LIST=0
+CLASSIFYTE_REPO="https://github.com/unavailable-2374/ClassifyTE.git"
+# ClassifyTE_Models.zip (Google Drive file id from the Pan_TE README).
+CLASSIFYTE_MODELS_GDRIVE_ID="1CuDciG0Ru5zRBhffjQmgJdqSMQB89mfh"
+
+usage() {
+    sed -n '2,16p' "$0" | sed 's/^# \{0,1\}//'
+    cat <<'EOF'
+
+Options:
+  --classifyte-dir DIR   Clone ClassifyTE here and install its models into DIR/models.
+                         Pass DIR to Pan_TE later as --model-dir.
+  --dfam-url URL         Download this Dfam famdb .h5 partition into RepeatMasker's
+                         Libraries/famdb/ directory (see --dfam-list for how to choose).
+  --dfam-list            Explain how to choose a Dfam partition URL, then exit.
+  -h, --help             Show this help.
+EOF
+}
+
+die() { echo "[pan_te-setup-data] ERROR: $*" >&2; exit 1; }
+log() { echo "[pan_te-setup-data] $*"; }
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --classifyte-dir) CLASSIFYTE_DIR="${2:?}"; shift 2 ;;
+        --dfam-url)       DFAM_URL="${2:?}"; shift 2 ;;
+        --dfam-list)      DFAM_LIST=1; shift ;;
+        -h|--help)        usage; exit 0 ;;
+        *) die "unknown argument: $1 (see --help)" ;;
+    esac
+done
+
+if [ "$DFAM_LIST" -eq 1 ]; then
+    cat <<'EOF'
+Choosing a Dfam partition for RepeatMasker
+------------------------------------------
+RepeatMasker reads TE families from a famdb HDF5 database under
+  <conda-env>/share/RepeatMasker/Libraries/famdb/
+The bioconda `repeatmasker` package ships only a small root partition. For real
+annotation, download a partition from the Dfam release directory and point --dfam-url at it:
+
+  Browse:   https://www.dfam.org/releases/   (pick a release, then the `families/` dir)
+  Files look like:  dfam39_full.0.h5.gz, dfam39_full.1.h5.gz, ...  (partition 0 = root + common)
+
+Pick the partition(s) covering your clade (partition 0 is always required), then:
+  pan_te-setup-data --dfam-url https://www.dfam.org/releases/Dfam_3.9/families/dfam39_full.0.h5.gz
+
+Note: full Dfam partitions are large (many GB). Verify the current release/filenames on the
+site above — Dfam version numbers change over time. This tool downloads exactly the URL you give.
+EOF
+    exit 0
+fi
+
+[ -n "$CLASSIFYTE_DIR" ] || [ -n "$DFAM_URL" ] || { usage; die "nothing to do: pass --classifyte-dir and/or --dfam-url"; }
+
+# ---------------------------------------------------------------------------
+# ClassifyTE: clone repo + fetch trained models
+# ---------------------------------------------------------------------------
+if [ -n "$CLASSIFYTE_DIR" ]; then
+    command -v git >/dev/null   || die "git not found on PATH"
+    command -v gdown >/dev/null || die "gdown not found (it is a pan_te run dependency; activate the pan_te env)"
+
+    mkdir -p "$CLASSIFYTE_DIR"
+    if [ -d "$CLASSIFYTE_DIR/.git" ]; then
+        log "ClassifyTE repo already present at $CLASSIFYTE_DIR (skipping clone)"
+    else
+        log "cloning ClassifyTE into $CLASSIFYTE_DIR"
+        git clone --depth 1 "$CLASSIFYTE_REPO" "$CLASSIFYTE_DIR"
+    fi
+
+    mkdir -p "$CLASSIFYTE_DIR/models"
+    local_zip="$CLASSIFYTE_DIR/ClassifyTE_Models.zip"
+    log "downloading ClassifyTE models (Google Drive id $CLASSIFYTE_MODELS_GDRIVE_ID)"
+    gdown --id "$CLASSIFYTE_MODELS_GDRIVE_ID" -O "$local_zip" \
+        || die "ClassifyTE model download failed (the Google Drive file may require manual download; see the Pan_TE README link)"
+
+    log "unzipping models"
+    command -v unzip >/dev/null || die "unzip not found on PATH"
+    tmp_extract="$(mktemp -d)"
+    unzip -q -o "$local_zip" -d "$tmp_extract"
+    # the zip contains a ClassifyTE_Models/ dir; copy its *.pkl into models/
+    found=0
+    while IFS= read -r -d '' m; do
+        cp "$m" "$CLASSIFYTE_DIR/models/"; found=$((found + 1))
+    done < <(find "$tmp_extract" -name '*.pkl' -print0)
+    rm -rf "$tmp_extract"
+    [ "$found" -gt 0 ] || die "no .pkl model files found inside $local_zip"
+    log "installed $found ClassifyTE model file(s) into $CLASSIFYTE_DIR/models"
+    log "pass this to Pan_TE:  --model-dir $CLASSIFYTE_DIR"
+fi
+
+# ---------------------------------------------------------------------------
+# Dfam: download a famdb partition into the active RepeatMasker install
+# ---------------------------------------------------------------------------
+if [ -n "$DFAM_URL" ]; then
+    command -v RepeatMasker >/dev/null || die "RepeatMasker not found on PATH (activate the pan_te env)"
+    rm_path="$(command -v RepeatMasker)"
+    # RepeatMasker lives at <prefix>/share/RepeatMasker/RepeatMasker on bioconda.
+    rm_share="$(cd "$(dirname "$rm_path")" && pwd)"
+    if [ ! -d "$rm_share/Libraries" ]; then
+        # bioconda symlinks the launcher into bin/; resolve to the real share dir.
+        real_rm="$(readlink -f "$rm_path")"
+        rm_share="$(dirname "$real_rm")"
+    fi
+    famdb_dir="$rm_share/Libraries/famdb"
+    [ -d "$rm_share/Libraries" ] || die "could not locate RepeatMasker Libraries dir (looked under $rm_share)"
+    mkdir -p "$famdb_dir"
+
+    fname="$(basename "$DFAM_URL")"
+    out="$famdb_dir/$fname"
+    log "downloading Dfam partition -> $out"
+    curl -fL --retry 3 -o "$out" "$DFAM_URL" || die "Dfam download failed for $DFAM_URL"
+
+    if [[ "$fname" == *.gz ]]; then
+        log "decompressing $fname"
+        gunzip -f "$out"
+        out="${out%.gz}"
+    fi
+    [ -s "$out" ] || die "downloaded Dfam file is empty: $out"
+    log "Dfam partition installed at $out"
+    log "verify RepeatMasker sees it:  famdb.py -i $famdb_dir info  (or run RepeatMasker on a test FASTA)"
+fi
+
+log "done."


### PR DESCRIPTION
## Summary
- Add Pan_TE v1.2.0 from immutable GitHub tag v1.2.0.
- Source SHA256: 661a7655ac4b5b00f6855f90e1e67eef5d88c80f4d0ea6eed1524c09e629ab71.
- Runtime dependencies look4ltrs, mdl-repeat, te-looker, and fastga are present in Bioconda.
- Include OpenJDK for the ClassifyTE Java components.
- Install the current Chinese methods DOCX and Markdown under share/pan_te/docx/.

## Validation
- The Pan_TE repository reports 57 passing unit tests.
- The v1.2.0 source archive, SHA256, LICENSE, and document files are verified.
- The noarch Conda artifact builds successfully with 179 packaged files.
- Recipe rendering and build.sh syntax checks pass locally.
- Bioconda CI provides the authoritative lint and cross-platform build tests.