### PR TITLE
Update ngless to 1.6.0

### DIFF
--- a/recipes/ngless/build.sh
+++ b/recipes/ngless/build.sh
@@ -2,23 +2,38 @@
 
 set -e -o pipefail -x
 
-if [ "$(uname)" == "Darwin" ]; then
-    BINARY=ngless
-else
-    BINARY=NGLess-v${PKG_VERSION}-Linux-static-no-deps
-fi
+# Workaround for SSH-based git connections from cargo, and point CARGO_HOME
+# somewhere writable (HOME is not passed on to conda-build).
+export CARGO_NET_GIT_FETCH_WITH_CLI=true
+export CARGO_HOME="$(pwd)/.cargo"
 
-mkdir -p ${PREFIX}/bin/
-chmod +x ${BINARY}
-cp -pir ${BINARY} ${PREFIX}/bin/ngless-wrapped
-cat >> ${PREFIX}/bin/ngless <<EOF
+cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
+
+# Upstream does not ship a Cargo.lock (it is git-ignored), so --locked cannot be used.
+cargo install -v --no-track --root "${PREFIX}" --path .
+rm -f "${PREFIX}/.crates.toml" "${PREFIX}/.crates2.json"
+
+# ngless looks up the external tools it drives in $NGLESS_*_BIN, falling back to
+# $PATH. Wrap the binary so the copies from this environment are always the ones
+# used, even when the environment has not been activated.
+#
+# The prefix is derived from the wrapper's own location rather than from
+# $CONDA_PREFIX: that variable is unset unless the environment is activated, and
+# it points at the wrong environment when a different one is active. Note that a
+# NGLESS_*_BIN that is set but does not point at an executable is a hard error in
+# ngless (there is no fallback to $PATH), so getting this wrong is fatal.
+mv "${PREFIX}/bin/ngless" "${PREFIX}/bin/ngless-wrapped"
+cat > "${PREFIX}/bin/ngless" <<'EOF'
 #!/usr/bin/env bash
 
-export NGLESS_SAMTOOLS_BIN=\${CONDA_PREFIX}/bin/samtools
-export NGLESS_BWA_BIN=\${CONDA_PREFIX}/bin/bwa
-export NGLESS_PRODIGAL_BIN=\${CONDA_PREFIX}/bin/prodigal
-export NGLESS_MEGAHIT_BIN=\${CONDA_PREFIX}/bin/megahit
-export NGLESS_MINIMAP2_BIN=\${CONDA_PREFIX}/bin/minimap2
+bindir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 
-exec \${CONDA_PREFIX}/bin/ngless-wrapped "\$@"
+export NGLESS_SAMTOOLS_BIN="${bindir}/samtools"
+export NGLESS_BWA_BIN="${bindir}/bwa"
+export NGLESS_PRODIGAL_BIN="${bindir}/prodigal"
+export NGLESS_MEGAHIT_BIN="${bindir}/megahit"
+export NGLESS_MINIMAP2_BIN="${bindir}/minimap2"
+
+exec "${bindir}/ngless-wrapped" "$@"
 EOF
+chmod +x "${PREFIX}/bin/ngless"

--- a/recipes/ngless/meta.yaml
+++ b/recipes/ngless/meta.yaml
@@ -1,7 +1,6 @@
 {% set name = "ngless" %}
-{% set version = "1.5.0" %}
-{% set linux_sha256 = "327295c9a4e4fe8d5b41af403caaf43e414eaa4c9d11dcb312f660f44a24e143" %}
-{% set osx_sha256 = "fe2d43e4964da31ce18b95a447596f43eebaec9c5ae13788f812960fb9bb94e4" %}
+{% set version = "1.6.0" %}
+{% set sha256 = "1f51937d20170273f525253ecced107a084ade4472bffda9d91982a9d10a7c89" %}
 
 
 package:
@@ -9,36 +8,52 @@ package:
   version: {{ version }}
 
 source:
-  - url: https://github.com/ngless-toolkit/ngless/releases/download/v{{ version }}/NGLess-v{{ version }}-Linux-static-no-deps # [linux]
-    sha256: {{ linux_sha256 }} # [linux]
-  - url: https://github.com/ngless-toolkit/ngless/releases/download/v{{ version }}/NGLess-v{{ version }}-MacOSX.zip # [osx]
-    sha256: {{ osx_sha256 }} # [osx]
+  url: https://github.com/ngless-toolkit/ngless/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: {{ sha256 }}
 
 build:
   number: 0
+  run_exports:
+    - {{ pin_subpackage('ngless', max_pin='x') }}
 
 requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('rust') }}
+    - {{ stdlib('c') }}
+    - cargo-bundle-licenses
   run:
-    - bwa
-    - prodigal
-    - megahit
-    - samtools
-    - minimap2
+    - bwa >=0.7.19
+    - prodigal >=2.6.3
+    - megahit >=1.2.9
+    - samtools >=1.23.1
+    - minimap2 >=2.31
 
 test:
   commands:
     - ngless --version
     - ngless --check-install --verbose
+    # --check-install is a no-op in this release, so check that the wrapper
+    # actually resolves each external tool (exits non-zero if not found)
+    - ngless --print-path bwa
+    - ngless --print-path prodigal
+    - ngless --print-path megahit
+    - ngless --print-path samtools
+    - ngless --print-path minimap2
 
 about:
   home: https://ngless.embl.de
   license: MIT
+  license_family: MIT
+  license_file:
+    - COPYING
+    - THIRDPARTY.yml
   summary: A tool for short-read processing with a focus on metagenomics
+  dev_url: https://github.com/ngless-toolkit/ngless
+  doc_url: https://ngless.embl.de
 
 extra:
   recipe-maintainers:
     - luispedro
   identifiers:
     - "doi:10.1186/s40168-019-0684-8" # Publication
-  skip-lints:
-    - should_be_noarch_generic


### PR DESCRIPTION
Version 1.6.0 is a Rust rewrite so needs a new build method

- Switch to the GitHub tag tarball as a single source
- Build with cargo install; add the rust/c compilers and cargo-bundle-licenses to the build requirements
- Keep the ngless-wrapped shim: the Rust code still honours the NGLESS_*_BIN environment variables
- Pin run dependency lower bounds to those in upstream's pixi.toml
- Add license_file (COPYING + generated THIRDPARTY.yml) and run_exports, and drop the now-obsolete should_be_noarch_generic skip-lint
- Test --print-path for each external tool

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
