### PR TITLE
Add directclean 1.1.1

### DIFF
--- a/recipes/directclean/meta.yaml
+++ b/recipes/directclean/meta.yaml
@@ -1,0 +1,56 @@
+{% set name = "directclean" %}
+{% set version = "1.1.1" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: bae918bcfde83411feff8c6c84b7af6cf1e7295bb02f4916609a173d40bf6263
+
+build:
+  number: 0
+  noarch: python
+  entry_points:
+    - directclean = directclean.cli.app:app
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  run_exports:
+    - {{ pin_subpackage("directclean", max_pin="x") }}
+
+requirements:
+  host:
+    - python >=3.10,<4.0
+    - poetry-core
+    - pip
+  run:
+    - python >=3.10,<4.0
+    - pysam >=0.21.0
+    - biopython >=1.81
+    - typer >=0.9.0
+    - rich >=13.0.0
+    - edlib >=1.3.9
+    - minimap2
+    - samtools
+    - "breakinator 1.1.1 *_2"
+    - "restrander 1.1.3 *_1"
+
+test:
+  imports:
+    - directclean
+  commands:
+    - pip check
+    - directclean --help
+    - python -c "from directclean.external.dependencies import check_all_dependencies; check_all_dependencies()"
+  requires:
+    - pip
+
+about:
+  home: https://github.com/ylab-hi/DirectClean
+  summary: Strand orientation, artifact removal, and chimeric read rescue for ONT direct-cDNA sequencing
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - qingxiangguo

--- a/recipes/directclean/meta.yaml
+++ b/recipes/directclean/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "directclean" %}
-{% set version = "1.1.1" %}
+{% set version = "1.1.2" %}
 
 package:
   name: {{ name }}
@@ -7,13 +7,11 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: bae918bcfde83411feff8c6c84b7af6cf1e7295bb02f4916609a173d40bf6263
+  sha256: e1c3a0adb63876f6a02d306a23880b78b1dc28159e79ebd5c8d984d4feb79d21
 
 build:
   number: 0
   noarch: python
-  entry_points:
-    - directclean = directclean.cli.app:app
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   run_exports:
     - {{ pin_subpackage("directclean", max_pin="x") }}


### PR DESCRIPTION
DirectClean is an artifact-aware preprocessing toolkit for Oxford Nanopore direct-cDNA sequencing. It performs strand orientation, foldback artifact removal, adapter-aware rescue, and homopolymer-mediated RT template-switch resolution.

This recipe installs DirectClean together with its required external dependencies, including minimap2, samtools, Breakinator, and Restrander.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
