### PR TITLE
Update tesseract-assembler to 1.2.4

### DIFF
--- a/recipes/tesseract-assembler/build.sh
+++ b/recipes/tesseract-assembler/build.sh
@@ -6,5 +6,15 @@ set -euo pipefail
 make -j"${CPU_COUNT:-4}" CXX="${CXX:-g++}"
 
 mkdir -p "${PREFIX}/bin"
-install -m 0755 tessera "${PREFIX}/bin/tessera"
-install -m 0755 tessera-model "${PREFIX}/bin/tessera-model"
+install -m 0755 tesseract-asm "${PREFIX}/bin/tesseract-asm"
+install -m 0755 tesseract-model "${PREFIX}/bin/tesseract-model"
+
+# The Klebsiella runner ships too, as `tesseract-klebsiella`. Without it an installed package
+# is the assembler and nothing else: the user still has to find the release page, download a
+# 339 MB model by hand and work out the flags. The script finds the model, checks it and
+# assembles, which is the difference between "installed" and "usable".
+#
+# It resolves the assembler as $(dirname $0)/tesseract-asm, which in an installed tree is the
+# TesserACT sitting beside it -- so the installed copy uses the installed binary, not whatever
+# happens to be on PATH.
+install -m 0755 tesseract-klebsiella "${PREFIX}/bin/tesseract-klebsiella"

--- a/recipes/tesseract-assembler/meta.yaml
+++ b/recipes/tesseract-assembler/meta.yaml
@@ -1,9 +1,9 @@
 {% set name = "tesseract-assembler" %}
-{% set version = "1.2.2" %}
-{% set sha256 = "531deb558ec928ab14e67c447ed3c900f67e719609d63a1aadf5d39daa3b8584" %}
+{% set version = "1.2.4" %}
+{% set sha256 = "a7a2dfb86915cc94e00036c88aa28f22c0dc25c50fa5e4d8af9553d1bfc15efa" %}
 
 package:
-  name: {{ name }}
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
@@ -35,6 +35,8 @@ requirements:
     - make
   host:
     - zlib
+  run:
+    - zlib
   # --map-polish shells out to one of these. They are not needed to assemble, so they
   # constrain rather than depend: installing the package should not drag in an aligner.
   run_constrained:
@@ -43,13 +45,14 @@ requirements:
 
 test:
   commands:
-    - tessera --version
-    - tessera --help
-    - tessera-model --help
+    - tesseract-asm --version
+    - tesseract-asm --help
+    - tesseract-model --help
+    - tesseract-klebsiella --help
     # The flag checks live in run_test.sh, against help text captured to a file.
     #
-    # They were `tessera --help | grep -q -- --flag` and that is a race: grep -q exits on
-    # the first match and closes the pipe while tessera is still writing, tessera takes
+    # They were `tesseract-asm --help | grep -q -- --flag` and that is a race: grep -q exits on
+    # the first match and closes the pipe while TesserACT is still writing, TesserACT takes
     # SIGPIPE and exits 141, and under pipefail the pipeline fails. Whether it fails depends
     # on which flag matches soon enough to kill the writer first, so it passed here and on
     # ARM and failed on the Linux runner, on --model, with --model plainly present in the
@@ -61,11 +64,11 @@ test:
     - python
 
 about:
-  home: "https://github.com/iowa69/TesserACT"
+  home: https://github.com/iowa69/TesserACT
   license: MIT
   license_family: MIT
   license_file: LICENSE
-  summary: "De novo short-read assembler for bacterial isolates, with optional genus models."
+  summary: De novo short-read assembler for bacterial isolates, with optional genus models
   description: |
     TesserACT assembles bacterial isolates from paired-end Illumina reads. It builds a de
     Bruijn graph over a ladder of k-mer sizes, simplifies it, resolves repeats with
@@ -73,7 +76,7 @@ about:
     dependencies beyond a compiler, zlib and pthreads.
 
     Where a repeat is longer than a sequencing fragment there is no paired evidence to
-    settle it, and tessera stops rather than guessing. Supplying a genus model built from
+    settle it, and TesserACT stops rather than guessing. Supplying a genus model built from
     closed genomes of the same organism lets it settle those junctions from independent
     evidence instead. Measured on 666 Klebsiella pneumoniae isolates that each have a closed
     reference genome, with leave-cluster-out models so no test genome is in its own panel:
@@ -83,12 +86,9 @@ about:
     With a model carrying a plasmid panel it also labels every contig chromosomal, plasmid
     or unknown, groups the contigs of one plasmid, and marks contigs whose two ends join as
     complete replicons. Pre-built Klebsiella models are attached to the GitHub releases.
-  doc_url: "https://github.com/iowa69/TesserACT#readme"
-  dev_url: "https://github.com/iowa69/TesserACT"
+  doc_url: https://github.com/iowa69/TesserACT#readme
+  dev_url: https://github.com/iowa69/TesserACT
 
 extra:
   recipe-maintainers:
     - iowa69
-  additional-platforms:
-    - linux-aarch64
-    - osx-arm64

--- a/recipes/tesseract-assembler/run_test.sh
+++ b/recipes/tesseract-assembler/run_test.sh
@@ -27,7 +27,7 @@ with open("r1.fq", "w") as a, open("r2.fq", "w") as b:
         b.write("@r%d/2\n%s\n+\n%s\n" % (i, rc(g[p + ins - read:p + ins]), "I" * read))
 PY
 
-tessera -1 r1.fq -2 r2.fq -o testasm -t 2
+tesseract-asm -1 r1.fq -2 r2.fq -o testasm -t 2
 
 test -s testasm/contigs.fasta
 
@@ -41,12 +41,12 @@ echo "assembled $n contig(s), $len bp (expected 1 contig, about 6000 bp)"
 
 # Flag checks, from help captured once. A flag that silently disappears is worse than one
 # that was never there: a pipeline built against it breaks with no explanation.
-tessera --help > tessera_help.txt
-tessera-model --help > model_help.txt
+tesseract-asm --help > tesseract_help.txt
+tesseract-model --help > model_help.txt
 for f in --organism --model --is-panel --map-polish; do
-    grep -q -- "$f" tessera_help.txt || { echo "tessera --help lost $f" >&2; exit 1; }
+    grep -q -- "$f" tesseract_help.txt || { echo "tesseract-asm --help lost $f" >&2; exit 1; }
 done
-grep -q -- --marker-density model_help.txt || { echo "tessera-model --help lost --marker-density" >&2; exit 1; }
+grep -q -- --marker-density model_help.txt || { echo "tesseract-model --help lost --marker-density" >&2; exit 1; }
 echo "help lists every expected flag"
 
 echo "package test passed"


### PR DESCRIPTION
Follow-up to #68032, which merged at 1.2.2.

That version installs commands named `tessera` and `tessera-model`. Upstream has since renamed everything to match the project's own name — [TesserACT](https://github.com/iowa69/TesserACT) — so those commands no longer exist. They are now `tesseract-asm` and `tesseract-model`.

Deliberately **not** plain `tesseract`: that binary belongs to the OCR engine in conda-forge, and a second package installing `bin/tesseract` would be a file conflict.

This also adds **`tesseract-klebsiella`**, new upstream. The previous package was the two binaries alone, which left a user to find the release page, download a 339 MB model by hand and work out the flags. The runner locates the model, verifies its checksum against a pinned SHA-256 and assembles.

### Testing

Built from the 1.2.4 release tarball with the `c_stdlib` pin CI supplies:

- package test passes
- the functional test assembles a 6 kb genome and asserts a single contig of the right length — a binary that installs but cannot assemble would pass a `--version` check
- help output is checked for the flags a pipeline may depend on
- installing the built package into a clean environment yields all three commands, reporting `TesserACT 1.2.4`

Linux-64 only here; I will follow whatever your CI reports for osx.