### PR TITLE
Add sar11-genome-atlas-tools

### DIFF
--- a/recipes/sar11-genome-atlas-tools/meta.yaml
+++ b/recipes/sar11-genome-atlas-tools/meta.yaml
@@ -1,0 +1,53 @@
+{% set name = "sar11-genome-atlas-tools" %}
+{% set version = "0.1.1" %}
+{% set python_min = "3.10" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/s/sar11-genome-atlas-tools/sar11_genome_atlas_tools-{{ version }}.tar.gz
+  sha256: 74a900e7de109e65af3d63d78cc0ab4fc7b9a9020a0511d14e6532d23b1a4fde
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x.x") }}
+
+requirements:
+  host:
+    - python {{ python_min }}
+    - pip
+    - setuptools >=68
+  run:
+    - python >={{ python_min }}
+    - biopython >=1.80
+    - pandas >=2.0
+    - pyyaml >=6.0
+    - rich >=13.7
+    - prodigal
+    - hmmer
+    - mafft
+    - epa-ng
+    - fastani
+
+test:
+  requires:
+    - python {{ python_min }}
+  commands:
+    - sga-mapper --version
+    - sga-classify --version
+    - sga-run --version
+
+about:
+  home: https://github.com/stsnsn/SAR11_Atlas
+  summary: SGAmapper and SGAclassifier for the SAR11 Genome Atlas
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - satoshinishino


### PR DESCRIPTION
This PR adds `sar11-genome-atlas-tools`, a command-line toolkit for SAR11 Genome Atlas analysis.

The package provides:

- `sga-mapper`: SAR11 Genome Atlas OG annotation from FAA input
- `sga-classify`: SAR11_165 marker alignment, EPA-ng placement, taxonomy assignment, and ANI
- `sga-run`: integrated Prodigal, mapper, and classifier workflow

The package is distributed from PyPI and depends on:

- Prodigal
- HMMER
- MAFFT
- EPA-ng
- fastANI
- Biopython
- pandas
- PyYAML
- Rich

EPA-ng is the only supported placement backend. Runtime reference archives are downloaded from the configured Zenodo record and cached under `~/.cache/sga-toolkit/`.

The package has been tested from the PyPI distribution with Python 3.14.