### PR TITLE
Add ResPro to Bioconda

### DIFF
--- a/recipes/respro/meta.yaml
+++ b/recipes/respro/meta.yaml
@@ -1,0 +1,50 @@
+{% set name = "respro" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/the-foxlab/ResistanceProfiler/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: c5030e9b3c7953e70f3e7e314be85eb3369c8e7e8d727bf6aef34608c1f6235d
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - python >=3.11
+    - pip
+    - hatchling
+  run:
+    - python >=3.11
+    - click >=8.1
+    - typer >=0.12
+    - rich >=13.0
+    - numpy >=1.24
+    - biopython >=1.81
+    - pysam >=0.22
+    - mappy >=2.24
+    - jinja2 >=3.1.5
+    - markupsafe >=2.1
+    - matplotlib >=3.7
+    - weasyprint >=62.3
+
+test:
+  commands:
+    - respro --help
+  imports:
+    - respro
+
+about:
+  home: https://github.com/the-foxlab/ResistanceProfiler
+  summary: Pathogen-agnostic framework for genotypic antiviral resistance profiling from variants.
+  license: AGPL-3.0-only
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - jonas-fuchs

--- a/recipes/respro/meta.yaml
+++ b/recipes/respro/meta.yaml
@@ -13,6 +13,8 @@ build:
   noarch: python
   number: 0
   script: {{ PYTHON }} -m pip install . -vv
+  run_exports:
+    - {{ pin_subpackage('respro', max_pin="x.x") }}
 
 requirements:
   host:
@@ -30,7 +32,7 @@ requirements:
     - mappy >=2.24
     - jinja2 >=3.1.5
     - markupsafe >=2.1
-    - matplotlib >=3.7
+    - matplotlib-base >=3.7
     - weasyprint >=62.3
 
 test:


### PR DESCRIPTION
## Description
Adds ResPro (ResistanceProfiler): A pathogen-agnostic drug-resistance analysis engine.

- Homepage: https://github.com/the-foxlab/ResistanceProfiler
- Documentation: https://the-foxlab.github.io/ResistanceProfiler/
- License: AGPL-3.0-only
- CLI: `respro`

## Checklist
- [x] Package builds locally / passes bioconda CI
- [x] License allows redistribution
- [x] Tests: `respro --help`
- [x] WebApp is NOT bundled