### PR TITLE
Add scanmst recipe

### DIFF
--- a/recipes/scanmst/meta.yaml
+++ b/recipes/scanmst/meta.yaml
@@ -20,6 +20,14 @@ build:
   script: |
     export HTSLIB_ROOT="$PREFIX"
     export SCANMST_EMBED_RPATH=ON
+    # Force Ninja explicitly: scikit-build-core's generator auto-detection
+    # does not reliably find the build-prefix `ninja` on bioconda's Linux CI
+    # runner and silently falls back to "Unix Makefiles", which then fails
+    # with CMAKE_MAKE_PROGRAM/compilers not set (no `make` dep, and cmake's
+    # own EnableLanguage compiler probe never runs the conda compiler wrappers
+    # in that path). Local conda-build runs didn't hit this because ninja was
+    # already resolved via the ambient PATH there.
+    export CMAKE_GENERATOR=Ninja
     {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:

--- a/recipes/scanmst/meta.yaml
+++ b/recipes/scanmst/meta.yaml
@@ -1,0 +1,86 @@
+{% set name = "scanmst" %}
+{% set version = "0.1.9" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/scanmst-{{ version }}.tar.gz
+  sha256: 27b0f827533cddffd702f2e33997645587d4d5368647580a01d732df11fbb7b5
+
+build:
+  # Compiled pybind11 extension linked against htslib -- not noarch.
+  # Linux-only and py39/py310-only, matching requires-python; no osx-arm64
+  # build exists for pysam at any version used here.
+  skip: True  # [not linux or py<39 or py>=311]
+  number: 0
+  run_exports:
+    - {{ pin_subpackage('scanmst', max_pin="x.x") }}
+  script: |
+    export HTSLIB_ROOT="$PREFIX"
+    export SCANMST_EMBED_RPATH=ON
+    {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - {{ stdlib('c') }}
+    - cmake >=3.18
+    - ninja
+  host:
+    - python
+    - pip
+    - scikit-build-core >=0.10
+    - pybind11 >=2.12,<4
+    # htslib pinned to the build whose bzip2/libcurl/libdeflate/openssl/
+    # zlib pins match pysam==0.22.0's verbatim -- see the run section note
+    # on why pysam is 0.22.0 here instead of PyPI's 0.19.0.
+    - htslib ==1.20
+    - zlib >=1.2.13,<1.3.0a0
+  run:
+    - python
+    - htslib ==1.20
+    # htseq/numpy are exact-pinned to the versions the published v0.1.9
+    # manuscript results were produced with. pysam is NOT exact-pinned here
+    # (PyPI has pysam==0.19.0) -- every bioconda build of htseq==2.0.5,
+    # across all rebuilds and python versions, hard-requires pysam>=0.22.0,
+    # so 0.19.0 is not installable alongside it on this channel. Bumped to
+    # the nearest compatible version instead (also dodges alignparse's own
+    # `pysam !=0.22.1` exclusion); approved as a deliberate, bioconda-only
+    # deviation from the PyPI exact pin.
+    - pysam ==0.22.0
+    - htseq ==2.0.5
+    - numpy ==1.26.4
+    - biopython >=1.81,<2
+    - pyfaidx >=0.8.1,<0.9
+    - psutil >=7.0.0,<8
+    - loguru >=0.7.0,<0.8
+    - rich >=14.0.0,<15
+    - networkx >=3.2,<4
+    - pyabpoa >=1.5.3,<2
+    - alignparse >=0.7.1,<0.8
+    - matplotlib-base >=3.9,<4
+    - intervaltree >=3.1.0,<4
+    - joblib >=1.5.0,<2
+    - pyyaml >=6,<7
+    - requests >=2.31,<3
+
+test:
+  imports:
+    - scanmst
+    - scanmst.cppext
+  commands:
+    - scanmst --version
+
+about:
+  home: https://github.com/ylab-hi/ScanMST
+  summary: A multi-segment transcript caller for long-read transcriptome sequencing data
+  license: GPL-3.0-or-later
+  license_file: LICENSE
+  doc_url: https://ylab-hi.github.io/ScanMST/
+
+extra:
+  recipe-maintainers:
+    - dolittle007


### PR DESCRIPTION
## Summary

Adds a recipe for [scanmst](https://github.com/ylab-hi/ScanMST), a multi-segment transcript caller for long-read transcriptome sequencing data, published on PyPI as [`scanmst` 0.1.9](https://pypi.org/project/scanmst/0.1.9/). Builds a compiled pybind11 extension linked against htslib via scikit-build-core + CMake.

## Notes

- `pysam` is pinned to `0.22.0` rather than the PyPI package's `0.19.0`: every bioconda build of `htseq==2.0.5`, across all rebuilds and python versions, requires `pysam>=0.22.0`, so the exact PyPI pin is not installable on this channel. `htseq==2.0.5` and `numpy==1.26.4` stay exact-pinned to match the published results.
- `htslib` is pinned to `1.20`, the build whose own `libcurl`/`libdeflate`/`libzlib`/`openssl` dependency pins match `pysam==0.22.0` verbatim.
- Depends on `alignparse >=0.7.1,<0.8`, already merged as #68144.

## Test plan

- [x] `bioconda-utils lint` passes (`All checks OK`)
- [x] Local `conda-build` for py39: compiles, full test-env solve succeeds, recipe test block (imports + `scanmst --version`) passes
- [x] Local `conda-build` for py310: same, all pass
- [x] Smoke-tested the built package in a fresh env with `LD_LIBRARY_PATH`/`HTSLIB_ROOT` unset: `scanmst.cppext.parseCigar('10M5I20M').ref_match == 30`, `scanmst --version` reports `0.1.9`