### PR TITLE
Update crisprme to 2.1.13

### DIFF
--- a/recipes/crisprme/meta.yaml
+++ b/recipes/crisprme/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.1.12" %}
+{% set version = "2.1.13" %}
 
 package:
   name: crisprme
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/pinellolab/CRISPRme/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 1fb5d1a532239781f275139dff617e6ebd13723c16b51cd93e01432e4a6c9bfb
+  sha256: fc015411371c31e7efb263da4cffd3863cb870e8c34a1d134ecba5f199214eaf
 
 build:
   run_exports:
@@ -59,5 +59,7 @@ about:
   doc_url: "https://github.com/pinellolab/CRISPRme/blob/v{{ version }}/README.md"
 
 extra:
+  recipe-maintainers:
+    - lucapinello
   identifiers:
     - doi:10.1038/s41588-022-01257-y


### PR DESCRIPTION
Bumps crisprme to 2.1.13.

This release folds in the #143 post-analysis hardening (pinellolab/CRISPRme#144): the reporting layer now survives malformed / column-shifted intermediate rows (skips + counts them instead of crashing) and no longer deletes completed results on a late-stage failure. The v2.1.13 tag + release tarball were refreshed to include this fix, hence the updated sha256.

Also adds `lucapinello` as a recipe maintainer (co-author / upstream author).

Supersedes the autobump PR #67833 (which carried the pre-fix tarball sha).