### PR TITLE
Add hydra-amr 1.3.0

### DIFF
--- a/recipes/hydra-amr/meta.yaml
+++ b/recipes/hydra-amr/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "hydra-amr" %}
-{% set version = "1.0.0" %}
+{% set version = "1.1.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/iowa69/hydra/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: e8cabef2b62076a4b8ed3356c68cad39eca788b92f95e907e65cc1979fecb6db
+  sha256: 86a06dd580e40faaa9476fcd22eaf22cd2e465931b94438cb9559d173783bd46
 
 build:
   number: 0
@@ -62,8 +62,7 @@ about:
     Hydra screens bacterial assemblies and raw reads for acquired resistance and
     virulence genes, organism-specific resistance point mutations, multi-locus
     sequence types and lineage typing schemes, in one pass over one set of
-    databases, replacing a pipeline of abricate, AMRFinderPlus, mlst and
-    Kleborate.
+    databases, replacing a pipeline of four or five single-purpose tools.
 
     It reports heteroresistance directly from reads: allele fractions are
     measured at every catalogued mutation position, so a resistance mutation
@@ -76,17 +75,18 @@ about:
     reads supporting them.
 
     Acquired genes are screened against NCBI, CARD, ResFinder, ARG-ANNOT,
-    MEGARes, VFDB, PlasmidFinder, EcOH and E. coli VF together, with the curated
-    AMRFinderPlus drug-class and gene-family annotation transferred onto every
-    one of them. Results come out as TSV, CSV, JSON, XLSX or a self-contained
-    HTML report with clustered heatmaps, pivoted on samples or genes, showing
+    MEGARes, VFDB, PlasmidFinder, EcOH and E. coli VF together, with curated
+    drug-class and gene-family annotation transferred onto every one of them.
+    Results come out as TSV, CSV, JSON, XLSX or a self-contained HTML report
+    with clustered heatmaps, pivoted on samples or genes, showing
     presence/absence, percent identity, coverage, read depth or allele fraction,
-    plus abricate- and AMRFinderPlus-compatible column layouts.
+    plus flat one-row-per-hit layouts that existing downstream scripts can read.
 
     Reference databases are not redistributed. After installation, `hydra db
-    import` builds them from abricate, ncbi-amrfinderplus, mlst or kleborate
-    installations already present on the machine, and `hydra db bundle` packs
-    them for machines that have neither those tools nor a network.
+    import` builds them from reference data already present on the machine, and
+    `hydra db bundle` packs them for machines that have neither that data nor a
+    network.
+
   doc_url: https://github.com/iowa69/hydra#readme
   dev_url: https://github.com/iowa69/hydra
 

--- a/recipes/hydra-amr/meta.yaml
+++ b/recipes/hydra-amr/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "hydra-amr" %}
-{% set version = "1.1.0" %}
+{% set version = "1.2.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/iowa69/hydra/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 86a06dd580e40faaa9476fcd22eaf22cd2e465931b94438cb9559d173783bd46
+  sha256: 928f822c43621c6f6f81f2c08f599ab3028824c8419ecd0c2a1cc78aef469dfd
 
 build:
   number: 0
@@ -83,9 +83,12 @@ about:
     plus flat one-row-per-hit layouts that existing downstream scripts can read.
 
     Reference databases are not redistributed. After installation, `hydra db
-    import` builds them from reference data already present on the machine, and
-    `hydra db bundle` packs them for machines that have neither that data nor a
-    network.
+    download` fetches the NCBI, CARD, ResFinder, PlasmidFinder and VFDB
+    references from their upstream sources and converts them, `hydra db import`
+    builds them from reference data already present on the machine, and `hydra db
+    bundle` packs them for machines with neither a source nor a network. Each
+    database keeps its own licence, which `hydra db info` prints along with its
+    citation.
 
   doc_url: https://github.com/iowa69/hydra#readme
   dev_url: https://github.com/iowa69/hydra

--- a/recipes/hydra-amr/meta.yaml
+++ b/recipes/hydra-amr/meta.yaml
@@ -15,6 +15,8 @@ build:
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:
     - hydra = hydra_amr.cli:main
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x") }}
 
 requirements:
   host:

--- a/recipes/hydra-amr/meta.yaml
+++ b/recipes/hydra-amr/meta.yaml
@@ -1,0 +1,93 @@
+{% set name = "hydra-amr" %}
+{% set version = "1.0.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/iowa69/hydra/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: e8cabef2b62076a4b8ed3356c68cad39eca788b92f95e907e65cc1979fecb6db
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  entry_points:
+    - hydra = hydra_amr.cli:main
+
+requirements:
+  host:
+    - python >=3.9
+    - pip
+    - setuptools >=68
+  run:
+    - python >=3.9
+    - pandas >=1.3
+    - numpy >=1.20
+    - scipy >=1.7
+    - pysam >=0.19
+    - openpyxl >=3.0
+    - blast >=2.12
+    - minimap2 >=2.24
+    - samtools >=1.15
+    - mash >=2.3
+
+test:
+  imports:
+    - hydra_amr
+    - hydra_amr.engines
+    - hydra_amr.typing
+    - hydra_amr.report
+  commands:
+    - hydra --version
+    - hydra --help
+    - hydra run --help
+    - hydra screen --help
+    - hydra db --help
+    - hydra presets
+    - blastn -version
+    - minimap2 --version
+    - samtools --version
+
+about:
+  home: https://github.com/iowa69/hydra
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: Unified AMR, virulence, point-mutation, heteroresistance, MLST and lineage typing
+  description: |
+    Hydra screens bacterial assemblies and raw reads for acquired resistance and
+    virulence genes, organism-specific resistance point mutations, multi-locus
+    sequence types and lineage typing schemes, in one pass over one set of
+    databases, replacing a pipeline of abricate, AMRFinderPlus, mlst and
+    Kleborate.
+
+    It reports heteroresistance directly from reads: allele fractions are
+    measured at every catalogued mutation position, so a resistance mutation
+    carried by only some copies of a multi-copy locus - the usual situation for
+    the 23S rRNA mutations behind linezolid resistance - is detected even though
+    the assembly consensus is wild type. A FASTQ-only sample is also sequence
+    typed, by mapping reads to the scheme's loci and reading the consensus back
+    against every allele, and each resistance gene it carries is compared with
+    the closest reference so its mutations are reported with the fraction of
+    reads supporting them.
+
+    Acquired genes are screened against NCBI, CARD, ResFinder, ARG-ANNOT,
+    MEGARes, VFDB, PlasmidFinder, EcOH and E. coli VF together, with the curated
+    AMRFinderPlus drug-class and gene-family annotation transferred onto every
+    one of them. Results come out as TSV, CSV, JSON, XLSX or a self-contained
+    HTML report with clustered heatmaps, pivoted on samples or genes, showing
+    presence/absence, percent identity, coverage, read depth or allele fraction,
+    plus abricate- and AMRFinderPlus-compatible column layouts.
+
+    Reference databases are not redistributed. After installation, `hydra db
+    import` builds them from abricate, ncbi-amrfinderplus, mlst or kleborate
+    installations already present on the machine, and `hydra db bundle` packs
+    them for machines that have neither those tools nor a network.
+  doc_url: https://github.com/iowa69/hydra#readme
+  dev_url: https://github.com/iowa69/hydra
+
+extra:
+  recipe-maintainers:
+    - iowa69

--- a/recipes/hydra-amr/meta.yaml
+++ b/recipes/hydra-amr/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "hydra-amr" %}
-{% set version = "1.2.0" %}
+{% set version = "1.3.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/iowa69/hydra/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 928f822c43621c6f6f81f2c08f599ab3028824c8419ecd0c2a1cc78aef469dfd
+  sha256: 6dc27d5e8c2c0a5a81b0c319b7666dea9364b3cd47fe1367e96bb267112a8fd2
 
 build:
   number: 0
@@ -83,12 +83,14 @@ about:
     plus flat one-row-per-hit layouts that existing downstream scripts can read.
 
     Reference databases are not redistributed. After installation, `hydra db
-    download` fetches the NCBI, CARD, ResFinder, PlasmidFinder and VFDB
-    references from their upstream sources and converts them, `hydra db import`
-    builds them from reference data already present on the machine, and `hydra db
-    bundle` packs them for machines with neither a source nor a network. Each
-    database keeps its own licence, which `hydra db info` prints along with its
-    citation.
+    download` fetches them from their own upstream sources and converts them -
+    the NCBI protein and point-mutation references, NCBI, CARD, ResFinder,
+    PlasmidFinder and VFDB gene catalogues, every PubMLST 7-locus scheme, and the
+    lineage typing loci and species sketches - so a fresh machine needs one
+    command and no other tool. `hydra db import` builds them instead from
+    reference data already present, and `hydra db bundle` packs them for machines
+    with neither a source nor a network. Each database keeps its own licence,
+    which `hydra db info` prints along with its citation.
 
   doc_url: https://github.com/iowa69/hydra#readme
   dev_url: https://github.com/iowa69/hydra


### PR DESCRIPTION
Adds `hydra-amr`, a command-line tool that screens bacterial assemblies and raw
reads for acquired resistance and virulence genes, organism-specific resistance
point mutations, multi-locus sequence types and lineage typing schemes in one
pass over one set of databases.

From reads it also measures allele fractions at every catalogued mutation
position, so heteroresistance — a resistance mutation carried by only some
copies of a multi-copy locus, as with the 23S rRNA mutations behind linezolid
resistance — is detected even where the assembly consensus is wild type. A
FASTQ-only sample is sequence typed by mapping reads to the scheme's loci and
reading the consensus back against every allele.

- Upstream: https://github.com/iowa69/hydra
- Licence: MIT (`license_file: LICENSE`)
- `noarch: python`, with `run_exports`
- Pure-Python at build time; the runtime requirements are the aligners and
  samtools it shells out to.

**No reference data is vendored.** After installation `hydra db download` fetches
each database from its own upstream source and converts it — NCBI's protein and
point-mutation references, the NCBI/CARD/ResFinder/PlasmidFinder/VFDB gene
catalogues, every PubMLST 7-locus scheme, and the lineage and species data from
the Kleborate release archive. `hydra db import` builds them instead from data
already on the machine, and `hydra db bundle` packs them for offline hosts. Each
database keeps its own licence, printed with its citation by `hydra db info`.

Updated from 1.0.0 to 1.3.0 while this PR was open. The packaging is unchanged
throughout apart from `version`, `sha256` and the description; the intervening
releases renamed some user-facing options and made the database installation
automatic.

---
* [x] This PR adds a new recipe.
* [x] The recipe builds `noarch: python` and declares `run_exports`.
* [x] AGPL/GPL-incompatible code is not vendored; the licence file is included.