### PR TITLE
Update iCount-Mini to v4 0 1

### DIFF
--- a/recipes/icount-mini/meta.yaml
+++ b/recipes/icount-mini/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "iCount-Mini" %}
-{% set version = "4.0.0" %}
+{% set version = "4.0.1" %}
 
 package:
   name: "{{ name|lower }}"

--- a/recipes/icount-mini/meta.yaml
+++ b/recipes/icount-mini/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: "https://github.com/ulelab/iCount-Mini/archive/refs/tags/v{{ version }}.tar.gz"
-  sha256: a248b4017e9886502f71e0b1d53f6fa90b278d88448b046635c672b8f05c65fb
+  sha256: ef6fcc9e22228fab0438c58ffc75b75cfc237e24f45531642ca548ca0ec7a77d
 
 build:
   number: 0


### PR DESCRIPTION
Update iCount-Mini to annotate all regions across genes, even if transcripts not included. 