### PR TITLE
Add weebill

### DIFF
--- a/recipes/weebill/build.sh
+++ b/recipes/weebill/build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -e
+set -ex
+
+export CFLAGS="${CFLAGS} -O3 -Wno-implicit-function-declaration"
+export CXXFLAGS="${CXXFLAGS} -O3"
+
+cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
+
+RUST_BACKTRACE=1
+cargo install -v --no-track --path . --root "${PREFIX}" --locked
+
+"${STRIP}" "${PREFIX}/bin/weebill"

--- a/recipes/weebill/meta.yaml
+++ b/recipes/weebill/meta.yaml
@@ -1,0 +1,46 @@
+{% set version = "0.3.0" %}
+{% set name = "weebill" %}
+{% set sha256 = "129489473ed959ebfe43164353cc60922b5bb99e2fd81b820c5c2784307ec8df" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/wwood/{{ name }}/archive/v{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x.x") }}
+
+requirements:
+  build:
+    - {{ compiler('rust') }}
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - {{ stdlib('c') }}
+    - cargo-bundle-licenses
+    - cmake
+    - make
+
+test:
+  commands:
+    - {{ name }} --version | grep '{{ version }}'
+
+about:
+  home: "https://github.com/wwood/weebill"
+  license: MIT
+  license_family: MIT
+  license_file:
+    - LICENSE
+    - THIRDPARTY.yml
+  summary: "Compression-focused fork of sylph, a fast species-level metagenomic profiler."
+  dev_url: "https://github.com/wwood/weebill"
+  doc_url: "https://github.com/wwood/weebill/blob/v{{ version }}/README.md"
+
+extra:
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64


### PR DESCRIPTION
## Description

Adds a recipe for [weebill](https://github.com/wwood/weebill), a compression-focused fork of [sylph](https://github.com/bluenote-1577/sylph), the fast species-level metagenomic profiler (ANI querying + taxonomic profiling). Weebill maintains compatibility with sylph's command-line interface and sketch formats where possible.

Note: I was not able to run `conda build` or `conda-smithy lint` locally in the environment that authored this recipe (no docker/conda-build available there). The recipe is modeled closely on the existing `galah` and `coverm` Rust-tool recipes in this repo. Will fix up based on CI feedback.

## Checklist

- [x] Followed the [conda-forge guidelines](https://conda-forge.org/docs/maintainer/adding_pkgs.html) (in absence of specific bioconda ones)
- [ ] Ran `conda-smithy lint recipe/` locally
- [ ] `conda build` succeeds locally
- [x] Add the `Biii:` tags if appropriate (not applicable)
- [x] If this PR adds a new recipe, I have not manually set the `build` number to anything other than `0`