### PR TITLE
Bump/nemo 2.4.2

### DIFF
--- a/recipes/nemo/build.sh
+++ b/recipes/nemo/build.sh
@@ -5,8 +5,14 @@ export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib"
 export CXXFLAGS="${CXXFLAGS} -O3"
 
 mkdir -p "${PREFIX}/bin"
+# The release tarball is a git archive and does not ship the (gitignored) bin/
+# output directory, so create it before building.
+mkdir -p bin/
 
-case $(uname -m) in
+
+ARCH=$(uname -m)
+
+case "$ARCH" in
     aarch64)
 	export CXXFLAGS="${CXXFLAGS} -march=armv8-a"
 	;;
@@ -18,7 +24,9 @@ case $(uname -m) in
 	;;
 esac
 
-case $(uname -m) in
+# The Makefile hard-codes "-march=native"; replace it with portable,
+# architecture-specific flags so the build is reproducible on CI.
+case "$ARCH" in
     aarch64)
 	sed -i.bak 's|-march=native|-O3 -std=c++14 -march=armv8-a -Wno-narrowing|' Makefile
 	;;
@@ -31,7 +39,22 @@ case $(uname -m) in
 esac
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
-	C_OPTS="${CPPFLAGS} ${CXXFLAGS}" make GSL_PATH="$PREFIX/" CC="$CXX" SHELL="/bin/bash" MAC=1 -j"${CPU_COUNT}"
+    
+	case "$ARCH" in
+        arm64|aarch64)
+            # Apple Silicon (M1, M2, M3, etc.) -> ARM architecture
+            C_OPTS="${CPPFLAGS} ${CXXFLAGS}" make GSL_PATH="$PREFIX/" CC="$CXX" SHELL="/bin/bash" MAC_ARM=1 -j"${CPU_COUNT}"
+            ;;
+        x86_64|i386)
+            # Legacy Intel architecture (or generic x86 container build)
+            C_OPTS="${CPPFLAGS} ${CXXFLAGS}" make GSL_PATH="$PREFIX/" CC="$CXX" SHELL="/bin/bash" MAC_x86=1 -j"${CPU_COUNT}"
+            ;;
+        *)
+            # Fallback or error handling for unexpected architectures
+            echo "Warning: Unknown macOS architecture detected ($ARCH). Using ARM fallback."
+            C_OPTS="${CPPFLAGS} ${CXXFLAGS}" make GSL_PATH="$PREFIX/" CC="$CXX" SHELL="/bin/bash" MAC_ARM=1 -j"${CPU_COUNT}"
+            ;;
+    esac
 else
 	C_OPTS="${CPPFLAGS} ${CXXFLAGS}" make GSL_PATH="$PREFIX/" CC="$CXX" SHELL="/bin/bash" -j"${CPU_COUNT}"
 fi

--- a/recipes/nemo/build.sh
+++ b/recipes/nemo/build.sh
@@ -59,8 +59,11 @@ else
 	C_OPTS="${CPPFLAGS} ${CXXFLAGS}" make GSL_PATH="$PREFIX/" CC="$CXX" SHELL="/bin/bash" -j"${CPU_COUNT}"
 fi
 
-make install BIN_INSTALL="$PREFIX/bin/" LIB_INSTALL="$PREFIX/lib/"
-
-# The Makefile installs a version-stamped binary (nemo<MAJOR>.<MINOR>.<REV>);
-# expose it under the package's command name.
-# mv "${PREFIX}/bin/nemo2.4.0" "${PREFIX}/bin/nemo"
+mkdir -p "${PREFIX}/bin"
+# `make` builds a single version-stamped binary into bin/. On macOS the
+# MAC_ARM / MAC_x86 flags suffix its name (e.g. nemo<ver>-macARM); the
+# Makefile's `install` target recomputes BIN_NAME *without* those flags and
+# looks for the unsuffixed name, which fails on osx-arm64. Install the binary
+# that was actually produced, under the canonical command name (nemo<version>).
+built="$(ls -1 bin/nemo* | head -n1)"
+cp "${built}" "${PREFIX}/bin/nemo${PKG_VERSION}"

--- a/recipes/nemo/build.sh
+++ b/recipes/nemo/build.sh
@@ -60,3 +60,7 @@ else
 fi
 
 make install BIN_INSTALL="$PREFIX/bin/" LIB_INSTALL="$PREFIX/lib/"
+
+# The Makefile installs a version-stamped binary (nemo<MAJOR>.<MINOR>.<REV>);
+# expose it under the package's command name.
+# mv "${PREFIX}/bin/nemo2.4.0" "${PREFIX}/bin/nemo"

--- a/recipes/nemo/build.sh
+++ b/recipes/nemo/build.sh
@@ -1,69 +1,64 @@
 #!/bin/bash
+set -euo pipefail
 
-export CPPFLAGS="${CPPFLAGS} -I${PREFIX}/include"
-export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib"
-export CXXFLAGS="${CXXFLAGS} -O3"
-
-mkdir -p "${PREFIX}/bin"
-# The release tarball is a git archive and does not ship the (gitignored) bin/
-# output directory, so create it before building.
-mkdir -p bin/
-
-
-ARCH=$(uname -m)
-
-case "$ARCH" in
-    aarch64)
-	export CXXFLAGS="${CXXFLAGS} -march=armv8-a"
-	;;
-    arm64)
-	export CXXFLAGS="${CXXFLAGS} -march=armv8.4-a"
-	;;
-    x86_64)
-	export CXXFLAGS="${CXXFLAGS} -march=x86-64-v3"
-	;;
-esac
-
-# The Makefile hard-codes "-march=native"; replace it with portable,
-# architecture-specific flags so the build is reproducible on CI.
-case "$ARCH" in
-    aarch64)
-	sed -i.bak 's|-march=native|-O3 -std=c++14 -march=armv8-a -Wno-narrowing|' Makefile
-	;;
-    arm64)
-	sed -i.bak 's|-march=native|-O3 -std=c++14 -march=armv8.4-a -Wno-narrowing|' Makefile
-	;;
-    x86_64)
-	sed -i.bak 's|-march=native|-O3 -std=c++14 -march=x86-64-v3 -Wno-narrowing|' Makefile
-	;;
-esac
-
-if [[ "$OSTYPE" == "darwin"* ]]; then
-    
-	case "$ARCH" in
-        arm64|aarch64)
-            # Apple Silicon (M1, M2, M3, etc.) -> ARM architecture
-            C_OPTS="${CPPFLAGS} ${CXXFLAGS}" make GSL_PATH="$PREFIX/" CC="$CXX" SHELL="/bin/bash" MAC_ARM=1 -j"${CPU_COUNT}"
-            ;;
-        x86_64|i386)
-            # Legacy Intel architecture (or generic x86 container build)
-            C_OPTS="${CPPFLAGS} ${CXXFLAGS}" make GSL_PATH="$PREFIX/" CC="$CXX" SHELL="/bin/bash" MAC_x86=1 -j"${CPU_COUNT}"
-            ;;
-        *)
-            # Fallback or error handling for unexpected architectures
-            echo "Warning: Unknown macOS architecture detected ($ARCH). Using ARM fallback."
-            C_OPTS="${CPPFLAGS} ${CXXFLAGS}" make GSL_PATH="$PREFIX/" CC="$CXX" SHELL="/bin/bash" MAC_ARM=1 -j"${CPU_COUNT}"
-            ;;
-    esac
-else
-	C_OPTS="${CPPFLAGS} ${CXXFLAGS}" make GSL_PATH="$PREFIX/" CC="$CXX" SHELL="/bin/bash" -j"${CPU_COUNT}"
+# The package version is taken from NEMO_VERSION at render time; src/version.h
+# is the actual source of truth and decides the binary's name. If a tag was cut
+# without bumping version.h (or vice versa) they disagree, and the package would
+# ship a binary whose name does not match its version. Fail here instead.
+src_version="$(./getVersion.sh)"
+if [ "${src_version}" != "${PKG_VERSION}" ]; then
+    echo "ERROR: src/version.h says ${src_version}, package version is ${PKG_VERSION}." >&2
+    echo "       Bump src/version.h and re-tag, or fix the tag." >&2
+    exit 1
 fi
 
-mkdir -p "${PREFIX}/bin"
-# `make` builds a single version-stamped binary into bin/. On macOS the
-# MAC_ARM / MAC_x86 flags suffix its name (e.g. nemo<ver>-macARM); the
-# Makefile's `install` target recomputes BIN_NAME *without* those flags and
-# looks for the unsuffixed name, which fails on osx-arm64. Install the binary
-# that was actually produced, under the canonical command name (nemo<version>).
+# `bin/` is gitignored, so a fresh checkout does not carry it.
+mkdir -p bin/
+
+ARCH="$(uname -m)"
+
+case "$ARCH" in
+    aarch64) MARCH="-march=armv8-a"    ;;
+    arm64)   MARCH="-march=armv8.4-a"  ;;
+    x86_64)  MARCH="-march=x86-64-v3"  ;;
+    *)       MARCH=""                  ;;
+esac
+
+# The Makefile hard-codes `C_OPTS=-fPIC -march=native`, which no CI builder can
+# use, so rewrite that line in place.
+#
+# Note this is the only way to get conda's flags into the build. The obvious
+# `C_OPTS="$CPPFLAGS $CXXFLAGS" make ...` is an *environment* assignment, and
+# environment variables lose to a makefile's own `C_OPTS=` line -- so it is
+# silently a no-op and conda's hardening/include flags never reach the compiler.
+# (`make C_OPTS=...`, the argument form, would win, but it also overrides the
+# `C_OPTS += -DHAS_GSL` the GSL block appends, and the build then fails outright
+# in Uniform.h.) Patching the line keeps the `+=` accumulations intact.
+sed -i.bak \
+    "s|^C_OPTS=-fPIC -march=native\$|C_OPTS=-fPIC ${MARCH} -std=c++14 -Wno-narrowing ${CXXFLAGS} ${CPPFLAGS}|" \
+    Makefile
+
+# Give the linker conda's flags (rpath into $PREFIX/lib above all). The MAC_ARM
+# and MAC_x86 blocks reset LD_OPTS outright, so patch those lines too.
+sed -i.bak "s|^LD_OPTS=-lstdc++\$|LD_OPTS=-lstdc++ ${LDFLAGS}|" Makefile
+sed -i.bak "s|^\( *LD_OPTS=-lstdc++ -L\$(GSL_PATH)lib .*\)\$|\1 ${LDFLAGS}|" Makefile
+
+MAKE_ARGS=(GSL_PATH="${PREFIX}/" CC="${CXX}" SHELL="/bin/bash")
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    case "$ARCH" in
+        arm64|aarch64) MAKE_ARGS+=(MAC_ARM=1) ;;
+        *)             MAKE_ARGS+=(MAC_x86=1) ;;
+    esac
+fi
+
+make "${MAKE_ARGS[@]}" -j"${CPU_COUNT}"
+
+# `make` emits a single version-stamped binary into bin/, and on macOS the
+# MAC_ARM / MAC_x86 flags suffix its name (nemo<ver>-macARM). The Makefile's
+# own `install` target recomputes BIN_NAME *without* those flags and so looks
+# for a name that was never produced. Install whatever was actually built,
+# under the canonical command name.
 built="$(ls -1 bin/nemo* | head -n1)"
+mkdir -p "${PREFIX}/bin"
 cp "${built}" "${PREFIX}/bin/nemo${PKG_VERSION}"

--- a/recipes/nemo/meta.yaml
+++ b/recipes/nemo/meta.yaml
@@ -1,19 +1,25 @@
 {% set version = "2.4.0" %}
+{% set commit = "e9e3a9ee947ca3140343c594a3e776783d292020" %}
 
 package:
   name: nemo
   version: {{ version }}
 
 source:
-  url: https://sourceforge.net/projects/nemo2/files/Nemo/{{ version }}/Nemo-{{ version }}-src.tgz
-  sha256: 4633d1b62186f672dd27761487e984016cdf98354f5cf78fa9e1a462191ef6b9
+  # Immutable, commit-pinned tarball from the public release repository.
+  # (Replaces the SourceForge tarball, whose contents were not stable.)
+  url: https://bitbucket.org/ecoevo/nemo-release/get/{{ commit }}.tar.gz
+  sha256: ea4b9361925bd06a89fe6c9c48d4c0ad8d0da3884f1e70f741d6cdd8c9310a54
 
 build:
-  number: 0
-  # Undefined symbols for architecture x86_64: "vtable for TTQuanti_diallelic_bitstring_no_pleio", referenced from:
-  # TProtoQuanti::hatch() in ttquanti.o
-  # NOTE: a missing vtable usually means the first non-inline virtual member function has no definition.
-  skip: True  # [osx and x86_64]
+  number: 1
+  # osx x86_64 fails to link:
+  #   Undefined symbols for architecture x86_64: "vtable for
+  #   TTQuanti_diallelic_bitstring_no_pleio", referenced from
+  #   TProtoQuanti::hatch() in ttquanti.o
+  # A missing vtable usually means the first non-inline virtual member function
+  # has no definition. Untested in new build #1
+  skip: true  # [osx and x86_64]
   run_exports:
     - {{ pin_subpackage('nemo', max_pin="x") }}
 
@@ -41,13 +47,13 @@ test:
     - nemo | grep "{{ version }}"
 
 about:
-  home: "https://nemo2.sourceforge.io"
+  home: "https://bitbucket.org/ecoevo/nemo-release"
   summary: "Individual-based forward-time genetics simulation software."
   license: "GPL-2.0-or-later"
   license_family: GPL
   license_file: COPYING
   doc_url: "https://nemo2.sourceforge.io"
-  dev_url: "https://sourceforge.net/projects/nemo2"
+  dev_url: "https://bitbucket.org/ecoevo/nemo-release"
 
 extra:
   additional-platforms:
@@ -55,3 +61,6 @@ extra:
     - osx-arm64
   identifiers:
     - doi:10.1093/bioinformatics/btl415
+  recipe-maintainers:
+    - fredgui
+    - mencian

--- a/recipes/nemo/meta.yaml
+++ b/recipes/nemo/meta.yaml
@@ -44,7 +44,7 @@ requirements:
 
 test:
   commands:
-    - nemo | grep "{{ version }}"
+    - nemo{{ version }} | grep "{{ version }}"
 
 about:
   home: "https://bitbucket.org/ecoevo/nemo-release"

--- a/recipes/nemo/meta.yaml
+++ b/recipes/nemo/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "2.4.0" %}
-{% set commit = "e9e3a9ee947ca3140343c594a3e776783d292020" %}
+{% set version = "2.4.2" %}
+{% set commit = "a007bc3d1a9d71b168cbc910a0c7bd0ffe96adf7" %}
 
 package:
   name: nemo
@@ -9,16 +9,18 @@ source:
   # Immutable, commit-pinned tarball from the public release repository.
   # (Replaces the SourceForge tarball, whose contents were not stable.)
   url: https://bitbucket.org/ecoevo/nemo-release/get/{{ commit }}.tar.gz
-  sha256: ea4b9361925bd06a89fe6c9c48d4c0ad8d0da3884f1e70f741d6cdd8c9310a54
+  sha256: 8b63a92904d29309116a0071c01335f4e2dc441b477dd204bb7663dc120abb11
 
 build:
-  number: 1
+  number: 0
   # osx x86_64 fails to link:
   #   Undefined symbols for architecture x86_64: "vtable for
   #   TTQuanti_diallelic_bitstring_no_pleio", referenced from
   #   TProtoQuanti::hatch() in ttquanti.o
   # A missing vtable usually means the first non-inline virtual member function
-  # has no definition. Untested in new build #1
+  # has no definition. As of 2.4.2 every virtual member of that class does have
+  # an out-of-line definition, so this skip may no longer be needed; it is kept
+  # because there is no osx x86_64 machine available to verify the link.
   skip: true  # [osx and x86_64]
   run_exports:
     - {{ pin_subpackage('nemo', max_pin="x") }}
@@ -26,30 +28,29 @@ build:
 requirements:
   build:
     - make
+    - sed          # build.sh patches two Makefile lines
     - {{ compiler('cxx') }}
     - {{ stdlib('c') }}
   host:
-    - libgomp  # [linux]
-    - llvm-openmp  # [osx]
-    - mpich-mpicxx
-    - sed
+    # GSL is the only library this build actually uses. MPI is never enabled
+    # (build.sh does not set MPI=1, so -DUSE_MPI is never defined), there is no
+    # `#pragma omp` anywhere in src/, and BLAS comes from GSL's own -lgslcblas;
+    # the previous mpich-mpicxx / libgomp / llvm-openmp / openblas entries were
+    # unused and only constrained the solve.
     - gsl
-    - openblas
   run:
-    - libgomp  # [linux]
-    - llvm-openmp  # [osx]
-    - mpich-mpicxx
     - gsl
-    - openblas
 
 test:
-  commands:
-    - nemo{{ version }} | grep "{{ version }}"
+  files:
+    - smoke.ini
+  # run_test.sh in this directory is picked up automatically. It runs a short
+  # simulation rather than only checking that the binary prints its version.
 
 about:
   home: "https://bitbucket.org/ecoevo/nemo-release"
   summary: "Individual-based forward-time genetics simulation software."
-  license: "GPL-2.0-or-later"
+  license: "GPL-3.0-or-later"
   license_family: GPL
   license_file: COPYING
   doc_url: "https://nemo2.sourceforge.io"

--- a/recipes/nemo/run_test.sh
+++ b/recipes/nemo/run_test.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -euo pipefail
+
+nemo="nemo${PKG_VERSION}"
+command -v "$nemo" >/dev/null || { echo "ERROR: $nemo not on PATH" >&2; exit 1; }
+
+# The banner carries the version; this is the check the Bioconda recipe had.
+# Run without arguments nemo looks for a Nemo2.ini it will not find, so ignore
+# its exit status and assert on the banner text instead.
+banner="$("$nemo" 2>&1 || true)"
+printf '%s\n' "$banner" | grep -F "${PKG_VERSION}" >/dev/null || {
+    echo "ERROR: version ${PKG_VERSION} absent from the startup banner:" >&2
+    printf '%s\n' "$banner" >&2
+    exit 1
+}
+
+# Run the simulation. Nemo returns 0 on success and writes <root_dir>/<filename>.txt;
+# locate it rather than hard-coding, so a change in naming shows up as a clear
+# failure here instead of a false pass.
+"$nemo" smoke.ini
+
+stats="$(find smoke-out -name '*.txt' -type f 2>/dev/null | head -n1 || true)"
+if [ -z "$stats" ]; then
+    echo "ERROR: no stats file produced under smoke-out/" >&2
+    ls -R . >&2
+    exit 1
+fi
+echo "stats file: $stats"
+cat "$stats"
+
+# The real check: additive genetic variance must be non-zero. An all-zero column
+# means mutation or the stat machinery did not actually run, which a binary that
+# starts up and exits 0 will not otherwise tell us.
+awk '
+  NR == 1 {
+      for (i = 1; i <= NF; i++) if ($i ~ /\.Va$/) va[i] = $i
+      if (length(va) == 0) {
+          print "ERROR: no .Va column in stats header:" > "/dev/stderr"
+          print $0 > "/dev/stderr"
+          exit 1
+      }
+      next
+  }
+  { for (i in va) if ($i + 0 != 0) found = 1 }
+  END {
+      if (!found) {
+          print "ERROR: every .Va value is zero -- no genetic variance accumulated," > "/dev/stderr"
+          print "       so mutation or the quanti stat machinery did not run" > "/dev/stderr"
+          exit 1
+      }
+      print "OK: non-zero additive genetic variance recorded"
+  }
+' "$stats"

--- a/recipes/nemo/smoke.ini
+++ b/recipes/nemo/smoke.ini
@@ -1,0 +1,56 @@
+## Nemo conda package smoke test.
+##
+## The Bioconda recipe only checked that `nemo <version>` prints its own version,
+## which a binary can do while being unable to run anything. This drives a real
+## simulation instead: `quanti_pleiotropy full` draws mutations through
+## Uniform::MultivariateGaussian and `stat adlt.quanti` runs TTQuantiSH::setStats,
+## so the GSL linkage, the RNG and the stat machinery all have to work.
+## run_test.sh then asserts a non-zero additive genetic variance was recorded.
+##
+## Scaled to run in a few seconds; it is a build check, not a simulation.
+
+run_mode                overwrite
+random_seed             13215
+
+root_dir                smoke-out
+filename                smoke
+
+replicates              1
+generations             500
+
+## POPULATION ##
+patch_number            1
+patch_nbfem             200
+patch_nbmal             0
+
+## LIFE CYCLE EVENTS ##
+## save_files is what actually flushes the registered file handlers; without it
+## the stats are recorded but never written to smoke-out/smoke.txt.
+breed_selection         1
+save_stats              2
+save_files              3
+
+## MATING SYSTEM ##
+mating_system           6   # hermaphrodites
+mating_isWrightFisher
+
+## SELECTION ##
+selection_trait         quant
+selection_model         gaussian
+selection_trait_dimension 2
+selection_variance      {{10}}
+selection_local_optima  {{0}}
+
+## QUANTI TRAIT ##
+quanti_traits           2
+quanti_loci             100
+quanti_pleiotropy       full
+quanti_allele_model     continuous
+quanti_mutation_rate    0.005
+quanti_mutation_matrix  {{0.10, 0.02}
+                         {0.02, 0.10}}
+quanti_init_model       0
+
+## STATS ##
+stat                    adlt.quanti
+stat_log_time           100


### PR DESCRIPTION
Updates `nemo` to 2.4.2.

2.4.2 is a bugfix release. `RAND::RandULong()` returned only 32 random bits, leaving the upper 32 bits of every 64-bit word zero, so within each word the loci at positions 32–63 were always inherited from the same parental chromosome instead of recombining. This affected free recombination in the bitstring trait architectures (`bdmi`, `delet`, `ntrl`, `quant`).

Beyond the version bump, a few things in the recipe were wrong and are fixed here:

**Dropped unused dependencies** — `mpich-mpicxx`, `libgomp`, `llvm-openmp` and `openblas`. None of them are used: `build.sh` never sets `MPI=1`, so `-DUSE_MPI` is never defined; there is no `#pragma omp` anywhere in `src/`; and BLAS comes from GSL's own `-lgslcblas`. They only constrained the solve. `sed` moved from `host` to `build`, where a tool used by `build.sh` belongs.

**A real test.** The previous test was `nemo{{ version }} | grep "{{ version }}"`, which a binary can pass while being unable to run a simulation. It is replaced by `smoke.ini` + `run_test.sh`, a ~500-generation quantitative-trait run that exercises the GSL linkage, the RNG and the stat machinery, then asserts that a non-zero additive genetic variance was recorded.

**`build.sh` now actually applies conda's flags.** `C_OPTS="..." make` is a shell *environment* assignment, and in GNU make the environment loses to the makefile's own `C_OPTS=` line — so conda's `CXXFLAGS`/`CPPFLAGS` never reached the compiler. The argument form `make C_OPTS=...` would win, but it also clobbers the `C_OPTS += -DHAS_GSL` that the `ifdef GSL` block appends, and the build then fails in `Uniform.h`. Patching the line in place is the only form that does both. `LDFLAGS` is now passed to the linker as well, and the script verifies `src/version.h` agrees with `PKG_VERSION` so a mis-tagged release fails loudly rather than shipping a mislabelled binary.

**License** corrected to `GPL-3.0-or-later`, matching `COPYING` as of 2.4.1.

The `skip: true  # [osx and x86_64]` is retained. Every virtual member of `TTQuanti_diallelic_bitstring_no_pleio` now has an out-of-line definition, so the missing-vtable link error may well be gone, but there is no osx x86_64 machine available to verify it, so this is not the PR to drop it in.

Built and tested on linux-64, linux-aarch64 and osx-arm64 before submitting.
