### PR TITLE
Add cyto 0.4.6

### DIFF
--- a/recipes/cyto/build.sh
+++ b/recipes/cyto/build.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-RUST_BACKTRACE=1 cargo install --no-track --verbose --root "${PREFIX}" --path crates/cyto
+cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
+
+RUST_BACKTRACE=1
+cargo install --no-track --verbose --root "${PREFIX}" --path crates/cyto

--- a/recipes/cyto/build.sh
+++ b/recipes/cyto/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euo pipefail
+
+RUST_BACKTRACE=1 cargo install --no-track --verbose --root "${PREFIX}" --path crates/cyto

--- a/recipes/cyto/meta.yaml
+++ b/recipes/cyto/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 0
   run_exports:
-    - {{ pin_subpackage("cyto", max_pin="x.x") }}
+    - {{ pin_subpackage('cyto', max_pin="x.x") }}
 
 requirements:
   build:
@@ -20,20 +20,23 @@ requirements:
     - {{ compiler("c") }}
     - {{ compiler("cxx") }}
     - {{ compiler("rust") }}
+    - cargo-bundle-licenses
     - cmake
     - make
+    - pkg-config
 
 test:
   commands:
     - cyto --help
 
 about:
-  home: https://github.com/arcinstitute/cyto
-  dev_url: https://github.com/arcinstitute/cyto
-  license: BSD-3-Clause
+  home: "https://github.com/arcinstitute/cyto"
+  dev_url: "https://github.com/arcinstitute/cyto"
+  license: "BSD-3-Clause"
   license_family: BSD
-  license_file: LICENSE.md
-  summary: Ultra high-throughput processing of 10x-flex single-cell sequencing data
+  license_file: "LICENSE.md"
+  summary: "Ultra high-throughput processing of 10x-flex single-cell sequencing data."
+  doc_url: "https://github.com/ArcInstitute/cyto/blob/{{ tag }}/README.md"
 
 extra:
   additional-platforms:

--- a/recipes/cyto/meta.yaml
+++ b/recipes/cyto/meta.yaml
@@ -1,0 +1,42 @@
+{% set version = "0.4.6" %}
+{% set tag = "cyto-" + version %}
+
+package:
+  name: cyto
+  version: {{ version }}
+
+source:
+  url: https://github.com/arcinstitute/cyto/archive/refs/tags/{{ tag }}.tar.gz
+  sha256: e0f780cbeb3370689c356ee019c697e3332a47e90ebf56780d41e1d2a7f08118
+
+build:
+  number: 0
+  run_exports:
+    - {{ pin_subpackage("cyto", max_pin="x.x") }}
+
+requirements:
+  build:
+    - {{ compiler("c") }}
+    - {{ compiler("cxx") }}
+    - {{ compiler("rust") }}
+    - cmake
+    - make
+
+test:
+  commands:
+    - cyto --help
+
+about:
+  home: https://github.com/arcinstitute/cyto
+  dev_url: https://github.com/arcinstitute/cyto
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE.md
+  summary: Ultra high-throughput processing of 10x-flex single-cell sequencing data
+
+extra:
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64
+  recipe-maintainers:
+    - mjsteinbaugh

--- a/recipes/cyto/meta.yaml
+++ b/recipes/cyto/meta.yaml
@@ -16,6 +16,7 @@ build:
 
 requirements:
   build:
+    - {{ stdlib("c") }}
     - {{ compiler("c") }}
     - {{ compiler("cxx") }}
     - {{ compiler("rust") }}

--- a/recipes/cyto/meta.yaml
+++ b/recipes/cyto/meta.yaml
@@ -40,3 +40,4 @@ extra:
     - osx-arm64
   recipe-maintainers:
     - mjsteinbaugh
+    - noamteyssier

--- a/recipes/cyto/meta.yaml
+++ b/recipes/cyto/meta.yaml
@@ -45,3 +45,5 @@ extra:
   recipe-maintainers:
     - mjsteinbaugh
     - noamteyssier
+  identifiers:
+    - doi:10.64898/2026.01.21.700936


### PR DESCRIPTION
Adds a recipe for [cyto](https://github.com/arcinstitute/cyto), a high-throughput Rust CLI for processing 10x Genomics Flex single-cell sequencing data (barcode correction, UMI deduplication, and pipeline components for probe/Flex experiments).

Closes arcinstitute/cyto#205.

- Builds from the GitHub tag archive (`cyto-0.4.6`), not the crates.io tarball, since `crates/cyto` is a workspace member and the crates.io per-crate package doesn't bundle `LICENSE.md` or resolve its sibling `cyto-*` crates via local paths.
- `cmake` + C/C++ compilers are required because `cyto-download` pulls in `reqwest` 0.13, whose default TLS backend (rustls + aws-lc-rs) needs cmake to build `aws-lc-sys`.
- No `--locked`: the repo doesn't commit a `Cargo.lock` (only the published crates.io packages get one auto-generated at publish time), matching the pattern used by other cmake+rust bioconda recipes (e.g. `gfaffix`, `paf2chain`, `cyrcular`).

cc @noamteyssier, listed as co-maintainer as the upstream author.