### PR TITLE
Add pdberellig 2.0.1

### DIFF
--- a/recipes/pdberellig/meta.yaml
+++ b/recipes/pdberellig/meta.yaml
@@ -1,0 +1,52 @@
+{% set name = "pdberellig" %}
+{% set version = "2.0.1" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/p/pdberellig/pdberellig-{{ version }}.tar.gz
+  sha256: 12472c56aad37d7becbe53cfab1184865d77a5e60d0e77f89d8ecf61099d891a
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x") }}
+
+requirements:
+  host:
+    - pip
+    - python {{ python_min }}.*
+    - setuptools
+  run:
+    - python >={{ python_min }}
+    - click >=8.4.0,<9.0.0
+    - pandas >=2.2.3,<3.0.0
+    - pdbeccdutils >=1.0.4
+    - sparqlwrapper >=2.0.0,<3.0.0
+
+test:
+  imports:
+    - pdberellig
+  commands:
+    - pdberellig --help
+    - pip check
+  requires:
+    - pip
+    - python {{ python_min }}.*
+
+about:
+  home: https://github.com/PDBeurope/rellig
+  summary: A toolkit for functional annotation of ligands in the PDB
+  dev_url: https://github.com/PDBeurope/rellig
+  license: Apache-2.0
+  license_family: APACHE
+
+extra:
+  identifiers:
+    - doi.org/10.1002/pro.70084
+  recipe-maintainers:
+    - roshkjr

--- a/recipes/pdberellig/meta.yaml
+++ b/recipes/pdberellig/meta.yaml
@@ -47,6 +47,6 @@ about:
 
 extra:
   identifiers:
-    - doi.org/10.1002/pro.70084
+    - doi:10.1002/pro.70084
   recipe-maintainers:
     - roshkjr


### PR DESCRIPTION
 Adds a new recipe for pdberellig, a toolkit for functional annotation of ligands in the PDB.

 - PyPI: https://pypi.org/project/pdberellig/
 - Source: https://github.com/PDBeurope/rellig
 - License: Apache-2.0
