### PR TITLE
Update Locityper to v1.7.2

### DIFF
--- a/recipes/locityper/meta.yaml
+++ b/recipes/locityper/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "locityper" %}
-{% set version = "1.7.0" %}
+{% set version = "1.7.2" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/tprodanov/locityper/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 479e2f910b749e28007474845743acb08e6dec72fef157fa23691ef1c541f17a
+  sha256: 6998d0918c1c45b4f0fb675c1d92f5793bba2c0da6b5b8cb6538f3d0827cd1b0
 
 build:
   number: 0


### PR DESCRIPTION
Manual update since [autobump](https://github.com/bioconda/bioconda-recipes/pull/68089) ran into some issues.