### PR TITLE
Add seqextractor

### DIFF
--- a/recipes/seqextractor/meta.yaml
+++ b/recipes/seqextractor/meta.yaml
@@ -1,0 +1,37 @@
+{% set name = "seqextractor" %}
+{% set version = "1.0.0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/ChongLC/seqExtractor/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: dc34894886d0afec2650390d741e8c30496d2fd3ca56c0f16709a3b49b5f08c4
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+
+requirements:
+  host:
+    - python >=3.8
+    - pip
+    - setuptools >=64
+  run:
+    - python >=3.8
+
+test:
+  commands:
+    - seqextractor --help
+
+about:
+  home: https://github.com/ChongLC/seqExtractor
+  license: MIT
+  license_file: LICENSE
+  summary: Extract FASTA records from a multiFASTA file by ID list or header substring
+
+extra:
+  recipe-maintainers:
+    - ChongLC


### PR DESCRIPTION
Adds seqextractor (v1.0.0), a small pure-Python CLI tool that extracts FASTA sequence records from a multiFASTA file by a list of record IDs or by a header substring. noarch: python, no dependencies beyond the standard library.

Upstream: https://github.com/ChongLC/seqExtractor