### PR TITLE
Update oxbreaker to 1.2

### DIFF
--- a/recipes/oxbreaker/meta.yaml
+++ b/recipes/oxbreaker/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "oxbreaker" %}
-{% set version = "1.1" %}
+{% set version = "1.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://gitlab.com/rc-reding/OxBreaker/-/archive/{{ version }}/OxBreaker-{{ version }}.tar.bz2
-  sha256: 0794a71efc4d67db35229c5f942ea837743952632bac5b1112a8d9dc832c0c38
+  sha256: f16a4bbfdb7883ce121878060facd2af9ed46434d5a85c0d93e4a978b783b261
 
 build:
   number: 0

--- a/recipes/oxbreaker/meta.yaml
+++ b/recipes/oxbreaker/meta.yaml
@@ -31,6 +31,7 @@ requirements:
     - pango
     - harfbuzz
     - glib
+    - mamba
     - nextflow 25.*
 
 entry_points:

--- a/recipes/oxbreaker/oxbreaker-desktop-helper
+++ b/recipes/oxbreaker/oxbreaker-desktop-helper
@@ -1,20 +1,102 @@
 #!/usr/bin/env bash
 set -e
 
-# Verify the user is running on a GUI-capable environment
-if [ -z "$XDG_DATA_HOME" ]; then
-    LOCAL_APPS_DIR="$HOME/.local/share/applications"
-else
-    LOCAL_APPS_DIR="$XDG_DATA_HOME/applications"
-fi
+# Detect Operating System
+OS="$(uname -s)"
 
-mkdir -p "$LOCAL_APPS_DIR"
-TARGET_FILE="$LOCAL_APPS_DIR/oxbreaker.desktop"
+case "$OS" in
+    Linux*)
+        # Verify the user is running on a GUI-capable environment
+        if [ -z "$XDG_DATA_HOME" ]; then
+            LOCAL_APPS_DIR="$HOME/.local/share/applications"
+        else
+            LOCAL_APPS_DIR="$XDG_DATA_HOME/applications"
+        fi
 
-# Copy and rewrite the template based on their active environment
-cp "$CONDA_PREFIX/share/oxbreaker/oxbreaker.desktop" "$TARGET_FILE"
-sed -i "s|__PREFIX__|$CONDA_PREFIX|g" "$TARGET_FILE"
-chmod +x "$TARGET_FILE"
+        mkdir -p "$LOCAL_APPS_DIR"
+        TARGET_FILE="$LOCAL_APPS_DIR/oxbreaker.desktop"
 
-echo "Success! Shortcut created at: $TARGET_FILE"
+        # Copy and rewrite the template based on their active environment
+        cp "$CONDA_PREFIX/share/oxbreaker/oxbreaker.desktop" "$TARGET_FILE"
+        sed -i "s|__PREFIX__|$CONDA_PREFIX|g" "$TARGET_FILE"
+        chmod +x "$TARGET_FILE"
 
+        echo "Success! Shortcut created at: $TARGET_FILE"
+        ;;
+    Darwin*)
+        APP_DIR="$HOME/Applications/OxBreaker.app"
+        PNG_ICON="$CONDA_PREFIX/share/oxbreaker/oxbreaker.png" # Needs to be converted to .icns
+
+        # 1. Create the standard macOS app directory structure
+        mkdir -p "$APP_DIR/Contents/MacOS"
+        mkdir -p "$APP_DIR/Contents/Resources"
+
+        # 2. Convert PNG to ICNS on the fly if the icon exists
+        if [ -f "$PNG_ICON" ]; then
+            ICONSET_DIR="$(mktemp -d)/OxBreaker.iconset"
+            mkdir -p "$ICONSET_DIR"
+
+            # Generate standard resolution sizes required by macOS
+            sips -z 16 16     "$PNG_ICON" --out "$ICONSET_DIR/icon_16x16.png" >/dev/null 2>&1
+            sips -z 32 32     "$PNG_ICON" --out "$ICONSET_DIR/icon_16x16@2x.png" >/dev/null 2>&1
+            sips -z 32 32     "$PNG_ICON" --out "$ICONSET_DIR/icon_32x32.png" >/dev/null 2>&1
+            sips -z 64 64     "$PNG_ICON" --out "$ICONSET_DIR/icon_32x32@2x.png" >/dev/null 2>&1
+            sips -z 128 128   "$PNG_ICON" --out "$ICONSET_DIR/icon_128x128.png" >/dev/null 2>&1
+            sips -z 256 256   "$PNG_ICON" --out "$ICONSET_DIR/icon_128x128@2x.png" >/dev/null 2>&1
+            sips -z 256 256   "$PNG_ICON" --out "$ICONSET_DIR/icon_256x256.png" >/dev/null 2>&1
+            sips -z 512 512   "$PNG_ICON" --out "$ICONSET_DIR/icon_256x256@2x.png" >/dev/null 2>&1
+            sips -z 512 512   "$PNG_ICON" --out "$ICONSET_DIR/icon_512x512.png" >/dev/null 2>&1
+            sips -z 1024 1024 "$PNG_ICON" --out "$ICONSET_DIR/icon_512x512@2x.png" >/dev/null 2>&1
+
+            # Compile the iconset into a single .icns file
+            iconutil -c icns "$ICONSET_DIR" -o "$APP_DIR/Contents/Resources/appicon.icns"
+
+            # Clean up temp folder
+            rm -rf "$(dirname "$ICONSET_DIR")"
+        fi
+
+        # 3. Create the executable launcher script inside the app bundle
+        cat <<'EOF' > "$APP_DIR/Contents/MacOS/OxBreaker"
+        #!/usr/bin/env bash
+        # Inherit environment or fallback to active Conda prefix
+        if [ -n "$CONDA_PREFIX" ]; then
+            export PATH="$CONDA_PREFIX/bin:$PATH"
+        fi
+
+        # Launch oxbreaker
+        exec oxbreaker "$@"
+        EOF
+
+        chmod +x "$APP_DIR/Contents/MacOS/OxBreaker"
+
+        # 4. Create Info.plist to register the app executable and icon
+        cat <<EOF > "$APP_DIR/Contents/Info.plist"
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+            <key>CFBundleExecutable</key>
+            <key>OxBreaker</key>
+            <key>CFBundleIconFile</key>
+            <key>appicon.icns</key>
+            <key>CFBundleIdentifier</key>
+            <key>com.oxbreaker.app</key>
+            <key>CFBundleName</key>
+            <key>OxBreaker</key>
+            <key>CFBundlePackageType</key>
+            <key>APPL</key>
+            <key>LSUIElement</key>
+            <false/>
+        </dict>
+        </plist>
+        EOF
+
+        # 5. Refresh Finder cache so the icon displays immediately
+        touch "$APP_DIR"
+        
+        echo "Success! Shortcut created at: $APP_DIR"
+    *)
+        echo "Error: Unsupported operative system ($OS)."  > &2
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
This PR updates oxbreaker from 1.1 -> 1.2

- All shebangs removed from python files, letting conda manage which interpreter to use [fixes crash in the specific case of installing anaconda through homebrew in macOS]
- Refactoring of the helper script `oxbreaker-desktop-helper` to let the users install a desktop shortcut to start OxBreaker with the mouse. Now also supporting macOS.