### PR TITLE
Add msbuddy 0.3.16

### DIFF
--- a/recipes/msbuddy/meta.yaml
+++ b/recipes/msbuddy/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "msbuddy" %}
-{% set version = "0.3.15" %}
+{% set version = "0.3.16" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: c2668faee6cddc2bfcafaa4642a857946ce2fbdc59b22fb1fb5cb67620286d7e
+  sha256: d3850fb4e8f40b1101710fd855f53d26d3f3ba9a04626614f095c97e060fc2df
 
 build:
   number: 0
@@ -41,8 +41,6 @@ test:
     - msbuddy
   commands:
     - msbuddy --help
-    # This second test makes sure that the databases can be initialised.
-    - python -c "from msbuddy.load import init_db, init_ml_models; d=init_db(); init_ml_models(d)"
 
 about:
   home: https://github.com/Philipbear/msbuddy

--- a/recipes/msbuddy/meta.yaml
+++ b/recipes/msbuddy/meta.yaml
@@ -1,0 +1,66 @@
+{% set name = "msbuddy" %}
+{% set version = "0.3.15" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: c2668faee6cddc2bfcafaa4642a857946ce2fbdc59b22fb1fb5cb67620286d7e
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x.x") }}
+
+requirements:
+  host:
+    # MSBuddy README.md states python >=3.9 and <3.13 
+    - python >=3.9,<3.13
+    - pip
+    - setuptools
+  run:
+    - python >=3.9,<3.13
+    - brain-isotopic-distribution
+    - chemparse
+    - gdown
+    - joblib
+    - lightgbm
+    - numba
+    - numpy
+    - pandas
+    - requests
+    - scipy
+    - tqdm
+
+test:
+  imports:
+    - msbuddy
+  commands:
+    - msbuddy --help
+
+about:
+  home: https://github.com/Philipbear/msbuddy
+  license: Apache-2.0
+  license_family: APACHE
+  license_file: LICENSE
+  summary: Molecular formula annotation for MS-based small molecule analysis
+  description: |
+    msbuddy performs bottom-up MS/MS interrogation for molecular formula
+    annotation of small molecules (below ~1500 Da), with false discovery rate
+    estimation. It accepts a precursor m/z plus ionization polarity as the
+    minimum query, and optionally MS1 isotope patterns and/or MS/MS spectra.
+    msbuddy does not perform adduct annotation -- the correct adduct must be
+    supplied by the user.
+  doc_url: https://msbuddy.readthedocs.io/
+  dev_url: https://github.com/Philipbear/msbuddy
+
+extra:
+  recipe-maintainers:
+    - RJMW
+    - neil-butcher
+  identifiers:
+    - doi:10.1038/s41592-023-01850-x

--- a/recipes/msbuddy/meta.yaml
+++ b/recipes/msbuddy/meta.yaml
@@ -41,6 +41,8 @@ test:
     - msbuddy
   commands:
     - msbuddy --help
+    # This second test makes sure that the databases can be initialised.
+    - python -c "from msbuddy.load import init_db, init_ml_models; d=init_db(); init_ml_models(d)"
 
 about:
   home: https://github.com/Philipbear/msbuddy


### PR DESCRIPTION
 ### Molecular formula annotation for MS-based small molecule analysis

msbuddy performs bottom-up MS/MS interrogation for molecular formula annotation of small molecules (below ~1500 Da), with false discovery rate estimation. It accepts a precursor m/z plus ionization polarity as the minimum query, and optionally MS1 isotope patterns and/or MS/MS spectra.


----

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

</details>
