### PR TITLE
Update cuttlefish to 3.0.0

### DIFF
--- a/recipes/cuttlefish/build.sh
+++ b/recipes/cuttlefish/build.sh
@@ -1,40 +1,7 @@
-#!/bin/bash
+#!/bin/bash -euo
 
-export INCLUDES="-I${PREFIX}/include"
-export LIBPATH="-L${PREFIX}/lib"
-export CPPFLAGS="${CPPFLAGS} -I${PREFIX}/include"
-export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib"
-export CFLAGS="${CFLAGS} -O3"
-export CXXFLAGS="${CXXFLAGS} -O3"
-# It's dumb and absurd that the KMC build can't find the bzip2 header <bzlib.h>
-export C_INCLUDE_PATH="${PREFIX}/include"
-export CPLUS_INCLUDE_PATH="${PREFIX}/include"
-
-case $(uname -m) in
-    aarch64)
-	export CXXFLAGS="${CXXFLAGS} -march=armv8-a"
-	;;
-    arm64)
-	export CXXFLAGS="${CXXFLAGS} -march=armv8.4-a"
-	;;
-    x86_64)
-	export CXXFLAGS="${CXXFLAGS} -march=x86-64-v3"
-	;;
-esac
-
-if [[ `uname -s` == 'Darwin' ]]; then
-	export MACOSX_DEPLOYMENT_TARGET='11.0'
-	export CONFIG_ARGS="-DCMAKE_FIND_FRAMEWORK=NEVER -DCMAKE_FIND_APPBUNDLE=NEVER"
-else
-	export CONFIG_ARGS=""
-fi
-
-cmake -S . -B build -DCMAKE_BUILD_TYPE=Release \
-	-DCMAKE_INSTALL_PREFIX="${PREFIX}" \
-	-DCMAKE_CXX_COMPILER="${CXX}" -DCMAKE_C_COMPILER="${CC}" \
-	-DCMAKE_CXX_FLAGS="${CXXFLAGS}" -DCMAKE_C_FLAGS="${CFLAGS}" \
-	-DINSTANCE_COUNT=64 -DCONDA_BUILD=ON \
-	-Wno-dev -Wno-deprecated --no-warn-unused-cli \
-	"${CONFIG_ARGS}"
-
-cmake --build build/ --clean-first --target install -j "${CPU_COUNT}"
+# Build and install the cuttlefish binary from the Rust workspace. The CLI
+# crate carries the `cuttlefish` binary; --locked holds the checked-in
+# Cargo.lock, and --no-track skips cargo's install metadata, which does not
+# belong in a conda package.
+cargo install --locked --no-track --root "${PREFIX}" --path crates/cuttlefish-rs-cli

--- a/recipes/cuttlefish/conda_build_config.yaml
+++ b/recipes/cuttlefish/conda_build_config.yaml
@@ -1,6 +1,0 @@
-cxx_compiler_version:
-  - 12  # [linux]
-  - 16  # [osx]
-c_compiler_version:
-  - 12  # [linux]
-  - 16  # [osx]

--- a/recipes/cuttlefish/meta.yaml
+++ b/recipes/cuttlefish/meta.yaml
@@ -1,30 +1,26 @@
 {% set name = "cuttlefish" %}
-{% set version = "2.2.0" %}
+{% set version = "3.0.0" %}
 
 package:
   name: {{ name }}
   version: {{ version }}
 
 build:
-  number: 5
+  number: 0
+  # Cuttlefish's major version tracks the product generation: a
+  # backward-incompatible change bumps the minor version, so pin to x.x.
   run_exports:
-    - {{ pin_subpackage('cuttlefish', max_pin="x") }}
+    - {{ pin_subpackage('cuttlefish', max_pin="x.x") }}
 
 source:
   url: https://github.com/COMBINE-lab/cuttlefish/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: d524aaeed5dd86ce256c5540661eda388cecbfad2ce4dde86e52539b2b1d6ed5
+  sha256: 8a6df5044d5daf26d2e728f74b4d0b241ae38e5c9bc76b4513e68b9b60d7cf78
 
 requirements:
   build:
-    - cmake >=3.14.0
+    - rust >=1.91
+    - {{ compiler('c') }}  # jemalloc-sys compiles jemalloc from source
     - make
-    - {{ compiler('cxx') }}
-    - {{ compiler('c') }}
-    - pkg-config
-  host:
-    - jemalloc >=5.1.0
-    - zlib
-    - bzip2
 
 test:
   commands:
@@ -37,17 +33,19 @@ about:
   license: "BSD-3-Clause"
   license_family: BSD
   license_file: LICENSE
-  summary: "Construction of the compacted de Bruijn graph efficiently."
+  summary: "Construction of the (colored) compacted de Bruijn graph efficiently."
   dev_url: "https://github.com/COMBINE-lab/cuttlefish"
-  doc_url: "https://github.com/COMBINE-lab/cuttlefish/blob/v{{ version }}/README.md"
+  doc_url: "https://combine-lab.github.io/cuttlefish/"
 
 extra:
   additional-platforms:
     - osx-arm64
+    - linux-aarch64
   recipe-maintainers:
     - jamshed
     - rob-p
   identifiers:
     - doi:10.1093/bioinformatics/btab309
     - doi:10.1186/s13059-022-02743-6
+    - doi:10.1101/2025.02.02.636161
     - biotools:cuttlefish

--- a/recipes/cuttlefish/meta.yaml
+++ b/recipes/cuttlefish/meta.yaml
@@ -18,8 +18,9 @@ source:
 
 requirements:
   build:
-    - rust >=1.91
+    - {{ compiler('rust') }}
     - {{ compiler('c') }}  # jemalloc-sys compiles jemalloc from source
+    - {{ stdlib('c') }}
     - make
 
 test:


### PR DESCRIPTION
## Update cuttlefish 2.2.0 → 3.0.0

Cuttlefish 3.0.0 is the new major release of [Cuttlefish](https://github.com/COMBINE-lab/cuttlefish): a ground-up Rust implementation of the Cuttlefish 3 algorithm ([RECOMB 2026 proceedings paper; preprint on bioRxiv](https://doi.org/10.1101/2025.02.02.636161)), constructing uncolored and colored compacted de Bruijn graphs from reference sequences or sequencing reads in external memory. It succeeds the C++ Cuttlefish 1/2 line, which remains available on the repository's `cuttlefish-1-2` branch.

Recipe changes:
- `version` 2.2.0 → 3.0.0, `build.number` reset to 0, new `sha256`
- The cmake + jemalloc/zlib/bzip2 build is replaced by a Rust toolchain build (`cargo install --locked`); the C compiler stays for `jemalloc-sys`, and the stale C++ compiler pins in `conda_build_config.yaml` are dropped
- `run_exports` pin tightened to `max_pin="x.x"`: upstream's major version tracks the product generation, so backward-incompatible changes bump the **minor** version
- `linux-aarch64` added alongside `osx-arm64` (upstream now ships and tests both)
- Docs URL now points at <https://combine-lab.github.io/cuttlefish/>

Maintainer note: I am a recipe maintainer (@rob-p) and the upstream author.

---

* [x] I have read the [guidelines for bioconda recipes](https://bioconda.github.io/contributor/guidelines.html).
* [x] This PR updates an existing recipe.
