### PR TITLE
crisprme: add lucapinello as recipe-maintainer

### DIFF
--- a/recipes/crisprme/meta.yaml
+++ b/recipes/crisprme/meta.yaml
@@ -59,5 +59,7 @@ about:
   doc_url: "https://github.com/pinellolab/CRISPRme/blob/v{{ version }}/README.md"
 
 extra:
+  recipe-maintainers:
+    - lucapinello
   identifiers:
     - doi:10.1038/s41588-022-01257-y

--- a/recipes/crisprme/meta.yaml
+++ b/recipes/crisprme/meta.yaml
@@ -9,9 +9,10 @@ source:
   sha256: 1fb5d1a532239781f275139dff617e6ebd13723c16b51cd93e01432e4a6c9bfb
 
 build:
+  # build bump for the recipe-maintainers metadata change (same 2.1.12 version)
   run_exports:
     - {{ pin_subpackage('crisprme', max_pin="x") }}
-  number: 0
+  number: 1
   noarch: generic
 
 requirements:


### PR DESCRIPTION
Add the upstream author (@lucapinello, pinellolab/CRISPRme) as a `recipe-maintainer` so future `crisprme` version bumps can be self-serviced via `@BiocondaBot please merge`. No functional/recipe changes.