### PR TITLE
Update breakinator 1.1.1 for ARM64 platforms

### DIFF
--- a/recipes/breakinator/build.sh
+++ b/recipes/breakinator/build.sh
@@ -10,5 +10,5 @@ export LIBZ_SYS_STATIC=0
 export PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig:${PREFIX}/share/pkgconfig:${PKG_CONFIG_PATH:-}"
 
 # --- 2. Build & Install ---
-cargo install --path breakinator --root "${PREFIX}" --no-track --verbose
+cargo install --locked --path breakinator --root "${PREFIX}" --no-track --verbose
 

--- a/recipes/breakinator/meta.yaml
+++ b/recipes/breakinator/meta.yaml
@@ -48,4 +48,5 @@ about:
 
 extra:
   additional-platforms:
+    - linux-aarch64
     - osx-arm64

--- a/recipes/breakinator/meta.yaml
+++ b/recipes/breakinator/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 3961a4c77e356881335c83f740517269993e391260dc4958f2f34a43c82e0516
 
 build:
-  number: 1
+  number: 2
   run_exports:
     - {{ pin_subpackage("breakinator", max_pin="x") }}
 
@@ -19,6 +19,7 @@ requirements:
   build:
     - {{ compiler('rust') }}
     - {{ compiler('c') }}
+    - {{ stdlib('c') }}
     - make
     - pkg-config
   host:
@@ -37,8 +38,14 @@ requirements:
 test:
   commands:
     - breakinator --help
+    - breakinator --version
+    - breakinator --help 2>&1 | grep -q -- "--threads"
 
 about:
   home: https://github.com/jheinz27/breakinator
   license: MIT
   summary: "Detection of foldback and chimeric read artifacts in SAM/BAM/CRAM and PAF files"
+
+extra:
+  additional-platforms:
+    - osx-arm64


### PR DESCRIPTION
The current Breakinator v1.1.1 Rust build is not available for osx-arm64. On Apple Silicon, conda therefore resolves to the older noarch Python build of v1.1.1, which exposes the legacy PAF-only CLI rather than the current Rust SAM/BAM/CRAM CLI.

This PR bumps the build number, enables osx-arm64 builds, and strengthens the tests to verify the current Rust CLI via --version and --threads.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
