### PR TITLE
Add syntactic 0.1.0

### DIFF
--- a/recipes/syntactic/meta.yaml
+++ b/recipes/syntactic/meta.yaml
@@ -1,0 +1,41 @@
+{% set version = "0.1.0" %}
+{% set github = "https://github.com/acidgenomics/py-syntactic" %}
+
+package:
+  name: syntactic
+  version: "{{ version }}"
+
+source:
+  url: "{{ github }}/archive/v{{ version }}.tar.gz"
+  sha256: be277baa1a3a89a4d2c6e7f9148a629eec3e76f1224554819db184f374da2522
+
+build:
+  number: 0
+  noarch: python
+  script: "{{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv"
+  run_exports:
+    - {{ pin_subpackage('syntactic', max_pin="x.x") }}
+
+requirements:
+  host:
+    - python >=3.12
+    - pip
+    - uv-build >=0.11,<1
+  run:
+    - python >=3.12
+
+test:
+  imports:
+    - syntactic
+
+about:
+  home: https://python.acidgenomics.com/syntactic/
+  dev_url: "{{ github }}"
+  license: Apache-2.0
+  license_file: LICENSE
+  summary: Make syntactically valid names out of strings.
+
+extra:
+  recipe-maintainers:
+    - acidgenomics
+    - mjsteinbaugh


### PR DESCRIPTION
New recipe for syntactic, makes syntactically valid names out of strings.

- noarch: python, built via uv_build (PEP 517), installed with pip
- No mandatory runtime dependencies
- License: Apache-2.0
- Homepage: https://python.acidgenomics.com/syntactic/
- R analog r-syntactic is an existing, actively maintained bioconda package