### PR TITLE
Update seqwish to 0.7.12

### DIFF
--- a/recipes/seqwish/build.sh
+++ b/recipes/seqwish/build.sh
@@ -7,4 +7,7 @@ set -xe
 # different CPU. Remove it so a portable baseline target is used.
 rm -f .cargo/config.toml .cargo/config
 
+# Bundle third-party crate licenses (bioconda Rust guideline).
+cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
+
 cargo install --locked --no-track --root "${PREFIX}" --path .

--- a/recipes/seqwish/build.sh
+++ b/recipes/seqwish/build.sh
@@ -2,24 +2,9 @@
 
 set -xe
 
-export LIBRARY_PATH=${PREFIX}/lib
-export LD_LIBRARY_PATH=${PREFIX}/lib
-export CPATH=${PREFIX}/include
-export C_INCLUDE_PATH=${PREFIX}/include
-export CPLUS_INCLUDE_PATH=${PREFIX}/include
-export CPP_INCLUDE_PATH=${PREFIX}/include
-export CXX_INCLUDE_PATH=${PREFIX}/include
+# seqwish 0.7.12+ is a Rust program. The repo pins target-cpu=native via
+# .cargo/config.toml, which would make the package crash on machines with a
+# different CPU. Remove it so a portable baseline target is used.
+rm -f .cargo/config.toml .cargo/config
 
-EXTRA_FLAGS="-Ofast"
-
-case $(uname -m) in
-    x86_64)
-        EXTRA_FLAGS="${EXTRA_FLAGS} -march=sandybridge"
-        ;;
-    *) ;;
-esac
-
-cmake -H. -Bbuild -DCMAKE_BUILD_TYPE=Generic -DEXTRA_FLAGS="${EXTRA_FLAGS}"
-cmake --build build -j ${CPU_COUNT}
-mkdir -p $PREFIX/bin
-mv bin/* $PREFIX/bin
+cargo install --locked --no-track --root "${PREFIX}" --path .

--- a/recipes/seqwish/meta.yaml
+++ b/recipes/seqwish/meta.yaml
@@ -19,6 +19,7 @@ requirements:
     - {{ compiler('rust') }}
     - {{ compiler('c') }}
     - {{ stdlib('c') }}
+    - cargo-bundle-licenses
 
 test:
   commands:
@@ -28,7 +29,9 @@ test:
 about:
   home: https://github.com/pangenome/seqwish
   license: MIT
-  license_file: LICENSE
+  license_file:
+    - LICENSE
+    - THIRDPARTY.yml
   summary: Alignment to variation graph inducer
 
 extra:

--- a/recipes/seqwish/meta.yaml
+++ b/recipes/seqwish/meta.yaml
@@ -1,40 +1,32 @@
 {% set name = "seqwish" %}
-{% set version = "0.7.11" %}
+{% set version = "0.7.12" %}
 
 package:
-  name: "{{ name }}"
-  version: "{{ version }}"
+  name: {{ name }}
+  version: {{ version }}
 
 source:
-  url: https://github.com/ekg/{{ name }}/releases/download/v{{ version }}/{{ name }}-v{{ version }}.tar.gz
-  sha256: 9cbf51990787a93c58a1ee04239608785beb7e8a38efeb02929121b3c8c4a103
+  url: https://github.com/pangenome/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 90d1525c14d6003ff2e498f29b8cca31e947216536230908a6078d54b840372c
 
 build:
-  skip: True  # [osx]
+  number: 0
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x') }}
-  number: 1
 
 requirements:
   build:
+    - {{ compiler('rust') }}
     - {{ compiler('c') }}
-    - {{ compiler('cxx') }}
-    - llvm-openmp  # [osx]
-    - cmake
-    - make
-  host:
-    - zlib
-    - jemalloc
-  run:
-    - llvm-openmp  # [osx]
-    - python >=3.6
+    - {{ stdlib('c') }}
 
 test:
   commands:
     - seqwish --help
+    - seqwish --version
 
 about:
-  home: https://github.com/ekg/seqwish
+  home: https://github.com/pangenome/seqwish
   license: MIT
   license_file: LICENSE
   summary: Alignment to variation graph inducer
@@ -42,7 +34,6 @@ about:
 extra:
   additional-platforms:
     - linux-aarch64
+    - osx-arm64
   recipe-maintainers:
     - AndreaGuarracino
-  skip-lints:
-    - uses_vcs_url


### PR DESCRIPTION
Updates seqwish to v0.7.12.

seqwish has been rewritten from C++ to Rust, so this switches the recipe from the CMake/C++ build to cargo:

- `source` now points at the `v0.7.12` GitHub tag archive.
- `build.sh` uses `cargo install`; removed the CMake build.
- `requirements.build`: `{{ compiler('rust') }}` + `{{ compiler('c') }}` (the latter for the bundled `zstd-sys`, pulled in via AGC support). Dropped cmake/make/cxx/openmp/jemalloc/zlib/python.
- Removed `skip: True  # [osx]` and added `osx-arm64` — the Rust version builds on macOS.
- `build.sh` removes the repo `.cargo/config.toml` (`target-cpu=native`) so the package is portable across CPUs.

Note for reviewers: one dependency (`ragc-core`, for AGC input) is a git dependency resolved at build time from Cargo.lock, so cargo fetches it during the build.