### PR TITLE
Update cgmlst-dists-py to 0.1.7

### DIFF
--- a/recipes/cgmlst-dists-py/meta.yaml
+++ b/recipes/cgmlst-dists-py/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "cgmlst-dists-py" %}
-{% set version = "0.1.6" %}
-{% set sha256 = "267ac181e30f38ccbf76aa21f55060aa92ba8654eadbda3283bed202a9fe14da" %}
+{% set version = "0.1.7" %}
+{% set sha256 = "5c2ad3e07b9ad8b8eafb5254ec689cb27057991e390a50e9511ee1ae745da720" %}
 {% set user = "genpat-it" %}
 
 package:
@@ -22,13 +22,16 @@ requirements:
     - python >=3.9
     - numpy
     - pandas
-    - numba
     - tqdm
     - psutil
     # Optional accelerator upstream, but included here: conda is the main install
     # route for this package, and without pyarrow the loader is 3-4x slower on
     # large inputs. The tool auto-detects it and falls back to pandas if absent.
     - pyarrow
+    # numba is NOT listed: as of 0.1.7 it is only needed for --gpu, and with
+    # llvmlite it adds ~199 MB. The CPU path computes with numpy and never
+    # imports it; --gpu without numba warns and computes on the CPU with
+    # identical results. GPU users should `conda install numba` as well.
 
 test:
   commands:
@@ -42,6 +45,8 @@ test:
     - cgmlst-dists.py -i in.tab -c -s > out.tsv
     - python -c "rows=[l.split() for l in open('out.tsv')]; assert rows[1][1:] == ['0', '1'], rows"
     - python -c "import pyarrow"
+    # The matrix above is computed in an environment where numba is not installed,
+    # which is the check that matters now that numba is no longer a dependency.
 
 about:
   home: "https://github.com/{{ user }}/{{ name }}"


### PR DESCRIPTION
Update `cgmlst-dists-py` to 0.1.7.

Release notes: https://github.com/genpat-it/cgmlst-dists-py/releases/tag/0.1.7

**`numba` is removed from the run requirements.** As of 0.1.7 it is only needed for `--gpu`: the CPU path computes with numpy and, since numba is now imported lazily, never loads it at all. With llvmlite it added ~199 MB to every environment, and it also constrained which Python versions this package could be installed on, since numba trails new releases. Without it, `--gpu` warns on stderr and computes on the CPU with identical results instead of failing, so nothing breaks for existing users; GPU users can `conda install numba` alongside. Existing environments upgrading in place keep the numba they already have.

`pyarrow` stays, as agreed in #67672: conda is the main install route and the Arrow loader is significantly faster on large profile tables.

The test section still computes a real distance matrix and checks the value, which now doubles as proof that the tool works without numba installed.

I am the recipe maintainer and the upstream author.
