### PR TITLE
Add recipe for glyco-csdb2snfg version 0.1.0

### DIFF
--- a/recipes/glyco-csdb2snfg/meta.yaml
+++ b/recipes/glyco-csdb2snfg/meta.yaml
@@ -10,6 +10,8 @@ build:
   noarch: python
   number: 0
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+  run_exports:
+    - {{ pin_subpackage("glyco-csdb2snfg", max_pin="x.x") }}
 
 requirements:
   host:
@@ -19,7 +21,7 @@ requirements:
   run:
     - python >=3.8
     - numpy >=1.21
-    - matplotlib >=3.5
+    - matplotlib-base >=3.5
     - python-pptx >=0.6.21
 
 test:

--- a/recipes/glyco-csdb2snfg/meta.yaml
+++ b/recipes/glyco-csdb2snfg/meta.yaml
@@ -1,0 +1,35 @@
+package:
+  name: glyco-csdb2snfg
+  version: "0.1.0"
+
+source:
+  url: https://pypi.io/packages/source/g/glyco-csdb2snfg/glyco_csdb2snfg-0.1.0.tar.gz
+  sha256: 966f476760db502110b23b172220fa794c42f7aabe9b4b6a61c1e332e546ad47
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+
+requirements:
+  host:
+    - python >=3.8
+    - pip
+    - setuptools
+  run:
+    - python >=3.8
+    - numpy >=1.21
+    - matplotlib >=3.5
+    - python-pptx >=0.6.21
+
+test:
+  imports:
+    - csdb2snfg
+  commands:
+    - csdb2snfg --help
+
+about:
+  home: https://github.com/sosyphe/glyco-csdb2snfg
+  license: MIT
+  license_file: LICENSE
+  summary: "A Python parser for converting Glyco CSDB format to SNFG drawings"


### PR DESCRIPTION
Add recipe for `glyco-csdb2snfg` (v0.1.0), a Python parser for converting Glyco CSDB format to SNFG drawings.

- PyPI: https://pypi.org/project/glyco-csdb2snfg/
- License: MIT