### PR TITLE
Update cerberus-mg to 0.2.1

### DIFF
--- a/recipes/cerberus-mg/meta.yaml
+++ b/recipes/cerberus-mg/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "cerberus-mg" %}
-{% set version = "0.1.1" %}
+{% set version = "0.2.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/iowa69/cerberus/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: c17944783acded3876b5d49a572ac77371b8e1737646b05f8b4c87f5d8d149bf
+  sha256: 2670716c8fd0bf1c5150fef813373054b6700172c36851bc0f97f75ca61ac7fb
 
 build:
   number: 0
@@ -26,21 +26,21 @@ requirements:
   run:
     - python >=3.10
     - tqdm >=4.66
-    - pyyaml >=6.0
+    # Invoked directly by the pipeline.
     - fastp >=0.24
+    - fastplong >=0.2
     - minimap2 >=2.28
     - bowtie2 >=2.5
     - bbmap >=39.0
     - kraken2 >=2.1.3
     - samtools >=1.20
-    - seqkit >=2.8
+    # zstd is required to unpack the published .tar.zst reference archives.
+    - zstd >=1.5
+    # Optional accelerators; each has a fallback path in code.
     - pigz
     - aria2
-    - multiqc >=1.25
-    - chopper >=0.9
+    # only reached by --long --double-pass on very long reads
     - winnowmap >=2.03
-    - bedtools >=2.31
-    - zstd >=1.5
 
 test:
   imports:
@@ -48,21 +48,32 @@ test:
   commands:
     - cerberus --version
     - cerberus --help
+    - cerberus --help-all
 
 about:
   home: https://github.com/iowa69/cerberus
   license: MIT
   license_family: MIT
   license_file: LICENSE
-  summary: "Three-headed host-removal pipeline for metagenomics: assembly, profiling, and GDPR-compliant outputs from one run."
+  summary: "Three-headed host removal for metagenomic data: assembly, profiling and privacy-scrubbed outputs from one run."
   description: |
     Cerberus is an opinionated all-in-one host-decontamination pipeline that
-    produces three publication-ready outputs from a single run: a paired-end
-    assembly-ready FASTQ pair (conservative), a single merged FASTQ for
-    taxonomic profiling (aggressive), and a GDPR-compliant zero-host scrubbed
-    output (via two orthogonal mechanisms: Kraken2 + minimap2). Works on
-    Illumina short reads, ONT long reads, and PacBio HiFi/CLR. Autotunes its
-    parameters from fastp QC.
+    produces three outputs from a single run: a paired-end assembly-ready
+    FASTQ pair (conservative — a pair is dropped only when both mates map to
+    the host), a single merged FASTQ for taxonomic profiling (aggressive — the
+    pair is dropped as soon as either mate maps), and a privacy-scrubbed
+    output for public release, from which host reads are removed by three
+    mechanisms in series: a Kraken2 host database, a bbduk human k-mer pass,
+    and minimap2 alignment against a masked T2T-CHM13v2.0 + HLA reference.
+
+    Because all three mechanisms derive from the same reference assemblies,
+    Cerberus reports the measured residual host removal per mechanism rather
+    than asserting that no host reads remain. Every run writes an HTML report
+    with the resolved parameters, per-stage read accounting and verification
+    of each output file.
+
+    Works on Illumina paired-end short reads, ONT long reads, and PacBio
+    HiFi/CLR, autotuning its parameters from a prescan of the input.
   doc_url: https://github.com/iowa69/cerberus
   dev_url: https://github.com/iowa69/cerberus
 


### PR DESCRIPTION
Updates `cerberus-mg` from 0.1.1 to 0.2.1.

Release notes: https://github.com/iowa69/cerberus/releases/tag/v0.2.1

## Why this is more than a version bump

0.1.1 shipped several defects that produced silently wrong scientific output, found by a ten-pass review of the code ([published in the repo](https://github.com/iowa69/cerberus/tree/main/docs/review)). The three that mattered most:

- A long-read minimap2 preset on paired input wrote **zero reads and exited 0** — minimap2 only emits paired records under `-x sr`, so `samtools fastq -1/-2` had nothing to write.
- The "conservative" (`--meta`) and "aggressive" (`--profiling`) filters compiled to the **same** filter, so `--meta` was discarding the microbial reads it promised to keep.
- `pipe()` checked only the last process's exit status, so an OOM-killed aligner produced a truncated dataset that looked like a successful run.

Users of 0.1.1 should regenerate their results, so I would rather this reach the channel than not.

## Recipe changes beyond the version and checksum

**Dependencies removed** — none of these is invoked by the package at runtime; I verified by grepping every `require_tools()`, `which()` and subprocess invocation in the codebase:

- `pyyaml` — never imported anywhere.
- `seqkit`, `multiqc` — appear only in the `cerberus doctor` display list, never executed.
- `bedtools` — used only by `scripts/build_refs/*.sh`, which `pyproject.toml` excludes from the install.
- `chopper` — a fallback for `fastplong`, which is now a hard dependency, so the fallback path is unreachable in a conda install.

Dropping these takes the install closure from 206 packages to 124, mostly by shedding multiqc's tree.

**Dependency added:** `fastplong >=0.2` — long-read QC. Its absence is why the fallback existed.

**Kept as-is:** `noarch: python`, `run_exports`, `license_family`, `about.description` and `extra.identifiers`, all unchanged from the merged 0.1.1 recipe.

**Summary/description reworded.** The old text claimed "GDPR-compliant zero-host scrubbed output (via two orthogonal mechanisms)". There was no detection step behind that claim, and both mechanisms derived from the same reference assemblies, so sequence absent from those assemblies was invisible to both. The tool now runs three mechanisms and reports *measured* per-mechanism removal rather than asserting an absence, and the packaging text matches.

## Verification

- Built locally with `conda build` against conda-forge + bioconda: produces `noarch/cerberus-mg-0.2.1-py_0.conda`.
- `test.imports` and all three `test.commands` pass from a clean install of the release tarball.
- `sha256` verified against `https://github.com/iowa69/cerberus/archive/refs/tags/v0.2.1.tar.gz` across repeated cache-busted fetches.
- Every run dependency resolves on linux-64, osx-64, osx-arm64 and linux-aarch64 with conda-forge enabled.
- Upstream CI runs the test suite on Python 3.10–3.13 plus an end-to-end smoke test that builds miniature references and asserts host removal by read provenance.
