### PR TITLE
Update iobrpy to 0.2.1

### DIFF
--- a/recipes/iobrpy/meta.yaml
+++ b/recipes/iobrpy/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "iobrpy" %}
-{% set version = "0.2.0" %}
+{% set version = "0.2.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://files.pythonhosted.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 23547ed6ce4171b4cb358b5c8e42a249e9ce338398b848a15fae8ecc4549a0d5
+  sha256: c46c8fff8846d829b8fb3bec972867cbb6945dc454a9995e08fc07c224d94902
 
 build:
   number: 0


### PR DESCRIPTION
Update the Bioconda recipe for `iobrpy` from version `0.2.0` to `0.2.1`.
- Updated the package version to `0.2.1`
- Updated the PyPI source SHA-256 checksum
- Kept the build number at `0` for the new upstream release
- PyPI: https://pypi.org/project/iobrpy/0.2.1/
- Upstream: https://github.com/IOBR/IOBRpy
