### PR TITLE
Update crispritz to 2.7.1

### DIFF
--- a/recipes/crispritz/meta.yaml
+++ b/recipes/crispritz/meta.yaml
@@ -19,6 +19,7 @@ build:
 requirements:
   build:
     - {{ compiler('cxx') }}
+    - {{ stdlib('c') }}
     - libgomp  # [linux]
     - llvm-openmp  # [osx]
     - make

--- a/recipes/crispritz/meta.yaml
+++ b/recipes/crispritz/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "crispritz" %}
-{% set version = "2.7.0" %}
+{% set version = "2.7.1" %}
 
 package:
   name: {{name}}
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://github.com/pinellolab/CRISPRitz/archive/v{{ version }}.tar.gz
-  sha256: 89edad0570e3766c41184139197320aae1263f8d91fbc8c30f12105329d67377
+  sha256: 7a89b467168e12dc16a14cf055c8350481e40cc85399bb6e6dba361b30c2178c
 
 build:
-  number: 2
+  number: 0
   run_exports:
     - {{ pin_subpackage(name, max_pin = "x") }}
 


### PR DESCRIPTION
This bumps **crispritz** from 2.7.0 to 2.7.1.

2.7.1 fixes a heap-buffer-overflow in the `searchTST` off-target search (CRISPRme #105) — ASan-validated, and search output is byte-identical to 2.7.0. No dependency or build changes; `build.number` reset to 0 for the new version.

cc @lucapinello (maintainer) — safe to merge once the linux-64 + linux-aarch64 builds pass.

##### Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

- [x] This PR adds a new recipe.  <!-- N/A: existing recipe update -->
- [x] AND/OR: This PR updates an existing recipe.
- [ ] AND/OR: This PR does something else (explain below).
