### PR TITLE
Bump wepp build number

### DIFF
--- a/recipes/wepp/build.sh
+++ b/recipes/wepp/build.sh
@@ -9,15 +9,15 @@ export CXXFLAGS="${CXXFLAGS} -O3"
 export CPPFLAGS="${CPPFLAGS} -I${PREFIX}/include"
 export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib"
 
+# x86_64 intentionally keeps the conda-forge default (-march=nocona -mtune=haswell).
+# Raising it to x86-64-v3 lets the compiler emit AVX2/FMA/BMI, which SIGILLs on any
+# pre-Haswell host, including the Ivy Bridge Xeons still widespread on HPC clusters.
 case $(uname -m) in
     aarch64)
 	export CXXFLAGS="${CXXFLAGS} -march=armv8-a"
 	;;
     arm64)
 	export CXXFLAGS="${CXXFLAGS} -march=armv8.4-a"
-	;;
-    x86_64)
-	export CXXFLAGS="${CXXFLAGS} -march=x86-64-v3"
 	;;
 esac
 

--- a/recipes/wepp/meta.yaml
+++ b/recipes/wepp/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 0c4b3b78aaf8947a5edf2a32dedbfea1fad32b5071b6eea76f38b69ae7e6b598
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage(name, max_pin="x.x") }}
 


### PR DESCRIPTION
## Summary
- Rebuild wepp 0.1.5.8 (build 0 → 1)
- Drop `-march=x86-64-v3` from `build.sh` so the binary uses the conda-forge x86_64 baseline and no longer SIGILLs on pre-Haswell / older HPC CPUs