### PR TITLE
Update deeplc to 4.0.0

### DIFF
--- a/recipes/deeplc/meta.yaml
+++ b/recipes/deeplc/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "DeepLC" %}
-{% set version = "3.1.13" %}
-{% set sha256 = "582a221774a8470f59792f53d3495a21b368b982595ce26958686b836968da1a" %}
+{% set version = "4.0.0" %}
+{% set sha256 = "5c6185ad87e1db3d33c69fe8ae09b87f25f3e99af8d3a22e83680d2b0b4cd160" %}
 
 package:
   name: {{ name|lower }}
@@ -22,17 +22,19 @@ build:
 
 requirements:
   host:
-    - python >=3.9
+    - python >=3.11
     - pip
     - setuptools
   run:
-    - python >=3.9
+    - python >=3.11
+    - pytorch >=2.6.0,<3
     - numpy >=1.17,<3
     - pandas >=0.25,<3
-    - tensorflow >=2.15.0,<3
-    - deeplcretrainer >=1,<2
-    - psm-utils >=1,<2
     - scikit-learn >=1.2.0,<2
+    - psm-utils >=1.5,<2
+    - onnx2torch >=1.5,<2
+    - click >=8,<9
+    - rich >=13,<15
 
 test:
   imports:


### PR DESCRIPTION
DeepLC 4.0.0 replaces tensorflow with pytorch and adds onnx2torch as a dependency; deeplcretrainer is no longer a runtime dependency. Updated `requirements` to match upstream `pyproject.toml`.

Supersedes #67514, whose Linux Tests failed with `ModuleNotFoundError: No module named 'torch'` (still listed tensorflow).

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.