### PR TITLE
Update get_mnv to 1.1.5

### DIFF
--- a/recipes/get_mnv/meta.yaml
+++ b/recipes/get_mnv/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "get_mnv" %}
-{% set version = "1.1.4" %}
-{% set sha256 = "482f3d0c4cb41134c37559c0b7cf9b9a6076a8075930804a13a64752c19ff0ec" %}
+{% set version = "1.1.5" %}
+{% set sha256 = "6134aff29a506c07e2efa6fdf7f90102712ed5b0f46d6042e9628bf704fe47d8" %}
 
 package:
   name: "{{ name|lower }}"
   version: "{{ version }}"
 
 source:
-  url: "https://github.com/PathoGenOmics-Lab/{{ name }}/archive/refs/tags/{{ version }}.tar.gz"
+  url: "https://github.com/PathoGenOmics-Lab/get_MNV/archive/refs/tags/{{ version }}.tar.gz"
   sha256: "{{ sha256 }}"
 
 build:


### PR DESCRIPTION
Updates `get_mnv` to [1.1.5](https://github.com/PathoGenOmics-Lab/get_MNV/releases/tag/1.1.5).

Also fixes the source URL so that autobump can see this recipe at all. The URL was built from `{{ name }}`, which is `get_mnv`, but the repository is `get_MNV`. GitHub serves the tags page under either spelling, so the request succeeds and nothing errors, but the links on that page carry the canonical name, and `GithubTag` matches them case-sensitively:

| project in the pattern | tags found on the page |
|---|---|
| `get_mnv` | none |
| `get_MNV` | 1.1.5, 1.1.4, 1.1.3, 1.1.2, 1.1.1 |

That is why every update to this recipe so far has been opened by hand. The package name stays lowercase; only the URL now spells the repository as it is.

Checksum verified against the tarball the new URL serves:

```
6134aff29a506c07e2efa6fdf7f90102712ed5b0f46d6042e9628bf704fe47d8  get_mnv-1.1.5.tar.gz
```

No change to the build script, requirements or tests: the CLI is pure Rust and its dependencies are resolved from the lockfile in the tarball.