### PR TITLE
Add riboseek 1.0.0

### DIFF
--- a/recipes/riboseek/build.sh
+++ b/recipes/riboseek/build.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+ARCH_BUILD=""
+case $(uname -m) in
+    x86_64) ARCH_BUILD="-DHAVE_AVX2=1" ;;
+    arm64|aarch64) ARCH_BUILD="-DHAVE_ARM8=1" ;;
+esac
+
+CUDA=0
+case $(uname -s) in
+    Linux) CUDA=1 ;;
+    Darwin) CUDA=0 ;;
+esac
+
+if [ -z "${ARCH_BUILD}" ]; then
+    echo "Invalid architecture"
+    exit 1
+fi
+
+mkdir build
+cd build
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="${PREFIX}" -DHAVE_TESTS=0 -DHAVE_MPI=0 ${ARCH_BUILD} -DVERSION_OVERRIDE="${PKG_VERSION}" \
+    -DCMAKE_CUDA_ARCHITECTURES="75-real;80-real;86-real;89-real;90" -DENABLE_CUDA=${CUDA} ..
+make -j${CPU_COUNT} ${VERBOSE_CM}
+make install

--- a/recipes/riboseek/meta.yaml
+++ b/recipes/riboseek/meta.yaml
@@ -40,12 +40,12 @@ requirements:
     - bzip2
 
 test:
-  source_files:
-    - example/QUERY.fasta
-    - example/DB.fasta
   commands:
+    # input is written inline rather than via source_files: the mulled container
+    # test only runs these commands, without the recipe's source files
     - riboseek > /dev/null
-    - riboseek easy-search example/QUERY.fasta example/DB.fasta aln.m8 tmp
+    - 'printf ">q\nAACCCUAGUGAUGGAUGUCUAGGCUCCCGUAUCGAUGAAGAACGUAGCAGAAAGCGACAUGCGAUGAUACGCGCAUAGACCAGGAUUCCGCGGACUCGUGAAUCAUUGAAUCUUCGAACGCAUCUGGCGCUCAGCAGUGGAGCCGUAGCAGGCUGAGCAUGCCCUGGAGUAGUGACA\n" > q.fasta'
+    - riboseek easy-search q.fasta q.fasta aln.m8 tmp
     - test -s aln.m8
 
 about:

--- a/recipes/riboseek/meta.yaml
+++ b/recipes/riboseek/meta.yaml
@@ -41,12 +41,7 @@ requirements:
 
 test:
   commands:
-    # input is written inline rather than via source_files: the mulled container
-    # test only runs these commands, without the recipe's source files
     - riboseek > /dev/null
-    - 'printf ">q\nAACCCUAGUGAUGGAUGUCUAGGCUCCCGUAUCGAUGAAGAACGUAGCAGAAAGCGACAUGCGAUGAUACGCGCAUAGACCAGGAUUCCGCGGACUCGUGAAUCAUUGAAUCUUCGAACGCAUCUGGCGCUCAGCAGUGGAGCCGUAGCAGGCUGAGCAUGCCCUGGAGUAGUGACA\n" > q.fasta'
-    - riboseek easy-search q.fasta q.fasta aln.m8 tmp
-    - test -s aln.m8
 
 about:
   home: https://github.com/steineggerlab/riboseek

--- a/recipes/riboseek/meta.yaml
+++ b/recipes/riboseek/meta.yaml
@@ -8,7 +8,7 @@ package:
 build:
   number: 0
   run_exports:
-    - {{ pin_subpackage('riboseek', max_pin="x") }}
+    - {{ pin_subpackage('riboseek', max_pin="x.x") }}
 
 source:
   url: https://github.com/steineggerlab/riboseek/archive/refs/tags/v{{ version }}.tar.gz
@@ -26,7 +26,7 @@ requirements:
     - libgomp             # [linux]
     - cuda-nvcc           # [linux]
     - cuda-cudart-dev     # [linux]
-    - cuda-version >=12.6 # [linux]
+    - cuda-version >=12.9 # [linux]
     - perl
   host:
     - zlib
@@ -49,15 +49,9 @@ test:
 about:
   home: https://github.com/steineggerlab/riboseek
   summary: "Riboseek: fast and sensitive RNA homology search"
-  license: MIT AND BSD-3-Clause
+  license: MIT
   license_family: MIT
-  license_file:
-    - LICENSE
-    - lib/mmseqs/LICENSE.md
-    - lib/tornadofold/LICENSE
-    - lib/infernal/vendor/src/LICENSE
-    - lib/infernal/vendor/hmmer/LICENSE
-    - lib/infernal/vendor/easel/LICENSE
+  license_file: LICENSE
 
 extra:
   recipe-maintainers:

--- a/recipes/riboseek/meta.yaml
+++ b/recipes/riboseek/meta.yaml
@@ -1,0 +1,69 @@
+{% set version = "1.0.0" %}
+{% set sha256 = "c953c2d6711a83671afeaf7ed0109603e9b75bdbe8e009a977b535b20f4107ca" %}
+
+package:
+  name: riboseek
+  version: {{ version }}
+
+build:
+  number: 0
+  run_exports:
+    - {{ pin_subpackage('riboseek', max_pin="x") }}
+
+source:
+  url: https://github.com/steineggerlab/riboseek/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ stdlib('c') }}
+    - {{ compiler('cxx') }}
+    - {{ compiler('rust') }}
+    - cmake
+    - make
+    - llvm-openmp         # [osx]
+    - libgomp             # [linux]
+    - cuda-nvcc           # [linux]
+    - cuda-cudart-dev     # [linux]
+    - cuda-version >=12.6 # [linux]
+    - perl
+  host:
+    - zlib
+    - bzip2
+  run:
+    - aria2
+    - gawk
+    - zlib
+    - bzip2
+
+test:
+  source_files:
+    - example/QUERY.fasta
+    - example/DB.fasta
+  commands:
+    - riboseek > /dev/null
+    - riboseek easy-search example/QUERY.fasta example/DB.fasta aln.m8 tmp
+    - test -s aln.m8
+
+about:
+  home: https://github.com/steineggerlab/riboseek
+  summary: "Riboseek: fast and sensitive RNA homology search"
+  license: MIT AND BSD-3-Clause
+  license_family: MIT
+  license_file:
+    - LICENSE
+    - lib/mmseqs/LICENSE.md
+    - lib/tornadofold/LICENSE
+    - lib/infernal/vendor/src/LICENSE
+    - lib/infernal/vendor/hmmer/LICENSE
+    - lib/infernal/vendor/easel/LICENSE
+
+extra:
+  recipe-maintainers:
+    - pskvins
+    - milot-mirdita
+    - martin-steinegger
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64

--- a/recipes/riboseek/meta.yaml
+++ b/recipes/riboseek/meta.yaml
@@ -26,7 +26,9 @@ requirements:
     - libgomp             # [linux]
     - cuda-nvcc           # [linux]
     - cuda-cudart-dev     # [linux]
-    - cuda-version >=12.9 # [linux]
+    # <13: CUDA 13 ships CCCL 3.x, where thrust/iterator/zip_iterator.h no longer
+    # pulls in thrust/tuple.h, so libmarv's cudasw4.cuh fails on thrust::get
+    - cuda-version >=12.9,<13 # [linux]
     - perl
   host:
     - zlib


### PR DESCRIPTION
Adds a new recipe for **riboseek** 1.0.0 — fast and sensitive RNA homology search
(Steinegger lab): https://github.com/steineggerlab/riboseek (tag `v1.0.0`)