### PR TITLE
Add pyeuk 0.7.0

### DIFF
--- a/recipes/pyeuk/meta.yaml
+++ b/recipes/pyeuk/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pyeuk" %}
-{% set version = "0.5.0" %}
+{% set version = "0.6.0" %}
 
 package:
   name: {{ name }}
@@ -7,14 +7,14 @@ package:
 
 source:
   url: https://github.com/spond/pyeuk/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 3bb4f26e8fb4a1ec42c3a34822022a6ccbae5da582911aae90c706dd7a336e58
+  sha256: 74dee55ed9dbcd6ec5569dfc25c9e5ce67e6befebbe7e5a6a87668dec7c7781a
 
 build:
   number: 0
   noarch: python
   entry_points:
-    - pyeuk=cyclospora_pyeuk.cli:main
-    - cyclospora-typing=cyclospora_pyeuk.cli:main
+    - pyeuk=pyeuk.cli:main
+    - cyclospora-typing=pyeuk.cli:main
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --no-cache-dir -vvv
   run_exports:
     - {{ pin_subpackage("pyeuk", max_pin="x.x") }}
@@ -35,11 +35,12 @@ requirements:
 
 test:
   imports:
+    - pyeuk
+    - pyeuk.distance_engine
+    - pyeuk.clustering
+    - pyeuk.naming
+    - pyeuk.amplicon
     - cyclospora_pyeuk
-    - cyclospora_pyeuk.distance_engine
-    - cyclospora_pyeuk.clustering
-    - cyclospora_pyeuk.naming
-    - cyclospora_pyeuk.amplicon
   commands:
     - pyeuk --help
     - cyclospora-typing --help

--- a/recipes/pyeuk/meta.yaml
+++ b/recipes/pyeuk/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pyeuk" %}
-{% set version = "0.6.0" %}
+{% set version = "0.7.0" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/spond/pyeuk/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 74dee55ed9dbcd6ec5569dfc25c9e5ce67e6befebbe7e5a6a87668dec7c7781a
+  sha256: 4184570bdff8622f9ad8906940547932e64b21753745c72764202c49fcdf7275
 
 build:
   number: 0
@@ -32,6 +32,7 @@ requirements:
     - scikit-learn >=1.0.0
     - numba >=0.53.0
     - pysam >=0.22
+    - pillow >=9
 
 test:
   imports:
@@ -40,6 +41,7 @@ test:
     - pyeuk.clustering
     - pyeuk.naming
     - pyeuk.amplicon
+    - pyeuk.report
     - cyclospora_pyeuk
   commands:
     - pyeuk --help
@@ -47,6 +49,7 @@ test:
     - pyeuk define-windows --help
     - pyeuk call-haplotypes --help
     - pyeuk build-sheet --help
+    - pyeuk report --help
 
 about:
   home: https://github.com/spond/pyeuk

--- a/recipes/pyeuk/meta.yaml
+++ b/recipes/pyeuk/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pyeuk" %}
-{% set version = "0.4.0" %}
+{% set version = "0.5.0" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/spond/pyeuk/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: e730e6d3a906971e20dbccf8670b236eabbef7fb57e49392a3a770aeea8aa1b2
+  sha256: 3bb4f26e8fb4a1ec42c3a34822022a6ccbae5da582911aae90c706dd7a336e58
 
 build:
   number: 0
@@ -31,15 +31,21 @@ requirements:
     - pandas >=1.3.0
     - scikit-learn >=1.0.0
     - numba >=0.53.0
+    - pysam >=0.22
 
 test:
   imports:
     - cyclospora_pyeuk
     - cyclospora_pyeuk.distance_engine
     - cyclospora_pyeuk.clustering
+    - cyclospora_pyeuk.naming
+    - cyclospora_pyeuk.amplicon
   commands:
     - pyeuk --help
     - cyclospora-typing --help
+    - pyeuk define-windows --help
+    - pyeuk call-haplotypes --help
+    - pyeuk build-sheet --help
 
 about:
   home: https://github.com/spond/pyeuk
@@ -56,8 +62,14 @@ about:
     assembled contigs, a weighted identity-by-state (wIBS) distance engine
     with selectable allele weighting, pairwise-complete dropout tolerance
     and optional PSD Gram matrix projection, and unsupervised Ward
-    hierarchical clustering with knee-based selection of the cluster
-    count.
+    hierarchical clustering with either knee-based selection of the
+    cluster count or a distance-threshold cut for surveillance cohorts
+    whose structure is mostly singletons. An amplicon front end turns
+    aligned reads into the haplotype sheet directly: analysis windows are
+    derived from the reads themselves, and each haplotype is read off a
+    single read that spans the window end to end, so linkage between
+    positions is observed on one molecule rather than inferred across
+    molecules.
   dev_url: https://github.com/spond/pyeuk
 
 extra:

--- a/recipes/pyeuk/meta.yaml
+++ b/recipes/pyeuk/meta.yaml
@@ -1,0 +1,64 @@
+{% set name = "pyeuk" %}
+{% set version = "0.3.0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/spond/pyeuk/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 8eccd6e453576a1ecb07139e3e38772ba881b20c4a9701ab0cfa09a7e7b8b3e6
+
+build:
+  number: 0
+  noarch: python
+  entry_points:
+    - pyeuk=cyclospora_pyeuk.cli:main
+    - cyclospora-typing=cyclospora_pyeuk.cli:main
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --no-cache-dir -vvv
+  run_exports:
+    - {{ pin_subpackage('pyeuk', max_pin="x") }}
+
+requirements:
+  host:
+    - python >=3.9
+    - pip
+    - setuptools >=61
+  run:
+    - python >=3.9
+    - numpy >=1.20.0
+    - scipy >=1.7.0
+    - pandas >=1.3.0
+    - scikit-learn >=1.0.0
+    - numba >=0.53.0
+
+test:
+  imports:
+    - cyclospora_pyeuk
+    - cyclospora_pyeuk.distance_engine
+    - cyclospora_pyeuk.clustering
+  commands:
+    - pyeuk --help
+    - cyclospora-typing --help
+
+about:
+  home: https://github.com/spond/pyeuk
+  license: Apache-2.0
+  license_family: APACHE
+  license_file: LICENSE
+  summary: MLST/cgMLST typing, dropout-robust genetic distance estimation, and outbreak clustering for eukaryotic and microbial pathogens.
+  description: |
+    PyEuk is a Python framework for molecular typing, genetic distance
+    estimation, and foodborne/waterborne outbreak cluster detection in
+    eukaryotic and microbial pathogens, including Cyclospora cayetanensis,
+    Cryptosporidium parvum/hominis, and general MLST/cgMLST schemes. It
+    provides reference-free de novo locus and haplotype discovery from
+    assembled contigs, a KING-weighted identity-by-state (wIBS) distance
+    engine with pairwise-complete dropout tolerance and PSD Gram matrix
+    projection, and unsupervised Ward hierarchical clustering with
+    automatic knee-based selection of the cluster count.
+  dev_url: https://github.com/spond/pyeuk
+
+extra:
+  recipe-maintainers:
+    - nekrut

--- a/recipes/pyeuk/meta.yaml
+++ b/recipes/pyeuk/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pyeuk" %}
-{% set version = "0.3.0" %}
+{% set version = "0.4.0" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/spond/pyeuk/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 8eccd6e453576a1ecb07139e3e38772ba881b20c4a9701ab0cfa09a7e7b8b3e6
+  sha256: e730e6d3a906971e20dbccf8670b236eabbef7fb57e49392a3a770aeea8aa1b2
 
 build:
   number: 0
@@ -53,10 +53,11 @@ about:
     eukaryotic and microbial pathogens, including Cyclospora cayetanensis,
     Cryptosporidium parvum/hominis, and general MLST/cgMLST schemes. It
     provides reference-free de novo locus and haplotype discovery from
-    assembled contigs, a KING-weighted identity-by-state (wIBS) distance
-    engine with pairwise-complete dropout tolerance and PSD Gram matrix
-    projection, and unsupervised Ward hierarchical clustering with
-    automatic knee-based selection of the cluster count.
+    assembled contigs, a weighted identity-by-state (wIBS) distance engine
+    with selectable allele weighting, pairwise-complete dropout tolerance
+    and optional PSD Gram matrix projection, and unsupervised Ward
+    hierarchical clustering with knee-based selection of the cluster
+    count.
   dev_url: https://github.com/spond/pyeuk
 
 extra:

--- a/recipes/pyeuk/meta.yaml
+++ b/recipes/pyeuk/meta.yaml
@@ -17,7 +17,7 @@ build:
     - cyclospora-typing=cyclospora_pyeuk.cli:main
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --no-cache-dir -vvv
   run_exports:
-    - {{ pin_subpackage('pyeuk', max_pin="x") }}
+    - {{ pin_subpackage("pyeuk", max_pin="x.x") }}
 
 requirements:
   host:


### PR DESCRIPTION
Adds a new recipe for **PyEuk** ([github.com/spond/pyeuk](https://github.com/spond/pyeuk)), a Python framework for molecular typing, genetic distance estimation, and foodborne/waterborne outbreak cluster detection in eukaryotic and microbial pathogens — *Cyclospora cayetanensis*, *Cryptosporidium parvum/hominis*, and general MLST/cgMLST schemes.

It provides reference-free de novo locus and haplotype discovery from assembled contigs, a KING-weighted identity-by-state (wIBS) distance engine with pairwise-complete dropout tolerance and PSD Gram-matrix projection, and unsupervised Ward hierarchical clustering with automatic knee-based selection of the cluster count.

### Recipe notes

- `noarch: python`, pure Python; runtime deps are `numpy`, `scipy`, `pandas`, `scikit-learn`, and `numba`, all already in conda-forge.
- Two console scripts are installed, `pyeuk` and `cyclospora-typing`; both are exercised in the `test:` section along with the module imports.
- `run_exports` uses `max_pin="x.x"` per the 0.x semantic-versioning row in the contributor guidelines.
- Source is the upstream `v0.3.0` tag tarball. Upstream added `LICENSE` (Apache-2.0) and a PEP 621 `pyproject.toml` in [spond/pyeuk#9](https://github.com/spond/pyeuk/pull/9) specifically so this recipe has a checksummable tarball with a `license_file` inside it.
- SPAdes is *optional* at runtime — `micro_assembly.py` looks it up with `shutil.which` and degrades gracefully when it is absent — so it is deliberately not a run dependency. Happy to add `spades` if reviewers would rather have that path work out of the box.

### Verification

Against the exact `v0.3.0` tarball this recipe pins (sha256 `8eccd6e4…b3e6`), in a clean environment:

```
$ pip install ./pyeuk-0.3.0
$ pyeuk --help              # OK
$ cyclospora-typing --help  # OK
$ python -c "import cyclospora_pyeuk, cyclospora_pyeuk.distance_engine, cyclospora_pyeuk.clustering"
imports OK 0.3.0
$ python -m pytest tests -q
27 passed
```