### PR TITLE
Update bioconda-repodata-patches for new htslib and libdeflate releases

### DIFF
--- a/recipes/bioconda-repodata-patches/gen_patch_json.py
+++ b/recipes/bioconda-repodata-patches/gen_patch_json.py
@@ -163,13 +163,13 @@ def _gen_new_index_per_key(repodata, packages_key, subdir):
         if has_dep(record, 'htslib'):
             # skip deps prior to 1.10, which was the first with soversion 3
             # TODO adjust replacement (exclusive) upper bound with each new compatible HTSlib
-            _pin_looser(fn, record, 'htslib', min_lower_bound='1.10', upper_bound='1.24')
+            _pin_looser(fn, record, 'htslib', min_lower_bound='1.10', upper_bound='1.25')
 
         # future libdeflate versions are compatible until they bump their soversion; relax dependencies accordingly
         if record_name in ['htslib', 'staden_io_lib', 'fastp', 'pysam'] and has_dep(record, 'libdeflate'):
             # skip deps that allow anything <1.3, which contained an incompatible library filename
             # TODO adjust the replacement (exclusive) upper bound each time a compatible new libdeflate is released
-            _pin_looser(fn, record, 'libdeflate', min_lower_bound='1.3', upper_bound='1.26')
+            _pin_looser(fn, record, 'libdeflate', min_lower_bound='1.3', upper_bound='1.27')
 
         # nanosim <=3.1.0 requires scikit-learn<=0.22.1
         if record_name.startswith('nanosim') and has_dep(record, "scikit-learn") and parse_version(version) <= parse_version("3.1.0"):

--- a/recipes/bioconda-repodata-patches/meta.yaml
+++ b/recipes/bioconda-repodata-patches/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "bioconda-repodata-patches" %}
-{% set version = "20260421" %}  # whenever you add or change patches in `gen_patch_json.py` or adjust any other code, ensure that this is the "current" date, and always higher than the latest version in master
+{% set version = "20260824" %}  # whenever you add or change patches in `gen_patch_json.py` or adjust any other code, ensure that this is the "current" date, and always higher than the latest version in master
 
 package:
   name: {{ name }}


### PR DESCRIPTION
Bump the patching for recent new HTSlib and libdeflate releases, which did not change the libraries' soversions. 

See #40675 (libdeflate) and #42895 (htslib) for details.

----

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
