### PR TITLE
Update matchms recipe

### DIFF
--- a/recipes/matchms/meta.yaml
+++ b/recipes/matchms/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: e7d238879cec83d66d2ab92c3e8a358a11bdc4b9dbda304786f9f1ec1146255d
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --no-cache-dir -vvv
   noarch: python
   run_exports:
@@ -27,18 +27,19 @@ requirements:
     - lxml >=6.0.2
     - matplotlib-base >=3.10.8
     - networkx >=3.4.2,<3.5
-    - numba >=0.61.2
+    - numba >=0.61.2,<0.62
     - numpy >=2.0.0
     - pandas >=2.2.3
     - pickydict >=0.5.0
     - pillow !=9.4.0
     - pubchempy >=1.0.5
-    - pynndescent
+    - pynndescent >=0.6.0
     - pyteomics >=4.7.5
+    - psims >=1.3.2
     - pyyaml >=6.0.3
     - rdkit >=2024.3.5
     - requests >=2.32.5
-    - scipy >=1.15.3
+    - scipy >=1.15.3,<1.17
     - sparsestack >=0.7.0
     - tqdm >=4.67.1
 


### PR DESCRIPTION
MatchMS 0.33.1’s recipe metadata was incomplete/incompatible with its published runtime requirements. This update adds the missing `psims >=1.3.2` dependency and pins `pynndescent >=0.6.0`, `scipy >=1.15.3,<1.17`, and `numba >=0.61.2,<0.62`. These constraints are needed because MatchMS’ `sparsestack ` dependency requires `numba <0.62`. Without these restrictions, the solver can select incompatible newer SciPy/Numba/PyNNDescent packages and pip check fails. The build number is therefore bumped.

~~Depends on https://github.com/conda-forge/pynndescent-feedstock/pull/29 being merged first.
**Edit:** https://github.com/conda-forge/pynndescent-feedstock/pull/29 was merged, but the build failed, so https://github.com/conda-forge/pynndescent-feedstock/pull/30 needs to be merged as well.~~
Both PRs have now been merged.

CC: @hechth @maximskorik


----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
