### PR TITLE
Update vine-phylo to 0.3.5

### DIFF
--- a/recipes/vine-phylo/meta.yaml
+++ b/recipes/vine-phylo/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.3.4" %}
+{% set version = "0.3.5" %}
 
 package:
   name: vine-phylo
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/CshlSiepelLab/vine/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: b1992ac7c9bd5515b2ae7857bbb559c830b5e35c6e82fb73e3dcf29cca9329e9
+  sha256: 8eb4e5359ac2afc55894118c6d3399efac225e66fde9eb16b96742c213035414
 
 build:
   number: 0

--- a/recipes/vine-phylo/meta.yaml
+++ b/recipes/vine-phylo/meta.yaml
@@ -32,6 +32,7 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
+    - {{ stdlib("c") }}
     - cmake
     - make
   host:

--- a/recipes/vine-phylo/meta.yaml
+++ b/recipes/vine-phylo/meta.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/CshlSiepelLab/vine/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 8eb4e5359ac2afc55894118c6d3399efac225e66fde9eb16b96742c213035414
+  sha256: 874a2a87b4937ee626c5c0381ab71301960d4af051650b46aba156d8b9f7967a
 
 build:
   number: 0
@@ -14,10 +14,14 @@ build:
   run_exports:
     - {{ pin_subpackage('vine-phylo', max_pin='x.x') }}
   script:
-    # On linux, conda-forge's libopenblas may not provide an unversioned libopenblas.so
-    # (only libopenblas.so.0). If CMake/FindBLAS (or a dependency's exported link line)
-    # expects the unversioned name, builds can fail with "No rule to make target ...libopenblas.so".
-    # Prefer passing explicit versioned paths rather than mutating $PREFIX/lib with symlinks.
+    # On linux, conda-forge's libopenblas ships only libopenblas.so.0 (no unversioned
+    # libopenblas.so). PHAST's exported CMake target (phast_linalg) baked the unversioned
+    # path from find_package(BLAS) at phast build time, and vine inherits it transitively
+    # when linking phast::phast -- so the link fails with "No rule to make target
+    # ...libopenblas.so" for every program. Provide the unversioned name for the link step.
+    - test -f ${PREFIX}/lib/libopenblas.so || ln -sf libopenblas.so.0 ${PREFIX}/lib/libopenblas.so  # [linux]
+    # BLAS_LIBRARIES is also passed to vine's own configure: it drives the check_function_exists
+    # probe that enables OpenBLAS thread limiting (openblas_set_num_threads) on this platform.
     - export VINE_BLAS_ARGS=""  # [not linux]
     - export VINE_BLAS_ARGS="-DBLAS_LIBRARIES=${PREFIX}/lib/libopenblas.so.0 -DLAPACK_LIBRARIES=${PREFIX}/lib/libopenblas.so.0"  # [linux]
     - export VINE_CODESIGN=OFF  # [osx]
@@ -28,6 +32,9 @@ build:
       ${VINE_BLAS_ARGS}
     - cmake --build build --parallel ${CPU_COUNT}
     - cmake --install build
+    # Remove the link-time helper symlink so it is not packaged into vine-phylo
+    # (that path belongs to libopenblas). It is only needed during linking above.
+    - rm -f ${PREFIX}/lib/libopenblas.so  # [linux]
 
 requirements:
   build:

--- a/recipes/vine-phylo/meta.yaml
+++ b/recipes/vine-phylo/meta.yaml
@@ -47,6 +47,7 @@ requirements:
   host:
     - phast
     - pcre
+    - libopenblas
     - libblas
     - liblapack
   run:

--- a/recipes/vine-phylo/meta.yaml
+++ b/recipes/vine-phylo/meta.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/CshlSiepelLab/vine/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 874a2a87b4937ee626c5c0381ab71301960d4af051650b46aba156d8b9f7967a
+  sha256: 9ec46b057c1cd36fc2dda36f9b93e51a1acdb922caa86bfaba29af99c5c33253
 
 build:
   number: 0
@@ -20,10 +20,10 @@ build:
     # when linking phast::phast -- so the link fails with "No rule to make target
     # ...libopenblas.so" for every program. Provide the unversioned name for the link step.
     - test -f ${PREFIX}/lib/libopenblas.so || ln -sf libopenblas.so.0 ${PREFIX}/lib/libopenblas.so  # [linux]
-    # BLAS_LIBRARIES is also passed to vine's own configure: it drives the check_function_exists
-    # probe that enables OpenBLAS thread limiting (openblas_set_num_threads) on this platform.
+    # This linux build links OpenBLAS, so opt in to vine's OpenBLAS thread limiting
+    # (VINE_ENABLE_OPENBLAS_THREADS) and pass the versioned BLAS/LAPACK paths.
     - export VINE_BLAS_ARGS=""  # [not linux]
-    - export VINE_BLAS_ARGS="-DBLAS_LIBRARIES=${PREFIX}/lib/libopenblas.so.0 -DLAPACK_LIBRARIES=${PREFIX}/lib/libopenblas.so.0"  # [linux]
+    - export VINE_BLAS_ARGS="-DVINE_ENABLE_OPENBLAS_THREADS=ON -DBLAS_LIBRARIES=${PREFIX}/lib/libopenblas.so.0 -DLAPACK_LIBRARIES=${PREFIX}/lib/libopenblas.so.0"  # [linux]
     - export VINE_CODESIGN=OFF  # [osx]
     - cmake -S . -B build
       -DCMAKE_BUILD_TYPE=Release

--- a/recipes/vine-phylo/meta.yaml
+++ b/recipes/vine-phylo/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [win]
+  skip: True  # [win]
   run_exports:
     - {{ pin_subpackage('vine-phylo', max_pin='x.x') }}
   script:
@@ -28,7 +28,8 @@ build:
     - cmake -S . -B build
       -DCMAKE_BUILD_TYPE=Release
       -DCMAKE_INSTALL_PREFIX=${PREFIX}
-      -DPHAST_ROOT=${PREFIX}      
+      -DPHAST_ROOT=${PREFIX}
+      -DCMAKE_C_COMPILER=${CC}
       ${VINE_BLAS_ARGS}
     - cmake --build build --parallel ${CPU_COUNT}
     - cmake --install build
@@ -42,11 +43,12 @@ requirements:
     - {{ stdlib("c") }}
     - cmake
     - make
+    - pkg-config
   host:
     - phast
     - pcre
-    - blas
-    - lapack
+    - libblas
+    - liblapack
   run:
     - phast
     
@@ -56,14 +58,18 @@ test:
     - evalTrees --help
     
 about:
-  home: https://github.com/CshlSiepelLab/vine
-  license: BSD-3-Clause
+  home: "https://github.com/CshlSiepelLab/vine"
+  license: "BSD-3-Clause"
+  license_family: BSD
   license_file: LICENSE
-  summary: "VINE (phylogenetics): Variational Inference with Node Embeddings"
-  dev_url: https://github.com/CshlSiepelLab/vine
+  summary: "VINE (phylogenetics): Variational Inference with Node Embeddings."
+  dev_url: "https://github.com/CshlSiepelLab/vine"
   description: |
     VINE is a tool for Bayesian variational phylogenetic inference.
 
 extra:
   recipe-maintainers:
     - asiepel
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64


### PR DESCRIPTION
Bump `vine-phylo` from 0.3.4 to 0.3.5.

- Updated `version` and `sha256` to the new upstream release tag `v0.3.5`.
- Release: https://github.com/CshlSiepelLab/vine/releases/tag/v0.3.5

##### Please note that this PR was created automatically. cc @asiepel