### PR TITLE
Update crisprme to 2.1.12

### DIFF
--- a/recipes/crisprme/meta.yaml
+++ b/recipes/crisprme/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.1.11" %}
+{% set version = "2.1.12" %}
 
 package:
   name: crisprme
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/pinellolab/CRISPRme/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: eded519b54c593699890512ea22b78de716b0826f6a92e66baf20189c3007e77
+  sha256: 1fb5d1a532239781f275139dff617e6ebd13723c16b51cd93e01432e4a6c9bfb
 
 build:
   run_exports:
@@ -24,7 +24,7 @@ requirements:
     - gdown
     - zip
     - numpy 1.20.0
-    - crispritz 2.7.0
+    - crispritz 2.7.1
     - dash 1.10.0
     - dash-bootstrap-components 0.10.0
     - dash-core-components 1.9.0


### PR DESCRIPTION
Update crisprme to 2.1.12 (stable release on the Python 3.8 / Dash 1.x stack).

- Bumps version 2.1.11 -> 2.1.12 (new sha256 for the v2.1.12 tag).
- **Pins `crispritz 2.7.1`** (was 2.7.0) so 2.1.12 pulls the #105 heap-overflow fix that landed in crispritz 2.7.1.

Release: https://github.com/pinellolab/CRISPRme/releases/tag/v2.1.12

Authored by the package author / a Bioconda maintainer (@lucapinello).