### PR TITLE
itsxrust 0.3.0

### DIFF
--- a/recipes/itsxrust/meta.yaml
+++ b/recipes/itsxrust/meta.yaml
@@ -7,16 +7,17 @@ package:
 
 source:
   url: https://github.com/ayobi/ITSxRust/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 0704914b508da10e1b2138ad0d9732ed34dc8d2b21163e6b1ab1cc673b01cfd0
+  sha256: 26dfcbd977668ab6d4982079a336ac17cefd05f41b2b7ca571a0d43aefacbb98
 
 build:
   number: 0
   run_exports:
-    - itsxrust >=0.2.2,<0.3.0a0
+    - itsxrust >=0.3.0,<0.4.0a0
 
 requirements:
   build:
     - {{ compiler('rust') }}
+    - {{ stdlib('c') }}
     - cargo-bundle-licenses
   host:
     - openssl

--- a/recipes/itsxrust/meta.yaml
+++ b/recipes/itsxrust/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "itsxrust" %}
-{% set version = "0.2.2" %}
+{% set version = "0.3.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://github.com/ayobi/ITSxRust/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 3e17ba8a5859acad18e3c13ef038c5e02caa0d9986eb12f19690c862608e51cf
+  sha256: 0704914b508da10e1b2138ad0d9732ed34dc8d2b21163e6b1ab1cc673b01cfd0
 
 build:
-  number: 1
+  number: 0
   run_exports:
     - itsxrust >=0.2.2,<0.3.0a0
 


### PR DESCRIPTION
Updates `itsxrust` 0.2.2 → 0.3.0. **Supersedes #67638**, which autobump could not complete correctly.

This branch contains the bot's version bump plus three fixes:

**1. Adds `{{ stdlib('c') }}`** — #67638 fails linting with `compiler_needs_stdlib_c`. The recipe requests `{{ compiler('rust') }}`, but Rust links the C standard library, so the stdlib pin is still required.

**2. Bumps `run_exports`** from `itsxrust >=0.2.2,<0.3.0a0` to `>=0.3.0,<0.4.0a0`. Autobump updates only `version` and `sha256`, so the 0.3.0 package fell outside its own compatibility range.

**3. Corrects `sha256`.** The upstream `v0.3.0` tag was moved shortly after creation — it had initially been placed on the pre-release commit — so the hash the bot captured (`0704914b…`) is for the wrong tree. The correct hash is `26dfcbd977668ab6d4982079a336ac17cefd05f41b2b7ca571a0d43aefacbb98`, verified as:

```console
$ curl -sL https://github.com/ayobi/ITSxRust/archive/refs/tags/v0.3.0.tar.gz -o v030.tar.gz
$ sha256sum v030.tar.gz
26dfcbd977668ab6d4982079a336ac17cefd05f41b2b7ca571a0d43aefacbb98  v030.tar.gz
$ tar -xzOf v030.tar.gz --wildcards '*/Cargo.toml' | grep '^version'
version = "0.3.0"
```

Release notes: https://github.com/ayobi/ITSxRust/blob/main/CHANGELOG.md

Upstream 0.3.0 adds `--region ssu` / `--region lsu` and `--plain-ids`, reports unrecognised HMM profile names, and fixes a memory issue in which `nhmmer`'s stdout report was buffered rather than discarded (peak RSS drops roughly sixfold on large inputs; extraction output is unchanged).

Could a maintainer please close #67638 in favour of this PR. I'm the recipe maintainer (`@ayobi`) but don't have push access to the bot's branch.