### PR TITLE
Fix sniffles 2.8.0: pin python <3.14 until python-edlib supports it

### DIFF
--- a/recipes/sniffles/meta.yaml
+++ b/recipes/sniffles/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --no-cache-dir -vvv
   run_exports:

--- a/recipes/sniffles/meta.yaml
+++ b/recipes/sniffles/meta.yaml
@@ -19,11 +19,11 @@ build:
 
 requirements:
   host:
-    - python >=3.10
+    - python >=3.10,<3.14
     - pip
     - setuptools
   run:
-    - python >=3.10
+    - python >=3.10,<3.14
     - pysam >=0.21.0
     - python-edlib >=1.3.9
     - psutil >=5.9.4


### PR DESCRIPTION
## Description

The sniffles 2.8.0 container build fails on Seqera Containers with:

```
error: [Errno 2] No such file or directory: 'g++'
ERROR: Failed building wheel for edlib
```

The Wave container build resolves to Python 3.14, which has no pre-built conda package for `python-edlib`. Conda falls back to installing it via pip from source, which requires `g++` which is not present in the container.

## Fix

Pin `python <3.14` in both `host` and `run` requirements until `python-edlib` ships pre-built packages for Python 3.14.

## Checklist

- [x] Source URL is stable
- [x] sha256 hash included
- [x] Appropriate build number (0, no successful build yet for 2.8.0)
- [x] No .bat files
- [x] No unnecessary comments
- [x] Adequate tests included (`sniffles --help`)
- [x] License indicated in meta.yaml