### PR TITLE
Add biocframe 0.7.3

### DIFF
--- a/recipes/biocframe/meta.yaml
+++ b/recipes/biocframe/meta.yaml
@@ -1,0 +1,47 @@
+{% set name = "biocframe" %}
+{% set version = "0.7.3" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: f118a764e256748bd2bce50cc0161ba30ea3b9bad4c537b29cff83af2132da53
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x.x") }}
+
+requirements:
+  host:
+    - python
+    - setuptools >=46.1.0
+    - setuptools-scm >=5
+    - pip
+  run:
+    - python
+    - numpy
+    - biocutils >=0.3.3
+
+test:
+  imports:
+    - biocframe
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/BiocPy/biocframe
+  summary: Flexible dataframe representation to support nested structures.
+  license: MIT
+  license_file: LICENSE.txt
+
+extra:
+  recipe-maintainers:
+    - acidgenomics
+    - mjsteinbaugh


### PR DESCRIPTION
New recipe for biocframe, a BiocPy container providing flexible dataframe representation to support nested structures.

- noarch: python, pure setuptools/setuptools_scm build, no compiled code
- Runtime dep: numpy, biocutils >=0.3.3 (biocutils is already live on bioconda)
- License: MIT
- Homepage: https://github.com/BiocPy/biocframe
- This unblocks acidgenomes, an existing acidgenomics bioconda package family (r-acidgenomes) whose Python counterpart depends transitively on biocframe/genomicranges/iranges.