### PR TITLE
Add spring2 1.3.4 recipe

### DIFF
--- a/recipes/spring2/build.sh
+++ b/recipes/spring2/build.sh
@@ -18,8 +18,10 @@ else
 fi
 
 # OpenMP_ROOT: keep FindOpenMP on the conda prefix instead of Homebrew's libomp
+# SPRING_ENABLE_PRECOMPILED_HEADERS=OFF: PCH is incompatible with conda-forge's macOS toolchain
 cmake ${CMAKE_ARGS} \
 	-DSPRING_ENABLE_COMPILER_CACHE=OFF \
+	-DSPRING_ENABLE_PRECOMPILED_HEADERS=OFF \
 	-DOpenMP_ROOT="${PREFIX}" \
 	"${PLATFORM_FLAGS[@]}" \
 	"${SRC_DIR}" || (cat CMakeFiles/CMakeConfigureLog.yaml && exit 1)

--- a/recipes/spring2/build.sh
+++ b/recipes/spring2/build.sh
@@ -24,5 +24,5 @@ cmake ${CMAKE_ARGS} \
 	"${PLATFORM_FLAGS[@]}" \
 	"${SRC_DIR}" || (cat CMakeFiles/CMakeConfigureLog.yaml && exit 1)
 
-make -j"${CPU_COUNT}"
-make install
+cmake --build . --parallel "${CPU_COUNT}" --target spring2
+cmake --install .

--- a/recipes/spring2/build.sh
+++ b/recipes/spring2/build.sh
@@ -13,12 +13,12 @@ if [[ "${target_platform}" == "linux-aarch64" ]]; then
 		"-DCMAKE_CXX_FLAGS=-march=armv8-a+crc"
 	)
 elif [[ "${target_platform}" == osx-* ]]; then
-	# std::filesystem requires macOS 10.15+; conda-forge osx-64 stdlib defaults MACOSX_DEPLOYMENT_TARGET
-	# to 10.13, which prevents cmake from propagating the right version min to compile commands.
-	export MACOSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-11.0}"
-	export CFLAGS="${CFLAGS} -mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET}"
-	export CXXFLAGS="${CXXFLAGS} -mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET}"
-	PLATFORM_FLAGS=("-DCMAKE_OSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET}")
+	# std::filesystem requires macOS 10.15+; conda-forge osx-64 c_stdlib sets
+	# MACOSX_DEPLOYMENT_TARGET=10.13 by default — override unconditionally.
+	export MACOSX_DEPLOYMENT_TARGET="11.0"
+	export CFLAGS="${CFLAGS} -mmacosx-version-min=11.0"
+	export CXXFLAGS="${CXXFLAGS} -mmacosx-version-min=11.0"
+	PLATFORM_FLAGS=("-DCMAKE_OSX_DEPLOYMENT_TARGET=11.0")
 else
 	# SPRING_NASM_EXECUTABLE: upstream otherwise prefers its vendored nasm over PATH
 	PLATFORM_FLAGS=("-DSPRING_NASM_EXECUTABLE=${BUILD_PREFIX}/bin/nasm")

--- a/recipes/spring2/build.sh
+++ b/recipes/spring2/build.sh
@@ -12,6 +12,13 @@ if [[ "${target_platform}" == "linux-aarch64" ]]; then
 		"-DCMAKE_C_FLAGS=-march=armv8-a+crc"
 		"-DCMAKE_CXX_FLAGS=-march=armv8-a+crc"
 	)
+elif [[ "${target_platform}" == osx-* ]]; then
+	# std::filesystem requires macOS 10.15+; conda-forge osx-64 stdlib defaults MACOSX_DEPLOYMENT_TARGET
+	# to 10.13, which prevents cmake from propagating the right version min to compile commands.
+	export MACOSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-11.0}"
+	export CFLAGS="${CFLAGS} -mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET}"
+	export CXXFLAGS="${CXXFLAGS} -mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET}"
+	PLATFORM_FLAGS=("-DCMAKE_OSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET}")
 else
 	# SPRING_NASM_EXECUTABLE: upstream otherwise prefers its vendored nasm over PATH
 	PLATFORM_FLAGS=("-DSPRING_NASM_EXECUTABLE=${BUILD_PREFIX}/bin/nasm")

--- a/recipes/spring2/build.sh
+++ b/recipes/spring2/build.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -ex
+
+mkdir -p build
+cd build
+
+if [[ "${target_platform}" == "linux-aarch64" ]]; then
+	# nasm is x86-only; disable ISA-L (which needs nasm asm) and set baseline march
+	PLATFORM_FLAGS=(
+		-DLIBRAPIDARCHIVE_WITH_ISAL=OFF
+		-DSPRING_ENABLE_IPO=OFF
+		"-DCMAKE_C_FLAGS=-march=armv8-a+crc"
+		"-DCMAKE_CXX_FLAGS=-march=armv8-a+crc"
+	)
+else
+	# SPRING_NASM_EXECUTABLE: upstream otherwise prefers its vendored nasm over PATH
+	PLATFORM_FLAGS=("-DSPRING_NASM_EXECUTABLE=${BUILD_PREFIX}/bin/nasm")
+fi
+
+# OpenMP_ROOT: keep FindOpenMP on the conda prefix instead of Homebrew's libomp
+cmake ${CMAKE_ARGS} \
+	-DSPRING_ENABLE_COMPILER_CACHE=OFF \
+	-DOpenMP_ROOT="${PREFIX}" \
+	"${PLATFORM_FLAGS[@]}" \
+	"${SRC_DIR}" || (cat CMakeFiles/CMakeConfigureLog.yaml && exit 1)
+
+make -j"${CPU_COUNT}"
+make install

--- a/recipes/spring2/meta.yaml
+++ b/recipes/spring2/meta.yaml
@@ -1,0 +1,50 @@
+{% set version = "1.3.4" %}
+
+package:
+  name: spring2
+  version: {{ version }}
+
+source:
+  url: https://github.com/thisisamirv/SPRING2/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 2258e58cc046ebf8f39dd1ac93acfe9344f96352d702d3b28ad454178c5c69d4
+
+build:
+  number: 0
+  skip: True  # [win]
+  run_exports:
+    - {{ pin_subpackage('spring2', max_pin="x") }}
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - {{ stdlib('c') }}
+    - cmake >=3.31
+    - nasm         # [not aarch64]
+    - python
+    - make         # [unix]
+    - ninja        # [win]
+  host:
+    - libgomp      # [linux]
+    - llvm-openmp  # [osx]
+
+test:
+  commands:
+    - spring2 --version > /dev/null
+    - spring2 --help > /dev/null 2>&1
+
+about:
+  home: https://spring2.readthedocs.io/
+  summary: Cross-platform FASTQ/FASTA compressor and decompressor
+  license: LicenseRef-SPRING
+  license_file:
+    - LICENSE
+    - REDISTRIBUTION_PERMISSION.md
+  dev_url: https://github.com/thisisamirv/SPRING2
+
+extra:
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64
+  recipe-maintainers:
+    - thisisamirv

--- a/recipes/spring2/meta.yaml
+++ b/recipes/spring2/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - {{ compiler('cxx') }}
     - {{ stdlib('c') }}
     - cmake >=3.31
-    - nasm         # [not aarch64]
+    - nasm         # [linux64]
     - python
     - make         # [unix]
     - ninja        # [win]


### PR DESCRIPTION
Add spring2 1.3.4 — a cross-platform FASTQ/FASTA compressor for genomic sequencing data.

SPRING2 is a C++20 rewrite and substantial modernization of [SPRING](https://github.com/shubhamchandak94/Spring), which is already packaged in Bioconda. It adds grouped-lane support (R1/R2/R3/I1/I2), assay-aware preprocessing (sc-ATAC, sc-RNA, bisulfite, RNA-seq), archive integrity auditing, preview without decompression, and backward-compatible decompression of legacy SPRING1 `.spring` archives.

**Platforms:** linux-64, linux-aarch64, osx-arm64

**Build notes:**

- Uses CMake + make; requires `cmake >=3.31`
- `LIBRAPIDARCHIVE_WITH_ISAL=OFF` on aarch64 (ISA-L requires NASM, which is x86-only); ISA-L enabled on linux-64 via `nasm` build dependency
- aarch64 also sets `-march=armv8-a+crc` and disables IPO, consistent with upstream CI
- `OpenMP_ROOT=${PREFIX}` directs FindOpenMP to conda's `libgomp`/`llvm-openmp` rather than Homebrew

**run_exports:** `pin_subpackage('spring2', max_pin="x")` — required by Bioconda linter for all compiled packages (semantic versioning, case 1).
