### PR TITLE
Add arsc 0.5.3

### DIFF
--- a/recipes/arsc/meta.yaml
+++ b/recipes/arsc/meta.yaml
@@ -13,6 +13,8 @@ build:
   number: 0
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x.x") }}
   entry_points:
     - arsc = ARSC.main:main
     - quickARSC = ARSC.main:main

--- a/recipes/arsc/meta.yaml
+++ b/recipes/arsc/meta.yaml
@@ -1,0 +1,47 @@
+{% set name = "arsc" %}
+{% set version = "0.5.3" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/a/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: cbe70d5390eeebf65a3a872f4cf567711d8e10ba38956ff81d754ea717429748
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  entry_points:
+    - arsc = ARSC.main:main
+    - quickARSC = ARSC.main:main
+
+requirements:
+  host:
+    - python >=3.8
+    - pip
+    - setuptools
+  run:
+    - python >=3.8
+    - biopython >=1.79
+    - prodigal >=2.6.3
+
+test:
+  imports:
+    - ARSC
+  commands:
+    - arsc --version
+    - quickARSC --version
+    - arsc --help
+    - prodigal -v
+
+about:
+  home: https://github.com/stsnsn/quickARSC
+  license: GPL-2.0-only
+  license_file: LICENSE
+  summary: Compute ARSC (N/C/S) from protein FASTA files
+
+extra:
+  recipe-maintainers:
+    - stsnsn


### PR DESCRIPTION
This PR adds quickARSC, a command-line tool for calculating nitrogen,
carbon, and sulfur content per amino-acid residue side chain from
protein or nucleotide FASTA files.

- Upstream: https://github.com/stsnsn/quickARSC
- PyPI: https://pypi.org/project/arsc/
- License: GPL-2.0-only
- Installs the `arsc` and `quickARSC` commands
- Includes Prodigal as a runtime dependency for nucleotide input
- Publication: *Microbiology Resource Announcements* (2026), https://doi.org/10.1128/mra.00031-26