### PR TITLE
Update grz-tools recipes: grz-check, grz-check-python, grz-common, grz-db, grz-cli, grzctl

### DIFF
--- a/recipes/grz-check-python/meta.yaml
+++ b/recipes/grz-check-python/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "0.3.1" %}
-{% set sha256 = "48795ee9eb6e89e49ea99a89ae42110814c3bbddf60de9fc0111a609e9b13f2b" %}
+{% set version = "0.4.0" %}
+{% set sha256 = "447f4aad9c9df09bd182877629109bf0843151918b641ec30baf2fa7eff6d7ec" %}
 
 package:
   name: grz-check-python

--- a/recipes/grz-check/meta.yaml
+++ b/recipes/grz-check/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "0.3.1" %}
-{% set sha256 = "48795ee9eb6e89e49ea99a89ae42110814c3bbddf60de9fc0111a609e9b13f2b" %}
+{% set version = "0.4.0" %}
+{% set sha256 = "447f4aad9c9df09bd182877629109bf0843151918b641ec30baf2fa7eff6d7ec" %}
 
 package:
   name: grz-check

--- a/recipes/grz-cli/meta.yaml
+++ b/recipes/grz-cli/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "grz-cli" %}
-{% set version = "1.7.2" %}
+{% set version = "1.8.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/grz_cli-{{ version }}.tar.gz
-  sha256: c719b902b79e7f25e2917349ee849a1f2db5290e7c042a1dc7998c89f0ea3fb5
+  sha256: 5027f9f4439d16a7cb141daf8a9faf5dd623f6693e10ebef5925fd8c9cbcf016
 
 build:
   entry_points:

--- a/recipes/grz-cli/meta.yaml
+++ b/recipes/grz-cli/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "grz-cli" %}
-{% set version = "1.8.0" %}
+{% set version = "2.0.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/grz_cli-{{ version }}.tar.gz
-  sha256: 5027f9f4439d16a7cb141daf8a9faf5dd623f6693e10ebef5925fd8c9cbcf016
+  sha256: d1b50dc72864d6179b68d9a20dd69363206dc94832b50331f861ffa214232080
 
 build:
   entry_points:
@@ -26,7 +26,7 @@ requirements:
   run:
     - python >=3.12
     - packaging >=23,<27
-    - grz-common >=2.1,<3
+    - grz-common >=3,<4
 
 test:
   imports:

--- a/recipes/grz-common/meta.yaml
+++ b/recipes/grz-common/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "grz-common" %}
-{% set version = "2.1.0" %}
+{% set version = "3.0.0" %}
 
 package:
   name: {{ name }}
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/grz_common-{{ version }}.tar.gz
-  sha256: 67ffe695313f22d79fa6945895e3cf9eb1a7c1f672f4b51f84bd0106854cd32c
+  sha256: b912d89be9009d768ae14473586ac0836fd46ba18373a0a3a97f5734e6af780f
 
 build:
-  number: 1
+  number: 0
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --no-cache-dir -vvv
   run_exports:

--- a/recipes/grz-common/meta.yaml
+++ b/recipes/grz-common/meta.yaml
@@ -24,6 +24,7 @@ requirements:
   run:
     - python >=3.12
     - boto3 >=1.36,<2
+    - botocore >=1.36,<2
     - click >=8.2,<9
     - python-crypt4gh >=1.8.6,<2
     - cryptography >=45.0.3,<49
@@ -31,10 +32,10 @@ requirements:
     - pyyaml >=6.0.2,<7
     - tqdm >=4.66.5,<5
     - pydantic >=2.12,<3
-    - pydantic-settings >=2.11,<3
+    - pydantic-settings >=2.11.0,<3
     - platformdirs >=4.3.6,<5
-    - grz-pydantic-models >=2.7,<3
-    - grz-check-python >=0.3.1,<1
+    - grz-pydantic-models >=3,<4
+    - grz-check-python >=0.3.1
 
 test:
   imports:

--- a/recipes/grz-db/meta.yaml
+++ b/recipes/grz-db/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "grz-db" %}
-{% set version = "2.1.2" %}
+{% set version = "3.0.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,12 +7,12 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/grz_db-{{ version }}.tar.gz
-  sha256: 4631ab7749c4f20c9b68140693979cd3e24c2a5f92f0c4d19ab7d52f1c23c368
+  sha256: 4c2790778e19d11f1bd64877456b42f7c4d6c52cad1b4a6abaf789554cccb5d9
 
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 1
+  number: 0
   run_exports:
     - {{ pin_subpackage(name, max_pin="x.x") }}
 

--- a/recipes/grz-db/meta.yaml
+++ b/recipes/grz-db/meta.yaml
@@ -22,10 +22,11 @@ requirements:
     - hatchling
     - pip
   run:
+    - python >=3.12
     - alembic >=1.16.1
     - cryptography >=45.0.3,<49
-    - sqlmodel >=0.0.27
-    - grz-pydantic-models >=2.7,<3
+    - sqlmodel >=0.0.38
+    - grz-pydantic-models >=3,<4
     - psycopg >=3.2,<4
 
 test:

--- a/recipes/grzctl/meta.yaml
+++ b/recipes/grzctl/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "grzctl" %}
-{% set version = "2.1.4" %}
+{% set version = "3.0.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/grzctl-{{ version }}.tar.gz
-  sha256: a001b0837d14a815a933164fcc176e2a466a32012e987a00546821009b9b7444
+  sha256: 700f88bb47b7391e2b78bfe413adfff6cfb9989a891afa1d2999d6ade049a730
 
 build:
   number: 0

--- a/recipes/grzctl/meta.yaml
+++ b/recipes/grzctl/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "grzctl" %}
-{% set version = "3.0.0" %}
+{% set version = "4.0.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/grzctl-{{ version }}.tar.gz
-  sha256: 700f88bb47b7391e2b78bfe413adfff6cfb9989a891afa1d2999d6ade049a730
+  sha256: 119a26f187ab9eaebf810a357fa4355b69ebd3bc2ddcb07b29f1e7922f4e1901
 
 build:
   number: 0
@@ -26,8 +26,8 @@ requirements:
   run:
     - python >=3.12
     - requests >=2.32.3,<3
-    - grz-db >=2.1.2,<3
-    - grz-cli >=1.7,<2
+    - grz-db >=3,<4
+    - grz-cli >=2,<3
     - textual >=5.3,<6
 
 test:


### PR DESCRIPTION
Updates the six interdependent `grz-tools` recipes to the versions released upstream on 2026-08-13, and corrects several run dependencies that had drifted from the metadata the packages actually publish.

| recipe | from | to |
| --- | --- | --- |
| grz-check | 0.3.1 | 0.4.0 |
| grz-check-python | 0.3.1 | 0.4.0 |
| grz-common | 2.1.0 | 3.0.0 |
| grz-db | 2.1.2 | 3.0.0 |
| grz-cli | 1.7.2 | 2.0.0 |
| grzctl | 2.1.4 | 4.0.0 |

All `sha256` values were verified against the PyPI sdists and the GitHub release tarball. Build numbers reset to 0 for `grz-common` and `grz-db`; the other four were already at 0 under their previous versions.


### Dependency corrections beyond the version bumps

The autobump PRs updated only `version` and `sha256`, leaving the run dependencies at their previous values. These were re-synced against the published metadata of each new release:

**grz-common**
* `grz-pydantic-models >=2.7,<3` → `>=3,<4`
* added `botocore >=1.36,<2`, a direct dependency upstream that the recipe never listed (previously satisfied only transitively via `boto3`)
* dropped the `<1` upper bound on `grz-check-python`; upstream declares none
* `pydantic-settings >=2.11,<3` → `>=2.11.0,<3` to match upstream exactly

**grz-db**
* `grz-pydantic-models >=2.7,<3` → `>=3,<4`
* `sqlmodel >=0.0.27` → `>=0.0.38`; upstream has required `>=0.0.38` since 2.1.2, so the recipe was already behind before this release
* added `python >=3.12`, which was missing from `run:` on a `noarch: python` recipe (upstream `requires-python = ">=3.12,<4.0"`)

**grz-cli**
* `grz-common >=2.1,<3` → `>=3,<4`

**grzctl**
* `grz-db >=2.1.2,<3` → `>=3,<4`
* `grz-cli >=1.7,<2` → `>=2,<3`

### run_exports

All six recipes already declare `run_exports` and this PR does not change them:

| recipe | run_exports |
| --- | --- |
| grz-check | `{{ pin_subpackage("grz-check", max_pin="x.x") }}` |
| grz-check-python | `{{ pin_subpackage("grz-check-python", max_pin="x.x") }}` |
| grz-common | `{{ pin_subpackage(name, max_pin="x") }}` |
| grz-db | `{{ pin_subpackage(name, max_pin="x.x") }}` |
| grz-cli | `{{ pin_subpackage(name, max_pin="x") }}` |
| grzctl | `{{ pin_subpackage(name, max_pin="x.x") }}` |

### Supersedes

Replaces the individual autobump PRs, which cannot be merged as-is because their dependency constraints resolve the old 2.x libraries:

* #68122 (grz-check 0.4.0)
* #68125 (grz-check-python 0.4.0)
* #68123 (grz-common 3.0.0)
* #68119 (grz-db 3.0.0)
* #68121 (grz-cli 1.8.0, superseded by 2.0.0)
* #68120 (grzctl 3.0.0, superseded by 4.0.0)

`grz-cli` 1.8.0 and `grzctl` 3.0.0 still declared bounds that pinned the pre-3.0.0 libraries, so they would have shipped without the behaviour changes their release notes describe. That was fixed upstream in `grz-cli` 2.0.0 and `grzctl` 4.0.0, which is why this PR targets those versions rather than the ones the bot picked up.
