### PR TITLE
Add cfm-id 4.4.10

### DIFF
--- a/recipes/cfm-id/add-cfloat-include.patch
+++ b/recipes/cfm-id/add-cfloat-include.patch
@@ -1,0 +1,40 @@
+Include <cfloat> where DBL_MAX is used.
+
+EmModel.cpp and cfm-train/main.cpp use DBL_MAX but never include <cfloat>.
+They compiled historically because older libstdc++ headers pulled it in
+transitively; current libstdc++ does not, so the build fails:
+
+    EmModel.cpp: error: 'DBL_MAX' was not declared in this scope
+
+This is unrelated to RDKit -- it is ordinary transitive-include tightening, and
+the fix is the include that should always have been there.
+
+Upstream status: not reported, because there is currently no channel to report to.
+Atlassian is sunsetting Bitbucket Issues and Wikis across Cloud; they could no
+longer be enabled from April 2026 and existing issues are removed on 20 August
+2026, so wishartlab/cfm-id-code has no usable tracker. The repository README
+carries no contact address and there is no CONTRIBUTING file. Pull requests are
+unaffected and remain possible; this change has been restated against current
+master and verified to apply with patch -Np1 --binary.
+Remove this patch once upstream adds the includes.
+
+--- a/cfm/cfm-code/EmModel.cpp
++++ b/cfm/cfm-code/EmModel.cpp
+@@ -17,6 +17,7 @@
+ #########################################################################*/
+ 
+ #include "mpi.h"
++#include <cfloat>
+ #include <ctime>
+ #include <chrono>
+ #include <iomanip>
+--- a/cfm/cfm-train/main.cpp
++++ b/cfm/cfm-train/main.cpp
+@@ -17,6 +17,7 @@
+ #########################################################################*/
+ 
+ #include "mpi.h"
++#include <cfloat>
+ 
+ #include <boost/algorithm/string.hpp>
+ #include <boost/lexical_cast.hpp>

--- a/recipes/cfm-id/add-cfloat-include.patch
+++ b/recipes/cfm-id/add-cfloat-include.patch
@@ -1,22 +1,10 @@
 Include <cfloat> where DBL_MAX is used.
 
-EmModel.cpp and cfm-train/main.cpp use DBL_MAX but never include <cfloat>.
-They compiled historically because older libstdc++ headers pulled it in
-transitively; current libstdc++ does not, so the build fails:
+EmModel.cpp and cfm-train/main.cpp use DBL_MAX without including <cfloat>.
+Older libstdc++ pulled it in transitively; current libstdc++ does not.
 
-    EmModel.cpp: error: 'DBL_MAX' was not declared in this scope
-
-This is unrelated to RDKit -- it is ordinary transitive-include tightening, and
-the fix is the include that should always have been there.
-
-Upstream status: not reported, because there is currently no channel to report to.
-Atlassian is sunsetting Bitbucket Issues and Wikis across Cloud; they could no
-longer be enabled from April 2026 and existing issues are removed on 20 August
-2026, so wishartlab/cfm-id-code has no usable tracker. The repository README
-carries no contact address and there is no CONTRIBUTING file. Pull requests are
-unaffected and remain possible; this change has been restated against current
-master and verified to apply with patch -Np1 --binary.
-Remove this patch once upstream adds the includes.
+Not reported upstream: Bitbucket Issues are being sunset, so the repository has
+no usable tracker. Remove this patch once upstream adds the includes.
 
 --- a/cfm/cfm-code/EmModel.cpp
 +++ b/cfm/cfm-code/EmModel.cpp

--- a/recipes/cfm-id/build.sh
+++ b/recipes/cfm-id/build.sh
@@ -7,7 +7,12 @@ set -euo pipefail
 
 export INCLUDE_PATH="${PREFIX}/include"
 export LIBRARY_PATH="${PREFIX}/lib"
-export LD_LIBRARY_PATH="${PREFIX}/lib"
+# macOS ignores LD_LIBRARY_PATH; the equivalent there is DYLD_LIBRARY_PATH.
+if [[ "$(uname -s)" == "Darwin" ]]; then
+    export DYLD_LIBRARY_PATH="${PREFIX}/lib"
+else
+    export LD_LIBRARY_PATH="${PREFIX}/lib"
+fi
 export LDFLAGS="-L${PREFIX}/lib"
 export CPPFLAGS="-I${PREFIX}/include"
 

--- a/recipes/cfm-id/build.sh
+++ b/recipes/cfm-id/build.sh
@@ -1,13 +1,8 @@
 #!/bin/bash
-# Adapted from the `cfm` (v33) recipe's build.sh. The environment exports, the
-# INCHI-API header shuffle and the cmake -D flags are all carried over: they
-# encode how CFM's CMake expects to find RDKit, LPSolve, Boost and LBFGS inside
-# a conda prefix, and none of that is discoverable from the upstream docs.
 set -euo pipefail
 
 export INCLUDE_PATH="${PREFIX}/include"
 export LIBRARY_PATH="${PREFIX}/lib"
-# macOS ignores LD_LIBRARY_PATH; the equivalent there is DYLD_LIBRARY_PATH.
 if [[ "$(uname -s)" == "Darwin" ]]; then
     export DYLD_LIBRARY_PATH="${PREFIX}/lib"
 else
@@ -16,14 +11,6 @@ fi
 export LDFLAGS="-L${PREFIX}/lib"
 export CPPFLAGS="-I${PREFIX}/include"
 
-# CFM includes <INCHI-API/inchi.h> from RDKit's External tree, but conda's rdkit
-# does not install the header at that path. INSTALL.md documents the same copy
-# for source installs, and the `cfm` v33 recipe hard-codes GraphMol/inchi.h.
-#
-# That hard-coded path is not safe to assume across rdkit generations, so locate
-# the header instead and fail loudly with a useful message if it is genuinely
-# absent -- CFM cannot build without INCHI support, so continuing would only
-# produce a more confusing error later.
 inchi_dst="${PREFIX}/include/rdkit/External/INCHI-API"
 mkdir -p "${inchi_dst}"
 if [ -f "${inchi_dst}/inchi.h" ]; then
@@ -41,25 +28,11 @@ else
     cp "${inchi_src}" "${inchi_dst}/"
 fi
 
-# CMakeLists.txt lives in cfm/, not at the archive root: the Bitbucket archive
-# also carries the model directories and the docker/ build definitions.
 cd cfm
 
 mkdir -p build
 cd build
 
-# INCLUDE_TRAIN=OFF is deliberate. CMakeLists.txt:121 requires MPI only when
-# INCLUDE_TRAIN or INCLUDE_TESTS is on ("Building the training code requires
-# extra dependencies, e.g. MPI"). With training on, CMake's MPI probe fails
-# under the sysroot that {{ stdlib('c') }} introduces:
-#     -- Could NOT find MPI_C (missing: MPI_C_WORKS)
-# and adding mpich to build: as well as host: did not fix it.
-#
-# The Galaxy wrapper uses cfm-id only, so the training binaries are out of
-# scope. Turning them off drops the MPI dependency entirely. NOTE this is a
-# deliberate difference from the older `cfm` v33 package, which does ship
-# cfm-train. If cfm-train is ever needed here, the MPI probe has to be solved
-# first.
 cmake .. \
     -DCMAKE_CXX_STANDARD=17 \
     -DCFM_OUTPUT_DIR="${PREFIX}/bin/" \
@@ -78,10 +51,6 @@ cmake .. \
 make -j"${CPU_COUNT}" VERBOSE=1
 make install VERBOSE=1
 
-# Install the pretrained CFM-ID 4 parameters so the tools have models to use.
-# cfm-cross-validation-models/ (~172 MB) is deliberately NOT installed: it is
-# 92% of the source archive and is only needed to reproduce the paper's
-# cross-validation, not to run predictions or identifications.
 cd "${SRC_DIR}"
 modeldir="${PREFIX}/share/${PKG_NAME}-${PKG_VERSION}"
 mkdir -p "${modeldir}"

--- a/recipes/cfm-id/build.sh
+++ b/recipes/cfm-id/build.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# Adapted from the `cfm` (v33) recipe's build.sh. The environment exports, the
+# INCHI-API header shuffle and the cmake -D flags are all carried over: they
+# encode how CFM's CMake expects to find RDKit, LPSolve, Boost and LBFGS inside
+# a conda prefix, and none of that is discoverable from the upstream docs.
+set -euo pipefail
+
+export INCLUDE_PATH="${PREFIX}/include"
+export LIBRARY_PATH="${PREFIX}/lib"
+export LD_LIBRARY_PATH="${PREFIX}/lib"
+export LDFLAGS="-L${PREFIX}/lib"
+export CPPFLAGS="-I${PREFIX}/include"
+
+# CFM includes <INCHI-API/inchi.h> from RDKit's External tree, but conda's rdkit
+# does not install the header at that path. INSTALL.md documents the same copy
+# for source installs, and the `cfm` v33 recipe hard-codes GraphMol/inchi.h.
+#
+# That hard-coded path is not safe to assume across rdkit generations, so locate
+# the header instead and fail loudly with a useful message if it is genuinely
+# absent -- CFM cannot build without INCHI support, so continuing would only
+# produce a more confusing error later.
+inchi_dst="${PREFIX}/include/rdkit/External/INCHI-API"
+mkdir -p "${inchi_dst}"
+if [ -f "${inchi_dst}/inchi.h" ]; then
+    echo "INCHI header already present at ${inchi_dst}/inchi.h"
+else
+    inchi_src="$(find "${PREFIX}/include/rdkit" -name inchi.h -print -quit 2>/dev/null || true)"
+    if [ -z "${inchi_src}" ]; then
+        echo "ERROR: no inchi.h found under ${PREFIX}/include/rdkit." >&2
+        echo "CFM-ID requires RDKit built with INCHI support (-DRDK_BUILD_INCHI_SUPPORT=ON)." >&2
+        echo "Headers present under GraphMol/:" >&2
+        ls -1 "${PREFIX}/include/rdkit/GraphMol" 2>/dev/null | head -20 >&2
+        exit 1
+    fi
+    echo "Found INCHI header at ${inchi_src}; copying to ${inchi_dst}/"
+    cp "${inchi_src}" "${inchi_dst}/"
+fi
+
+# CMakeLists.txt lives in cfm/, not at the archive root: the Bitbucket archive
+# also carries the model directories and the docker/ build definitions.
+cd cfm
+
+mkdir -p build
+cd build
+
+# INCLUDE_TRAIN=OFF is deliberate. CMakeLists.txt:121 requires MPI only when
+# INCLUDE_TRAIN or INCLUDE_TESTS is on ("Building the training code requires
+# extra dependencies, e.g. MPI"). With training on, CMake's MPI probe fails
+# under the sysroot that {{ stdlib('c') }} introduces:
+#     -- Could NOT find MPI_C (missing: MPI_C_WORKS)
+# and adding mpich to build: as well as host: did not fix it.
+#
+# The Galaxy wrapper uses cfm-id only, so the training binaries are out of
+# scope. Turning them off drops the MPI dependency entirely. NOTE this is a
+# deliberate difference from the older `cfm` v33 package, which does ship
+# cfm-train. If cfm-train is ever needed here, the MPI probe has to be solved
+# first.
+cmake .. \
+    -DCMAKE_CXX_STANDARD=17 \
+    -DCFM_OUTPUT_DIR="${PREFIX}/bin/" \
+    -DLPSOLVE_INCLUDE_DIR="${PREFIX}/include/lpsolve" \
+    -DLPSOLVE_LIBRARY_DIR="${PREFIX}/lib" \
+    -DBoost_INCLUDE_DIR="${PREFIX}/include" \
+    -DBOOST_LIBRARYDIR="${PREFIX}/lib" \
+    -DRDKIT_INCLUDE_DIR="${PREFIX}/include/rdkit" \
+    -DRDKIT_INCLUDE_EXT_DIR="${PREFIX}/include/rdkit/External" \
+    -DLBFGS_INCLUDE_DIR="${PREFIX}/include" \
+    -DLBFGS_LIBRARY_DIR="${PREFIX}/lib" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DINCLUDE_TESTS=OFF \
+    -DINCLUDE_TRAIN=OFF
+
+make -j"${CPU_COUNT}" VERBOSE=1
+make install VERBOSE=1
+
+# Install the pretrained CFM-ID 4 parameters so the tools have models to use.
+# cfm-cross-validation-models/ (~172 MB) is deliberately NOT installed: it is
+# 92% of the source archive and is only needed to reproduce the paper's
+# cross-validation, not to run predictions or identifications.
+cd "${SRC_DIR}"
+modeldir="${PREFIX}/share/${PKG_NAME}-${PKG_VERSION}"
+mkdir -p "${modeldir}"
+cp -rp cfm-pretrained-models/* "${modeldir}/"
+
+echo "Installed CFM-ID binaries:"
+ls -1 "${PREFIX}/bin" | grep -E '^(cfm|fraggraph)' || true
+echo "Installed models under ${modeldir}:"
+ls -1 "${modeldir}"

--- a/recipes/cfm-id/make-cxx-standard-overridable.patch
+++ b/recipes/cfm-id/make-cxx-standard-overridable.patch
@@ -1,0 +1,51 @@
+Let the C++ standard be chosen from the cmake command line.
+
+CFM-ID pins CMAKE_CXX_STANDARD to 11 (14 on upstream master). That matched
+RDKit 2017_09_3, which upstream's Dockerfile still builds against, but RDKit's
+public headers have since moved to C++17. Building against any currently
+packaged RDKit fails inside RDKit's own headers before CFM's code is reached:
+
+    RDGeneral/RDValue.h: error: 'any' in namespace 'std' does not name a type
+    RDGeneral/RDValue.h: error: 'any_cast' is not a member of 'std'
+    RDGeneral/Invariant.h: error: 'string_view' is not a member of 'std'
+    error: 'is_same_v' is not a member of 'std'; did you mean 'is_same'?
+    error: 'exchange' is not a member of 'std'
+
+std::any, std::string_view, std::is_same_v and std::exchange are all C++17.
+Measured, not assumed: a build with CMAKE_CXX_STANDARD 14 and the other two
+patches applied still fails on std::any.
+
+The obvious fix -- passing -DCMAKE_CXX_STANDARD=17 -- does not work on its own,
+because a plain set() creates a normal variable that shadows the cache variable
+the command line defines. So the set() has to be made conditional.
+
+This patch does NOT raise the standard. It only makes the existing default
+yield to an explicit choice; build.sh then passes -DCMAKE_CXX_STANDARD=17.
+That distinction matters upstream: their default is untouched, so anyone still
+building against RDKit 2017 is unaffected, which would not be true of a patch
+that simply forced 17 on everyone.
+
+Upstream note: cfm/INSTALL.md already says "Newer RDKit may work but we have not
+test it yet". This is part of what it takes for that to be true.
+Upstream status: not reported, because there is currently no channel to report to.
+Atlassian is sunsetting Bitbucket Issues and Wikis across Cloud; they could no
+longer be enabled from April 2026 and existing issues are removed on 20 August
+2026, so wishartlab/cfm-id-code has no usable tracker. The repository README
+carries no contact address and there is no CONTRIBUTING file. Pull requests are
+unaffected and remain possible; this change has been restated against current
+master and verified to apply with patch -Np1 --binary.
+Remove this patch once upstream accepts the overridable form.
+
+--- a/cfm/CMakeLists.txt
++++ b/cfm/CMakeLists.txt
+@@ -13,7 +13,9 @@
+ #########################################################################*/
+ # We may need higher verison cmake
+ cmake_minimum_required(VERSION 3.7.0)
+-set(CMAKE_CXX_STANDARD 11)
++if(NOT DEFINED CMAKE_CXX_STANDARD)
++    set(CMAKE_CXX_STANDARD 11)
++endif()
+ set(CMAKE_CXX_STANDARD_REQUIRED ON)
+ 
+ # Set a default build type if none was specified

--- a/recipes/cfm-id/make-cxx-standard-overridable.patch
+++ b/recipes/cfm-id/make-cxx-standard-overridable.patch
@@ -1,40 +1,15 @@
 Let the C++ standard be chosen from the cmake command line.
 
-CFM-ID pins CMAKE_CXX_STANDARD to 11 (14 on upstream master). That matched
-RDKit 2017_09_3, which upstream's Dockerfile still builds against, but RDKit's
-public headers have since moved to C++17. Building against any currently
-packaged RDKit fails inside RDKit's own headers before CFM's code is reached:
+CFM-ID pins CMAKE_CXX_STANDARD to 11, but RDKit's public headers now require
+C++17 (std::any, std::string_view, std::is_same_v). A plain set() shadows the
+cache variable, so -DCMAKE_CXX_STANDARD=17 has no effect until it is made
+conditional.
 
-    RDGeneral/RDValue.h: error: 'any' in namespace 'std' does not name a type
-    RDGeneral/RDValue.h: error: 'any_cast' is not a member of 'std'
-    RDGeneral/Invariant.h: error: 'string_view' is not a member of 'std'
-    error: 'is_same_v' is not a member of 'std'; did you mean 'is_same'?
-    error: 'exchange' is not a member of 'std'
+This does not raise the default, only lets an explicit choice win, so anyone
+building against older RDKit is unaffected. build.sh passes the 17.
 
-std::any, std::string_view, std::is_same_v and std::exchange are all C++17.
-Measured, not assumed: a build with CMAKE_CXX_STANDARD 14 and the other two
-patches applied still fails on std::any.
-
-The obvious fix -- passing -DCMAKE_CXX_STANDARD=17 -- does not work on its own,
-because a plain set() creates a normal variable that shadows the cache variable
-the command line defines. So the set() has to be made conditional.
-
-This patch does NOT raise the standard. It only makes the existing default
-yield to an explicit choice; build.sh then passes -DCMAKE_CXX_STANDARD=17.
-That distinction matters upstream: their default is untouched, so anyone still
-building against RDKit 2017 is unaffected, which would not be true of a patch
-that simply forced 17 on everyone.
-
-Upstream note: cfm/INSTALL.md already says "Newer RDKit may work but we have not
-test it yet". This is part of what it takes for that to be true.
-Upstream status: not reported, because there is currently no channel to report to.
-Atlassian is sunsetting Bitbucket Issues and Wikis across Cloud; they could no
-longer be enabled from April 2026 and existing issues are removed on 20 August
-2026, so wishartlab/cfm-id-code has no usable tracker. The repository README
-carries no contact address and there is no CONTRIBUTING file. Pull requests are
-unaffected and remain possible; this change has been restated against current
-master and verified to apply with patch -Np1 --binary.
-Remove this patch once upstream accepts the overridable form.
+Not reported upstream: Bitbucket Issues are being sunset, so the repository has
+no usable tracker. Remove once upstream accepts the overridable form.
 
 --- a/cfm/CMakeLists.txt
 +++ b/cfm/CMakeLists.txt

--- a/recipes/cfm-id/meta.yaml
+++ b/recipes/cfm-id/meta.yaml
@@ -2,61 +2,6 @@
 {% set version = "4.4.10" %}
 {% set commit = "cced92452e0f230acacc0427d19908b266811dc9" %}
 
-# NEW package, deliberately not a bump of the existing `cfm` recipe.
-#
-# `cfm` is pinned at version 33, which is CFM-ID 3-era software built against
-# rdkit 2018.09.1. This packages the CFM-ID 4 generation under a name matching
-# the software and its executables, and leaves `cfm=33` working for anything
-# that still depends on it.
-#
-# Most of the build knowledge below (build.sh, the cmake flags, the INCHI-API
-# header copy, the dependency shape) comes straight from the `cfm` recipe. What
-# is NOT carried over: its source.patch, which fixes version-33 bugs and must
-# not be applied blind to 4.4.10.
-#
-# SOURCE: upstream publishes tags on Bitbucket. Pinned to the commit the
-# CFM-ID_4.4.10 tag points at, rather than the tag name, because Bitbucket's
-# auto-generated tag archives are not guaranteed byte-stable.
-#
-# RDKIT WINDOW -- measured, not guessed.
-#
-# CEILING (<2024) comes from the INCHI headers. CFM includes
-# <INCHI-API/inchi.h>; conda-forge's rdkit ships that as GraphMol/inchi.h, but
-# stopped at some point. Probed by downloading each package and looking:
-#
-#     rdkit 2020.09.5  -> GraphMol/inchi.h present
-#     rdkit 2021.03.1  -> present
-#     rdkit 2022.03.1  -> present
-#     rdkit 2023.09.6  -> present
-#     rdkit 2024.03.5  -> ABSENT
-#     rdkit 2024.09.6  -> ABSENT
-#
-# Both 2024 releases were checked, so the ceiling really is at the 2023/2024
-# boundary rather than being extrapolated from one probe.
-#
-# FLOOR (>=2021.03.1) is conservative rather than derived, and an earlier
-# version of this comment justified it wrongly:
-#
-#   * It is NOT the oldest rdkit with the INCHI header -- 2020.09.5 has it too.
-#   * It is NOT "the oldest rdkit conda-forge ships". conda-forge still carries
-#     rdkit 2017.09.3, the very version upstream pins. Nothing was deleted. It
-#     is unusable for a different reason: it was only ever built for Python
-#     2.7/3.5/3.6 against boost 1.66, so it cannot enter a modern solve.
-#
-# The genuine hard floor is rdkit 2018.03, where ROMol::operator[] changed to
-# return a raw Bond* -- see rdkit-operator-returns-raw-bond.patch, which will
-# not compile against anything older. Verified against RDKit's own source:
-# Release_2017_09_3 returns BOND_SPTR, Release_2018_03_1 returns Bond*.
-#
-# 2021.03.1 is kept as a deliberately cautious floor: it is well clear of the
-# 2018.03 API break, and in practice only rdkit >=2022.03.1 has builds for
-# python >=3.10 anyway, so nothing older is reachable in a current environment.
-# Upstream's INSTALL.md says "Newer RDKit may work but we have not test it yet",
-# so this whole window is the untested case, entered with a bounded pin.
-#
-# If CFM-ID is ever to build against current rdkit, conda-forge would need to
-# ship INCHI headers again, or upstream would need to stop depending on them.
-
 package:
   name: {{ name }}
   version: {{ version }}
@@ -65,36 +10,15 @@ source:
   url: https://bitbucket.org/wishartlab/cfm-id-code/get/{{ commit }}.tar.gz
   sha256: 41dd958bc70e353eb2e8956b5c93ac63421dd720a8580360074ccb2effd7d7cb
   patches:
-    # Two minimal, upstreamable patches are needed to build 4.4.10 against a
-    # modern RDKit. Order matters: the standard bump first, then the API fix it
-    # exposes. Both carry their full diagnosis in the patch header and should be
-    # dropped once upstream supports current RDKit.
-    #
-    # 1. CFM pins CMAKE_CXX_STANDARD 11; modern RDKit headers need C++17.
-    #    Without this the build dies inside RDKit's own headers on std::any /
-    #    std::string_view / std::is_same_v.
     - make-cxx-standard-overridable.patch
-    # 2. ROMol::operator[] now returns a raw Bond*, so the old .get() call no
-    #    longer compiles. One line, one file.
     - rdkit-operator-returns-raw-bond.patch
-    # 3. DBL_MAX used without <cfloat>. Unrelated to RDKit: current libstdc++
-    #    no longer pulls it in transitively.
     - add-cfloat-include.patch
 
 build:
   number: 0
-  # Skipped on arm, not on macOS. conda-forge has no arm64 build of liblbfgs
-  # for either osx-arm64 or linux-aarch64, and CFM cannot build without it.
-  # osx-64 and linux-64 both have liblbfgs 1.10 and are supported.
   skip: True  # [aarch64 or arm64]
   run_exports:
     - {{ pin_subpackage(name, max_pin="x") }}
-  # `cfm` and `cfm-id` both install binaries named cfm-id, cfm-predict and
-  # fraggraph-gen, so they cannot share an environment. Without this the clash
-  # surfaces late, as a file-clobber error after solving; with it the solver
-  # refuses up front. Nothing satisfies "<0a0", making the two mutually
-  # exclusive. run_constrained never pulls a package in -- it only constrains
-  # one that is being installed anyway.
   run_constrained:
     - cfm <0a0
 
@@ -103,32 +27,9 @@ requirements:
     - make
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    # Required by bioconda lint (compiler_needs_stdlib_c) whenever a compiler
-    # is requested: pins the C standard library the package is built against.
-    #
     - {{ stdlib('c') }}
     - cmake >=3.7
   host:
-    # INSTALL.md requires Boost >=1.62 with regex, serialization, filesystem,
-    # system, thread, program_options and test.
-    # boost-cpp, deliberately, even though conda-forge has renamed the boost
-    # packages and boost-cpp is now only a ~17 kB shim over libboost-devel,
-    # frozen at 1.85.0 while libboost-devel has reached 1.91.0.
-    #
-    # Switching to libboost-devel BREAKS THE BUILD, and it is worth knowing
-    # why before anyone modernises this line again:
-    #
-    #     conda-forge-pinning pins   libboost_devel: 1.88
-    #     rdkit 2023.09.6 requires   libboost >=1.84.0,<1.85.0a0
-    #
-    # Naming libboost-devel therefore drags in the pinned 1.88 and the solve
-    # fails against every rdkit in our <2024 window. boost-cpp is not in the
-    # global pinning, so it floats and settles on whatever boost rdkit wants
-    # (1.84.0 in practice). The legacy name is doing real work here.
-    #
-    # This is fragile: if conda-forge ever removes boost-cpp outright, this
-    # recipe needs an explicit libboost-devel bound matching the rdkit window
-    # rather than the pinned default.
     - boost-cpp
     - liblbfgs =1.10
     - lp_solve =5.5
@@ -145,20 +46,12 @@ test:
     - which cfm-annotate
     - which cfm-id-precomputed
     - which fraggraph-gen
-    # cfm-train is intentionally NOT built (see build.sh: it needs MPI, which
-    # does not probe successfully under the stdlib sysroot, and training is out
-    # of scope for the Galaxy wrapper).
-    # Real work, not just presence: fragment graph generation needs the
-    # compiled RDKit/lp_solve stack to actually function.
     - fraggraph-gen CC 2 + fullgraph
     - fraggraph-gen CC 2 "*" fragonly
-    # Proves the pretrained parameters installed by build.sh are found.
     - test -d "${PREFIX}/share/{{ name }}-{{ version }}/cfmid4"
 
 about:
   home: https://cfmid.wishartlab.com/
-  # Verified from LICENSE.md in the 4.4.10 source. The `cfm` v33 recipe says
-  # GPL-2; 4.4.10 ships LGPL-2.1.
   license: LGPL-2.1-only
   license_family: LGPL
   license_file: LICENSE.md

--- a/recipes/cfm-id/meta.yaml
+++ b/recipes/cfm-id/meta.yaml
@@ -1,0 +1,184 @@
+{% set name = "cfm-id" %}
+{% set version = "4.4.10" %}
+{% set commit = "cced92452e0f230acacc0427d19908b266811dc9" %}
+
+# NEW package, deliberately not a bump of the existing `cfm` recipe.
+#
+# `cfm` is pinned at version 33, which is CFM-ID 3-era software built against
+# rdkit 2018.09.1. This packages the CFM-ID 4 generation under a name matching
+# the software and its executables, and leaves `cfm=33` working for anything
+# that still depends on it.
+#
+# Most of the build knowledge below (build.sh, the cmake flags, the INCHI-API
+# header copy, the dependency shape) comes straight from the `cfm` recipe. What
+# is NOT carried over: its source.patch, which fixes version-33 bugs and must
+# not be applied blind to 4.4.10.
+#
+# SOURCE: upstream publishes tags on Bitbucket. Pinned to the commit the
+# CFM-ID_4.4.10 tag points at, rather than the tag name, because Bitbucket's
+# auto-generated tag archives are not guaranteed byte-stable.
+#
+# RDKIT WINDOW -- measured, not guessed.
+#
+# CEILING (<2024) comes from the INCHI headers. CFM includes
+# <INCHI-API/inchi.h>; conda-forge's rdkit ships that as GraphMol/inchi.h, but
+# stopped at some point. Probed by downloading each package and looking:
+#
+#     rdkit 2020.09.5  -> GraphMol/inchi.h present
+#     rdkit 2021.03.1  -> present
+#     rdkit 2022.03.1  -> present
+#     rdkit 2023.09.6  -> present
+#     rdkit 2024.03.5  -> ABSENT
+#     rdkit 2024.09.6  -> ABSENT
+#
+# Both 2024 releases were checked, so the ceiling really is at the 2023/2024
+# boundary rather than being extrapolated from one probe.
+#
+# FLOOR (>=2021.03.1) is conservative rather than derived, and an earlier
+# version of this comment justified it wrongly:
+#
+#   * It is NOT the oldest rdkit with the INCHI header -- 2020.09.5 has it too.
+#   * It is NOT "the oldest rdkit conda-forge ships". conda-forge still carries
+#     rdkit 2017.09.3, the very version upstream pins. Nothing was deleted. It
+#     is unusable for a different reason: it was only ever built for Python
+#     2.7/3.5/3.6 against boost 1.66, so it cannot enter a modern solve.
+#
+# The genuine hard floor is rdkit 2018.03, where ROMol::operator[] changed to
+# return a raw Bond* -- see rdkit-operator-returns-raw-bond.patch, which will
+# not compile against anything older. Verified against RDKit's own source:
+# Release_2017_09_3 returns BOND_SPTR, Release_2018_03_1 returns Bond*.
+#
+# 2021.03.1 is kept as a deliberately cautious floor: it is well clear of the
+# 2018.03 API break, and in practice only rdkit >=2022.03.1 has builds for
+# python >=3.10 anyway, so nothing older is reachable in a current environment.
+# Upstream's INSTALL.md says "Newer RDKit may work but we have not test it yet",
+# so this whole window is the untested case, entered with a bounded pin.
+#
+# If CFM-ID is ever to build against current rdkit, conda-forge would need to
+# ship INCHI headers again, or upstream would need to stop depending on them.
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://bitbucket.org/wishartlab/cfm-id-code/get/{{ commit }}.tar.gz
+  sha256: 41dd958bc70e353eb2e8956b5c93ac63421dd720a8580360074ccb2effd7d7cb
+  patches:
+    # Two minimal, upstreamable patches are needed to build 4.4.10 against a
+    # modern RDKit. Order matters: the standard bump first, then the API fix it
+    # exposes. Both carry their full diagnosis in the patch header and should be
+    # dropped once upstream supports current RDKit.
+    #
+    # 1. CFM pins CMAKE_CXX_STANDARD 11; modern RDKit headers need C++17.
+    #    Without this the build dies inside RDKit's own headers on std::any /
+    #    std::string_view / std::is_same_v.
+    - make-cxx-standard-overridable.patch
+    # 2. ROMol::operator[] now returns a raw Bond*, so the old .get() call no
+    #    longer compiles. One line, one file.
+    - rdkit-operator-returns-raw-bond.patch
+    # 3. DBL_MAX used without <cfloat>. Unrelated to RDKit: current libstdc++
+    #    no longer pulls it in transitively.
+    - add-cfloat-include.patch
+
+build:
+  number: 0
+  skip: True  # [osx]
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x") }}
+  # `cfm` and `cfm-id` both install binaries named cfm-id, cfm-predict and
+  # fraggraph-gen, so they cannot share an environment. Without this the clash
+  # surfaces late, as a file-clobber error after solving; with it the solver
+  # refuses up front. Nothing satisfies "<0a0", making the two mutually
+  # exclusive. run_constrained never pulls a package in -- it only constrains
+  # one that is being installed anyway.
+  run_constrained:
+    - cfm <0a0
+
+requirements:
+  build:
+    - make
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    # Required by bioconda lint (compiler_needs_stdlib_c) whenever a compiler
+    # is requested: pins the C standard library the package is built against.
+    #
+    - {{ stdlib('c') }}
+    - cmake >=3.7
+  host:
+    # INSTALL.md requires Boost >=1.62 with regex, serialization, filesystem,
+    # system, thread, program_options and test.
+    # boost-cpp, deliberately, even though conda-forge has renamed the boost
+    # packages and boost-cpp is now only a ~17 kB shim over libboost-devel,
+    # frozen at 1.85.0 while libboost-devel has reached 1.91.0.
+    #
+    # Switching to libboost-devel BREAKS THE BUILD, and it is worth knowing
+    # why before anyone modernises this line again:
+    #
+    #     conda-forge-pinning pins   libboost_devel: 1.88
+    #     rdkit 2023.09.6 requires   libboost >=1.84.0,<1.85.0a0
+    #
+    # Naming libboost-devel therefore drags in the pinned 1.88 and the solve
+    # fails against every rdkit in our <2024 window. boost-cpp is not in the
+    # global pinning, so it floats and settles on whatever boost rdkit wants
+    # (1.84.0 in practice). The legacy name is doing real work here.
+    #
+    # This is fragile: if conda-forge ever removes boost-cpp outright, this
+    # recipe needs an explicit libboost-devel bound matching the rdkit window
+    # rather than the pinned default.
+    - boost-cpp
+    - liblbfgs =1.10
+    - lp_solve =5.5
+    - rdkit >=2021.03.1,<2024
+  run:
+    - boost-cpp
+    - lp_solve =5.5
+    - rdkit >=2021.03.1,<2024
+
+test:
+  commands:
+    - which cfm-id
+    - which cfm-predict
+    - which cfm-annotate
+    - which cfm-id-precomputed
+    - which fraggraph-gen
+    # cfm-train is intentionally NOT built (see build.sh: it needs MPI, which
+    # does not probe successfully under the stdlib sysroot, and training is out
+    # of scope for the Galaxy wrapper).
+    # Real work, not just presence: fragment graph generation needs the
+    # compiled RDKit/lp_solve stack to actually function.
+    - fraggraph-gen CC 2 + fullgraph
+    - fraggraph-gen CC 2 "*" fragonly
+    # Proves the pretrained parameters installed by build.sh are found.
+    - test -d "${PREFIX}/share/{{ name }}-{{ version }}/cfmid4"
+
+about:
+  home: https://cfmid.wishartlab.com/
+  # Verified from LICENSE.md in the 4.4.10 source. The `cfm` v33 recipe says
+  # GPL-2; 4.4.10 ships LGPL-2.1.
+  license: LGPL-2.1-only
+  license_family: LGPL
+  license_file: LICENSE.md
+  summary: CFM-ID 4 - Competitive Fragmentation Modeling for MS/MS prediction and metabolite identification
+  description: |
+    CFM-ID applies Competitive Fragmentation Modeling to predict ESI-MS/MS
+    spectra from molecular structures, to annotate peaks, and to rank candidate
+    structures against an experimental spectrum.
+
+    This package provides the CFM-ID 4 generation. The older `cfm` package
+    (version 33) is CFM-ID 3-era software; the two install binaries with the
+    same names and cannot be installed together.
+
+    Pretrained CFM-ID 4 parameters are installed under
+    $PREFIX/share/cfm-id-<version>/. The upstream repository also ships
+    ~172 MB of cross-validation models, which are not needed at runtime and are
+    deliberately not packaged.
+  dev_url: https://bitbucket.org/wishartlab/cfm-id-code
+
+extra:
+  recipe-maintainers:
+    - RJMW
+    - neil-butcher
+  identifiers:
+    - doi:10.1021/acs.analchem.1c01465
+    - doi:10.1093/nar/gkac383

--- a/recipes/cfm-id/meta.yaml
+++ b/recipes/cfm-id/meta.yaml
@@ -83,7 +83,10 @@ source:
 
 build:
   number: 0
-  skip: True  # [osx]
+  # Skipped on arm, not on macOS. conda-forge has no arm64 build of liblbfgs
+  # for either osx-arm64 or linux-aarch64, and CFM cannot build without it.
+  # osx-64 and linux-64 both have liblbfgs 1.10 and are supported.
+  skip: True  # [aarch64 or arm64]
   run_exports:
     - {{ pin_subpackage(name, max_pin="x") }}
   # `cfm` and `cfm-id` both install binaries named cfm-id, cfm-predict and

--- a/recipes/cfm-id/rdkit-operator-returns-raw-bond.patch
+++ b/recipes/cfm-id/rdkit-operator-returns-raw-bond.patch
@@ -1,0 +1,37 @@
+Adapt to RDKit's ROMol::operator[] returning a raw Bond*.
+
+In the RDKit generation CFM-ID 4.4.10 targets (2017_09_3), ROMol::operator[]
+returned a smart-pointer-like wrapper, so `.get()` was needed to reach the
+underlying Bond. In currently packaged RDKit it returns `RDKit::Bond*`
+directly, and calling .get() on a raw pointer fails to compile:
+
+    MILP.cpp:276: error: request for member 'get' in
+    '...RDKit::ROMol::operator[](...)', which is of pointer type
+    'RDKit::Bond*' (maybe you meant to use '->' ?)
+
+The dereference is simply no longer required. This is the only occurrence of
+the pattern in the CFM sources.
+
+Applied on top of cxx17-for-modern-rdkit.patch; both are needed to build
+against a modern RDKit.
+
+Upstream status: not reported, because there is currently no channel to report to.
+Atlassian is sunsetting Bitbucket Issues and Wikis across Cloud; they could no
+longer be enabled from April 2026 and existing issues are removed on 20 August
+2026, so wishartlab/cfm-id-code has no usable tracker. The repository README
+carries no contact address and there is no CONTRIBUTING file. Pull requests are
+unaffected and remain possible; this change has been restated against current
+master and verified to apply with patch -Np1 --binary.
+Remove this patch once upstream supports current RDKit itself.
+
+--- a/cfm/cfm-code/MILP.cpp
++++ b/cfm/cfm-code/MILP.cpp
+@@ -273,7 +273,7 @@
+ 
+             for ( ; cbond_beg != cbond_end; ++ cbond_beg ){
+             //for (; it != ip.second; ++it) {
+-                RDKit::Bond *cbond = (*mol)[*cbond_beg].get();
++                RDKit::Bond *cbond = (*mol)[*cbond_beg];
+                 int cbond_broken;
+                 cbond->getProp("Broken", cbond_broken);
+                 if(cbond_broken)

--- a/recipes/cfm-id/rdkit-operator-returns-raw-bond.patch
+++ b/recipes/cfm-id/rdkit-operator-returns-raw-bond.patch
@@ -1,28 +1,14 @@
 Adapt to RDKit's ROMol::operator[] returning a raw Bond*.
 
-In the RDKit generation CFM-ID 4.4.10 targets (2017_09_3), ROMol::operator[]
-returned a smart-pointer-like wrapper, so `.get()` was needed to reach the
-underlying Bond. In currently packaged RDKit it returns `RDKit::Bond*`
-directly, and calling .get() on a raw pointer fails to compile:
+RDKit 2017_09_3 returned a smart-pointer wrapper, so .get() was needed to reach
+the Bond. Current RDKit returns RDKit::Bond* directly and .get() no longer
+compiles. This is the only occurrence of the pattern in the CFM sources.
 
-    MILP.cpp:276: error: request for member 'get' in
-    '...RDKit::ROMol::operator[](...)', which is of pointer type
-    'RDKit::Bond*' (maybe you meant to use '->' ?)
-
-The dereference is simply no longer required. This is the only occurrence of
-the pattern in the CFM sources.
-
-Applied on top of cxx17-for-modern-rdkit.patch; both are needed to build
+Applied on top of make-cxx-standard-overridable.patch; both are needed to build
 against a modern RDKit.
 
-Upstream status: not reported, because there is currently no channel to report to.
-Atlassian is sunsetting Bitbucket Issues and Wikis across Cloud; they could no
-longer be enabled from April 2026 and existing issues are removed on 20 August
-2026, so wishartlab/cfm-id-code has no usable tracker. The repository README
-carries no contact address and there is no CONTRIBUTING file. Pull requests are
-unaffected and remain possible; this change has been restated against current
-master and verified to apply with patch -Np1 --binary.
-Remove this patch once upstream supports current RDKit itself.
+Not reported upstream: Bitbucket Issues are being sunset, so the repository has
+no usable tracker. Remove once upstream supports current RDKit itself.
 
 --- a/cfm/cfm-code/MILP.cpp
 +++ b/cfm/cfm-code/MILP.cpp


### PR DESCRIPTION
Adds CFM-ID 4 as a new recipe rather than an update to `cfm`.

`recipes/cfm` is at version 33, which is the CFM-ID 3 generation. Both install binaries called `cfm-id`, `cfm-predict` and `fraggraph-gen`, so they cannot share an environment. This recipe sets `run_constrained: cfm <0a0` so the solver rejects the combination up front instead of it failing later as clobbered files. Existing `cfm` users are unaffected. Bumping `cfm` in place would also mean a version decrease, since CFM-ID renumbered from 33 to 4.4.10.

The source is pinned to the commit behind the `CFM-ID_4.4.10` tag, because Bitbucket's generated tag archives are not byte-stable.

Three patches are needed to build against a current RDKit. One makes `CMAKE_CXX_STANDARD` overridable from the command line so `build.sh` can ask for C++17, which RDKit's headers now require. One drops a `.get()` call, since `ROMol::operator[]` returns a raw `Bond *` in current RDKit. One adds a missing `<cfloat>` include. Each patch header says what it does and when it can be dropped. They are not reported upstream yet: Bitbucket is removing Issues and the repository has no contact address, so I am contacting the authors directly.