### PR TITLE
Add pyrho and ldpop recipes

### DIFF
--- a/recipes/ldpop/meta.yaml
+++ b/recipes/ldpop/meta.yaml
@@ -1,0 +1,47 @@
+{% set name = "ldpop" %}
+{% set version = "1.0.2" %}
+{% set commit = "cceed0150194ea8bf3415aa9bf3ee002e6b6e480" %}
+{% set sha256 = "c8b6aff543bf3b588ab2bd8b40f83fd9053ecee6594e5d01320bec28995ac966" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/popgenmethods/{{ name }}/archive/{{ commit }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  run_exports:
+    - {{ pin_subpackage('ldpop', max_pin='x') }}
+
+requirements:
+  host:
+    - python >=3.8
+    - pip
+    - setuptools
+  run:
+    - python >=3.8
+    - numpy
+    - scipy >=1.0.0
+    - pandas
+    - future
+
+test:
+  imports:
+    - ldpop
+
+about:
+  home: https://github.com/popgenmethods/ldpop
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: Two-locus sampling probability for variable population size
+  dev_url: https://github.com/popgenmethods/ldpop
+
+extra:
+  recipe-maintainers:
+    - d-callan

--- a/recipes/pyrho/meta.yaml
+++ b/recipes/pyrho/meta.yaml
@@ -1,0 +1,59 @@
+{% set name = "pyrho" %}
+{% set version = "0.2.1" %}
+{% set commit = "fe7d1cfe1e5b10bee1f1d0828dbf1dc5391d9888" %}
+{% set sha256 = "84d074c18af4e6ced0be85a3e0053d245db89c3ca7e1f7d0e1e6bd14e3a76417" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/popgenmethods/{{ name }}/archive/{{ commit }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  noarch: python
+  entry_points:
+    - pyrho = pyrho.frontend:main
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  run_exports:
+    - {{ pin_subpackage('pyrho', max_pin='x.x') }}
+
+requirements:
+  host:
+    - python >=3.8
+    - pip
+    - setuptools
+  run:
+    - python >=3.8
+    - numpy >=1.14.2
+    - scipy >=1.0.0
+    - msprime >=0.7.0,<1.0
+    - numba >=0.47.0
+    - pandas >=0.23.4
+    - pytables >=3.3.0
+    - cyvcf2 >=0.10.9
+    - ldpop
+    - importlib_resources
+
+test:
+  imports:
+    - pyrho
+  commands:
+    - pyrho --help
+
+about:
+  home: https://github.com/popgenmethods/pyrho
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE.txt
+  summary: Fast inference of fine-scale recombination rates using fused-LASSO
+  dev_url: https://github.com/popgenmethods/pyrho
+  doc_url: https://github.com/popgenmethods/pyrho#readme
+
+extra:
+  recipe-maintainers:
+    - d-callan
+  identifiers:
+    - doi:10.1126/sciadv.aaw9206


### PR DESCRIPTION
was trying to add pyrho and realized it had ldpop dep along the way

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
