### PR TITLE
Update gtdb-genomes to 0.2.2

### DIFF
--- a/recipes/gtdb-genomes/meta.yaml
+++ b/recipes/gtdb-genomes/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "gtdb-genomes" %}
-{% set version = "0.2.1" %}
+{% set version = "0.2.2" %}
 
 package:
   name: {{ name }}
@@ -16,7 +16,7 @@ build:
 
 source:
   url: https://github.com/asuq/gtdb-genomes/releases/download/v{{ version }}/gtdb_genomes-{{ version }}.tar.gz
-  sha256: c1a0ebf2b7f4a483b1536adc5b83b6ff5283a580c9cb3c4e845f42b3dcf78931
+  sha256: 687fa8778b84c4f96edabef0160f8d34141ff9b02d632d388a58661a14948b66
 
 requirements:
   host:
@@ -28,7 +28,7 @@ requirements:
     - polars >=1.31.0,<2.0.0
     - tqdm >=4.60.0,<5.0.0
     - unzip >=6.0,<7.0
-    - ncbi-datasets-cli >=18.4.0,<18.27.0
+    - ncbi-datasets-cli >=18.4.0,<19.0.0
 
 test:
   commands:


### PR DESCRIPTION
## Summary

- update gtdb-genomes from 0.2.1 to 0.2.2
- use the published v0.2.2 sdist checksum
- widen ncbi-datasets-cli from >=18.4.0,<18.27.0 to >=18.4.0,<19.0.0

## Rationale

NCBI Datasets publishes 18.x updates frequently. The previous patch-level upper bound rejected compatible releases and imposed unnecessary recipe maintenance. Upstream v0.2.2 keeps the tested minimum at 18.4.0 while accepting all 18.x releases and excluding the next major version.

## Tests and validation

- bioconda-utils lint --git-range upstream/master HEAD
- native bioconda-utils build and recipe tests on osx-arm64
- resolved and tested with ncbi-datasets-cli 18.34.0
- upstream wheel and sdist release-validation workflows passed

Docker/mulled testing was not run locally because the Docker daemon was unavailable; Bioconda CI provides the Linux container coverage.

No scientific outputs or schemas change; this is a packaging and download-reliability release.