### PR TITLE
Update molamola to v0.5.0

### DIFF
--- a/recipes/molamola/meta.yaml
+++ b/recipes/molamola/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "molamola" %}
-{% set version = "0.3.0" %}
+{% set version = "0.4.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 1dec3cb110fd507e53632e28e2272031ceea1f2248307a4079ad93d22f2c0b28
+  sha256: ee2fe3ba593dd53baeb499a6c14334ad4d849c0ddabf94069d16a4429d0c1631
 
 build:
   number: 0
@@ -63,7 +63,7 @@ about:
   license: MIT
   license_family: MIT
   license_file: LICENSE
-  doc_url: https://github.com/martinandclaude/molamola
+  doc_url: https://martinandclaude.github.io/molamola/
   dev_url: https://github.com/martinandclaude/molamola
 
 extra:

--- a/recipes/molamola/meta.yaml
+++ b/recipes/molamola/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "molamola" %}
-{% set version = "0.4.0" %}
+{% set version = "0.5.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: ee2fe3ba593dd53baeb499a6c14334ad4d849c0ddabf94069d16a4429d0c1631
+  sha256: 0e3175b1122a37958775523244bb040e82877f5bdb6b0f803b44f6cee9ccb0cf
 
 build:
   number: 0


### PR DESCRIPTION
## Summary

Version bump of `molamola` from v0.3.0 to v0.4.0. Recipe change is the version, the sdist sha256, and `doc_url` now pointing at the live GitHub Pages docs instead of the repo root. No dependency, build, or test changes.

PyPI sdist: <https://pypi.org/project/molamola/0.4.0/>

### What is in v0.4.0

- **Fix:** BND records whose ALT began with the real reference base (`G]chr16:12345]`) were silently dropped by the VCF parser, which matched a literal `N` instead. Sniffles2 >= 2.8 and DRAGEN_SV both write the real base, so roughly half of every BND set was being discarded with no warning. Multi-base replacement sequences at the breakpoint were also dropped. Parsing is now delimiter-based and handles all four spec-valid ALT forms.
- **Change:** BND VAF is rendered as three discrete classes rather than a continuous colour ramp, for legibility.
- **Add:** `--plotvaf` prints per-breakend VAF percentages on the circos rim (off by default; aimed at targeted / panel runs).

Upstream changelog: <https://github.com/martinandclaude/molamola/blob/main/CHANGELOG.md>

## Notes for reviewers

- Pure-Python `noarch`; unchanged from the v0.1.0 / v0.2.0 / v0.3.0 recipes apart from version and sha256.
- `matplotlib-base` rather than `matplotlib`: molamola never opens a GUI.
- `pycirclize` is on conda-forge.
- `pyliftover` is a script-time-only dependency of `scripts/derive_canonical_exons.py --lift-to <chain>`, exposed as an optional `[derive]` extra in `pyproject.toml`. Deliberately not in `requirements.run`.
- The sdist is ~29 MB because reference data is bundled in `molamola/data/` (ClinVar subset, MANE canonical exons, cytobands, karyotype exclusion masks and GC tables). This is the same bundled-only-refs design accepted in the three previous reviews: molamola is a closed-system tool with deterministic output and does not download references at run time.