### PR TITLE
Update nebulizer to 0.7.2 (fix auto-bump PR)

### DIFF
--- a/recipes/nebulizer/meta.yaml
+++ b/recipes/nebulizer/meta.yaml
@@ -16,6 +16,8 @@ build:
   script: python setup.py install --single-version-externally-managed --record=record.txt
   entry_points:
     - nebulizer = nebulizer.cli:nebulizer
+  run_exports:
+    - {{ pin_subpackage('nebulizer', max_pin="x.x") }}
   
 requirements:
   host:

--- a/recipes/nebulizer/meta.yaml
+++ b/recipes/nebulizer/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "nebulizer" %}
-{% set version = "0.7.1" %}
-{% set hash_value = "e6dbafe3681a99e5adc82f7d672380aa7e66d155d9c207770fa779ca87011403" %}
+{% set version = "0.7.2" %}
+{% set hash_value = "049fe95c84e8fe4cc7e299061d84ce7fbb9660e3234749a1f832de2348951d51" %}
 
 package:
   name: '{{ name|lower }}'


### PR DESCRIPTION
Update [`nebulizer`](https://bioconda.github.io/recipes/nebulizer/README.html): **0.7.1** &rarr; **0.7.2**

[![install with bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg?style=flat)](http://bioconda.github.io/recipes/nebulizer/README.html) [![Conda](https://img.shields.io/conda/dn/bioconda/nebulizer.svg)](https://anaconda.org/bioconda/nebulizer/files)

Info | Link or Description
-----|--------------------
Recipe | [`recipes/nebulizer`](https://github.com//bioconda/bioconda-recipes/tree/bump/nebulizer/recipes/nebulizer) (click to view/edit other files)
Summary | Command-line utilities to help with managing users, data libraries and tools in a Galaxy instance
Home | [https://github.com/pjbriggs/nebulizer](https://github.com/pjbriggs/nebulizer)
Releases |[https://github.com/pjbriggs/nebulizer/tags](https://github.com/pjbriggs/nebulizer/tags)
Author | @pjbriggs
***

PR to fix the linting error from the original auto-bump PR #68277 (which I've closed in favour of this one).

In addition to bumping to nebulizer version 0.7.2, also adds the missing `run_exports` statement to the `[build]` section of `meta.yaml`.