### PR TITLE
Update coot-headless to 1.3.3

### DIFF
--- a/recipes/coot-headless/build.sh
+++ b/recipes/coot-headless/build.sh
@@ -20,17 +20,11 @@ else
   export CXXFLAGS="${CXXFLAGS} -march=x86-64-v3"
 fi
 
-pushd api/doxy-sphinx
-doxygen coot-api-dox.cfg
-popd
-
-mkdir -p "${PREFIX}/share/doxy-sphinx"
-cp -r api/doxy-sphinx/* "${PREFIX}/share/doxy-sphinx"
-
 # Boost 1.88.0 still needs `system` component
 sed -i 's|Boost COMPONENTS iostreams|Boost COMPONENTS iostreams system|' CMakeLists.txt
 sed -i 's|Boost::thread Boost::iostreams|Boost::thread Boost::iostreams Boost::system|' CMakeLists.txt
 
+# Propagate RDKit include directories through rdkit_base for downstream targets
 sed -i '/find_package(RDKit CONFIG COMPONENTS RDGeneral REQUIRED)/a\
 set_target_properties(RDKit::rdkit_base PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${RDKit_INCLUDE_DIRS}")' CMakeLists.txt
 

--- a/recipes/coot-headless/meta.yaml
+++ b/recipes/coot-headless/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "coot-headless" %}
-{% set version = "Release-1.3.2" %}
+{% set version = "Release-1.3.3" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/pemsley/coot/archive/refs/tags/{{ version }}.tar.gz
-  sha256: 8bd71e6582e87a8d2959bc1b956875a7f62c575b5a93ca60f2e575eaab42ff57
+  sha256: 5144e3d96b56c8f27173aeac2db5826eead98dda7bd9f1af846fa8cc2055b0d5
 
 build:
   number: 0
@@ -23,11 +23,9 @@ requirements:
     - {{ stdlib("c") }}
     - cmake
     - doxygen
-    - ghostscript
     - ninja
     - pkg-config
     - sed  # [osx]
-    - texlive-core
   host:
     - cairo
     - clipper

--- a/recipes/coot-headless/meta.yaml
+++ b/recipes/coot-headless/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "coot-headless" %}
-{% set version = "Release-1.3.1" %}
+{% set version = "Release-1.3.2" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/pemsley/coot/archive/refs/tags/{{ version }}.tar.gz
-  sha256: 39069510b2bd499a407d5cc9202d4df591b353c344dd21aaf30e2ceab8260025
+  sha256: 8bd71e6582e87a8d2959bc1b956875a7f62c575b5a93ca60f2e575eaab42ff57
 
 build:
   number: 0


### PR DESCRIPTION
This pull request updates the `coot-headless` recipe to version 1.3.2 and makes improvements to the build process, especially regarding documentation generation and downstream compatibility with RDKit. The most important changes are summarized below:

**Version and Source Update:**
* Bumped the `coot-headless` package version from 1.3.1 to 1.3.2 and updated the source SHA256 checksum in `meta.yaml` to match the new release.

**Build and Documentation Process:**
* Removed the generation and installation of the Doxygen documentation (`api/doxy-sphinx`) from the build script, simplifying the build process.

**Downstream Compatibility:**
* Modified the build script to explicitly propagate RDKit include directories through the `rdkit_base` target, improving downstream build compatibility for projects depending on RDKit.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
