### PR TITLE
Add goalie 0.1.0

### DIFF
--- a/recipes/goalie/meta.yaml
+++ b/recipes/goalie/meta.yaml
@@ -1,0 +1,41 @@
+{% set version = "0.1.0" %}
+{% set github = "https://github.com/acidgenomics/py-goalie" %}
+
+package:
+  name: goalie
+  version: "{{ version }}"
+
+source:
+  url: "{{ github }}/archive/v{{ version }}.tar.gz"
+  sha256: 289e35fc5d3e29402d3464bc5f729f459a103615e1d544738ff96087746071df
+
+build:
+  number: 0
+  noarch: python
+  script: "{{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv"
+  run_exports:
+    - {{ pin_subpackage('goalie', max_pin="x.x") }}
+
+requirements:
+  host:
+    - python >=3.12
+    - pip
+    - uv-build >=0.11,<1
+  run:
+    - python >=3.12
+
+test:
+  imports:
+    - goalie
+
+about:
+  home: https://python.acidgenomics.com/goalie/
+  dev_url: "{{ github }}"
+  license: Apache-2.0
+  license_file: LICENSE
+  summary: Assertive check functions for defensive Python programming.
+
+extra:
+  recipe-maintainers:
+    - acidgenomics
+    - mjsteinbaugh


### PR DESCRIPTION
New recipe for goalie, assertive check functions for defensive Python programming.

- noarch: python, built via uv_build (PEP 517), installed with pip
- No mandatory runtime dependencies
- License: Apache-2.0
- Homepage: https://python.acidgenomics.com/goalie/
- R analog r-goalie is an existing, actively maintained bioconda package