### PR TITLE
Add zwdzwd as a yame recipe maintainer

### DIFF
--- a/recipes/yame/meta.yaml
+++ b/recipes/yame/meta.yaml
@@ -42,3 +42,4 @@ extra:
     - osx-arm64
   recipe-maintainers:
     - Hongxiang2023
+    - zwdzwd

--- a/recipes/yame/meta.yaml
+++ b/recipes/yame/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: fc9edadf320de812166e4594a636a168dc6bb258160ff26972875c739271294a 
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage(name, max_pin="x") }}
   


### PR DESCRIPTION
Adds `zwdzwd` alongside the existing maintainer for `recipes/yame`.

I am the upstream author of YAME (https://github.com/zhou-lab/YAME) and would like to be pinged on PRs touching this recipe, including automated version bumps.

Build number bumped to 1, as `build_number_needs_bump` requires for any recipe change.