### PR TITLE
Add telox-pyabpoa 1.5.6.post1

### DIFF
--- a/recipes/telox-pyabpoa/meta.yaml
+++ b/recipes/telox-pyabpoa/meta.yaml
@@ -18,6 +18,7 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
+    - {{ stdlib("c") }}
   host:
     - python
     - pip

--- a/recipes/telox-pyabpoa/meta.yaml
+++ b/recipes/telox-pyabpoa/meta.yaml
@@ -1,0 +1,54 @@
+{% set name = "telox-pyabpoa" %}
+{% set version = "1.5.6.post1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/hhuili/abPOA/releases/download/v{{ version }}/telox_pyabpoa-{{ version }}.tar.gz
+  sha256: f8a96a6562b6a5e4026b1281a124ba79edfdb06a74184af7ebec6cd34e0aefef
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --no-cache-dir --use-pep517 -vvv
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x") }}
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+  host:
+    - python
+    - pip
+    - setuptools
+    - cython
+    - zlib
+  run:
+    - python
+
+test:
+  imports:
+    - telox_pyabpoa
+  commands:
+    - python -c "import telox_pyabpoa as p; a = p.msa_aligner(is_ascii=True); r = a.msa(['A@%Z', 'A@%Z'], out_cons=True, out_msa=False); assert r.cons_seq == ['A@%Z']"
+
+about:
+  home: https://github.com/hhuili/abPOA
+  summary: TeloXplorer-maintained abPOA fork with 128-character ASCII alignment support
+  license: MIT
+  license_family: MIT
+  license_file:
+    - LICENSE
+    - include/simde/COPYING
+  dev_url: https://github.com/hhuili/abPOA
+
+extra:
+  recipe-maintainers:
+    - hhuili
+  identifiers:
+    - doi:10.1093/bioinformatics/btaa963
+    - biotools:abpoa
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64


### PR DESCRIPTION
## Summary

- add `telox-pyabpoa` 1.5.6.post1 as an independently named package/import (`telox_pyabpoa`) so it can coexist with upstream `pyabpoa`
- package the 128-character ASCII alignment support required by TeloXplorer
- build from a fixed GitHub Release sdist with a verified SHA256

## Upstream status

The ASCII support was proposed upstream in:

- https://github.com/yangao07/abPOA/issues/91
- https://github.com/yangao07/abPOA/pull/92

The upstream maintainer indicated that the fork could be used until upstream support is added, so this recipe uses the scoped `telox-` name rather than replacing the existing `pyabpoa` package.

## Local validation

- `bioconda-utils lint --git-range origin/master HEAD`: passed
- `bioconda-utils build recipes config.yml --packages telox-pyabpoa --force --lint`: passed on osx-arm64
- built and tested Python 3.10, 3.11, 3.12, and 3.13 variants
- verified the `telox_pyabpoa` import and an ASCII MSA assertion
- re-downloaded the release sdist and confirmed SHA256: `f8a96a6562b6a5e4026b1281a124ba79edfdb06a74184af7ebec6cd34e0aefef`

Linux and additional architecture builds are left to Bioconda CI because Docker is unavailable locally.