### PR TITLE
Add genotopep

### DIFF
--- a/recipes/genotopep/meta.yaml
+++ b/recipes/genotopep/meta.yaml
@@ -20,7 +20,7 @@ requirements:
   host:
     - python >=3.10
     - pip
-    - hatchling
+    - hatchling >=1.25
   run:
     - python >=3.10
     - pyrodigal >=3.6,<4

--- a/recipes/genotopep/meta.yaml
+++ b/recipes/genotopep/meta.yaml
@@ -1,0 +1,46 @@
+{% set name = "genotopep" %}
+{% set version = "0.1.0.1" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: f7438775e072aeb499e01b849763d0ed6745933275c95c85c3d50b774ea0a465
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --no-cache-dir -vvv
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x.x") }}
+
+requirements:
+  host:
+    - python >=3.10
+    - pip
+    - hatchling
+  run:
+    - python >=3.10
+    - pyrodigal >=3.6,<4
+    - pyyaml >=6,<7
+
+test:
+  imports:
+    - genotopep
+  commands:
+    - genotopep --version
+    - genotopep --help
+
+about:
+  home: https://github.com/ljunwon1114/GenoToPep
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  license_file: LICENSE
+  summary: Reproducible peptide candidate generation from genome and metagenome assemblies or protein FASTA files.
+  dev_url: https://github.com/ljunwon1114/GenoToPep
+
+extra:
+  recipe-maintainers:
+    - ljunwon1114


### PR DESCRIPTION
## Summary

Adds GenoToPep 0.1.0.1, a noarch Python command-line tool for reproducible peptide candidate generation from genome and metagenome assemblies or protein FASTA files.

## Recipe details

- Source: PyPI sdist with SHA-256 verification
- Build backend: Hatchling
- Runtime dependencies: pyrodigal and pyyaml
- Tests: Python import, `genotopep --version`, and `genotopep --help`
- License: GPL-3.0-or-later

Upstream: https://github.com/ljunwon1114/GenoToPep
PyPI: https://pypi.org/project/genotopep/0.1.0.1/