### PR TITLE
Update snakemake-executor-plugin-slurm to allow pandas 3

### DIFF
--- a/recipes/snakemake-executor-plugin-slurm/meta.yaml
+++ b/recipes/snakemake-executor-plugin-slurm/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: b78bc1fe6de633c281fbb9c122af7c838656083df076a5860271a68b6ecba5b3
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . -vvv --no-deps --no-build-isolation --no-cache-dir
   run_exports:
@@ -27,7 +27,7 @@ requirements:
     - snakemake-interface-executor-plugins >=9.3.9,<10.0.0
     - snakemake-executor-plugin-slurm-jobstep >=0.4.0,<0.5.0
     - throttler >=1.2.2,<2.0.0
-    - pandas >=2.2.3,<3.0
+    - pandas >=2.3.3,<4
     - numpy >=1.26.4,<3.0
     - pyyaml
 


### PR DESCRIPTION
Upstream 2.7.1 declares [`pandas>=2.3.3,<4` on PyPI](https://github.com/snakemake/snakemake-executor-plugin-slurm/blob/main/pyproject.toml#L29), but the recipe still carries the previous bound `pandas >=2.2.3,<3.0`, so the package cannot be installed alongside pandas 3.