### PR TITLE
Add litlog 0.1.1

### DIFF
--- a/recipes/litlog/meta.yaml
+++ b/recipes/litlog/meta.yaml
@@ -1,0 +1,50 @@
+{% set name = "litlog" %}
+{% set version = "0.1.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/isomlab/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 594b871ba1f71f8d11c26e28ea9a5aa066e7c3d596f202ebf57b8a13c73c33ab
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x") }}
+  entry_points:
+    - litlog = litlog.cli:main
+
+requirements:
+  host:
+    - python >=3.9
+    - pip
+    - setuptools >=64
+  run:
+    - python >=3.9
+    - pymupdf >=1.23
+    - python-docx >=1.1
+    - scikit-learn >=1.3
+
+test:
+  imports:
+    - litlog
+    - litlog.graph
+    - litlog.server
+  commands:
+    - litlog --help
+
+about:
+  home: https://github.com/isomlab/litlog
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: Local-first tracker for the papers you read and how they interconnect.
+  dev_url: https://github.com/isomlab/litlog
+
+extra:
+  recipe-maintainers:
+    - dangerisom


### PR DESCRIPTION
Adds a recipe for **litlog** — a local-first tool to track the papers you read and how they interconnect.

- `noarch: python`, sourced from the tagged GitHub release tarball (isomlab/litlog v0.1.1).
- Core is pure standard library; run deps cover the optional ingest/graph features (pymupdf for PDF ingest + the citation layer, python-docx for Word ingest, scikit-learn for the abstract-similarity layer) — all on conda-forge.
- Upstream: https://github.com/isomlab/litlog
- License: MIT (license_file included).

Maintainer: @dangerisom