### PR TITLE
ngs45, easy45: 0.3.0 (pin barrnap >=0.9,<1.0)

### DIFF
--- a/recipes/easy45/meta.yaml
+++ b/recipes/easy45/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "easy45" %}
-{% set version = "0.2.0" %}
+{% set version = "0.3.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/maidinhvn/easy45/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: a007a6a652de23985cf45c82628d29ba0731ab48aca7e4a7b9dcc453a50cf8e9
+  sha256: 6108233b57f8d725314fddc7c4ac91abc6004bd40a81ed76ceb7cdd56b81ba72
 
 build:
   noarch: python
@@ -30,7 +30,7 @@ requirements:
     - seqkit
     - vsearch
     - itsx
-    - barrnap
+    - barrnap >=0.9,<1.0
     - abpoa
     - infernal
 

--- a/recipes/ngs45/meta.yaml
+++ b/recipes/ngs45/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.2.0" %}
+{% set version = "0.3.0" %}
 
 package:
   name: ngs45
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/maidinhvn/ngs45/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 248bb4dda2e760cca16615c55182952cc7db1112cf2fc9a36beb1f5d6931227b
+  sha256: 397098ff651687bc90df7be884d62269075a8660ff32620da1c4ed2e02c0b854
 
 build:
   noarch: python
@@ -27,7 +27,7 @@ requirements:
     - python
     - biopython >=1.79
     # external tools invoked via subprocess (the package itself is pure-Python)
-    - barrnap
+    - barrnap >=0.9,<1.0
     - bcftools
     - blast
     - bowtie2


### PR DESCRIPTION
Bumps ngs45 and easy45 to 0.3.0 and pins their barrnap run-dependency.

The unpinned `barrnap` could resolve to bioconda's barrnap 1.10.6, which ships
only the bac/arc/fun HMM databases (no eukaryote DB) and rejects `--kingdom euk`,
crashing both tools on plant rRNA. Pin to the Torsten Seemann line
(`>=0.9,<1.0`) that ships the euk DB. easy45's `check-deps` test now also guards
the euk capability.

- ngs45  0.2.0 -> 0.3.0 (new sha256)
- easy45 0.2.0 -> 0.3.0 (new sha256)