### PR TITLE
Update vg: add license_file so the package ships its MIT license

### DIFF
--- a/recipes/vg/meta.yaml
+++ b/recipes/vg/meta.yaml
@@ -13,7 +13,6 @@ source:
   # vg ships as a prebuilt binary, so the source tree has no LICENSE to point
   # license_file at; fetch it explicitly so the package carries its MIT text.
   - url: https://raw.githubusercontent.com/vgteam/vg/v{{ version }}/LICENSE
-    fn: LICENSE
     sha256: 7c3fe1c48ef0594c8d6728353d9325b5f4335eceea5bda3734820d7478bdeaef
 
 build:

--- a/recipes/vg/meta.yaml
+++ b/recipes/vg/meta.yaml
@@ -10,9 +10,14 @@ source:
     sha256: d5752977237e801d971f0d044f43fde4f3005da35f0451b4f452d1c1c9b8414b    # [linux and x86_64]
   - url: https://github.com/vgteam/vg/releases/download/v{{ version }}/vg-arm64 # [linux and aarch64]
     sha256: 1042a08014a3b3765ecedc395f88eeb6c1791962a8ac62a65da318ca6c4a5c60    # [linux and aarch64]
+  # vg ships as a prebuilt binary, so the source tree has no LICENSE to point
+  # license_file at; fetch it explicitly so the package carries its MIT text.
+  - url: https://raw.githubusercontent.com/vgteam/vg/v{{ version }}/LICENSE
+    fn: LICENSE
+    sha256: 7c3fe1c48ef0594c8d6728353d9325b5f4335eceea5bda3734820d7478bdeaef
 
 build:
-  number: 0
+  number: 1
   skip: true  # [osx]
   script:
     - mkdir -p ${PREFIX}/bin
@@ -29,6 +34,7 @@ about:
   home: https://github.com/vgteam/vg
   license: MIT
   license_family: MIT
+  license_file: LICENSE
   summary: Variation graph data structures, interchange formats, alignment, genotyping, and variant calling methods
 
 extra:


### PR DESCRIPTION
### Rationale

The `vg` package declares `license: MIT` but sets no `license_file`, so the
built package ships no license text — `$PREFIX/share/licenses/vg/` is absent
in the resulting conda package and any image built from it.

Because the recipe installs a **prebuilt release binary** (not a source
build), the work tree has no `LICENSE` to point at. This PR fetches the
upstream `LICENSE` for the pinned tag as an extra source (guarded by
`sha256`) and sets `about.license_file` to it, so the MIT text travels with
the package. Build number bumped `0 → 1`.

- Upstream license file: https://github.com/vgteam/vg/blob/v1.73.0/LICENSE (2972 bytes, MIT)
- `sha256: 7c3fe1c48ef0594c8d6728353d9325b5f4335eceea5bda3734820d7478bdeaef`

No version change; binary sources and their checksums are untouched.
