### PR TITLE
Update minibwa to v0.7

### DIFF
--- a/recipes/minibwa/build.sh
+++ b/recipes/minibwa/build.sh
@@ -15,3 +15,4 @@ make \
 install -m 0755 minibwa "${PREFIX}/bin"
 install -m 0644 libminibwa.a "${PREFIX}/lib"
 install -m 0644 minibwa.h "${PREFIX}/include"
+install -m 0644 minibwa.1 "${PREFIX}/man/man1"

--- a/recipes/minibwa/build.sh
+++ b/recipes/minibwa/build.sh
@@ -4,46 +4,11 @@ set -xe
 
 mkdir -p "${PREFIX}/bin" "${PREFIX}/lib" "${PREFIX}/include"
 
-# Build the vendored zlib-ng (fetched as the `_zlib_ng` source) in ZLIB_COMPAT
-# mode: a static, drop-in libz.a + zlib.h with a faster inflate. Static so the
-# speedup is baked in without adding a runtime dependency or a track_features
-# anchor.
-DEPS="${SRC_DIR}/_deps"
-mkdir -p "${DEPS}"
-cmake -S "${SRC_DIR}/_zlib_ng" -B "${SRC_DIR}/_zlib_ng/build" -G Ninja \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_INSTALL_PREFIX="${DEPS}" \
-    -DZLIB_COMPAT=ON \
-    -DBUILD_SHARED_LIBS=OFF \
-    -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
-    -DZLIB_ENABLE_TESTS=OFF \
-    -DWITH_GTEST=OFF
-cmake --build "${SRC_DIR}/_zlib_ng/build" --parallel "${CPU_COUNT}"
-cmake --install "${SRC_DIR}/_zlib_ng/build"
-
-# zlib-ng may install into lib or lib64 depending on the platform.
-ZLIBNG_LIBDIR="${DEPS}/lib"
-[ -f "${DEPS}/lib64/libz.a" ] && ZLIBNG_LIBDIR="${DEPS}/lib64"
-
-# The bundled SSE->NEON shim (s2n-lite.h) reinterprets uint32x4_t results
-# through signed int32x4_t intrinsics, which GCC on aarch64 rejects. Permit
-# the conversion as GCC itself suggests (clang/macOS already accepts it).
-case "$(uname -m)" in
-    aarch64 | arm64)
-        export CFLAGS="${CFLAGS} -flax-vector-conversions"
-        ;;
-esac
-
-# CPPFLAGS points at the vendored zlib.h; LIBS replaces the Makefile's `-lz`
-# with the static zlib-ng archive so minibwa embeds the compat build rather
-# than linking the shared system zlib.
-export CPPFLAGS="-I${DEPS}/include ${CPPFLAGS}"
 make \
     CC="${CC}" \
     CFLAGS="${CFLAGS}" \
     CPPFLAGS="${CPPFLAGS}" \
     LDFLAGS="${LDFLAGS}" \
-    LIBS="-lpthread ${ZLIBNG_LIBDIR}/libz.a -lm" \
     -j"${CPU_COUNT}" \
     minibwa
 

--- a/recipes/minibwa/meta.yaml
+++ b/recipes/minibwa/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "minibwa" %}
-{% set version = "0.6" %}
-{% set zlibng_version = "2.3.3" %}
+{% set version = "0.7" %}
 
 package:
   name: {{ name }}
@@ -8,17 +7,7 @@ package:
 
 source:
   - url: https://github.com/lh3/{{ name }}/archive/v{{ version }}.tar.gz
-    sha256: 5a5123b85c21220492518802dc8527585a006689de2440ac4a9f4063e41fd0d2
-  # zlib-ng built in ZLIB_COMPAT mode is a drop-in libz with a much faster
-  # inflate. minibwa's gzip read path (kseq gzread) is single-threaded, so at
-  # high thread counts one inflate stream bottlenecks the mappers; statically
-  # linking zlib-ng lifts that ceiling (~7% faster at 96 threads on Graviton4).
-  # Vendored + static because the conda-forge `zlib-ng-compat` track_features
-  # anchor is not on the main channel; cf. the salmon recipe, which does the
-  # same. Declared as a second source so the build stays hermetic (no network).
-  - url: https://github.com/zlib-ng/zlib-ng/archive/refs/tags/{{ zlibng_version }}.tar.gz
-    sha256: f9c65aa9c852eb8255b636fd9f07ce1c406f061ec19a2e7d508b318ca0c907d1
-    folder: _zlib_ng
+    sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 
 build:
   number: 0
@@ -28,13 +17,10 @@ build:
 requirements:
   build:
     - make
-    - cmake
-    - ninja
     - {{ compiler('c') }}
     - {{ stdlib("c") }}
   host:
-    # zlib-ng is vendored and statically linked in build.sh (see source above),
-    # so no `zlib` here.
+    - zlib
     - llvm-openmp  # [osx]
   run:
     - llvm-openmp  # [osx]

--- a/recipes/minibwa/meta.yaml
+++ b/recipes/minibwa/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   - url: https://github.com/lh3/{{ name }}/archive/v{{ version }}.tar.gz
-    sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    sha256: 8a1129bcba045e4af4b6fbf73b3fc6b42208afbab870c774c5f0cd2716d748ae
 
 build:
   number: 0


### PR DESCRIPTION
Changes:
* Update minibwa to v0.7.
* Remove zlib-ng as it interferes with autobump but doesn't improve performance in most practical use cases. Hope autobump will work next time.
* Remove `-flax-vector-conversions`. I removed these few lines a while ago but got added by another PR.
* Install manpage

Describe your pull request here

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
