### PR TITLE
Update egt to v0.2.5

### DIFF
--- a/recipes/egt/meta.yaml
+++ b/recipes/egt/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "egt" %}
-{% set version = "0.2.3" %}
+{% set version = "0.2.5" %}
 
 package:
   name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://files.pythonhosted.org/packages/00/fa/0b1688ed2e1eacdbd3990ee5c064eacb515647d349781dd8334286db811a/egt-{{ version }}.tar.gz
-  sha256: fd9f85888630bf875b7125822c09fc576d8253ae202f8cc16dc174449057fd15
+  url: https://files.pythonhosted.org/packages/2c/26/9737d2fd448bd912ba033fd74c91f249a2061792c6da45fda7037c54f6ef/egt-{{ version }}.tar.gz
+  sha256: 019375814c2e1e024e416ae2d3b5cc89c31268b33c635ab4d6bcc2932a0798f7
 
 build:
   number: 0
@@ -62,5 +62,6 @@ about:
 extra:
   identifiers:
     - pypi:egt
+    - doi:10.1126/sciadv.adz5561
   recipe-maintainers:
     - conchoecia


### PR DESCRIPTION
Version bump `0.2.3` → `0.2.5`, plus the published-paper DOI under `extra.identifiers`.

The tool's citation moved from a bioRxiv preprint to *Science Advances* 12(34):eadz5561, so `doi:10.1126/sciadv.adz5561` is now recorded in the recipe.

Checked for the version jump: runtime dependencies are byte-identical between v0.2.3 and v0.2.5, and the entry point is unchanged (`egt = egt.cli:main`), so `requirements/run` and `build/entry_points` need no edits. `build/number` reset to 0 per the version bump.

Recipe maintainer (`conchoecia`).