### PR TITLE
Add actinn-jax

### DIFF
--- a/recipes/actinn-jax/meta.yaml
+++ b/recipes/actinn-jax/meta.yaml
@@ -1,0 +1,55 @@
+{% set name = "actinn-jax" %}
+{% set version = "0.3.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/actinn_jax-{{ version }}.tar.gz
+  sha256: c597ad467078a00004b01748c0501e0bf0d496badda96783768897eb3d415b00
+
+build:
+  number: 0
+  noarch: python
+  entry_points:
+    - actinn-jax = actinn_jax.cli:main
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --no-cache-dir --use-pep517 -vvv
+  run_exports:
+    - {{ pin_subpackage("actinn-jax", max_pin="x.x") }}
+
+requirements:
+  host:
+    - pip
+    - python >=3.10
+    - setuptools >=61.0
+    - wheel
+  run:
+    - python >=3.10
+    - numpy >=1.23
+    - scipy >=1.9
+    - anndata >=0.9
+    - pandas >=1.5
+    - h5py
+    - scanpy >=1.10
+    - jax >=0.4.0
+    - jaxlib >=0.4.0
+    - optax >=0.1.5
+
+test:
+  imports:
+    - actinn_jax
+  commands:
+    - actinn-jax --help
+
+about:
+  home: "https://github.com/iandriver/actinn-jax"
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: "Fast JAX reimplementation of ACTINN for single-cell cell-type reference mapping"
+  dev_url: "https://github.com/iandriver/actinn-jax"
+
+extra:
+  recipe-maintainers:
+    - iandriver


### PR DESCRIPTION
Adds a recipe for [actinn-jax](https://github.com/iandriver/actinn-jax), a JAX
reimplementation of ACTINN for cell-type annotation of single-cell RNA-seq data. It trains
a classifier from a labelled AnnData reference and annotates query AnnData objects on CPU,
with a pre-trained human reference included in the package.

- Pure Python, so `noarch: python`.
- All run dependencies are available on conda-forge.
- Source is the PyPI sdist; sha256 verified against a local download.
- The sdist contains `LICENSE` and the bundled reference data, so `actinn_jax.bundled_reference()`
  works from a conda install without a network fetch.
- `run_exports` uses `max_pin="x.x"` per the 0.x.x row of the table in the PR template.

I am the author and maintainer of the package.
