### PR TITLE
Update nexcision to 0.1.1

### DIFF
--- a/recipes/nexcision/meta.yaml
+++ b/recipes/nexcision/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "nexcision" %}
-{% set version = "0.1.0" %}
+{% set version = "0.1.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/RhysWhite/nexcision/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: a03684b573d5450e8753f99d725dc0789f01c3fc4edbebd43bc838c0ac8a7d32
+  sha256: 2f9fd761359f1652b03202f344c833187467d94168e1cb7a60a9686e3d4b10f7
 
 build:
   number: 0


### PR DESCRIPTION
Updates NEXCISION from 0.1.0 to 0.1.1.

The updated recipe has been linted successfully with `bioconda-utils lint --packages nexcision` and built/tested locally with `bioconda-utils build --packages nexcision`.

Local build result:
`BUILD SUCCESS nexcision-0.1.1-pyhdfd78af_0.conda`