### PR TITLE
Add vcftools-ng 0.13.0

### DIFF
--- a/recipes/vcftools-ng/build.sh
+++ b/recipes/vcftools-ng/build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -euo pipefail
+
+cmake -S . -B build \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+    -DCMAKE_CXX_COMPILER="${CXX}" \
+    -DCMAKE_CXX_FLAGS="${CXXFLAGS}" \
+    -DCMAKE_EXE_LINKER_FLAGS="${LDFLAGS}" \
+    -DBUILD_TESTING=OFF \
+    -DHTSLIB_ROOT="${PREFIX}"
+cmake --build build --parallel "${CPU_COUNT}"
+cmake --install build

--- a/recipes/vcftools-ng/build.sh
+++ b/recipes/vcftools-ng/build.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 cmake -S . -B build \
+    ${CMAKE_ARGS} \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
     -DCMAKE_CXX_COMPILER="${CXX}" \

--- a/recipes/vcftools-ng/meta.yaml
+++ b/recipes/vcftools-ng/meta.yaml
@@ -23,11 +23,13 @@ requirements:
     - cmake >=3.20,<4
     - make
   host:
+    - blis
     - htslib >=1.24
     - liblapack
     - zlib
   run:
     - bcftools >=1.24
+    - {{ pin_compatible('blis', max_pin='x') }}
 
 test:
   commands:

--- a/recipes/vcftools-ng/meta.yaml
+++ b/recipes/vcftools-ng/meta.yaml
@@ -1,0 +1,52 @@
+{% set name = "vcftools-ng" %}
+{% set version = "0.13.0" %}
+{% set sha256 = "32e11ecff08532bcc22ad0c38e87486065cf944a40f6d4bf1ec8dc5b1b35757c" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/VensinMa/vcftools-ng/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  skip: true  # [not linux]
+
+requirements:
+  build:
+    - {{ compiler('cxx') }}
+    - {{ stdlib('c') }}
+    - cmake >=3.20,<4
+    - make
+  host:
+    - htslib >=1.24
+    - liblapack
+    - zlib
+  run:
+    - bcftools >=1.24
+
+test:
+  commands:
+    - vcftools-ng --version | grep -F "vcftools-ng {{ version }}"
+    - vcftools-ng --help | grep -F "QUICK EXAMPLES:"
+
+about:
+  home: https://github.com/VensinMa/vcftools-ng
+  license: LGPL-3.0-only
+  license_family: LGPL
+  license_file: LICENSE
+  summary: High-performance, output-compatible successor to VCFtools 0.1.17
+  description: |
+    vcftools-ng is an HTSlib-based, multithreaded VCF/BCF filtering,
+    statistics, conversion, and population-genetics tool. It preserves exact
+    VCFtools 0.1.17 scientific output for its documented compatibility surface
+    while adding adaptive input backends, deterministic BGZF output,
+    transactional writes, and reproducible run logs.
+  dev_url: https://github.com/VensinMa/vcftools-ng
+  doc_url: https://github.com/VensinMa/vcftools-ng/blob/v{{ version }}/README.md
+
+extra:
+  recipe-maintainers:
+    - VensinMa

--- a/recipes/vcftools-ng/meta.yaml
+++ b/recipes/vcftools-ng/meta.yaml
@@ -13,6 +13,8 @@ source:
 build:
   number: 0
   skip: true  # [not linux]
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x.x") }}
 
 requirements:
   build:


### PR DESCRIPTION
## Summary

Add the first Bioconda recipe for `vcftools-ng` 0.13.0, an HTSlib-based,
multithreaded and output-compatible successor to VCFtools 0.1.17.

The recipe:

- builds the tagged C++20 source with CMake;
- links against Bioconda/conda-forge HTSlib, LAPACK and zlib;
- installs bcftools 1.24 or newer for adaptive CSI construction;
- is initially limited to Linux, matching the upstream tested release
  platforms; and
- tests the installed version and full help output.

## Upstream validation

- v0.13.0 source tag and GitHub Release are published.
- Release CTest: 7/7 PASS.
- ASan/UBSan CTest: 7/7 PASS.
- Full-data first-repeat compatibility gate: 108/108 PASS.
- Portable Linux archive: PASS on clean CentOS 7 and Ubuntu 20.04.

Upstream release:
https://github.com/VensinMa/vcftools-ng/releases/tag/v0.13.0
