### PR TITLE
Add ploidypatch 1.0.0

### DIFF
--- a/recipes/ploidypatch/meta.yaml
+++ b/recipes/ploidypatch/meta.yaml
@@ -13,6 +13,8 @@ build:
   noarch: python
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x") }}
   entry_points:
     - ploidypatch = ploidypatch.cli:main
 

--- a/recipes/ploidypatch/meta.yaml
+++ b/recipes/ploidypatch/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "ploidypatch" %}
-{% set version = "1.0.0" %}
+{% set version = "1.1.0" %}
 
 package:
   name: {{ name }}
@@ -7,14 +7,12 @@ package:
 
 source:
   url: https://github.com/707728642li/PloidyPatch/releases/download/v{{ version }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 9a65b2f752b099f87d1eddc3b75115d79ded819e54ceaf390b22c452590fbaef
+  sha256: d7bf43bbee947de3a04243cb6bb6e0703a018eff42cd0e30aeafa3de51eb9ec5
 
 build:
   noarch: python
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  run_exports:
-    - {{ pin_subpackage(name, max_pin="x") }}
   entry_points:
     - ploidypatch = ploidypatch.cli:main
 
@@ -33,7 +31,7 @@ test:
     - ploidypatch --version
     - ploidypatch --help
     - ploidypatch patch --help
-    - python -c "import ploidypatch; assert ploidypatch.__version__ == '1.0.0'"
+    - python -c "import ploidypatch; assert ploidypatch.__version__ == '1.1.0'"
     - pip check
   requires:
     - pip

--- a/recipes/ploidypatch/meta.yaml
+++ b/recipes/ploidypatch/meta.yaml
@@ -27,14 +27,14 @@ requirements:
     - python >=3.11
 
 test:
-  source_files:
-    - examples/minimal_reviewed_patch
   imports:
     - ploidypatch
   commands:
     - ploidypatch --version
     - ploidypatch --help
-    - python examples/minimal_reviewed_patch/run_example.py --output-dir conda-smoke
+    - ploidypatch patch --help
+    - python -c "import ploidypatch; assert ploidypatch.__version__ == '1.0.0'"
+    - pip check
   requires:
     - pip
 

--- a/recipes/ploidypatch/meta.yaml
+++ b/recipes/ploidypatch/meta.yaml
@@ -1,13 +1,14 @@
 {% set name = "ploidypatch" %}
-{% set version = "1.1.0" %}
+{% set version = "1.0.0" %}
+{% set release_tag = "v1.0" %}
 
 package:
   name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://github.com/707728642li/PloidyPatch/releases/download/v{{ version }}/{{ name }}-{{ version }}.tar.gz
-  sha256: d7bf43bbee947de3a04243cb6bb6e0703a018eff42cd0e30aeafa3de51eb9ec5
+  url: https://github.com/707728642li/PloidyPatch/releases/download/{{ release_tag }}/{{ name }}-{{ version }}.tar.gz
+  sha256: f63772f27a432e18da44f544d6a98a7b27c934a532e4079d7cb624d9ba0af38c
 
 build:
   noarch: python
@@ -33,7 +34,7 @@ test:
     - ploidypatch --version
     - ploidypatch --help
     - ploidypatch patch --help
-    - python -c "import ploidypatch; assert ploidypatch.__version__ == '1.1.0'"
+    - python -c "import ploidypatch; assert ploidypatch.__version__ == '1.0.0'"
     - pip check
   requires:
     - pip

--- a/recipes/ploidypatch/meta.yaml
+++ b/recipes/ploidypatch/meta.yaml
@@ -1,0 +1,54 @@
+{% set name = "ploidypatch" %}
+{% set version = "1.0.0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/707728642li/PloidyPatch/releases/download/v{{ version }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 9a65b2f752b099f87d1eddc3b75115d79ded819e54ceaf390b22c452590fbaef
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  entry_points:
+    - ploidypatch = ploidypatch.cli:main
+
+requirements:
+  host:
+    - python >=3.11
+    - pip
+    - setuptools >=77
+  run:
+    - python >=3.11
+
+test:
+  source_files:
+    - examples/minimal_reviewed_patch
+  imports:
+    - ploidypatch
+  commands:
+    - ploidypatch --version
+    - ploidypatch --help
+    - python examples/minimal_reviewed_patch/run_example.py --output-dir conda-smoke
+  requires:
+    - pip
+
+about:
+  home: https://github.com/707728642li/PloidyPatch
+  dev_url: https://github.com/707728642li/PloidyPatch
+  doc_url: https://github.com/707728642li/PloidyPatch#documentation
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE
+  summary: Duplication-aware, review-oriented plant gene-model repair
+  description: |
+    PloidyPatch preserves structurally distinct plant gene-model candidates,
+    adds duplication-aware evidence when applicable, records explicit human
+    review, and applies immutable reversible GFF3 annotation patches.
+
+extra:
+  recipe-maintainers:
+    - 707728642li


### PR DESCRIPTION
## Summary

Adds **PloidyPatch 1.0.0**, a plant-specific, duplication-aware toolkit for review-oriented gene-model repair and immutable, reversible GFF3 patches.

## Source and package

- immutable GitHub release source distribution with published SHA-256
- BSD-3-Clause license
- noarch Python package supporting Python >=3.11
- dependency-light core with a `ploidypatch` console entry point
- semantic-version run export that constrains downstream packages to the compatible 1.x series

## Validation

The exact recipe was rendered and built successfully with `conda-build`. Installed-package tests cover import, exact version, top-level and patch-command help, and dependency consistency (`pip check`). The upstream public suite separately exercises the checksum-bound reviewed-patch example, byte-identical source restoration, and zero automatic approvals.

Upstream release: https://github.com/707728642li/PloidyPatch/releases/tag/v1.0.0

Maintainer contact: litaishan@caf.ac.cn