### PR TITLE
 Update pangbank cli to 0.3.0

### DIFF
--- a/recipes/pangbank-cli/meta.yaml
+++ b/recipes/pangbank-cli/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - rich >=10.0.0
     - pydantic >=2.10.0,<3.0.0
     - pandas >=2.0.0,<3.0.0
-    - pangbank-api >=0.3.0
+    - pangbank-api >=0.6.0
     - mash >=2.3, <3.0.0
     - httpx >=0.28.1
 

--- a/recipes/pangbank-cli/meta.yaml
+++ b/recipes/pangbank-cli/meta.yaml
@@ -1,13 +1,13 @@
-{% set name = "pangbank-cli" %}
-{% set version = "0.2.0" %}
+{% set name = "PanGBank-cli" %}
+{% set version = "0.3.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://github.com/labgem/{{ name|lower }}/archive/{{ version }}.tar.gz
-  sha256: 7b6c98a68e1343c1e1a709a7293c1f6131eab35875455da6ce9e2ec0b3a1f63a
+  url: https://github.com/labgem/{{ name }}/archive/{{ version }}.tar.gz
+  sha256: 5eda4c8e0d0760b2c0ed39f7e6f59d8802654ae3161d761f0965a87e9e562898
 
 build:
   entry_points:
@@ -43,8 +43,8 @@ test:
     - pip
 
 about:
-  home: https://github.com/labgem/{{ name|lower }}
-  license: CECILL-2.1
+  home: https://github.com/labgem/{{ name }}
+  license: "CeCiLL-2.1"
   license_file: LICENSE
   summary: "Command-line tool for retrieving pangenomes using the PanGBank API."
 

--- a/recipes/pangbank-cli/meta.yaml
+++ b/recipes/pangbank-cli/meta.yaml
@@ -32,6 +32,7 @@ requirements:
     - pandas >=2.0.0,<3.0.0
     - pangbank-api >=0.3.0
     - mash >=2.3, <3.0.0
+    - httpx >=0.28.1
 
 test:
   imports:


### PR DESCRIPTION
This PR updates `pangbank-cli` to version `0.3.0`.

* Update pangbank-api to 0.6.0
* Add `httpx` as a dependency to use pangbank-api SDK.
* Fix the repository URL where the repository name was incorrectly written in lowercase. This prevents Bioconda autobump from correctly detecting the repository and updating the recipe automatically.