### PR TITLE
Fix COMEBin 1.1.0 recipe

### DIFF
--- a/recipes/comebin/meta.yaml
+++ b/recipes/comebin/meta.yaml
@@ -35,7 +35,7 @@ requirements:
     - samtools >=1.20,<2
     - scikit-learn >=1.5,<1.10
     - scipy >=1.13,<2
-    - setuptools <81
+    - setuptools <82
     - tensorboard >=2.18,<3
     - tqdm >=4.66,<5
 

--- a/recipes/comebin/meta.yaml
+++ b/recipes/comebin/meta.yaml
@@ -7,56 +7,48 @@ source:
   sha256: d17310f5b96e8295ba785c731a86f2782b8386befdd2a2ed54842f2fa9f321bf
 
 build:
-  number: 1
+  number: 2
   noarch: generic
   run_exports:
     - {{ pin_subpackage('comebin', max_pin="x.x") }}
 
 requirements:
   run:
-    - atomicwrites >=1.4.1
-    - bedtools >=2.31.0
-    - biolib >=0.1.6
-    - biopython >=1.76
-    - bwa >=0.7.17
-    - checkm-genome >=1.2.3
-    - click >=8.4.2
-    - fraggenescan >=1.31 
-    - gdown >=6.1.0
-    - hmmer >=3.4
-    - hnswlib >=0.8.0
-    - igraph >=1.0.0
-    - joblib >=1.5.3
-    - leidenalg >=0.12.0
-    - matplotlib-base >=3.10
-    - matplotlib-inline >=0.1.3
-    - numba >=0.66.0
-    - networkx >=3.6.1
-    - numpy >=2.4.6
-    - pandas >=3.0.3
-    - pplacer >=1.1.alpha19
-    - prodigal >=2.6.3
-    - python >=3.13
-    - python-dateutil >=2.8.2
-    - python-fastjsonschema >=2.15.3
-    - pytorch >=2.13.0
-    - pyyaml >=6.0
-    - ruamel.yaml >=0.19.1
-    - samtools >=1.24
-    - scanpy >=1.12.2
-    - scikit-learn >=1.9.0
-    - scipy >=1.18.0
-    - seaborn >=0.13.2
-    - setuptools >=80.9.0
-    - tensorboard >=2.20.0
-    - tqdm
+    - python >=3.11,<3.14
+    - bedtools >=2.31,<3
+    - biolib >=0.1.9,<0.2
+    - biopython >=1.85,<2
+    - bwa >=0.7.17,<0.8
+    - checkm-genome >=1.2,<2
+    - click >=8,<9
+    - fraggenescan >=1.31,<2
+    - hmmer >=3.4,<4
+    - hnswlib >=0.8,<1
+    - leidenalg >=0.12,<0.13
+    - numpy >=2,<3
+    - perl
+    - pplacer 1.1.alpha19
+    - prodigal >=2.6,<3
+    - python-igraph >=1,<2
+    - pytorch >=2.13,<2.14
+    - pyyaml >=6,<7
+    - samtools >=1.20,<2
+    - scikit-learn >=1.5,<1.10
+    - scipy >=1.13,<2
+    - setuptools <81
+    - tensorboard >=2.18,<3
+    - tqdm >=4.66,<5
 
 test:
   commands:
-    - which run_comebin.sh 
+    - run_comebin.sh -h
+    - run_comebin.sh -V
     - which gen_cov_file.sh
+    - python -c "import Bio, hnswlib, igraph, leidenalg, numpy, scipy, sklearn, torch, tqdm, yaml"
+    - python -c "from biolib.common import make_sure_path_exists; from checkm.defaultValues import DefaultValues; from torch.utils.tensorboard import SummaryWriter"
 
 about:
   home: "https://github.com/ziyewang/COMEBin"
-  license: BSD
+  license: GPL-3.0-only
+  license_file: LICENSE.txt
   summary: "COMEBin allows effective binning of metagenomic contigs using COntrastive Multi-viEw representation learning"


### PR DESCRIPTION
This is a follow-up to #68292 for COMEBin 1.1.0.

The build 1 recipe copied a complete development environment into the runtime requirements. This update replaces it with the packages used by COMEBin at runtime and explicit compatibility ranges, while retaining the external bioinformatics tools required by the workflow.

It also:

- bumps the build number to 2;
- corrects the upstream license to `GPL-3.0-only` and packages `LICENSE.txt`;
- uses the conda package name `python-igraph`;
- keeps `setuptools <82` because CheckM 1.2.3 imports `pkg_resources`, which was removed in Setuptools 82;
- adds CLI and Python import smoke tests.

Validation performed:

- verified the release tarball SHA256 against the recipe;
- successfully solved the complete runtime dependency set with conda-forge and bioconda using a Mamba dry run;
- successfully solved the documented GPU installation with `pytorch-gpu` and `cuda-version=13.0`;
- ran `build.sh` against the release tarball;
- ran `run_comebin.sh -h`, `run_comebin.sh -V`, and the Python import smoke tests successfully.
