### PR TITLE
Update bioleads to 0.2.0

### DIFF
--- a/recipes/bioleads/meta.yaml
+++ b/recipes/bioleads/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "bioleads" %}
-{% set version = "0.1.0" %}
+{% set version = "0.2.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/isomlab/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: e75615984d9fb4947d47f1161083718baf4e66fc30f67ecc95c3123d3d567e14
+  sha256: b13e586d4437b3ffba64bf946dd0d4128907be0c598353c08ba30bb0633e77ec
 
 build:
   noarch: python
@@ -32,7 +32,6 @@ requirements:
     - networkx >=3.1
     - pandas >=2.0
     - tqdm >=4.65
-    - pymupdf >=1.23
     - biopython >=1.81
     - requests >=2.31
     - plotly >=5.18


### PR DESCRIPTION
Version bump for [isomlab/bioleads v0.2.0](https://github.com/isomlab/bioleads/releases/tag/v0.2.0). I am the package author and the recipe maintainer.

Notable change in this release: term clustering is now density-based (HDBSCAN infers the cluster count) instead of KMeans with a fixed k. No new dependencies — `scikit-learn >=1.3`, already pinned, is where `sklearn.cluster.HDBSCAN` lives.

This also drops `pymupdf`, which backed a `pdf` extra that no longer exists upstream: the package has no `--pdf` flag and no PyMuPDF import, so the recipe has been carrying an unused runtime dependency.

Build number reset to 0 for the new version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)