### PR TITLE
Update bioconductor-maaslin2 to 1.22.0 (BioC 3.21)

### DIFF
--- a/recipes/bioconductor-maaslin2/meta.yaml
+++ b/recipes/bioconductor-maaslin2/meta.yaml
@@ -1,6 +1,6 @@
-{% set version = "1.18.0" %}
+{% set version = "1.22.0" %}
 {% set name = "Maaslin2" %}
-{% set bioc = "3.19" %}
+{% set bioc = "3.21" %}
 
 package:
   name: 'bioconductor-{{ name|lower }}'
@@ -11,7 +11,7 @@ source:
     - 'https://bioconductor.org/packages/{{ bioc }}/bioc/src/contrib/Archive/{{ name }}/{{ name }}_{{ version }}.tar.gz'
     - 'https://bioarchive.galaxyproject.org/{{ name }}_{{ version }}.tar.gz'
     - 'https://depot.galaxyproject.org/software/bioconductor-{{ name|lower }}/bioconductor-{{ name|lower }}_{{ version }}_src_all.tar.gz'
-  md5: 65689f289ef30a89d727f676e645719a
+  md5: 7f5c262861a87a22260455344dee7f44
   patches:
     - rpath.patch
 build:
@@ -24,8 +24,8 @@ build:
 # Suggests: knitr, testthat (>= 2.1.0), rmarkdown, markdown
 requirements:
   host:
-    - 'bioconductor-edger >=4.0.0,<4.1.0'
-    - 'bioconductor-metagenomeseq >=1.43.0,<1.44.0'
+    - 'bioconductor-edger >=4.8.0,<4.9.0'
+    - 'bioconductor-metagenomeseq >=1.52.0,<1.53.0'
     - r-base
     - r-biglm
     - r-car
@@ -49,8 +49,8 @@ requirements:
     - r-tibble
     - r-vegan
   run:
-    - 'bioconductor-edger >=4.0.0,<4.1.0'
-    - 'bioconductor-metagenomeseq >=1.43.0,<1.44.0'
+    - 'bioconductor-edger >=4.8.0,<4.9.0'
+    - 'bioconductor-metagenomeseq >=1.52.0,<1.53.0'
     - r-base
     - r-biglm
     - r-car


### PR DESCRIPTION
Title: Update bioconductor-maaslin2 to 1.22.0 (BioC 3.21)

Description:
Update bioconductor-maaslin2 from 1.18.0 (BioC 3.19) to 1.22.0 (BioC 3.21).

Changes:
Version: 1.18.0 → 1.22.0
Bioconductor release: 3.19 → 3.21
Updated md5 hash
Updated dependency pins: bioconductor-edger >=4.8.0, bioconductor-metagenomeseq >=1.52.0
No changes to the R package dependencies (same Imports list). The existing rpath.patch still applies cleanly.