### PR TITLE
Update vardict-java to 1.8.4

### DIFF
--- a/recipes/vardict-java/build.sh
+++ b/recipes/vardict-java/build.sh
@@ -29,6 +29,11 @@ cat > "$outdir/bin/vardict-java" <<'LAUNCH'
 # Resolve this script through symlinks (portable: Linux + macOS), then run VarDict.
 # JVM defaults keep peak memory bounded (footprint only; override with JAVA_OPTS).
 PRG="$0"
+# If invoked via $PATH, "$0" is usually not a path; resolve it so symlink handling works.
+case "$PRG" in
+  */*) ;;
+  *) PRG="$(command -v "$PRG")" ;;
+esac
 while [ -h "$PRG" ]; do
   ls=$(ls -ld "$PRG")
   link=$(expr "$ls" : '.*-> \(.*\)$')

--- a/recipes/vardict-java/build.sh
+++ b/recipes/vardict-java/build.sh
@@ -17,7 +17,9 @@ jar cfe "$outdir/lib/VarDict-${PKG_VERSION}.jar" com.astrazeneca.vardict.Main -C
 cp deps/*.jar "$outdir/lib/"
 
 # --- helper scripts (from the vdscripts source) + launcher ---
-scriptdir="$(dirname "$(find vdscripts -name teststrandbias.R | head -1)")"
+script="$(find vdscripts -name teststrandbias.R | head -1)"
+[ -n "$script" ] || { echo "ERROR: VarDict helper scripts not found under vdscripts/ (check the pinned source)" >&2; exit 1; }
+scriptdir="$(dirname "$script")"
 cp "$scriptdir/teststrandbias.R" "$scriptdir/testsomatic.R" \
    "$scriptdir/var2vcf_valid.pl" "$scriptdir/var2vcf_paired.pl" "$outdir/bin/"
 cat > "$outdir/bin/vardict-java" <<'LAUNCH'
@@ -31,7 +33,7 @@ while [ -h "$PRG" ]; do
   if expr "$link" : '/.*' > /dev/null; then PRG="$link"; else PRG="$(dirname "$PRG")/$link"; fi
 done
 APP_HOME="$(cd "$(dirname "$PRG")/.." >/dev/null && pwd -P)"
-exec java ${JAVA_OPTS:--Xms768m -Xmx8g -XX:+UseG1GC -XX:+UseStringDeduplication} \
+exec java ${JAVA_OPTS:--Xmx8g -XX:+UseG1GC -XX:+UseStringDeduplication} \
   -classpath "$APP_HOME/lib/*" com.astrazeneca.vardict.Main "$@"
 LAUNCH
 

--- a/recipes/vardict-java/build.sh
+++ b/recipes/vardict-java/build.sh
@@ -11,8 +11,10 @@ mkdir -p "$outdir/lib" "$outdir/bin" "$PREFIX/bin"
 # --- compile the VarDict jar (Java 8 bytecode) ---
 if javac --release 8 -version >/dev/null 2>&1; then RELFLAG="--release 8"; else RELFLAG="-source 8 -target 8"; fi
 mkdir -p classes
+vardict_src="VarDictJava-${PKG_VERSION}"
+[ -d "$vardict_src/src/main/java" ] || vardict_src="."
 # shellcheck disable=SC2046
-javac $RELFLAG -encoding UTF-8 -cp "deps/*" -d classes $(find src/main/java -name '*.java')
+javac $RELFLAG -encoding UTF-8 -cp "deps/*" -d classes $(find "$vardict_src/src/main/java" -name '*.java')
 jar cfe "$outdir/lib/VarDict-${PKG_VERSION}.jar" com.astrazeneca.vardict.Main -C classes .
 cp deps/*.jar "$outdir/lib/"
 

--- a/recipes/vardict-java/build.sh
+++ b/recipes/vardict-java/build.sh
@@ -1,14 +1,61 @@
 #!/bin/bash
-outdir=$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM
-mkdir -p $outdir
-mkdir -p $outdir/bin
-mkdir -p $outdir/lib
-mkdir -p $PREFIX/bin
+set -euo pipefail
 
-cp lib/*.jar $outdir/lib
-cp bin/VarDict $outdir/bin/vardict-java
-cp bin/*.{R,pl} $outdir/bin
-for executable in vardict-java testsomatic.R teststrandbias.R var2vcf_paired.pl var2vcf_valid.pl; do
-  chmod +x $outdir/bin/$executable
-  ln -s $outdir/bin/$executable $PREFIX/bin
+# The release ships only the source archive (no pre-built dist), so build from source: fetch the pinned
+# Java deps from Maven Central and the pinned Perl/R helper scripts from the VarDict submodule commit,
+# compile the jar with javac, and assemble the runnable distribution.
+
+VERSION="1.8.4"
+outdir="$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM"
+mkdir -p "$outdir/lib" "$outdir/bin" "$PREFIX/bin"
+
+fetch() {  # url  sha256  dest
+  curl -L --retry 3 --fail -o "$3" "$1"
+  echo "$2  $3" | sha256sum -c -
+}
+
+# --- pinned Java dependencies (Maven Central) ---
+mkdir -p deps
+fetch https://repo1.maven.org/maven2/commons-cli/commons-cli/1.2/commons-cli-1.2.jar \
+      e7cd8951956d349b568b7ccfd4f5b2529a8c113e67c32b028f52ffda371259d9 deps/commons-cli-1.2.jar
+fetch https://repo1.maven.org/maven2/org/apache/commons/commons-math3/3.6.1/commons-math3-3.6.1.jar \
+      1e56d7b058d28b65abd256b8458e3885b674c1d588fa43cd7d1cbb9c7ef2b308 deps/commons-math3-3.6.1.jar
+fetch https://repo1.maven.org/maven2/com/github/samtools/htsjdk/2.21.1/htsjdk-2.21.1.jar \
+      b11093b94452445a9b0c4212a18fe424632376cff3e4f25fe3afb06226e0eed3 deps/htsjdk-2.21.1.jar
+fetch https://repo1.maven.org/maven2/com/edropple/jregex/jregex/1.2_01/jregex-1.2_01.jar \
+      fb66a55aecf33337dab0f23ad3821ed2b70aea41c5bd1415059344dccfbbb25a deps/jregex-1.2_01.jar
+
+# --- pinned Perl/R helper scripts (VarDict submodule commit) ---
+fetch https://github.com/AstraZeneca-NGS/VarDict/archive/009e017d90b25e497ddd50645dc4fa27c484a193.tar.gz \
+      a129e64224f8e2ddfbab89c328719232407cc20cbcf949dd145dd48a7f555d52 vdscripts.tar.gz
+mkdir -p vdscripts && tar xzf vdscripts.tar.gz -C vdscripts --strip-components=1
+
+# --- compile the VarDict jar (Java 8 bytecode) ---
+if javac --release 8 -version >/dev/null 2>&1; then RELFLAG="--release 8"; else RELFLAG="-source 8 -target 8"; fi
+mkdir -p classes
+# shellcheck disable=SC2046
+javac $RELFLAG -encoding UTF-8 -cp "deps/*" -d classes $(find src/main/java -name '*.java')
+jar cfe "$outdir/lib/VarDict-${VERSION}.jar" com.astrazeneca.vardict.Main -C classes .
+cp deps/*.jar "$outdir/lib/"
+
+# --- helper scripts + launcher ---
+cp vdscripts/teststrandbias.R vdscripts/testsomatic.R vdscripts/var2vcf_valid.pl vdscripts/var2vcf_paired.pl "$outdir/bin/"
+cat > "$outdir/bin/vardict-java" <<'LAUNCH'
+#!/usr/bin/env bash
+# Resolve this script through symlinks (portable: Linux + macOS), then run VarDict.
+# JVM defaults keep peak memory bounded (footprint only; override with JAVA_OPTS).
+PRG="$0"
+while [ -h "$PRG" ]; do
+  ls=$(ls -ld "$PRG")
+  link=$(expr "$ls" : '.*-> \(.*\)$')
+  if expr "$link" : '/.*' > /dev/null; then PRG="$link"; else PRG="$(dirname "$PRG")/$link"; fi
+done
+APP_HOME="$(cd "$(dirname "$PRG")/.." >/dev/null && pwd -P)"
+exec java ${JAVA_OPTS:--Xms768m -Xmx8g -XX:+UseG1GC -XX:+UseStringDeduplication} \
+  -classpath "$APP_HOME/lib/*" com.astrazeneca.vardict.Main "$@"
+LAUNCH
+
+for exe in vardict-java testsomatic.R teststrandbias.R var2vcf_paired.pl var2vcf_valid.pl; do
+  chmod +x "$outdir/bin/$exe"
+  ln -s "$outdir/bin/$exe" "$PREFIX/bin/$exe"
 done

--- a/recipes/vardict-java/build.sh
+++ b/recipes/vardict-java/build.sh
@@ -1,45 +1,25 @@
 #!/bin/bash
 set -euo pipefail
 
-# The release ships only the source archive (no pre-built dist), so build from source: fetch the pinned
-# Java deps from Maven Central and the pinned Perl/R helper scripts from the VarDict submodule commit,
-# compile the jar with javac, and assemble the runnable distribution.
+# The release ships only the source archive (no pre-built dist), so build from source. The Java deps and
+# the VarDict Perl/R helper scripts are provided as pinned `source:` entries (deps/ and vdscripts/), so
+# no build-time downloads: compile the jar with javac and assemble the runnable distribution.
 
-VERSION="1.8.4"
 outdir="$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM"
 mkdir -p "$outdir/lib" "$outdir/bin" "$PREFIX/bin"
-
-fetch() {  # url  sha256  dest
-  curl -L --retry 3 --fail -o "$3" "$1"
-  echo "$2  $3" | sha256sum -c -
-}
-
-# --- pinned Java dependencies (Maven Central) ---
-mkdir -p deps
-fetch https://repo1.maven.org/maven2/commons-cli/commons-cli/1.2/commons-cli-1.2.jar \
-      e7cd8951956d349b568b7ccfd4f5b2529a8c113e67c32b028f52ffda371259d9 deps/commons-cli-1.2.jar
-fetch https://repo1.maven.org/maven2/org/apache/commons/commons-math3/3.6.1/commons-math3-3.6.1.jar \
-      1e56d7b058d28b65abd256b8458e3885b674c1d588fa43cd7d1cbb9c7ef2b308 deps/commons-math3-3.6.1.jar
-fetch https://repo1.maven.org/maven2/com/github/samtools/htsjdk/2.21.1/htsjdk-2.21.1.jar \
-      b11093b94452445a9b0c4212a18fe424632376cff3e4f25fe3afb06226e0eed3 deps/htsjdk-2.21.1.jar
-fetch https://repo1.maven.org/maven2/com/edropple/jregex/jregex/1.2_01/jregex-1.2_01.jar \
-      fb66a55aecf33337dab0f23ad3821ed2b70aea41c5bd1415059344dccfbbb25a deps/jregex-1.2_01.jar
-
-# --- pinned Perl/R helper scripts (VarDict submodule commit) ---
-fetch https://github.com/AstraZeneca-NGS/VarDict/archive/009e017d90b25e497ddd50645dc4fa27c484a193.tar.gz \
-      a129e64224f8e2ddfbab89c328719232407cc20cbcf949dd145dd48a7f555d52 vdscripts.tar.gz
-mkdir -p vdscripts && tar xzf vdscripts.tar.gz -C vdscripts --strip-components=1
 
 # --- compile the VarDict jar (Java 8 bytecode) ---
 if javac --release 8 -version >/dev/null 2>&1; then RELFLAG="--release 8"; else RELFLAG="-source 8 -target 8"; fi
 mkdir -p classes
 # shellcheck disable=SC2046
 javac $RELFLAG -encoding UTF-8 -cp "deps/*" -d classes $(find src/main/java -name '*.java')
-jar cfe "$outdir/lib/VarDict-${VERSION}.jar" com.astrazeneca.vardict.Main -C classes .
+jar cfe "$outdir/lib/VarDict-${PKG_VERSION}.jar" com.astrazeneca.vardict.Main -C classes .
 cp deps/*.jar "$outdir/lib/"
 
-# --- helper scripts + launcher ---
-cp vdscripts/teststrandbias.R vdscripts/testsomatic.R vdscripts/var2vcf_valid.pl vdscripts/var2vcf_paired.pl "$outdir/bin/"
+# --- helper scripts (from the vdscripts source) + launcher ---
+scriptdir="$(dirname "$(find vdscripts -name teststrandbias.R | head -1)")"
+cp "$scriptdir/teststrandbias.R" "$scriptdir/testsomatic.R" \
+   "$scriptdir/var2vcf_valid.pl" "$scriptdir/var2vcf_paired.pl" "$outdir/bin/"
 cat > "$outdir/bin/vardict-java" <<'LAUNCH'
 #!/usr/bin/env bash
 # Resolve this script through symlinks (portable: Linux + macOS), then run VarDict.

--- a/recipes/vardict-java/meta.yaml
+++ b/recipes/vardict-java/meta.yaml
@@ -1,18 +1,23 @@
-{% set version = "1.8.3" %}
+{% set version = "1.8.4" %}
 
 package:
   name: vardict-java
   version: {{ version }}
 
 source:
-  url: https://github.com/AstraZeneca-NGS/VarDictJava/releases/download/v{{ version }}/VarDict-{{ version }}.zip
-  sha256: c1940c1b0308a431879010b52036c02c39ca0f97af04fd56c2f1b6febe75734b
+  url: https://github.com/joachimwolff/VarDictJava/archive/refs/tags/v{{ version }}.zip
+  sha256: 23f532557c1a17646f630fd67f3767ac23210a53e19cfd4f4d86db6fdba4d142
 
 build:
   number: 0
   noarch: generic
+  run_exports:
+    - {{ pin_subpackage('vardict-java', max_pin="x") }}
 
 requirements:
+  build:
+    - openjdk
+    - curl
   run:
     - openjdk
     - perl
@@ -25,9 +30,15 @@ test:
     - echo -e "Sample\tchrM\tchrM\t16263\t16263\tC\tT\t4\t4\t0\t0\t2\t2\tT/T\t1.0000\t0;2\t25.8\t1\t34.2\t1\t60.0\t3.000\t1.0000\t0\t4\t4.000\t1\t3.0\t3\t3\tACTGCAACTCCAAAGCCACC\tCTCACCCACTAGGATACCAA\tchrM:2-16571\tSNV\t0\t0" | teststrandbias.R
 
 about:
-  home: https://github.com/AstraZeneca-NGS/VarDictJava
+  home: https://github.com/joachimwolff/VarDictJava
   license: MIT
   summary: Java port of the VarDict variant discovery program
+  description: |
+    Community-maintained fork of AstraZeneca-NGS/VarDictJava (upstream's final,
+    unmaintained 1.8.3). Release 1.8.4 reduces peak memory (G1GC + string-dedup JVM
+    defaults, opt-in --chunk region splitting) while keeping variant output
+    byte-identical to 1.8.3.
+  dev_url: https://github.com/joachimwolff/VarDictJava
 
 extra:
   recipe-maintainers:

--- a/recipes/vardict-java/meta.yaml
+++ b/recipes/vardict-java/meta.yaml
@@ -7,7 +7,7 @@ package:
 source:
   - url: https://github.com/joachimwolff/VarDictJava/archive/refs/tags/v{{ version }}.zip
     sha256: 23f532557c1a17646f630fd67f3767ac23210a53e19cfd4f4d86db6fdba4d142
-  # Java dependencies (pinned; not extracted, .jar is not a decompressible ext)
+  # Java dependencies (pinned). conda-build keeps .jar downloads as plain files (as in e.g. picard-slim).
   - url: https://repo1.maven.org/maven2/commons-cli/commons-cli/1.2/commons-cli-1.2.jar
     sha256: e7cd8951956d349b568b7ccfd4f5b2529a8c113e67c32b028f52ffda371259d9
     folder: deps

--- a/recipes/vardict-java/meta.yaml
+++ b/recipes/vardict-java/meta.yaml
@@ -5,8 +5,25 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/joachimwolff/VarDictJava/archive/refs/tags/v{{ version }}.zip
-  sha256: 23f532557c1a17646f630fd67f3767ac23210a53e19cfd4f4d86db6fdba4d142
+  - url: https://github.com/joachimwolff/VarDictJava/archive/refs/tags/v{{ version }}.zip
+    sha256: 23f532557c1a17646f630fd67f3767ac23210a53e19cfd4f4d86db6fdba4d142
+  # Java dependencies (pinned; not extracted, .jar is not a decompressible ext)
+  - url: https://repo1.maven.org/maven2/commons-cli/commons-cli/1.2/commons-cli-1.2.jar
+    sha256: e7cd8951956d349b568b7ccfd4f5b2529a8c113e67c32b028f52ffda371259d9
+    folder: deps
+  - url: https://repo1.maven.org/maven2/org/apache/commons/commons-math3/3.6.1/commons-math3-3.6.1.jar
+    sha256: 1e56d7b058d28b65abd256b8458e3885b674c1d588fa43cd7d1cbb9c7ef2b308
+    folder: deps
+  - url: https://repo1.maven.org/maven2/com/github/samtools/htsjdk/2.21.1/htsjdk-2.21.1.jar
+    sha256: b11093b94452445a9b0c4212a18fe424632376cff3e4f25fe3afb06226e0eed3
+    folder: deps
+  - url: https://repo1.maven.org/maven2/com/edropple/jregex/jregex/1.2_01/jregex-1.2_01.jar
+    sha256: fb66a55aecf33337dab0f23ad3821ed2b70aea41c5bd1415059344dccfbbb25a
+    folder: deps
+  # VarDict Perl/R helper scripts (pinned submodule commit)
+  - url: https://github.com/AstraZeneca-NGS/VarDict/archive/009e017d90b25e497ddd50645dc4fa27c484a193.tar.gz
+    sha256: a129e64224f8e2ddfbab89c328719232407cc20cbcf949dd145dd48a7f555d52
+    folder: vdscripts
 
 build:
   number: 0
@@ -17,7 +34,6 @@ build:
 requirements:
   build:
     - openjdk
-    - curl
   run:
     - openjdk
     - perl


### PR DESCRIPTION
Point the recipe at the maintained fork's v1.8.4 release (joachimwolff/VarDictJava): upstream (AstraZeneca-NGS) declares 1.8.3 the final, unmaintained version; 1.8.4 reduces peak memory while keeping variant output byte-identical to 1.8.3. Only the source is changed (version, url, sha256).

Describe your pull request here

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
