### PR TITLE
Add cellosaurus 0.2.0

### DIFF
--- a/recipes/cellosaurus/meta.yaml
+++ b/recipes/cellosaurus/meta.yaml
@@ -1,0 +1,42 @@
+{% set version = "0.2.0" %}
+{% set github = "https://github.com/acidgenomics/py-cellosaurus" %}
+
+package:
+  name: cellosaurus
+  version: "{{ version }}"
+
+source:
+  url: "{{ github }}/archive/v{{ version }}.tar.gz"
+  sha256: 8a60050a8ed35fb52b1453ec2205c9a6328eb175a0c3b525b165cad0de69850b
+
+build:
+  number: 0
+  noarch: python
+  script: "{{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv"
+  run_exports:
+    - {{ pin_subpackage('cellosaurus', max_pin="x.x") }}
+
+requirements:
+  host:
+    - python >=3.12
+    - pip
+    - uv-build >=0.11,<1
+  run:
+    - python >=3.12
+    - pandas
+
+test:
+  imports:
+    - cellosaurus
+
+about:
+  home: https://python.acidgenomics.com/cellosaurus/
+  dev_url: "{{ github }}"
+  license: Apache-2.0
+  license_file: LICENSE
+  summary: Cellosaurus identifier mapping toolkit.
+
+extra:
+  recipe-maintainers:
+    - acidgenomics
+    - mjsteinbaugh


### PR DESCRIPTION
New recipe for cellosaurus, a Cellosaurus cell-line identifier mapping toolkit.

- noarch: python, built via uv_build (PEP 517), installed with pip
- Runtime deps: pandas (on conda-forge)
- License: Apache-2.0
- Homepage: https://python.acidgenomics.com/cellosaurus/
- R analog r-cellosaurus is an existing, actively maintained bioconda package