### PR TITLE
Update abacus-str: add missing minigraph dependency

### DIFF
--- a/recipes/abacus-str/meta.yaml
+++ b/recipes/abacus-str/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: "7ae1c0ac927e6de4afd873ad468624c304b082861ee5228dc27f5a7d6090c8d0"
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: "{{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation"
   run_exports:
@@ -35,6 +35,7 @@ requirements:
     - scipy >=1.15.2
     - typer >=0.12.4
     - pyspoa >=0.2.1
+    - minigraph >=0.21
     - r-base
     - r-dplyr
     - r-ggplot2


### PR DESCRIPTION
Adds missing minigraph>=0.21 runtime dependency to abacus-str and bumps build number.