### PR TITLE
update falco to 2.0.1

### DIFF
--- a/recipes/falco/build.sh
+++ b/recipes/falco/build.sh
@@ -1,58 +1,13 @@
 #!/bin/bash
-set -xe
+set -euo pipefail
 
-# add Configuration and example files to opt
-export falco="$PREFIX/share/${PKG_NAME}-${PKG_VERSION}"
-mkdir -p $falco
-cp -rf ./* $falco
+cmake -S . -B build \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+  -DCMAKE_PREFIX_PATH="${PREFIX}" \
+  -DHTSLIB_ROOT="${PREFIX}" \
+  -DUSE_ISAL=off \
+  -DFALCO_TESTS=off
 
-cp -f ${BUILD_PREFIX}/share/gnuconfig/config.* .
-
-#to fix problems with htslib
-export C_INCLUDE_PATH=$C_INCLUDE_PATH:"${PREFIX}/include"
-export CPLUS_INCLUDE_PATH=$CPLUS_INCLUDE_PATH:"${PREFIX}/include"
-export LIBRARY_PATH=$LIBRARY_PATH:"${PREFIX}/lib"
-export LD_LIBRARY_PATH=$LIBRARY_PATH:"${PREFIX}/lib"
-
-export INCLUDES="-I${PREFIX}/include"
-export LIBPATH="-L${PREFIX}/lib"
-export CPPFLAGS="${CPPFLAGS} -I${PREFIX}/include"
-export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib"
-export CXXFLAGS="${CXXFLAGS} -O3"
-
-case $(uname -m) in
-    aarch64)
-	export CXXFLAGS="${CXXFLAGS} -march=armv8-a"
-	;;
-    arm64)
-	export CXXFLAGS="${CXXFLAGS} -march=armv8.4-a"
-	;;
-    x86_64)
-	export CXXFLAGS="${CXXFLAGS} -march=x86-64-v3"
-	;;
-esac
-
-if [[ `uname -s` == "Darwin" ]]; then
-	export CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
-fi
-
-cd $falco
-
-autoreconf -if
-./configure --prefix="$falco" \
-  CXX="${CXX}" CXXFLAGS="${CXXFLAGS}" \
-  LDFLAGS="${LDFLAGS}" CPPFLAGS="${CPPFLAGS}" \
-  --enable-hts --disable-option-checking \
-  --enable-silent-rules --disable-dependency-tracking
-
-make clean
-
-make CXXFLAGS="${CXXFLAGS}" -j"${CPU_COUNT}";
-make install
-
-for i in $(ls -1 | grep -v Configuration | grep -v bin);
-do
-  rm -rf ${i};
-done
-
-install -v -m 0755 $falco/bin/falco "$PREFIX/bin"
+cmake --build build -j"${CPU_COUNT}"
+cmake --install build

--- a/recipes/falco/meta.yaml
+++ b/recipes/falco/meta.yaml
@@ -10,6 +10,7 @@ source:
 
 build:
   number: 0
+  skip: True
   run_exports:
     - {{ pin_subpackage('falco', max_pin="x.x") }}
 
@@ -42,7 +43,6 @@ about:
 extra:
   additional-platforms:
     - linux-aarch64
-    - osx-arm64
   recipe-maintainers:
     - andrewdavidsmith
     - guilhermesena1

--- a/recipes/falco/meta.yaml
+++ b/recipes/falco/meta.yaml
@@ -1,43 +1,39 @@
-{% set version = "1.3.2" %}
+{% set version = "2.0.1" %}
 
 package:
   name: falco
   version: {{ version }}
 
 source:
-  url: https://github.com/smithlabcode/falco/releases/download/v{{ version }}/falco-{{ version }}.tar.gz
-  sha256: d8dbc7d98d1aafdbf8199f8df3d7f76503a4f6a8924a151c953eb23dd47d44a0
+  url: https://github.com/smithlabcode/falco/releases/download/v{{ version }}/falco-{{ version }}-Source.tar.gz
+  sha256: efa42486923c0ae754d2b4fa1313b6e88dbc65bebde00af828e970a31af362ff
 
 build:
   number: 0
   run_exports:
-    # falco is currently not intended to be stable between minor versions (x.x).
     - {{ pin_subpackage('falco', max_pin="x.x") }}
 
 requirements:
   build:
-    - make
     - {{ stdlib('c') }}
     - {{ compiler('cxx') }}
-    - pkg-config
-    - autoconf
-    - automake
-    - libtool
-    - gnuconfig
+    - cmake >=3.30
+    - make
   host:
     - zlib
-    - htslib
+    - libdeflate
+    - htslib >=1.18
   run:
-    - htslib
 
 test:
   commands:
-    - falco
+    - falco --help
+    - falco --version
 
 about:
   home: "https://github.com/smithlabcode/falco"
-  license: "GPL-3.0-only"
-  license_family: GPL3
+  license: "MIT"
+  license_family: MIT
   license_file: LICENSE
   summary: "falco is a drop-in C++ implementation of FastQC to assess the quality of sequence reads."
   doc_url: "https://falco.readthedocs.io"


### PR DESCRIPTION
## Update falco to 2.0.1

- updated source url
- switched from `autotools` to `cmake`
- added `libdeflate` dependency
- changed license from GPL-3.0 to MIT.