### PR TITLE
Add spacna 0.1.0

### DIFF
--- a/recipes/spacna/build.sh
+++ b/recipes/spacna/build.sh
@@ -7,7 +7,8 @@
 #   bin/spacna
 #   share/spacna/{scripts,reference,bin,config,...}
 #
-# This script unpacks that package into $PREFIX.
+# This script unpacks that package into $PREFIX and installs thin wrappers so
+# `spacna` works even when CONDA_PREFIX is unset during tests.
 set -euo pipefail
 
 SHARE_DIR="${PREFIX}/share/spacna"
@@ -34,7 +35,7 @@ if [[ ! -d "${TMP}/share/spacna" ]]; then
   echo "ERROR: ${PKG} missing share/spacna/" >&2
   exit 1
 fi
-if [[ ! -x "${TMP}/bin/spacna" && ! -f "${TMP}/bin/spacna" ]]; then
+if [[ ! -f "${TMP}/bin/spacna" ]]; then
   echo "ERROR: ${PKG} missing bin/spacna" >&2
   exit 1
 fi
@@ -49,24 +50,41 @@ tar -C "${TMP}/share/spacna" \
     --exclude='*.pyc' \
     -cf - . | tar -C "${SHARE_DIR}" -xf -
 
-install -m 0755 "${TMP}/bin/spacna" "${BIN_DIR}/spacna"
-if [[ -f "${TMP}/bin/axis-dna" ]]; then
-  install -m 0755 "${TMP}/bin/axis-dna" "${BIN_DIR}/axis-dna"
-fi
-
-# Keep a copy under share for `spacna path` users
+# Keep payload CLI under share/spacna/bin (resolves via ../scripts)
 mkdir -p "${SHARE_DIR}/bin"
-cp -f "${BIN_DIR}/spacna" "${SHARE_DIR}/bin/spacna"
+cp -f "${TMP}/bin/spacna" "${SHARE_DIR}/bin/spacna"
 chmod +x "${SHARE_DIR}/bin/spacna"
-if [[ -f "${BIN_DIR}/axis-dna" ]]; then
-  cp -f "${BIN_DIR}/axis-dna" "${SHARE_DIR}/bin/axis-dna"
+if [[ -f "${TMP}/bin/axis-dna" ]]; then
+  cp -f "${TMP}/bin/axis-dna" "${SHARE_DIR}/bin/axis-dna"
   chmod +x "${SHARE_DIR}/bin/axis-dna"
 fi
 
-find "${SHARE_DIR}/scripts" -type f \( -name '*.sh' -o -name '*.py' \) -exec chmod +x {} + 2>/dev/null || true
+# Thin wrappers in $PREFIX/bin: do not rely on CONDA_PREFIX being set
+cat > "${BIN_DIR}/spacna" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "${HERE}/../share/spacna" && pwd)"
+export SPACNA_REPO_ROOT="${ROOT}"
+export AXIS_REPO_ROOT="${ROOT}"
+exec bash "${ROOT}/bin/spacna" "$@"
+EOF
+chmod +x "${BIN_DIR}/spacna"
 
-# Prefer LICENSE from payload if recipe license_file needs it at source root;
-# bioconda copies LICENSE from source before build — SpaCNA repo root already has LICENSE.
+if [[ -f "${SHARE_DIR}/bin/axis-dna" ]]; then
+  cat > "${BIN_DIR}/axis-dna" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "${HERE}/../share/spacna" && pwd)"
+export SPACNA_REPO_ROOT="${ROOT}"
+export AXIS_REPO_ROOT="${ROOT}"
+exec bash "${ROOT}/bin/axis-dna" "$@"
+EOF
+  chmod +x "${BIN_DIR}/axis-dna"
+fi
+
+find "${SHARE_DIR}/scripts" -type f \( -name '*.sh' -o -name '*.py' \) -exec chmod +x {} + 2>/dev/null || true
 
 cat > "${SHARE_DIR}/conda_env_hint.txt" <<EOF
 SpaCNA (bioconda)

--- a/recipes/spacna/build.sh
+++ b/recipes/spacna/build.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Bioconda build script for SpaCNA (noarch: generic).
+#
+# SpaCNA GitHub release ships a prebuilt conda package under dist/:
+#   dist/spacna-<version>-*.tar.bz2
+# which already contains:
+#   bin/spacna
+#   share/spacna/{scripts,reference,bin,config,...}
+#
+# This script unpacks that package into $PREFIX.
+set -euo pipefail
+
+SHARE_DIR="${PREFIX}/share/spacna"
+BIN_DIR="${PREFIX}/bin"
+
+mkdir -p "${SHARE_DIR}" "${BIN_DIR}"
+
+PKG="$(ls -1 dist/spacna-*.tar.bz2 2>/dev/null | head -n 1 || true)"
+if [[ -z "${PKG}" ]]; then
+  echo "ERROR: no dist/spacna-*.tar.bz2 found in source tree" >&2
+  echo "cwd=$(pwd)" >&2
+  ls -la >&2 || true
+  exit 1
+fi
+
+echo "Installing SpaCNA payload from ${PKG}"
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP}"' EXIT
+
+# conda package layout: bin/ + share/spacna/
+tar -xjf "${PKG}" -C "${TMP}"
+
+if [[ ! -d "${TMP}/share/spacna" ]]; then
+  echo "ERROR: ${PKG} missing share/spacna/" >&2
+  exit 1
+fi
+if [[ ! -x "${TMP}/bin/spacna" && ! -f "${TMP}/bin/spacna" ]]; then
+  echo "ERROR: ${PKG} missing bin/spacna" >&2
+  exit 1
+fi
+
+# Copy pipeline tree (scripts, reference, config, docs, ...)
+tar -C "${TMP}/share/spacna" \
+    --exclude='build_env_setup.sh' \
+    --exclude='conda_build.sh' \
+    --exclude='conda_env_hint.txt' \
+    --exclude='metadata_conda_debug.yaml' \
+    --exclude='__pycache__' \
+    --exclude='*.pyc' \
+    -cf - . | tar -C "${SHARE_DIR}" -xf -
+
+install -m 0755 "${TMP}/bin/spacna" "${BIN_DIR}/spacna"
+if [[ -f "${TMP}/bin/axis-dna" ]]; then
+  install -m 0755 "${TMP}/bin/axis-dna" "${BIN_DIR}/axis-dna"
+fi
+
+# Keep a copy under share for `spacna path` users
+mkdir -p "${SHARE_DIR}/bin"
+cp -f "${BIN_DIR}/spacna" "${SHARE_DIR}/bin/spacna"
+chmod +x "${SHARE_DIR}/bin/spacna"
+if [[ -f "${BIN_DIR}/axis-dna" ]]; then
+  cp -f "${BIN_DIR}/axis-dna" "${SHARE_DIR}/bin/axis-dna"
+  chmod +x "${SHARE_DIR}/bin/axis-dna"
+fi
+
+find "${SHARE_DIR}/scripts" -type f \( -name '*.sh' -o -name '*.py' \) -exec chmod +x {} + 2>/dev/null || true
+
+# Prefer LICENSE from payload if recipe license_file needs it at source root;
+# bioconda copies LICENSE from source before build — SpaCNA repo root already has LICENSE.
+
+cat > "${SHARE_DIR}/conda_env_hint.txt" <<EOF
+SpaCNA (bioconda)
+Package root: ${SHARE_DIR}
+CLI: spacna
+
+R: cd "\$(spacna path)" && source("scripts/R/spacna.R")
+EOF

--- a/recipes/spacna/build.sh
+++ b/recipes/spacna/build.sh
@@ -16,11 +16,22 @@ BIN_DIR="${PREFIX}/bin"
 
 mkdir -p "${SHARE_DIR}" "${BIN_DIR}"
 
+# Resolve payload path for both:
+# - cwd already inside SpaCNA-<version>/ (normal conda-build)
+# - cwd is parent of SpaCNA-<version>/ (some folder:/CI layouts)
+if ! compgen -G "dist/spacna-*.tar.bz2" >/dev/null; then
+  FOUND="$(find . -maxdepth 3 -type f -name 'spacna-*.tar.bz2' | head -n 1 || true)"
+  if [[ -n "${FOUND}" ]]; then
+    cd "$(dirname "${FOUND}")/.."
+  fi
+fi
+
 PKG="$(ls -1 dist/spacna-*.tar.bz2 2>/dev/null | head -n 1 || true)"
 if [[ -z "${PKG}" ]]; then
   echo "ERROR: no dist/spacna-*.tar.bz2 found in source tree" >&2
   echo "cwd=$(pwd)" >&2
   ls -la >&2 || true
+  find . -maxdepth 3 -type f -name 'spacna-*.tar.bz2' >&2 || true
   exit 1
 fi
 

--- a/recipes/spacna/meta.yaml
+++ b/recipes/spacna/meta.yaml
@@ -1,0 +1,95 @@
+{% set name = "spacna" %}
+{% set version = "0.1.0" %}
+{#
+  REQUIRED before opening the bioconda PR:
+  1. Create a GitHub release/tag: v0.1.0 on https://github.com/liuyang-zhao/SpaCNA
+     (repo should contain dist/spacna-0.1.0-0.tar.bz2 + LICENSE)
+  2. Run: bash spacna_conda/scripts/compute_sha256.sh 0.1.0
+  3. Replace sha256 below with the printed value
+#}
+{% set sha256 = "f4a5d860dbc150590aec87d1e2bffa25cd327220fd66f5772cfc469c6e1e2c5d" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  # SpaCNA GitHub release: README/LICENSE + dist/spacna-*.tar.bz2
+  # Payload (bin/, scripts/, reference/) lives inside dist/*.tar.bz2 → share/spacna/
+  url: https://github.com/liuyang-zhao/SpaCNA/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+  # GitHub archive extracts to SpaCNA-{{ version }}/
+  folder: SpaCNA-{{ version }}
+
+build:
+  number: 0
+  noarch: generic
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x.x") }}
+
+requirements:
+  run:
+    - python >=3.8,<3.13
+    - numpy
+    - pandas
+    - matplotlib-base
+    - pysam
+    - natsort
+    - biopython
+    - pigz
+    - parallel
+    - bowtie2
+    - samtools
+    - bedtools
+    - fastp
+    - seqkit
+    - umi_tools
+    - trim-galore
+    - mosdepth
+    - ucsc-bigwigaverageoverbed
+    - r-base >=4.2
+    - r-data.table
+    - r-matrix
+    - r-ggplot2
+    - r-dplyr
+    - r-tidyr
+    - r-fnn
+    - r-patchwork
+    - r-cluster
+    - r-rtsne
+    - r-viridis
+    - r-fields
+    - r-hexbin
+    - r-ape
+
+test:
+  commands:
+    - spacna help
+    - spacna path
+    - test -d "$(spacna path)/scripts"
+    - test -d "$(spacna path)/reference"
+    - test -x "$(spacna path)/bin/spacna" || test -x "${PREFIX}/bin/spacna"
+    - python -c "import pysam, natsort, pandas, numpy"
+
+about:
+  home: https://github.com/liuyang-zhao/SpaCNA
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: SpaCNA — spatial DNA CNV, SPI lineage, and RNA–DNA multi-omics toolkit
+  description: |
+    SpaCNA (Spatial DNA Copy Number Analysis) is a toolkit for spatial DNA
+    sequencing. It supports spatial and bulk DNA alignment, CNV-based spatial
+    clustering, SPI lineage analysis, RNA–DNA multi-omics helpers, bundled
+    1 Mb genomic references, and the `spacna` command-line entry point.
+  dev_url: https://github.com/liuyang-zhao/SpaCNA
+  doc_url: https://github.com/liuyang-zhao/SpaCNA/blob/main/README.md
+
+extra:
+  recipe-maintainers:
+    - liuyang-zhao
+  notes: |
+    After install, set genome paths via SPACNA_* environment variables (see
+    README). Sample barcodes are not shipped; download from GitHub.
+    R entry point: source("scripts/R/spacna.R") after `cd $(spacna path)`.
+    Generate non-1Mb references with: spacna gen-reference --species human --bin-size 500kb --mode bins

--- a/recipes/spacna/meta.yaml
+++ b/recipes/spacna/meta.yaml
@@ -1,12 +1,5 @@
 {% set name = "spacna" %}
 {% set version = "0.1.0" %}
-{#
-  REQUIRED before opening the bioconda PR:
-  1. Create a GitHub release/tag: v0.1.0 on https://github.com/liuyang-zhao/SpaCNA
-     (repo should contain dist/spacna-0.1.0-0.tar.bz2 + LICENSE)
-  2. Run: bash spacna_conda/scripts/compute_sha256.sh 0.1.0
-  3. Replace sha256 below with the printed value
-#}
 {% set sha256 = "f4a5d860dbc150590aec87d1e2bffa25cd327220fd66f5772cfc469c6e1e2c5d" %}
 
 package:
@@ -14,11 +7,11 @@ package:
   version: {{ version }}
 
 source:
-  # SpaCNA GitHub release: README/LICENSE + dist/spacna-*.tar.bz2
-  # Payload (bin/, scripts/, reference/) lives inside dist/*.tar.bz2 → share/spacna/
+  # SpaCNA GitHub release ships dist/spacna-*.tar.bz2
+  # Payload (bin/, scripts/, reference/) is inside that package under share/spacna/
   url: https://github.com/liuyang-zhao/SpaCNA/archive/refs/tags/v{{ version }}.tar.gz
   sha256: {{ sha256 }}
-  # GitHub archive extracts to SpaCNA-{{ version }}/
+  # GitHub archive extracts to SpaCNA-<version>/
   folder: SpaCNA-{{ version }}
 
 build:

--- a/recipes/spacna/meta.yaml
+++ b/recipes/spacna/meta.yaml
@@ -9,10 +9,10 @@ package:
 source:
   # SpaCNA GitHub release ships dist/spacna-*.tar.bz2
   # Payload (bin/, scripts/, reference/) is inside that package under share/spacna/
+  # Do not set folder: — conda-build already cds into the single top-level dir
+  # SpaCNA-<version>/ from the GitHub archive.
   url: https://github.com/liuyang-zhao/SpaCNA/archive/refs/tags/v{{ version }}.tar.gz
   sha256: {{ sha256 }}
-  # GitHub archive extracts to SpaCNA-<version>/
-  folder: SpaCNA-{{ version }}
 
 build:
   number: 0

--- a/recipes/spacna/run_test.sh
+++ b/recipes/spacna/run_test.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Optional bioconda test script (meta.yaml test.commands is usually enough).
+set -euo pipefail
+
+spacna help
+spacna path
+test -d "$(spacna path)/scripts"
+test -d "$(spacna path)/reference"
+python -c "import pysam, natsort, pandas, numpy"


### PR DESCRIPTION
## Description
Add SpaCNA (spatial DNA CNV / SPI lineage / RNA–DNA helpers) as a noarch generic package.

- Homepage: https://github.com/liuyang-zhao/SpaCNA
- License: MIT
- CLI: `spacna`
- Source: https://github.com/liuyang-zhao/SpaCNA/archive/refs/tags/v0.1.0.tar.gz
- Ships 1 Mb references only; other bin sizes via `spacna gen-reference`

SpaCNA provides spatial/bulk DNA alignment, CNV-based spatial clustering, SPI lineage analysis, and RNA–DNA multi-omics helpers.

## Checklist
- [x] Package builds locally / passes bioconda CI
- [x] License allows redistribution
- [x] Tests: `spacna help`, `spacna path`, reference dirs present
- [x] Cell Ranger / proprietary tools are NOT bundled (documented)