### PR TITLE
Update muat to version 0.1.24

### DIFF
--- a/recipes/muat/meta.yaml
+++ b/recipes/muat/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "muat" %}
-{% set version = "0.1.22" %}
+{% set version = "0.1.24" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,8 @@ package:
 
 source:
   url: https://github.com/primasanjaya/muat/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 0c2b1a83b882b66d787a443043e1c281637c2691517df9d73f08ed2a2209f57c
+  sha256: 3d460e43d8e45f97fb5983e0fb29ff8ef80eebc3e60cfe74356127279194e59a
+
 
 build:
   number: 0


### PR DESCRIPTION
Fix bug:

- Fix silent mutation loss in hg38-native genic/exonic/strand annotation