### PR TITLE
Add nexcision recipe

### DIFF
--- a/recipes/nexcision/meta.yaml
+++ b/recipes/nexcision/meta.yaml
@@ -1,0 +1,48 @@
+{% set name = "nexcision" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/RhysWhite/nexcision/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: a03684b573d5450e8753f99d725dc0789f01c3fc4edbebd43bc838c0ac8a7d32
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --no-cache-dir -vv
+  run_exports:
+    - {{ pin_subpackage('nexcision', max_pin="x.x") }}
+
+requirements:
+  host:
+    - python >=3.10
+    - pip
+    - setuptools >=68,<82
+    - wheel
+  run:
+    - python >=3.10
+
+test:
+  imports:
+    - nexcision
+  commands:
+    - nexcise --help
+    - nexcise --version
+
+about:
+  home: https://github.com/RhysWhite/nexcision
+  license: MIT
+  license_file: LICENSE
+  summary: Precise region-based excision of coordinate-labelled rows from NEXUS matrices.
+  description: |
+    NEXCISION is a dependency-free command-line tool for exact and
+    reproducible excision of coordinate-defined genomic regions from
+    transposed NEXUS matrices.
+  dev_url: https://github.com/RhysWhite/nexcision
+
+extra:
+  recipe-maintainers:
+    - RhysWhite


### PR DESCRIPTION
This pull request adds a Bioconda recipe for NEXCISION v0.1.0, a dependency-free Python command-line tool for exact and reproducible excision of coordinate-defined genomic regions from transposed NEXUS matrices.

The recipe uses the tagged v0.1.0 GitHub source archive with SHA-256 verification, installs the `nexcise` command as a noarch Python package, and tests the package import, `nexcise --help`, and `nexcise --version`.

Local validation completed successfully:

* `bioconda-utils lint --packages nexcision`
* `bioconda-utils build --packages nexcision`

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
