### PR TITLE
Add molnetpack 1.4.0

### DIFF
--- a/recipes/molnetpack/meta.yaml
+++ b/recipes/molnetpack/meta.yaml
@@ -36,8 +36,6 @@ requirements:
     - platformdirs
     - requests
     - tqdm
-    # An optional `train` extra upstream, imported lazily in fit_scaler.
-    # Declared so MolNet.train(task="rt", use_scaler=True) works as installed.
     - scikit-learn
 
 test:
@@ -45,7 +43,6 @@ test:
     - molnetpack
   commands:
     - python -c "from molnetpack import MolNet; print('molnetpack import OK')"
-    # Checkpoints download on demand, so tests must not reach a pred_* method.
     - python -c "import torch; from molnetpack import MolNet; MolNet(torch.device('cpu'), seed=42)"
 
 about:

--- a/recipes/molnetpack/meta.yaml
+++ b/recipes/molnetpack/meta.yaml
@@ -1,0 +1,80 @@
+{% set name = "molnetpack" %}
+{% set version = "1.4.0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 43810265d2a16637b12db32b4ced9d051890032edaa372ddb7a559b8325e7d40
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x.x") }}
+
+requirements:
+  host:
+    - python >=3.10
+    - pip
+    # Backend has changed at every release: setuptools -> flit -> hatchling.
+    - hatchling
+  run:
+    - python >=3.10
+    - pytorch
+    - molmass
+    - numpy
+    - pandas
+    - pyteomics
+    - pyyaml
+    - rdkit
+    - matplotlib-base
+    - pillow
+    - platformdirs
+    - requests
+    - tqdm
+    # An optional `train` extra upstream, imported lazily in fit_scaler.
+    # Declared so MolNet.train(task="rt", use_scaler=True) works as installed.
+    - scikit-learn
+
+test:
+  imports:
+    - molnetpack
+  commands:
+    - python -c "from molnetpack import MolNet; print('molnetpack import OK')"
+    # Checkpoints download on demand, so tests must not reach a pred_* method.
+    - python -c "import torch; from molnetpack import MolNet; MolNet(torch.device('cpu'), seed=42)"
+
+about:
+  home: https://github.com/JosieHong/3DMolMS
+  license: CC-BY-NC-SA-4.0
+  license_file: LICENSE
+  summary: 3DMolMS - tandem mass spectrum prediction from 3D molecular conformations
+  description: |
+    3DMolMS predicts MS/MS spectra from three-dimensional molecular
+    conformations using a deep neural network, with qTOF and Orbitrap models.
+    It also predicts retention time and collision cross section, and supports
+    feature extraction and model training.
+
+    The PyPI distribution is named molnetpack; the software is 3DMolMS.
+
+    Pretrained checkpoints are downloaded on demand by the pred_* methods.
+    Deployments needing reproducibility or offline operation should pass an
+    explicit checkpoint path instead. Checkpoints are version-specific: 1.4.0
+    retrained the QTOF, Orbitrap, RT and CCS models, and loading refuses any
+    checkpoint whose embedded config does not match.
+
+    NOTE: MolNet.load_data accepts a .pkl input deserialised with pickle.load,
+    which permits arbitrary code execution. Do not pass untrusted .pkl files.
+  doc_url: https://3dmolms.readthedocs.io/
+  dev_url: https://github.com/JosieHong/3DMolMS
+
+extra:
+  recipe-maintainers:
+    - RJMW
+    - neil-butcher
+  identifiers:
+    - doi:10.1093/bioinformatics/btad354


### PR DESCRIPTION
New recipe for **3DMolMS** — a deep neural network predicting MS/MS spectra from three-dimensional molecular conformations, with qTOF and Orbitrap models, plus retention-time and collision-cross-section prediction.

- Upstream: https://github.com/JosieHong/3DMolMS
- Paper: [doi:10.1093/bioinformatics/btad354](https://doi.org/10.1093/bioinformatics/btad354)

### On the package name

The software is called **3DMolMS**; **molnetpack** is its PyPI distribution and import name. Upstream's own install instruction reads *"3DMolMS is available on PyPI: `pip install molnetpack`"*, so the recipe is named for the distribution — the package ships no console script, so it is a library and `conda install` / `import` / error messages all agree. "3DMolMS" is carried in `summary`, `home`, `doc_url` and `description` for discoverability.

### Built and tested

- **linux-64**, in `quay.io/bioconda/bioconda-utils-build-env-cos7` under `--platform linux/amd64`
- **osx-arm64**

Both test commands ran on each; `MolNet(torch.device('cpu'), seed=42)` reports `MolNetPack version: 1.4.0`, which also confirms the declared dependency set is sufficient to import and instantiate. `bioconda-utils lint` (4.4.1) clean.

The tests deliberately stop at instantiation: `pred_*` methods **download checkpoints on demand**, so reaching one would put a network fetch inside the build.

### One deliberate departure from upstream metadata

`scikit-learn` is declared as a runtime dependency although 1.4.0 moved it to an optional `train` extra.

It is reachable through exactly one path — `fit_scaler()`, called from `MolNet.train(task="rt", use_scaler=True)` — and is imported lazily inside that function, so prediction genuinely does not need it. It is declared anyway so that retention-time training works from the installed package. Cost is 5 packages (`scikit-learn`, `scipy`, `joblib`, `threadpoolctl`, `narwhals`), negligible beside pytorch.

Flagging it because it looks like an error against `pyproject.toml` and would otherwise be a reasonable thing for a reviewer to ask me to remove.

### Licence

**CC-BY-NC-SA-4.0** — not an OSI-approved licence, and non-commercial. Carried accurately in the recipe rather than glossed.