### PR TITLE
Update accusnv to 1.1.0

### DIFF
--- a/recipes/accusnv/meta.yaml
+++ b/recipes/accusnv/meta.yaml
@@ -26,9 +26,10 @@ requirements:
   run:
     - python >=3.11
     # Python dependencies
-    - snakemake >=8
+    - snakemake >=8,<10
     - snakemake-executor-plugin-slurm
     - numpy
+    - pyyaml
     - scipy
     - pandas
     - pytorch
@@ -48,8 +49,6 @@ requirements:
     - phylip
 
 test:
-  source_files:
-    - tests
   imports:
     - accusnv
     - accusnv.accusnv
@@ -57,16 +56,18 @@ test:
     - accusnv.preprocessing
   commands:
     - accusnv --help
-    - dnapars < /dev/null || true
-    - python -m unittest discover -s tests
-
+    - which dnapars
+    - which bwa
+    - which samclip
+    - which samtools
+    - which bowtie2
 about:
   home: "https://github.com/liaoherui/AccuSNV"
   license: MIT
   license_family: MIT
   license_file: LICENSE
   summary: "High-accuracy SNV calling for bacterial isolates."
-  doc_url: "https://github.com/liaoherui/AccuSNV/blob/main/README.md"
+  doc_url: "https://github.com/liaoherui/AccuSNV#readme"
   dev_url: "https://github.com/liaoherui/AccuSNV"
 
 extra:

--- a/recipes/accusnv/meta.yaml
+++ b/recipes/accusnv/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "accusnv" %}
-{% set version = "1.0.0.5" %}
+{% set version = "1.1.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,62 +7,71 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/accusnv-{{ version }}.tar.gz
-  sha256: 47181d53fac4e4baf992542813864bf7d162caa9ec9f2054f84ae37ab8384ac6
+  sha256: cd0fda54fd0d9c70932fa6c209e5df9bd9ca737fde6516a8c0ea4203ff9d014d
 
 build:
   number: 0
   noarch: python
   entry_points:
-    - accusnv = accusnv.accusnv_main:main
-    - accusnv_snakemake = accusnv.accusnv_snakemake:main
-    - accusnv_downstream = accusnv.downstream:main
+    - accusnv = accusnv.cli:main
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --no-cache-dir -vvv
   run_exports:
     - {{ pin_subpackage('accusnv', max_pin="x") }}
 
 requirements:
   host:
+    - python >=3.11
     - pip
-    - python >=3.9,<3.10
+    - setuptools >=61
   run:
-    - python >=3.9,<3.10
-    - bcbio-gff ==0.6.9
-    - biopython ==1.78
-    - cutadapt
-    - matplotlib-base
+    - python >=3.11
+    # Python dependencies
+    - snakemake >=8
+    - snakemake-executor-plugin-slurm
     - numpy
-    - pandas
-    - pulp ==2.7.0
     - scipy
+    - pandas
+    - pytorch
+    - biopython
+    - bcbio-gff
+    - matplotlib-base
     - statsmodels
-    - pytorch >=2.6,<2.7
-    - tqdm
-    - snakemake ==7.32.3
-    - sickle-trim
+    # External binaries invoked by the Snakemake workflow
     - bwa
+    - bowtie2
     - samtools
     - bcftools
     - tabix
+    - samclip
+    - sickle-trim
+    - cutadapt
     - phylip
 
 test:
+  source_files:
+    - tests
   imports:
     - accusnv
-    - accusnv.modules
+    - accusnv.accusnv
+    - accusnv.downstream
+    - accusnv.preprocessing
   commands:
     - accusnv --help
-    - accusnv_snakemake --help
-    - accusnv_downstream --help
+    - dnapars < /dev/null || true
+    - python -m unittest discover -s tests
 
 about:
   home: "https://github.com/liaoherui/AccuSNV"
   license: MIT
   license_family: MIT
-  license_file: "LICENSE.md"
-  summary: "High-accuracy SNV calling for bacterial isolates using AccuSNV."
+  license_file: LICENSE
+  summary: "High-accuracy SNV calling for bacterial isolates."
   doc_url: "https://github.com/liaoherui/AccuSNV/blob/main/README.md"
   dev_url: "https://github.com/liaoherui/AccuSNV"
 
 extra:
   recipe-maintainers:
     - liaoherui
+    - alexcritschristoph
+  identifiers:
+    - doi:10.1101/gr.281341.125


### PR DESCRIPTION
Hello, I am a new maintainer for https://github.com/liaoherui/AccuSNV, and we are updating the bioconda package to the new version.

----

Update [`accusnv`](https://bioconda.github.io/recipes/accusnv/README.html): **1.0.0.5** &rarr; **1.1.0**

[![install with bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg?style=flat)](http://bioconda.github.io/recipes/accusnv/README.html) [![Conda](https://img.shields.io/conda/dn/bioconda/accusnv.svg)](https://anaconda.org/bioconda/accusnv/files)

Info | Link or Description
-----|--------------------
Recipe | [`recipes/accusnv`](https://github.com//bioconda/bioconda-recipes/tree/bump/accusnv/recipes/accusnv) (click to view/edit other files)
Summary | High-accuracy SNV calling for bacterial isolates using AccuSNV.
Home | [https://github.com/liaoherui/AccuSNV](https://github.com/liaoherui/AccuSNV)
Releases |[https://pypi.org/pypi/accusnv/json](https://pypi.org/pypi/accusnv/json)
Recipe Maintainer(s) |@alexcritschristoph, @liaoherui

***

