### PR TITLE
Update ploidypatch to 1.0.1

### DIFF
--- a/recipes/ploidypatch/meta.yaml
+++ b/recipes/ploidypatch/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "ploidypatch" %}
-{% set version = "1.0.0" %}
-{% set release_tag = "v1.0" %}
+{% set version = "1.0.1" %}
+{% set release_tag = "v1.0.1" %}
 
 package:
   name: {{ name }}
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://github.com/707728642li/PloidyPatch/releases/download/{{ release_tag }}/{{ name }}-{{ version }}.tar.gz
-  sha256: f63772f27a432e18da44f544d6a98a7b27c934a532e4079d7cb624d9ba0af38c
+  sha256: 7403f56f10588fe49ff133c08614f7db39a23a2de0f7c48d5a480d114e079606
 
 build:
   noarch: python
@@ -34,7 +34,7 @@ test:
     - ploidypatch --version
     - ploidypatch --help
     - ploidypatch patch --help
-    - python -c "import ploidypatch; assert ploidypatch.__version__ == '1.0.0'"
+    - python -c "import ploidypatch; assert ploidypatch.__version__ == '1.0.1'"
     - pip check
   requires:
     - pip


### PR DESCRIPTION
PloidyPatch 1.0.1 is a metadata-only patch release.

- records Taishan Li and Gaigai Du consistently as software authors
- updates the public installation description now that Bioconda 1.0.0 is available
- does not change scientific methods, command behavior, dependencies, or the recipe build number

The source SHA-256 is bound to the immutable v1.0.1 GitHub release. The recipe was rendered, built, installed, and tested locally; `ploidypatch --version`, command help, Python import, and `pip check` all passed.