### PR TITLE
Restore CUDA 12.6 support for COMEBin

### DIFF
--- a/recipes/comebin/meta.yaml
+++ b/recipes/comebin/meta.yaml
@@ -7,7 +7,7 @@ source:
   sha256: d17310f5b96e8295ba785c731a86f2782b8386befdd2a2ed54842f2fa9f321bf
 
 build:
-  number: 2
+  number: 3
   noarch: generic
   run_exports:
     - {{ pin_subpackage('comebin', max_pin="x.x") }}
@@ -30,7 +30,7 @@ requirements:
     - pplacer 1.1.alpha19
     - prodigal >=2.6,<3
     - python-igraph >=1,<2
-    - pytorch >=2.13,<2.14
+    - pytorch >=2.7.1,<3
     - pyyaml >=6,<7
     - samtools >=1.20,<2
     - scikit-learn >=1.5,<1.10


### PR DESCRIPTION
This increments the COMEBin 1.1.0 build number to 3 and relaxes the PyTorch runtime range from >=2.13,<2.14 to >=2.7.1,<3.

The previous lower bound made CUDA 12.6 unsatisfiable because the newest conda-forge PyTorch build for CUDA 12.6 is 2.7.1.

Validation:
- CUDA 12.6 resolves to PyTorch 2.7.1 cuda126.
- CUDA 13.0 resolves to PyTorch 2.13.0 cuda130.
- CPU resolves to PyTorch 2.13.0 cpu.
- The upstream COMEBin README now uses CUDA 12.6 by default.