### PR TITLE
 Update pangbank api to 0.6.0

### DIFF
--- a/recipes/pangbank-api/meta.yaml
+++ b/recipes/pangbank-api/meta.yaml
@@ -1,13 +1,13 @@
-{% set name = "pangbank-api" %}
-{% set version = "0.3.0" %}
+{% set name = "PanGBank-api" %}
+{% set version = "0.6.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://github.com/labgem/{{ name|lower }}/archive/{{ version }}.tar.gz
-  sha256: cb7b1807274b9a7329ea1beec1186d92c1eda72c777976170a682a7b9e546e3b
+  url: https://github.com/labgem/{{ name }}/archive/{{ version }}.tar.gz
+  sha256: a62403cc020662dc8557cdc88c985660a1ba0a4d199e3f326e02fd1be7cc1af3
 
 build:
   entry_points:
@@ -31,6 +31,7 @@ requirements:
     - pyyaml >=6.0.2
     - packaging >=24
     - pydantic-settings >=2.12.0
+    - httpx >=0.28.1
 
 
 test:
@@ -43,7 +44,7 @@ test:
     - pip
 
 about:
-  home: https://github.com/labgem/{{ name|lower }}
+  home: https://github.com/labgem/{{ name }}
   license: "CeCiLL-2.1"
   license_family: OTHER
   license_file: LICENCE


### PR DESCRIPTION
This PR updates `pangbank-api` to version `0.6.0`.

* Add `httpx` as a dependency.
* Fix the repository URL where the repository name was incorrectly written in lowercase. This prevents Bioconda autobump from correctly detecting the repository and updating the recipe automatically.
