### PR TITLE
Update kcftools python wrapper

### DIFF
--- a/recipes/kcftools/kcftools.py
+++ b/recipes/kcftools/kcftools.py
@@ -7,44 +7,46 @@ import subprocess
 DEFAULT_XMS = "-Xms512m"
 DEFAULT_XMX = "-Xmx2g"
 
-def has_memory_opts(args):
-    """Check if any -Xms or -Xmx options are already passed."""
-    return any(arg.startswith("-Xms") or arg.startswith("-Xmx") for arg in args)
+BIN_DIR = os.path.dirname(os.path.realpath(__file__))
+PREFIX = os.path.dirname(BIN_DIR)
+JAVA_PATH = os.path.join(BIN_DIR, "java")
+JAR_PATH = os.path.join(PREFIX, "share", "kcftools", "kcftools.jar")
 
-def get_heap_opts():
-    """Get heap size options from env var if available."""
+def split_jvm_opts(args):
+    jvm_opts, app_args = [], []
+    for arg in args:
+        if arg.startswith("-Xms") or arg.startswith("-Xmx"):
+            jvm_opts.append(arg)
+        else:
+            app_args.append(arg)
+    return jvm_opts, app_args
+
+
+def default_heap_opts():
     heap_size = os.environ.get("KCFTOOLS_HEAP_SIZE")
     if heap_size:
-        return [DEFAULT_XMS, f"-Xmx{heap_size}"]
-    else:
-        return [DEFAULT_XMS, DEFAULT_XMX]
+        return [DEFAULT_XMS, "-Xmx{}".format(heap_size)]
+    return [DEFAULT_XMS, DEFAULT_XMX]
+
 
 def main():
-    conda_prefix = os.environ.get("CONDA_PREFIX", "")
-    if not conda_prefix:
-        print("Error: CONDA_PREFIX is not set. Are you running inside a conda environment?", file=sys.stderr)
-        sys.exit(1)
+    if not os.access(JAVA_PATH, os.X_OK):
+        sys.exit("Error: no executable java at {}.".format(JAVA_PATH))
 
-    jar_path = os.path.join(conda_prefix, "share", "kcftools", "kcftools.jar")
-    if not os.path.isfile(jar_path):
-        print(f"Error: Could not find kcftools.jar at {jar_path}", file=sys.stderr)
-        sys.exit(1)
+    if not os.path.isfile(JAR_PATH):
+        sys.exit("Error: could not find kcftools.jar at {}".format(JAR_PATH))
 
-    java_cmd = ["java"]
+    jvm_opts, app_args = split_jvm_opts(sys.argv[1:])
+    if not jvm_opts:
+        jvm_opts = default_heap_opts()
 
-    if not has_memory_opts(sys.argv[1:]):
-        java_cmd.extend(get_heap_opts())
+    java_cmd = [JAVA_PATH] + jvm_opts + ["-jar", JAR_PATH] + app_args
 
-    java_cmd.extend(["-jar", jar_path])
-    java_cmd.extend(sys.argv[1:])
+    rc = subprocess.call(java_cmd)
 
-    try:
-        result = subprocess.run(java_cmd)
-        sys.exit(result.returncode)
-    except FileNotFoundError:
-        print("Error: Java is not installed or not available in PATH.", file=sys.stderr)
-        sys.exit(1)
+    # flip dead child negative return code
+    sys.exit(128 - rc if rc < 0 else rc)
+
 
 if __name__ == "__main__":
     main()
-#EOF

--- a/recipes/kcftools/meta.yaml
+++ b/recipes/kcftools/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
     noarch: generic
-    number: 0
+    number: 1
     run_exports:
         - {{ pin_subpackage(name, max_pin="x") }}
 


### PR DESCRIPTION
Recipe currently broken for automatically built containers:

```
msmith@gruffalo ~> apptainer exec docker://quay.io/biocontainers/kcftools:0.4.0--hdfd78af_0 kcftools --help
INFO:    Using cached SIF image
Error: CONDA_PREFIX is not set. Are you running inside a conda environment?
```

This PR refactors Java and `.jar` path handling in line with other bioconda python wrappers. A bug where user specified memory options would be appended after `-jar` has been fixed. Return code for subprocess call has also been adjusted to include a flip from negative values if child process dies, for clarity.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
