### PR TITLE
Add bioleads 0.1.0

### DIFF
--- a/recipes/bioleads/meta.yaml
+++ b/recipes/bioleads/meta.yaml
@@ -1,0 +1,60 @@
+{% set name = "bioleads" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/isomlab/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: e75615984d9fb4947d47f1161083718baf4e66fc30f67ecc95c3123d3d567e14
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x") }}
+  entry_points:
+    - bioleads = bioleads.cli:main
+    - bioleads-gui = bioleads.gui:main
+
+requirements:
+  host:
+    - python >=3.10
+    - pip
+    - setuptools >=68
+  run:
+    - python >=3.10
+    - numpy >=1.24
+    - scipy >=1.10
+    - scikit-learn >=1.3
+    - networkx >=3.1
+    - pandas >=2.0
+    - tqdm >=4.65
+    - pymupdf >=1.23
+    - biopython >=1.81
+    - requests >=2.31
+    - plotly >=5.18
+    - pyvis >=0.3.2
+    - umap-learn >=0.5
+
+test:
+  imports:
+    - bioleads
+    - bioleads.pipeline
+    - bioleads.enrichment
+  commands:
+    - bioleads --help
+
+about:
+  home: https://github.com/isomlab/bioleads
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: Mine biomedical literature for enriched terms, co-occurrence networks, and Swanson-style hypothesis leads.
+  dev_url: https://github.com/isomlab/bioleads
+
+extra:
+  recipe-maintainers:
+    - dangerisom


### PR DESCRIPTION
Adds a recipe for **bioleads** — a Python tool to mine biomedical literature for enriched terms, co-occurrence networks, and Swanson-style hypothesis leads from PDFs and PubMed/PMC.

- `noarch: python`, sourced from the tagged GitHub release tarball (isomlab/bioleads v0.1.0).
- Run deps are the CPU-only core plus the light extras (PDF input, PubMed/PMC fetching, interactive viz) — all available on conda-forge. Heavier ML extras (scispaCy NER, PubMedBERT clustering) remain pip-only.
- Upstream: https://github.com/isomlab/bioleads
- License: MIT (license_file included).

Maintainer: @dangerisom