### PR TITLE
Update to FLAIR v3.0.1 release

### DIFF
--- a/recipes/flair/meta.yaml
+++ b/recipes/flair/meta.yaml
@@ -1,61 +1,40 @@
 {% set name = "flair" %}
-{% set version = "3.0.0" %}
+{% set version = "3.0.1" %}
 
 package:
   name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://files.pythonhosted.org/packages/ca/a3/0af20795e6c22af703bd68c6a23376138470bd893b03c3a382f12793ae74/flair_brookslab-3.0.0.tar.gz
-  sha256: 4a6633baeb5c15d855535c0bea5ba021b141a191838bbe445f5a7626cace6de6
+  url: https://files.pythonhosted.org/packages/64/c6/a5fb6bf91a36577e594753ebf97008c3536da9de0959e68343e7c5e33d5f/flair_brookslab-3.0.1.tar.gz
+  sha256: 04554034b62f95a74b1f062d5c48d39fcb21ffd122085ed7ffddb6b13de60bcf
 
 build:
   noarch: python
   number: 0
   script: {{ PYTHON }} -m pip install . --no-build-isolation --no-deps --no-cache-dir -vvv
-  entry_points:
-    - flair = flair.flair_cli:main
-    - assign_variants_to_transcripts = flair.assign_variants_to_transcripts:main
-    - junctions_from_sam = flair.junctions_from_sam:main
-    - mark_intron_retention = flair.mark_intron_retention:main
-    - mark_productivity = flair.mark_productivity:main
-    - normalize_counts_matrix = flair.normalize_counts_matrix:main
-    - bam2Bed12 = flair.bam2Bed12:main
-    - plot_isoform_usage = flair.plot_isoform_usage:main
-    - predictProductivity = flair.predictProductivity:main
-    - sam_to_map = flair.sam_to_map:main
-    - fasta_seq_lengths = flair.fasta_seq_lengths:main
-    - gtf_to_bed = flair.gtf_to_bed:main
-    - bed_to_gtf = flair.bed_to_gtf:main
-    - bed_to_sequence = flair.bed_to_sequence:main
-    - identify_annotated_gene = flair.identify_annotated_gene:main
-    - identify_gene_isoform = flair.identify_gene_isoform:main
-    - diff_iso_usage = flair.diff_iso_usage:main
-    - diffsplice_fishers_exact = flair.diffsplice_fishers_exact:main
-    - flair_partition = flair.flair_partition:main
   run_exports:
     - {{ pin_subpackage('flair', max_pin="x") }}
 
 requirements:
   host:
-    - python >=3.12,<3.13
+    - python >=3.12,<3.15
     - pip
     - poetry-core
   run:
-    - python >=3.12,<3.13
+    - python >=3.12,<3.15
     - pysam >=0.23.0,<0.24.0
     - pipettor >=1.1.0,<2.0.0
-    - pybedtools >=0.11.0,<0.12.0
     - ncls >=0.0.70,<0.1.0
     - mappy >=2.28,<3.0
     - numpy >=2.2,<3.0
     - scipy >=1.15.1,<2.0.0
-    - setuptools >=75.8.0,<76.0.0
+    - setuptools >=80.2.0,<81.0.0
     - minimap2 >=2.28,<3.00
     - samtools >=1.21
     - bedtools >=2.31.1,<3.0
     - matplotlib-base >=3.10,<4.0
-    
+
 test:
   imports:
     - flair


### PR DESCRIPTION
Update to 3.0.1.
- Various bug fixes
- Python 3.14 added
- drop pybedtools, no longer used
- drop entry points that pyproject.toml no longer defines: assign_variants_to_transcripts, mark_productivity, bam2Bed12, sam_to_map
