### PR TITLE
Disable autobump for amalgkit

### DIFF
--- a/recipes/amalgkit/meta.yaml
+++ b/recipes/amalgkit/meta.yaml
@@ -55,6 +55,10 @@ about:
   summary: "Tools for transcriptome amalgamation"
 
 extra:
+  # Patch releases are intentionally skipped; update this recipe manually for
+  # amalgkit major and minor releases.
+  autobump:
+    enable: false
   notes: |
     Optional runtime dependencies:
       - inmoose: required for `amalgkit finalize --batch_effect_alg combatseq`


### PR DESCRIPTION
Disable automated version bumps for the amalgkit recipe so that it is updated manually only for major and minor amalgkit releases. Patch-only releases will remain available from GitHub and will be picked up by Bioconda at the next major or minor update.

The packaged version remains unchanged at 0.16.37.