### PR TITLE
Add teloxplorer 0.5.0

### DIFF
--- a/recipes/teloxplorer/meta.yaml
+++ b/recipes/teloxplorer/meta.yaml
@@ -1,0 +1,88 @@
+{% set name = "teloxplorer" %}
+{% set version = "0.5.0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/hhuili/TeloXplorer/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: c5f16dfadc0c8bd86ba541dec47d555f6205053be391f33a7e030540bccc39f6
+
+build:
+  number: 0
+  skip: true  # [win or py < 310 or py >= 314]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --no-cache-dir -vvv
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x.x") }}
+  entry_points:
+    - telox = telox.cli:app
+
+requirements:
+  build:
+    - {{ compiler("cxx") }}
+    - {{ stdlib("c") }}
+    - cmake >=3.15
+    - make
+  host:
+    - cmake >=3.15
+    - python >=3.10,<3.14
+    - pip
+    - scikit-build-core >=0.5.1
+    - pybind11 >=2.10.0
+    - zlib
+    - re2
+    - llvm-openmp  # [osx]
+    - libgomp      # [linux]
+  run:
+    - python >=3.10,<3.14
+    - click >=8.0
+    - numpy
+    - pandas
+    - pysam >=0.19.1
+    - regex
+    - scipy
+    - hdbscan
+    - matplotlib-base
+    - telox-pyabpoa ==1.5.6.post1
+    - natsort >=8.0.0
+    - polyleven
+    - typer >=0.16.0
+    - minimap2
+    - samtools
+    - seqtk
+    - llvm-openmp  # [osx]
+    - libgomp      # [linux]
+
+test:
+  imports:
+    - telox
+    - telox.bloom_core
+    - telox.motiflev
+    - telox.telohmm
+    - telox.telox_tvr
+  commands:
+    - telox --version
+    - telox --help
+    - telogrep --help
+    - command -v minimap2
+    - python -c "import telox.telox_tvr as t; assert t.pyabpoa.__name__ == 'telox_pyabpoa'"
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/hhuili/TeloXplorer
+  license: GPL-3.0-only
+  license_family: GPL3
+  license_file: LICENSE
+  summary: Chromosome-end-resolved telomere analysis using long-read sequencing data
+  description: |
+    TeloXplorer is a modular framework for chromosome-end-resolved telomere
+    analysis using Oxford Nanopore and PacBio long-read sequencing data or
+    genome assemblies.
+  dev_url: https://github.com/hhuili/TeloXplorer
+
+extra:
+  recipe-maintainers:
+    - hhuili


### PR DESCRIPTION
## Summary

- add TeloXplorer 0.5.0, a chromosome-end-resolved telomere analysis framework for long-read data and genome assemblies
- build its C++17/pybind11 extensions and `telogrep` executable with CMake
- use the merged Bioconda `telox-pyabpoa` package for the ASCII-aware MSA backend
- package Python 3.10-3.13 on Linux and macOS x86_64

## Platform note

`polyleven` is not yet available from conda-forge for osx-arm64 (conda-forge/polyleven-feedstock#24 is still under review), so this recipe does not request osx-arm64 as an additional platform. This does not affect the standard Linux and macOS x86_64 builds.

## Validation

- `bioconda-utils lint recipes config.yml --git-range upstream/master HEAD --full-report`: passed (`All checks OK`)
- built the wheel from the tagged source and verified all three extension modules plus `telogrep`
- built and tested a native conda package locally, including imports, entry points, linked libraries, and `pip check`
- ran the installed CLI contract suite: 22 tests passed
- verified the GitHub source archive SHA256: `c5f16dfadc0c8bd86ba541dec47d555f6205053be391f33a7e030540bccc39f6`

Release: https://github.com/hhuili/TeloXplorer/releases/tag/v0.5.0