### PR TITLE
Add msfiddle 2.1.0

### DIFF
--- a/recipes/msfiddle/meta.yaml
+++ b/recipes/msfiddle/meta.yaml
@@ -27,8 +27,6 @@ requirements:
     - setuptools
   run:
     - python >=3.8
-    # Upstream declares numpy>=1.20.0,<2.0.0. The upper bound is a hard
-    # constraint, not a courtesy pin -- carry it verbatim.
     - numpy >=1.20.0,<2.0a0
     - pandas >=2.0.0
     - tqdm >=4.60.0
@@ -39,8 +37,6 @@ requirements:
     - rdkit >=2022.03.5
     - molmass
     - pyteomics
-    # Upstream ships this as the [inference] extra. Declared explicitly here
-    # rather than installing the PyPI extra through pip, so the solver sees it.
     - pytorch
 
 test:
@@ -50,8 +46,6 @@ test:
     - msfiddle --help
     - msfiddle-download-models --help
     - msfiddle-checkpoint-paths --help
-    # Bundled demo fixtures ship inside the package; this confirms package_data
-    # was actually installed, which a bare import would not catch.
     - python -c "import msfiddle, pathlib; p = pathlib.Path(msfiddle.__file__).parent; assert (p / 'config').is_dir(); assert list((p / 'demo').glob('*.mgf')), 'demo MGF fixtures missing'"
 
 about:

--- a/recipes/msfiddle/meta.yaml
+++ b/recipes/msfiddle/meta.yaml
@@ -1,0 +1,80 @@
+{% set name = "msfiddle" %}
+{% set version = "2.1.0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: e3a35d14a534795066468a1f5688b25e177a9ca171fc3a28ab3fb236b67c7ca0
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  entry_points:
+    - msfiddle = msfiddle.main:main
+    - msfiddle-download-models = msfiddle.download:download_models_cli
+    - msfiddle-checkpoint-paths = msfiddle.download:print_checkpoint_paths_cli
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x") }}
+
+requirements:
+  host:
+    - python >=3.8
+    - pip
+    - setuptools
+  run:
+    - python >=3.8
+    # Upstream declares numpy>=1.20.0,<2.0.0. The upper bound is a hard
+    # constraint, not a courtesy pin -- carry it verbatim.
+    - numpy >=1.20.0,<2.0a0
+    - pandas >=2.0.0
+    - tqdm >=4.60.0
+    - pyyaml >=6.0
+    - scikit-learn >=1.0.0
+    - scipy >=1.8.0
+    - pyarrow >=10.0.0
+    - rdkit >=2022.03.5
+    - molmass
+    - pyteomics
+    # Upstream ships this as the [inference] extra. Declared explicitly here
+    # rather than installing the PyPI extra through pip, so the solver sees it.
+    - pytorch
+
+test:
+  imports:
+    - msfiddle
+  commands:
+    - msfiddle --help
+    - msfiddle-download-models --help
+    - msfiddle-checkpoint-paths --help
+    # Bundled demo fixtures ship inside the package; this confirms package_data
+    # was actually installed, which a bare import would not catch.
+    - python -c "import msfiddle, pathlib; p = pathlib.Path(msfiddle.__file__).parent; assert (p / 'config').is_dir(); assert list((p / 'demo').glob('*.mgf')), 'demo MGF fixtures missing'"
+
+about:
+  home: https://github.com/JosieHong/msfiddle
+  license: Apache-2.0
+  license_family: APACHE
+  license_file: LICENSE
+  summary: FIDDLE - chemical formula prediction from tandem mass spectra by deep learning
+  description: |
+    FIDDLE (Formula IDentification by Deep LEarning) predicts molecular formulas
+    from tandem mass spectra using Orbitrap and Q-TOF models. It can optionally
+    incorporate native BUDDY/msbuddy and SIRIUS formula results as external
+    candidates for comparison or rescoring. Formula prediction is not structural
+    identification.
+
+    Pre-trained checkpoints are not bundled. They must be installed ahead of
+    time; do not invoke msfiddle-download-models from inside a compute job.
+  doc_url: https://github.com/JosieHong/msfiddle
+  dev_url: https://github.com/JosieHong/msfiddle
+
+extra:
+  recipe-maintainers:
+    - RJMW
+    - neil-butcher
+  identifiers:
+    - doi:10.1038/s41467-025-66060-9


### PR DESCRIPTION
New recipe for **FIDDLE** (Formula IDentification by Deep LEarning) — predicts molecular formulas from tandem mass spectra using Orbitrap and Q-TOF models. It can optionally incorporate BUDDY/msbuddy and SIRIUS results as external candidates for rescoring.

- Upstream: https://github.com/JosieHong/msfiddle
- Paper: [doi:10.1038/s41467-025-66060-9](https://doi.org/10.1038/s41467-025-66060-9)
- Licence: Apache-2.0

### Built and tested

Built in `quay.io/bioconda/bioconda-utils-build-env-cos7` under `--platform linux/amd64`:

```
BUILD START: ['msfiddle-2.1.0-py_0.conda']
TEST START / TEST END        exit 0
```

`bioconda-utils lint` (4.4.1) clean. Source sha256 verified against PyPI.

The test section exercises all three console scripts, and additionally asserts that the packaged `config/` directory and the bundled demo `.mgf` fixtures were actually installed — a `package_data` failure that a bare `import msfiddle` would not catch.

### Two dependency decisions worth a reviewer's eye

**`numpy >=1.20.0,<2.0a0`** — upstream declares `numpy>=1.20.0,<2.0.0`, and the upper bound is carried verbatim because it is a hard constraint rather than a courtesy pin.

**`pytorch` is declared explicitly** rather than relying on upstream's `[inference]` extra. Installing the extra through pip would hide the dependency from the conda solver; declaring it makes the environment resolvable and complete.

### Checkpoints

Pretrained checkpoints are **not bundled**, and nothing in the build or test section downloads them — `msfiddle-download-models` exists for that and is expected to be run ahead of time by whoever deploys the package. `msfiddle-checkpoint-paths` reports where they are looked for.