### PR TITLE
Update fastaguard to 0.7.0

### DIFF
--- a/recipes/fastaguard/meta.yaml
+++ b/recipes/fastaguard/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "fastaguard" %}
-{% set version = "0.6.0" %}
+{% set version = "0.7.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/ehsanestaji/FastaGuard/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: b57e967ccaa03ef5e70c14b96247a644750d8bd492360633988f2f53fe84184b
+  sha256: 80a5a350cb58c708c4c15a01cf76cb67356aa45c31f97fe3e104414de690a54c
 
 build:
   number: 0


### PR DESCRIPTION
Updates FastaGuard from 0.6.0 to 0.7.0.

- Updates the source version and checksum for the published v0.7.0 tag.
- Keeps build number 0 for the new upstream version.
- Preserves the existing run exports, platforms, build requirements, and test commands.

The tagged source archive was downloaded independently and matched the checksum in the recipe.