### PR TITLE
Update radte to 0.3.0

### DIFF
--- a/recipes/radte/meta.yaml
+++ b/recipes/radte/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "radte" %}
-{% set version = "0.2.3" %}
+{% set version = "0.3.0" %}
 
 package:
   name: "{{ name|lower }}"
   version: "{{ version }}"
 
 source:
-  url: https://github.com/kfuku52/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: c2084ac220e632c339a23484be0fa57f248cacdbbee210962caeaffe66b1b160
+  url: https://github.com/kfuku52/RADTE/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: b2db4815be56a5c3702aeb1e993460f267ac9986c1ac0ef9222dff8b343f0618
 
 build:
   number: 0
@@ -35,7 +35,7 @@ test:
     - radte.r
 
 about:
-  home: "https://github.com/kfuku52/radte"
+  home: "https://github.com/kfuku52/RADTE"
   license: MIT
   license_file: LICENSE
   summary: "Reconciliation-Assisted Divergence Time Estimation for gene families."


### PR DESCRIPTION
Updates RADTE from 0.2.3 to the existing 0.3.0 minor release.

The source and home URLs now use the repository canonical capitalization (`RADTE`). This also lets GitHub tag discovery match the canonical project path for future major/minor releases.

- Verified the v0.3.0 source archive SHA-256
- Kept build number at 0
- No dependency changes