### PR TITLE
Add seqproc 0.1.1

### DIFF
--- a/recipes/seqproc/build.sh
+++ b/recipes/seqproc/build.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# The upstream repository deliberately uses target-cpu=native for local
+# profiling. Redistributed Conda packages instead use the compiler toolchain's
+# portable target flags and ANTISEQUENCE's SSE2/NEON baseline matcher.
+cp .cargo/config-baseline.toml .cargo/config.toml
+
+cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
+cargo install -v --locked --no-track --root "${PREFIX}" --path . \
+  --no-default-features --features antisequence/baseline-simd

--- a/recipes/seqproc/meta.yaml
+++ b/recipes/seqproc/meta.yaml
@@ -30,7 +30,7 @@ test:
     - seqproc --version --verbose
     - 'if seqproc --version --verbose | grep -F "compiler CPU target: native"; then exit 1; fi'
     - 'seqproc --version --verbose | grep -F "SIMD backend: x86-sse2"'  # [x86_64]
-    - 'seqproc --version --verbose | grep -F "SIMD backend: arm-neon"'  # [aarch64 or arm64]
+    - 'seqproc --version --verbose | grep -F "SIMD backend: aarch64-neon"'  # [aarch64 or arm64]
 
 about:
   home: https://github.com/COMBINE-lab/seqproc

--- a/recipes/seqproc/meta.yaml
+++ b/recipes/seqproc/meta.yaml
@@ -1,0 +1,51 @@
+{% set name = "seqproc" %}
+{% set version = "0.1.1" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/COMBINE-lab/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 538e746bc9f1882aff355ee1099d85e8a1b5c3aa9494d80c86c40c27147d956b
+
+build:
+  number: 0
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x.x") }}
+
+requirements:
+  build:
+    - {{ compiler("c") }}
+    - {{ stdlib("c") }}
+    - {{ compiler("rust") }}
+    - cargo-bundle-licenses
+    - pkg-config
+  host:
+    - xz
+
+test:
+  commands:
+    - seqproc --version
+    - seqproc --version --verbose
+    - 'if seqproc --version --verbose | grep -F "compiler CPU target: native"; then exit 1; fi'
+    - 'seqproc --version --verbose | grep -F "SIMD backend: x86-sse2"'  # [x86_64]
+    - 'seqproc --version --verbose | grep -F "SIMD backend: arm-neon"'  # [aarch64 or arm64]
+
+about:
+  home: https://github.com/COMBINE-lab/seqproc
+  dev_url: https://github.com/COMBINE-lab/seqproc
+  doc_url: https://combine-lab.github.io/seqproc
+  license: BSD-3-Clause
+  license_file:
+    - LICENSE
+    - THIRDPARTY.yml
+  summary: A fast, programmable preprocessing engine for sequencing reads
+
+extra:
+  additional-platforms:
+    - linux-aarch64
+    - osx-64
+    - osx-arm64
+  recipe-maintainers:
+    - rob-p

--- a/recipes/seqproc/run_test.sh
+++ b/recipes/seqproc/run_test.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+version_output="$(seqproc --version --verbose)"
+printf '%s\n' "${version_output}"
+printf '%s\n' "${version_output}" | grep -F "seqproc 0.1.1"
+
+# Bioconda artifacts must never inherit the build worker's native ISA. The
+# backend name is stable public provenance supplied by ANTISEQUENCE.
+if printf '%s\n' "${version_output}" | grep -F "compiler CPU target: native"; then
+  echo "Bioconda package was compiled for the build host's native CPU" >&2
+  exit 1
+fi
+case "$(uname -m)" in
+  x86_64) printf '%s\n' "${version_output}" | grep -F "SIMD backend: x86-sse2" ;;
+  arm64|aarch64) printf '%s\n' "${version_output}" | grep -F "SIMD backend: arm-neon" ;;
+  *) echo "unsupported test architecture: $(uname -m)" >&2; exit 1 ;;
+esac
+
+test_dir="$(mktemp -d)"
+trap 'rm -rf "${test_dir}"' EXIT
+printf '1{r:}\n' > "${test_dir}/passthrough.efgdl"
+printf '@read1\nACGTACGT\n+\nIIIIIIII\n' > "${test_dir}/input.fastq"
+
+seqproc validate "${test_dir}/passthrough.efgdl"
+seqproc run --geom "${test_dir}/passthrough.efgdl" \
+  --read1 "${test_dir}/input.fastq" --out1 "${test_dir}/output.fastq" \
+  --threads 1
+cmp "${test_dir}/input.fastq" "${test_dir}/output.fastq"
+
+seqproc run --geom "${test_dir}/passthrough.efgdl" \
+  --read1 "${test_dir}/input.fastq" --out1 - --threads 1 \
+  | cmp "${test_dir}/input.fastq" -

--- a/recipes/seqproc/run_test.sh
+++ b/recipes/seqproc/run_test.sh
@@ -13,7 +13,7 @@ if printf '%s\n' "${version_output}" | grep -F "compiler CPU target: native"; th
 fi
 case "$(uname -m)" in
   x86_64) printf '%s\n' "${version_output}" | grep -F "SIMD backend: x86-sse2" ;;
-  arm64|aarch64) printf '%s\n' "${version_output}" | grep -F "SIMD backend: arm-neon" ;;
+  arm64|aarch64) printf '%s\n' "${version_output}" | grep -F "SIMD backend: aarch64-neon" ;;
   *) echo "unsupported test architecture: $(uname -m)" >&2; exit 1 ;;
 esac
 


### PR DESCRIPTION
Adds the first Bioconda recipe for seqproc, a programmable preprocessing engine for sequencing reads.

Release: https://github.com/COMBINE-lab/seqproc/releases/tag/v0.1.1
Crates.io: https://crates.io/crates/seqproc/0.1.1

Recipe details:
- uses the immutable v0.1.1 source archive with a verified SHA-256 checksum
- installs from Cargo.lock with --locked
- bundles third-party license metadata
- deliberately replaces the upstream local target-cpu=native configuration with portable compiler target flags
- selects ANTISEQUENCE baseline SIMD (SSE2 on x86_64 and NEON on ARM) and verifies provenance at test time
- includes validate, file-output, and stdout FASTQ smoke tests
- requests linux-aarch64, osx-64, and osx-arm64 in addition to linux-64

Validation performed locally with bioconda-utils 4.5.0:
- official lint: passed
- complete linux-64 conda-build and installed-package test: passed
- built package: seqproc-0.1.1-h4bf21ff_0.conda

Version 0.1.1 is used because it includes the Rust 1.88/MSRV compatibility correction identified immediately after 0.1.0; no user-facing processing semantics changed.