### PR TITLE
Update Earl Grey ParTEA to v0.2.1, including modified dependencies

### DIFF
--- a/recipes/earlgrey-partea/meta.yaml
+++ b/recipes/earlgrey-partea/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "earlgrey-partea" %}
-{% set version = "0.2.0" %}
+{% set version = "0.2.1" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/TobyBaril/EarlGreyParTEA/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: be01122d6ab284b2c675f392e176c13a074afb6396b92e41b55d3de2fa856e39
+  sha256: 1ce55a053d259b058825f907f2ec736a3d17a5d0874227887f583dfc55d9fe6a
 
 build:
   number: 0
@@ -18,7 +18,7 @@ build:
 requirements:
   run:
     - python >=3.9,<3.13
-    - earlgrey >=7.1.0
+    - earlgrey >=7.3.1
     - snakemake-minimal >=9.0
     - snakemake-executor-plugin-slurm
     - snakemake-executor-plugin-lsf
@@ -28,7 +28,6 @@ requirements:
     - numpy
     - biopython
     - pandas
-    - busco >=5.4
     - mafft
     - clipkit
     - fasttree


### PR DESCRIPTION
This PR updates ParTEA to v0.2.1, including dependency modifications that are required to prevent unsatisfiable dependencies between BUSCO and RMBLAST. BUSCO is removed and now implemented within the snakemake workflow in v0.2.1, so the dependency is removed. In addition, the latest version requires Dfam 4.0, so Earl Grey 7.3.1 minimum is needed for correct function. 

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
