### PR TITLE
Update crispritz to 2.8.0

### DIFF
--- a/recipes/crispritz/meta.yaml
+++ b/recipes/crispritz/meta.yaml
@@ -59,7 +59,7 @@ test:
 
 about:
   home: https://github.com/pinellolab/CRISPRitz
-  license: GPL3
+  license: AGPL-3.0-or-later
   license_file: LICENSE
   summary: CRISPRitz, tool package for CRISPR experiments assessment and analysis.
 extra:

--- a/recipes/crispritz/meta.yaml
+++ b/recipes/crispritz/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/pinellolab/CRISPRitz/archive/v{{ version }}.tar.gz
-  sha256: 071a0ccc121e922c598e76450fb4bc859105cd7007cc61974d031b11db82376e
+  sha256: 7957c7936831f7bdd468ee7cdbde45f091a9c31c2c0fe4c2868546ce45f12927
 
 build:
   number: 0

--- a/recipes/crispritz/meta.yaml
+++ b/recipes/crispritz/meta.yaml
@@ -63,5 +63,7 @@ about:
   license_file: LICENSE
   summary: CRISPRitz, tool package for CRISPR experiments assessment and analysis.
 extra:
+  recipe-maintainers:
+    - lucapinello
   additional-platforms:
     - linux-aarch64

--- a/recipes/crispritz/meta.yaml
+++ b/recipes/crispritz/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "crispritz" %}
-{% set version = "2.7.1" %}
+{% set version = "2.8.0" %}
 
 package:
   name: {{name}}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/pinellolab/CRISPRitz/archive/v{{ version }}.tar.gz
-  sha256: 7a89b467168e12dc16a14cf055c8350481e40cc85399bb6e6dba361b30c2178c
+  sha256: 071a0ccc121e922c598e76450fb4bc859105cd7007cc61974d031b11db82376e
 
 build:
   number: 0
@@ -25,25 +25,31 @@ requirements:
     - make
   host:
     - boost-cpp
-    - python >=3.8,<3.9
+    # The C++ enricher (add-variants) links against zlib; header needed at build.
+    - zlib
+    - python >=3.11,<3.12
   run:
     - rename
     - bedtools
     - bedops
-    - scikit-learn =0.23.2
+    # The azimuth (Doench 2016) on-target model is vendored from CRISPR-HAWK and
+    # only unpickles on this scikit-learn/numpy/pandas/scipy combo. Do NOT bump
+    # scikit-learn past 1.1.x without re-serializing the model: sklearn 1.2
+    # removed sklearn.ensemble._gb_losses, which the model references.
+    - scikit-learn ==1.1.3
+    - numpy ==1.24.4
+    - pandas ==2.0.3
+    - scipy ==1.10.1
     - biopython
     - intervaltree
     - matplotlib-base
-    - pandas
-    - scipy
-    - numpy
     - more-itertools
     - statsmodels
     - bcftools
     - boost-cpp
     - tk
-    - openmp     # [osx]
-    - python >=3.8,<3.9
+    - openmp     # [osx]
+    - python >=3.11,<3.12
     - pysam 0.22.1
     - htslib
 

--- a/recipes/crispritz/meta.yaml
+++ b/recipes/crispritz/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/pinellolab/CRISPRitz/archive/v{{ version }}.tar.gz
-  sha256: 7957c7936831f7bdd468ee7cdbde45f091a9c31c2c0fe4c2868546ce45f12927
+  sha256: 3542c313cc48b77b1b8771c795292a79a74516e23b38f9fbf1528e1fb760ffd4
 
 build:
   number: 0


### PR DESCRIPTION
Update `crispritz` to **2.8.0** (release: https://github.com/pinellolab/CRISPRitz/releases/tag/v2.8.0).

### What's new upstream
- **Python 3.11**; azimuth (Doench 2016) on-target scoring restored and made matplotlib-independent for inference.
- **C++ enricher** (byte-identical to the previous Python `enricher.py`) + memory-bounded cross-chromosome parallelism for `add-variants` (~26× faster genome-wide enrichment).

### Recipe changes
- `version` 2.7.1 → 2.8.0, new `sha256`.
- Modern scientific stack required by the vendored azimuth model:
  `scikit-learn ==1.1.3`, `numpy ==1.24.4`, `pandas ==2.0.3`, `scipy ==1.10.1`, `python >=3.11,<3.12`
  (previously `scikit-learn =0.23.2` / `python >=3.8,<3.9`). Pins are exact because the pickled model
  only unpickles on this combo; a comment in the recipe documents this.
- Added `zlib` to `host` — the new C++ enricher links against it.
- Kept `skip: True  # [osx]` (buildTST uses GCC `__gnu_parallel`, absent from Apple clang) and
  `additional-platforms: linux-aarch64`.

Builds and runs verified on `linux-64` and `linux-aarch64` (genome-wide hg38 + 1000G enrichment; azimuth scoring reproduces reference scores).
