### PR TITLE
Add LongAIRR 1.1.0

### DIFF
--- a/recipes/longairr/build.sh
+++ b/recipes/longairr/build.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+share_dir="${PREFIX}/share/longairr"
+script_dir="${share_dir}/longairr_scripts"
+
+mkdir -p "${PREFIX}/bin" "${share_dir}/docs/images_design/images"
+
+install -m 0644 README.md "${share_dir}/README.md"
+install -m 0644 LICENSE "${share_dir}/LICENSE"
+install -m 0755 install.sh "${share_dir}/install.sh"
+
+cp -R longairr_scripts "${share_dir}/"
+cp -R longairr_example_workflow "${share_dir}/"
+
+install -m 0644 \
+  docs/images_design/images/longairr_logo_small.png \
+  "${share_dir}/docs/images_design/images/longairr_logo_small.png"
+install -m 0644 \
+  docs/images_design/images/longairr_profiling_overview.png \
+  "${share_dir}/docs/images_design/images/longairr_profiling_overview.png"
+
+find "${script_dir}" -maxdepth 1 -type f -exec chmod 0755 {} +
+find "${script_dir}/db_scripts" -maxdepth 1 -type f ! -name LICENSE -exec chmod 0755 {} +
+
+install -m 0755 "${RECIPE_DIR}/longairr_wrapper.sh" "${PREFIX}/bin/longairr"
+install -m 0755 "${RECIPE_DIR}/longairr_setup.sh" "${PREFIX}/bin/longairr-setup"

--- a/recipes/longairr/longairr_setup.sh
+++ b/recipes/longairr/longairr_setup.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+prefix="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+share_dir="${prefix}/share/longairr"
+setup_dir="$(mktemp -d "${TMPDIR:-/tmp}/longairr-setup.XXXXXXXX")"
+
+cleanup() {
+  rm -rf "${setup_dir}"
+}
+trap cleanup EXIT
+
+install -m 0755 "${share_dir}/install.sh" "${setup_dir}/install.sh"
+cp -R "${share_dir}/longairr_scripts" "${setup_dir}/longairr_scripts"
+
+if [[ $# -eq 0 ]]; then
+  set -- --help
+fi
+
+cd "${setup_dir}"
+
+bash ./install.sh \
+  "$@" \
+  --env FALSE \
+  --scripts-dir ./longairr_scripts/
+ 

--- a/recipes/longairr/longairr_wrapper.sh
+++ b/recipes/longairr/longairr_wrapper.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+prefix="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+share_dir="${prefix}/share/longairr"
+script_dir="${share_dir}/longairr_scripts"
+
+export PATH="${script_dir}:${PATH}"
+export LONGAIRR_LOGO="${share_dir}/docs/images_design/images/longairr_logo_small.png"
+
+exec bash "${script_dir}/longairr.sh" "$@"

--- a/recipes/longairr/meta.yaml
+++ b/recipes/longairr/meta.yaml
@@ -1,0 +1,100 @@
+{% set name = "longairr" %}
+{% set version = "1.1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/AGImkeller/LongAIRR/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 10045d1688e6a5d78720863d26ece56e118540451ce686aa503c3b16ff6ad687
+
+build:
+  number: 0
+  noarch: generic
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x") }}
+
+requirements:
+  run:
+    - python 3.10.0.*
+    - biopython 1.83.*
+    - blast 2.16.0.*
+    - igblast 1.22.0.*
+    - muscle 3.8.1551.*
+    - nanoget 1.19.3.*
+    - nanoplot 1.44.1.*
+    - numpy 1.24.4.*
+    - pandas 2.0.3.*
+    - presto 0.7.5.*
+    - samtools 1.21.*
+    - scipy 1.10.1.*
+    - seqkit 2.9.0.*
+    - snakemake 7.32.4.*
+    - vsearch 2.30.0.*
+    - pysam 0.22.*
+    - pyyaml 6.0.2.*
+    - pyarrow 17.0.0.*
+    - airr 1.5.1.*
+    - changeo 1.3.3.*
+    - bash
+    - coreutils
+    - curl
+    - gawk
+    - grep
+    - sed
+    - tar
+    - wget
+
+test:
+  commands:
+    - longairr --version
+    - longairr --help
+    - longairr basecall --help
+    - longairr filter --help
+    - longairr demux --help
+    - longairr collapse --help
+    - longairr seqtag --help
+    - longairr airr --help
+    - longairr report --help
+    - longairr-setup --help
+    - test -f "$PREFIX/share/longairr/README.md"
+    - test -f "$PREFIX/share/longairr/docs/images_design/images/longairr_logo_small.png"
+    - test -f "$PREFIX/share/longairr/docs/images_design/images/longairr_profiling_overview.png"
+    - test -f "$PREFIX/share/longairr/longairr_scripts/db_scripts/LICENSE"
+    - test -f "$PREFIX/share/longairr/longairr_example_workflow/snakemake/visium/snakefile_visium_hd"
+    - test -f "$PREFIX/share/longairr/longairr_example_workflow/snakemake/takara/snakefile_takara"
+    - test -f "$PREFIX/share/longairr/longairr_example_workflow/example_inputs/datasets/visium_v1_demo/basecall/demo_airr.fastq"
+
+about:
+  home: https://github.com/AGImkeller/LongAIRR
+  doc_url: https://longairr.readthedocs.io/en/latest/
+  dev_url: https://github.com/AGImkeller/LongAIRR
+  license: Apache-2.0 AND AGPL-3.0-only
+  license_file:
+    - LICENSE
+    - longairr_scripts/db_scripts/LICENSE
+  summary: Long-read adaptive immune receptor repertoire processing and annotation
+  description: |
+    LongAIRR is a modular command-line framework for processing and annotating
+    full-length adaptive immune receptor repertoire sequences from long-read
+    bulk and spatial transcriptomics libraries. It supports Oxford Nanopore
+    Technologies and PacBio HiFi data and produces AIRR-compliant output.
+
+extra:
+  notes: |
+    Set up IgBLAST and IMGT references after installation with, for example:
+
+      longairr-setup --fetch-db TRUE --save-db /path/to/references/ --species human
+
+    Dorado is required only for `longairr basecall` and may be installed with:
+
+      longairr-setup --dorado TRUE
+
+    Copy the bundled example workflows into a writable working directory with:
+
+      cp -r "$CONDA_PREFIX/share/longairr/longairr_example_workflow" ./longairr_example_workflow
+
+    Documentation: https://longairr.readthedocs.io/en/latest/
+  recipe-maintainers:
+    - Jonas-Schuck


### PR DESCRIPTION
Adds Bioconda recipe for LongAIRR v1.1.0.

LongAIRR is a modular command-line framework for processing and annotating full-length adaptive immune receptor repertoire (AIRR) sequences from Oxford Nanopore Technologies and PacBio HiFi bulk and spatial transcriptomics libraries.

Upstream: https://github.com/AGImkeller/LongAIRR
Documentation: https://longairr.readthedocs.io/en/stable/
License: Apache-2.0 AND AGPL-3.0-only

LongAIRR is distributed under Apache-2.0, while two modified database scripts derived from the Immcantation project remain licensed under AGPL-3.0-only.

---