### PR TITLE
Update gtdb-genomes to 0.3.0

### DIFF
--- a/recipes/gtdb-genomes/meta.yaml
+++ b/recipes/gtdb-genomes/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "gtdb-genomes" %}
-{% set version = "0.2.2" %}
+{% set version = "0.3.0" %}
 
 package:
   name: {{ name }}
@@ -16,7 +16,7 @@ build:
 
 source:
   url: https://github.com/asuq/gtdb-genomes/releases/download/v{{ version }}/gtdb_genomes-{{ version }}.tar.gz
-  sha256: 687fa8778b84c4f96edabef0160f8d34141ff9b02d632d388a58661a14948b66
+  sha256: 43b5e0387ba87649e78f8b4759580fdac546a7864c9766d796fd9705c46f88e9
 
 requirements:
   host:
@@ -27,7 +27,6 @@ requirements:
     - python >=3.12
     - polars >=1.31.0,<2.0.0
     - tqdm >=4.60.0,<5.0.0
-    - unzip >=6.0,<7.0
     - ncbi-datasets-cli >=18.4.0,<19.0.0
 
 test:


### PR DESCRIPTION
Supersedes #68294.

Update `gtdb-genomes` to 0.3.0 using the verified published sdist checksum. Unlike the automated version bump, this also removes the obsolete `unzip` runtime dependency because upstream now uses Python's standard library for ZIP extraction.

Validation:

- `bioconda-utils lint` passed.
- The noarch package built locally and all recipe tests passed on Python 3.14.
- Upstream wheel and sdist release validation passed.

Thank you for reviewing this update.
