### PR TITLE
Restore gatk4 compatibility package

### DIFF
--- a/recipes/gatk4/meta.yaml
+++ b/recipes/gatk4/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   noarch: generic
-  number: 0
+  number: 1
   run_exports:
      - {{ pin_subpackage('gatk4-main', max_pin="x") }}
 
@@ -42,6 +42,18 @@ test:
     - gatk DetermineGermlineContigPloidy --help
 
 outputs:
+  - name: gatk4
+    build:
+      noarch: generic
+    requirements:
+      run:
+        - {{ pin_subpackage("gatk4-main", exact=True) }}
+    test:
+      commands:
+        - gatk -h
+        - gatk --list
+        - gatk HaplotypeCaller --help
+        - gatk DetermineGermlineContigPloidy --help
   - name: gatk4-main
     script: build_main.sh
     requirements:


### PR DESCRIPTION
Follow-up to #68238, which updated GATK to 4.7.0.0 and published the modular `gatk4-main` and `gatk4-spark` outputs.

The preceding OpenJDK update (#67946) renamed the established `gatk4` output to `gatk4-main`. Consequently, the Bioconda `gatk4` package remains at 4.6.2.0 despite #68238 successfully publishing `gatk4-main` 4.7.0.0.

This PR restores `gatk4` as a noarch compatibility package that depends exactly on `gatk4-main`. It preserves the modular split and lets existing `gatk4` consumers upgrade to 4.7.0.0.

- Leaves `gatk4-main` and `gatk4-spark` unchanged.
- Bumps the recipe build number to publish the compatibility package.