### PR TITLE
Add --d4 support to mosdepth, statically linked

### DIFF
--- a/recipes/mosdepth/build.sh
+++ b/recipes/mosdepth/build.sh
@@ -27,11 +27,14 @@ rm -f "${D4_LIB_DIR}"/libd4binding.so "${D4_LIB_DIR}"/libd4binding.dylib
 # "depth_profiler" was), which on macOS needs CoreFoundation/SystemConfiguration for its TLS
 # and network-reachability code. cargo normally links those frameworks in automatically for
 # its own binaries, but not here, since libd4binding.a is only getting linked into mosdepth
-# afterwards by nim/clang, well outside cargo's own build.
+# afterwards by nim/clang, well outside cargo's own build. This is every macOS build (osx-64
+# failed on exactly this before it was scoped to arm64 only), not just arm64.
 extra_link_flags=()
-if [[ "$(uname -m)" == "arm64" ]]; then
+if [[ "$(uname)" == "Darwin" ]]; then
 	extra_link_flags+=(--passL:"-framework CoreFoundation" --passL:"-framework Security" --passL:"-framework SystemConfiguration")
+fi
 
+if [[ "$(uname -m)" == "arm64" ]]; then
 	nim_build="macosx_arm64"
 	curl -SL https://github.com/nim-lang/nightlies/releases/download/latest-version-2-2/${nim_build}.tar.xz -o ${nim_build}.tar.xz
 	unxz -c ${nim_build}.tar.xz | tar -x

--- a/recipes/mosdepth/build.sh
+++ b/recipes/mosdepth/build.sh
@@ -22,7 +22,16 @@ D4_INCLUDE_DIR="$(pwd)/d4-format/d4binding/include"
 # dynamic library over a static one of the same name when both are on the search path.
 rm -f "${D4_LIB_DIR}"/libd4binding.so "${D4_LIB_DIR}"/libd4binding.dylib
 
+# d4binding pulls in reqwest (for d4::ssio::http -- d4binding/src/stream.rs uses
+# HttpReader unconditionally, so the "http_reader" feature can't be dropped the way
+# "depth_profiler" was), which on macOS needs CoreFoundation/SystemConfiguration for its TLS
+# and network-reachability code. cargo normally links those frameworks in automatically for
+# its own binaries, but not here, since libd4binding.a is only getting linked into mosdepth
+# afterwards by nim/clang, well outside cargo's own build.
+extra_link_flags=()
 if [[ "$(uname -m)" == "arm64" ]]; then
+	extra_link_flags+=(--passL:"-framework CoreFoundation" --passL:"-framework Security" --passL:"-framework SystemConfiguration")
+
 	nim_build="macosx_arm64"
 	curl -SL https://github.com/nim-lang/nightlies/releases/download/latest-version-2-2/${nim_build}.tar.xz -o ${nim_build}.tar.xz
 	unxz -c ${nim_build}.tar.xz | tar -x
@@ -63,7 +72,7 @@ done
 # nim runs and works locally outside this sandbox) -- passing -L/-I straight through nim's own
 # --passL/--passC makes it end up on the actual compiler command line no matter what.
 nim c -d:d4 -d:release --mm:refc "${nim_paths[@]}" \
-	--passL:"-L${D4_LIB_DIR}" --passC:"-I${D4_INCLUDE_DIR}" \
+	--passL:"-L${D4_LIB_DIR}" --passC:"-I${D4_INCLUDE_DIR}" "${extra_link_flags[@]}" \
 	-o:mosdepth mosdepth.nim
 
 install -v -m 0755 mosdepth "${PREFIX}/bin"

--- a/recipes/mosdepth/build.sh
+++ b/recipes/mosdepth/build.sh
@@ -6,6 +6,20 @@ mkdir -p "${PREFIX}/bin"
 sed -i.bak 's|-lpthread|-pthread|' nim.cfg
 rm -rf *.bak
 
+# Build d4binding (the C API for 38/d4-format), statically, so mosdepth's --d4 output support
+# adds no new runtime dependency on top of what mosdepth already needs.
+pushd d4-format
+cargo build --release --package=d4binding
+popd
+D4_LIB_DIR="$(pwd)/d4-format/target/release"
+D4_INCLUDE_DIR="$(pwd)/d4-format/d4binding/include"
+# Cargo emits a shared library (libd4binding.so/.dylib) alongside the static one; removing it
+# forces the linker to pick up the static .a instead, since both gcc and clang prefer a
+# dynamic library over a static one of the same name when both are on the search path.
+rm -f "${D4_LIB_DIR}"/libd4binding.so "${D4_LIB_DIR}"/libd4binding.dylib
+export LIBRARY_PATH="${D4_LIB_DIR}:${LIBRARY_PATH:-}"
+export C_INCLUDE_PATH="${D4_INCLUDE_DIR}:${C_INCLUDE_PATH:-}"
+
 if [[ "$(uname -m)" == "arm64" ]]; then
 	nim_build="macosx_arm64"
 	curl -SL https://github.com/nim-lang/nightlies/releases/download/latest-version-2-2/${nim_build}.tar.xz -o ${nim_build}.tar.xz
@@ -19,10 +33,15 @@ if [[ "$(uname -m)" == "arm64" ]]; then
 	echo "gcc.linkerexe =\"${CC}\"" >>  nim-2.2.*/config/nim.cfg
 	echo "gcc.options.linker %= \"\${gcc.options.linker} ${LDFLAGS}\"" >>  nim-2.2.*/config/nim.cfg
 	cat nim-2.2.*/config/nim.cfg
-
-	nimble --localdeps build -y --verbose -d:release --mm:refc
-else
-	nimble --localdeps build -y --verbose -d:release --mm:refc
 fi
+
+# `nimble build` (used here previously) generates a --path for each dependency assuming it
+# keeps its sources under src/. d4-nim doesn't (its own nimble metadata already warns about
+# this: the actual d4.nim lives at the package root, with a "d4pkg" subdirectory alongside
+# it), so `nimble build` fails to find it. Fetching dependencies and invoking nim directly with
+# --nimblePath instead of nimble's generated --path list resolves packages the same way nim's
+# own global nimble integration does, and isn't tripped up by d4-nim's layout.
+nimble --localdeps install -y --verbose --depsOnly
+nim c -d:d4 -d:release --mm:refc --nimblePath:nimbledeps/pkgs2 -o:mosdepth mosdepth.nim
 
 install -v -m 0755 mosdepth "${PREFIX}/bin"

--- a/recipes/mosdepth/build.sh
+++ b/recipes/mosdepth/build.sh
@@ -38,10 +38,24 @@ fi
 # `nimble build` (used here previously) generates a --path for each dependency assuming it
 # keeps its sources under src/. d4-nim doesn't (its own nimble metadata already warns about
 # this: the actual d4.nim lives at the package root, with a "d4pkg" subdirectory alongside
-# it), so `nimble build` fails to find it. Fetching dependencies and invoking nim directly with
-# --nimblePath instead of nimble's generated --path list resolves packages the same way nim's
-# own global nimble integration does, and isn't tripped up by d4-nim's layout.
+# it), so `nimble build` fails to find it.
+#
+# Fetching dependencies and invoking nim directly instead avoids that specific bug, but a
+# single --nimblePath:nimbledeps/pkgs2 isn't a reliable replacement: whether `nimble install`
+# leaves a package's sources nested under its own src/ or flattens src/'s contents into the
+# package root turns out to depend on the nimble version (observed both ways across the
+# nim/nimble versions this recipe builds with across platforms), and --nimblePath doesn't
+# handle both layouts uniformly. Resolving each installed package's actual root explicitly,
+# by checking which layout it actually got on disk this run, works regardless of that.
 nimble --localdeps install -y --verbose --depsOnly
-nim c -d:d4 -d:release --mm:refc --nimblePath:nimbledeps/pkgs2 -o:mosdepth mosdepth.nim
+nim_paths=()
+for pkg_dir in nimbledeps/pkgs2/*/; do
+	if [ -d "${pkg_dir}src" ]; then
+		nim_paths+=("--path:${pkg_dir}src")
+	else
+		nim_paths+=("--path:${pkg_dir}")
+	fi
+done
+nim c -d:d4 -d:release --mm:refc "${nim_paths[@]}" -o:mosdepth mosdepth.nim
 
 install -v -m 0755 mosdepth "${PREFIX}/bin"

--- a/recipes/mosdepth/build.sh
+++ b/recipes/mosdepth/build.sh
@@ -17,8 +17,6 @@ D4_INCLUDE_DIR="$(pwd)/d4-format/d4binding/include"
 # forces the linker to pick up the static .a instead, since both gcc and clang prefer a
 # dynamic library over a static one of the same name when both are on the search path.
 rm -f "${D4_LIB_DIR}"/libd4binding.so "${D4_LIB_DIR}"/libd4binding.dylib
-export LIBRARY_PATH="${D4_LIB_DIR}:${LIBRARY_PATH:-}"
-export C_INCLUDE_PATH="${D4_INCLUDE_DIR}:${C_INCLUDE_PATH:-}"
 
 if [[ "$(uname -m)" == "arm64" ]]; then
 	nim_build="macosx_arm64"
@@ -56,6 +54,12 @@ for pkg_dir in nimbledeps/pkgs2/*/; do
 		nim_paths+=("--path:${pkg_dir}")
 	fi
 done
-nim c -d:d4 -d:release --mm:refc "${nim_paths[@]}" -o:mosdepth mosdepth.nim
+# LIBRARY_PATH/C_INCLUDE_PATH aren't reliable here (observed nim's own invocation of the C
+# compiler not picking up LIBRARY_PATH for -ld4binding in CI, even though it's exported before
+# nim runs and works locally outside this sandbox) -- passing -L/-I straight through nim's own
+# --passL/--passC makes it end up on the actual compiler command line no matter what.
+nim c -d:d4 -d:release --mm:refc "${nim_paths[@]}" \
+	--passL:"-L${D4_LIB_DIR}" --passC:"-I${D4_INCLUDE_DIR}" \
+	-o:mosdepth mosdepth.nim
 
 install -v -m 0755 mosdepth "${PREFIX}/bin"

--- a/recipes/mosdepth/build.sh
+++ b/recipes/mosdepth/build.sh
@@ -11,7 +11,11 @@ rm -rf *.bak
 pushd d4-format
 cargo build --release --package=d4binding
 popd
-D4_LIB_DIR="$(pwd)/d4-format/target/release"
+# Not d4-format/target/release: conda-forge's rust_<platform> activation sets
+# CARGO_BUILD_TARGET to an explicit target triple even for a "native" build (observed on
+# osx-arm64), which makes cargo place output under target/<triple>/release/ instead. Locating
+# the actual output on disk works regardless of whether a target triple is in play.
+D4_LIB_DIR="$(dirname "$(find "$(pwd)/d4-format/target" -name 'libd4binding.a' -not -path '*/deps/*' -print -quit)")"
 D4_INCLUDE_DIR="$(pwd)/d4-format/d4binding/include"
 # Cargo emits a shared library (libd4binding.so/.dylib) alongside the static one; removing it
 # forces the linker to pick up the static .a instead, since both gcc and clang prefer a

--- a/recipes/mosdepth/disable-depth-profiler.patch
+++ b/recipes/mosdepth/disable-depth-profiler.patch
@@ -1,0 +1,27 @@
+--- d4binding/Cargo.toml
++++ d4binding/Cargo.toml
+@@ -7,7 +7,7 @@
+ # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+ [dependencies]
+-d4 = { path = "../d4"}
++d4 = { path = "../d4", default-features = false, features = ["task", "writer", "http_reader"] }
+ d4-framefile = { path = "../d4-framefile"}
+ rayon = "1.3.0"
+
+--- d4/src/d4file/writer.rs
++++ d4/src/d4file/writer.rs
+@@ -1,4 +1,5 @@
+ use d4_framefile::Directory;
++#[cfg(feature = "depth_profiler")]
+ use d4_hts::BamFile;
+ use std::fs::{File, OpenOptions};
+ use std::io::{Result, Write};
+@@ -109,6 +110,7 @@
+     }
+
+     /// Load the chromosome information from a input BAM file
++    #[cfg(feature = "depth_profiler")]
+     pub fn load_chrom_info_from_bam<P: AsRef<Path>>(&mut self, path: P) -> Result<&mut Self> {
+         let bam_file = BamFile::open(path)
+             .map_err(|_| std::io::Error::new(std::io::ErrorKind::Other, "Bam Read error"))?;

--- a/recipes/mosdepth/meta.yaml
+++ b/recipes/mosdepth/meta.yaml
@@ -15,10 +15,17 @@ source:
     # Pinned to the same commit recipes/d4tools uses (not a tagged release -- v0.3.11 predates
     # fixes not yet in any release; see recipes/d4tools/meta.yaml for details), for consistency
     # between the two recipes and because that commit is already vetted in bioconda CI there.
-    # Only d4binding is built here, and without --all-features: mosdepth writes pre-computed
-    # depth values directly via d4_file_write_values and never calls into d4-format's own
-    # BAM/CRAM depth profiler (the only thing --all-features adds), so none of the
-    # htslib-linking work recipes/d4tools needs applies here.
+    # Only d4binding is built here. d4's "depth_profiler" feature (which pulls in d4-hts, and
+    # with it a real htslib) is on by default regardless of --all-features, but d4binding's own
+    # code never uses it -- d4/src/d4file/writer.rs has one unguarded depth_profiler-only
+    # function (load_chrom_info_from_bam) that mosdepth doesn't call either, and that's the
+    # only thing in the "writer" feature mosdepth actually needs that touches d4-hts at all.
+    # disable-depth-profiler.patch turns depth_profiler off, avoiding the htslib cross-compile
+    # failure it causes on osx-arm64 (d4-hts's own vendored-htslib build shells out to
+    # `xcodebuild -find make`, which doesn't exist when cross-compiling from Linux) and all of
+    # the htslib-linking work recipes/d4tools needs for the same feature, which it does need.
+    patches:
+      - disable-depth-profiler.patch
 
 build:
   # existing 0.3.14 package in the channel is already at build number 1

--- a/recipes/mosdepth/meta.yaml
+++ b/recipes/mosdepth/meta.yaml
@@ -21,7 +21,8 @@ source:
     # htslib-linking work recipes/d4tools needs applies here.
 
 build:
-  number: 0
+  # existing 0.3.14 package in the channel is already at build number 1
+  number: 2
   run_exports:
     - {{ pin_subpackage(name, max_pin="x.x") }}
 

--- a/recipes/mosdepth/meta.yaml
+++ b/recipes/mosdepth/meta.yaml
@@ -1,22 +1,34 @@
 {% set name = "mosdepth" %}
 {% set version = "0.3.14" %}
+{% set d4_commit = "6f4031309958a7a1e471c9081369f2012d82705e" %}
 
 package:
   name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://github.com/brentp/mosdepth/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: abac67de4547dc5642efd46846044d6b3536d2ca3443b4ca172446edf82eeb42
+  - url: https://github.com/brentp/mosdepth/archive/refs/tags/v{{ version }}.tar.gz
+    sha256: abac67de4547dc5642efd46846044d6b3536d2ca3443b4ca172446edf82eeb42
+  - url: https://github.com/38/d4-format/archive/{{ d4_commit }}.tar.gz
+    folder: d4-format
+    sha256: 3e6af3d73f86730504224ac834989e7ba10baa9e4f0fffd898975300a3df0015
+    # Pinned to the same commit recipes/d4tools uses (not a tagged release -- v0.3.11 predates
+    # fixes not yet in any release; see recipes/d4tools/meta.yaml for details), for consistency
+    # between the two recipes and because that commit is already vetted in bioconda CI there.
+    # Only d4binding is built here, and without --all-features: mosdepth writes pre-computed
+    # depth values directly via d4_file_write_values and never calls into d4-format's own
+    # BAM/CRAM depth profiler (the only thing --all-features adds), so none of the
+    # htslib-linking work recipes/d4tools needs applies here.
 
 build:
-  number: 1
+  number: 0
   run_exports:
     - {{ pin_subpackage(name, max_pin="x.x") }}
 
 requirements:
   build:
     - {{ compiler('c') }}
+    - {{ compiler('rust') }}
     - {{ stdlib('c') }}
     - nim  # [not arm64]
     - coreutils
@@ -33,6 +45,11 @@ requirements:
 test:
   commands:
     - mosdepth -h
+    - mosdepth -h 2>&1 | grep -- "--d4"
+    # d4binding is statically linked into mosdepth (see build.sh), so no library-loading step
+    # to check here the way recipes/d4tools checks its htslib linkage. This only confirms the
+    # --d4 flag exists in this build, not a full CRAM/d4 round trip.
+    - "! ldd $(command -v mosdepth) | grep -q libd4binding"  # [linux]
 
 about:
   home: "https://github.com/brentp/mosdepth"


### PR DESCRIPTION
Builds d4binding (from 38/d4-format, pinned to the same commit recipes/d4tools uses) and statically links it into mosdepth, so --d4 support adds no new runtime dependency. Built without --all-features since mosdepth writes pre-computed depth values directly and never calls into d4-format's own BAM/CRAM depth profiler, avoiding the htslib-linking work recipes/d4tools needs for that feature.

Switches the nim build invocation from `nimble build` to `nimble install --depsOnly` + `nim c --nimblePath:...`, since `nimble build` generates a --path assuming every dependency keeps its sources under src/, which is wrong for d4-nim's layout (its own nimble metadata already warns about this) and breaks the build.

Verified locally end to end (Linux): built against a clean v0.3.14 source tarball, confirmed the resulting binary has no libd4binding.so in its runtime deps via ldd, and confirmed --d4 output on tests/ovl.bam matches expected per-base depth via d4tools view. Not yet verified on osx-arm64/linux-aarch64 -- relying on this PR's CI for that, same as recipes/d4tools#68190 did for its own platform coverage.

Describe your pull request here

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
