### PR TITLE
Update augustus: Remove x86_64) block in augustus/build.sh

### DIFF
--- a/recipes/augustus/build.sh
+++ b/recipes/augustus/build.sh
@@ -29,9 +29,6 @@ case $(uname -m) in
     arm64)
 	export CXXFLAGS="${CXXFLAGS} -march=armv8.4-a"
 	;;
-    x86_64)
-	export CXXFLAGS="${CXXFLAGS} -march=x86-64-v3"
-	;;
 esac
 
 ## Make the software

--- a/recipes/augustus/meta.yaml
+++ b/recipes/augustus/meta.yaml
@@ -16,7 +16,7 @@ source:
     - patches/0002-sqliteDB.patch
 
 build:
-  number: 9
+  number: 10
   run_exports:
     - {{ pin_subpackage('augustus', max_pin="x") }}
 

--- a/recipes/augustus/meta.yaml
+++ b/recipes/augustus/meta.yaml
@@ -24,6 +24,7 @@ requirements:
   build:
     - make
     - {{ compiler('cxx') }}
+    - {{ stdlib('c') }}
   host:
     - zlib
     - samtools


### PR DESCRIPTION
Pull request #57554 added osx-arm64 support. For ARM targets, specifying `-march` makes sense — you're targeting a known hardware tier (`armv8-a` for aarch64 Linux servers, `armv8.4-a` for Apple Silicon). The pull request applied the same pattern symmetrically to `x86_64` with `-march=x86-64-v3`, likely with the intention of "optimise for modern hardware", without realising the distributional consequences. 

`x86-64-v3` is a CPU microarchitecture baseline that requires Haswell-era (2013+) instructions: AVX2, BMI1, BMI2, FMA3, MOVBE, F16C. Any CPU that doesn't meet that baseline gets `SIGILL` at the first AVX2/BMI2 instruction executed.
This was reported but not addressed at the end of the pull request conversation: https://github.com/bioconda/bioconda-recipes/pull/57554#issuecomment-3299232895

Removing the `x86_64` flag is an appropriate fix for the following reasons:

1. Augustus does not benefit from manual vectorisation. It is an HMM-based gene predictor — its hot paths are dynamic programming and I/O. The compute-heavy linear algebra is inside SuiteSparse and OpenBLAS, which already have their own internal SIMD dispatch (they detect the CPU at runtime and use AVX2 where available regardless of how augustus was compiled).

2. `-O3` is already there and stays. The PR kept `-O3` which enables auto-vectorisation and loop unrolling without restricting which CPUs can run the result. Removing `-march=x86-64-v3` does not undo `-O3`.

3. The arm64/aarch64 cases are fine and should be kept. Those targets always run on known hardware (Apple Silicon or actual ARM servers), so specifying `-march=armv8-a` / `-march=armv8.4-a` is safe and appropriate.

4. No runtime dispatch exists in augustus. If there were a multi-variant mechanism in the code, a `-march` flag would make sense for each variant. There isn't one.

If someday a maintainer wants proper microarch-optimised builds for augustus on `x86_64` (unlikely to be worth it), the right way is the `microarch-level` helper packages from conda-forge, which produce separate build variants with appropriate `run_constraints` so conda installs the right one per machine — rather than a single binary that crashes on anything older than Haswell.

Note: the above debugging diagnosis and reasoning was made by Claude Sonnet 4.6.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
