### PR TITLE
Update vcftools-ng to 0.14.2

### DIFF
--- a/recipes/vcftools-ng/meta.yaml
+++ b/recipes/vcftools-ng/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "vcftools-ng" %}
-{% set version = "0.13.0" %}
-{% set sha256 = "32e11ecff08532bcc22ad0c38e87486065cf944a40f6d4bf1ec8dc5b1b35757c" %}
+{% set version = "0.14.1" %}
+{% set sha256 = "4712bb383285ec08dae7056469ebd9dedd8aacff2fbcab0599d600085839213a" %}
 
 package:
   name: {{ name }}

--- a/recipes/vcftools-ng/meta.yaml
+++ b/recipes/vcftools-ng/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "vcftools-ng" %}
-{% set version = "0.14.1" %}
-{% set sha256 = "4712bb383285ec08dae7056469ebd9dedd8aacff2fbcab0599d600085839213a" %}
+{% set version = "0.14.2" %}
+{% set sha256 = "611864cf79813d5d903e42b0295ad010aa910e74feecb11c33a683fbbc9286c9" %}
 
 package:
   name: {{ name }}


### PR DESCRIPTION
Updates vcftools-ng from 0.13.0 to 0.14.2.

- resets/keeps build number at 0 for the new upstream version
- locks the published GitHub tag archive SHA-256 (`611864cf79813d5d903e42b0295ad010aa910e74feecb11c33a683fbbc9286c9`)
- retains the validated BLIS host/runtime pin
- retains HTSlib >=1.24 and bcftools >=1.24
- upstream Release CTest: 8/8 PASS
- upstream ASan+UBSan CTest: 8/8 PASS
- locked 2.3-million-record differential: PASS
- upstream manylinux2014 portable smoke: CentOS 7 and Ubuntu 20.04 PASS with HTSlib/bcftools 1.24 and libdeflate 1.25

Upstream release: https://github.com/VensinMa/vcftools-ng/releases/tag/v0.14.2
