### PR TITLE
Add r-nmf recipe (0.28)

### DIFF
--- a/recipes/r-nmf/build.sh
+++ b/recipes/r-nmf/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+
+# shellcheck disable=SC2086
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-nmf/meta.yaml
+++ b/recipes/r-nmf/meta.yaml
@@ -1,0 +1,93 @@
+{% set version = "0.28" %}
+
+package:
+  name: r-nmf
+  version: '{{ version }}'
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/NMF_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/NMF/NMF_{{ version }}.tar.gz
+  sha256: 77dfe7b323ee5e5f8801851d1d4356932e2ffc810a7ac7faf5542cbfd92eeefb
+
+build:
+  number: 0
+  rpaths:
+    - lib/R/lib/
+    - lib/
+  run_exports:
+    - {{ pin_subpackage('r-nmf', max_pin="x.x") }}
+
+requirements:
+  build:
+    - cross-r-base {{ r_base }}  # [build_platform != target_platform]
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - {{ stdlib('c') }}
+    - make
+  host:
+    # Depends:
+    - r-base >=3.0.0
+    - r-registry
+    - r-rngtools >=1.2.3
+    - r-cluster
+    # Imports:
+    - r-stringr >=1.0.0
+    - r-digest
+    - r-gridbase
+    - r-colorspace
+    - r-rcolorbrewer
+    - r-foreach
+    - r-doparallel
+    - r-ggplot2
+    - r-reshape2
+    - bioconductor-biobase
+    - r-biocmanager
+  run:
+    # Depends:
+    - r-base >=3.0.0
+    - r-registry
+    - r-rngtools >=1.2.3
+    - r-cluster
+    # Imports:
+    - r-stringr >=1.0.0
+    - r-digest
+    - r-gridbase
+    - r-colorspace
+    - r-rcolorbrewer
+    - r-foreach
+    - r-doparallel
+    - r-ggplot2
+    - r-reshape2
+    - bioconductor-biobase
+    - r-biocmanager
+
+test:
+  commands:
+    - $R -e "library('NMF')"
+
+about:
+  home: https://renozao.github.io/NMF/
+  dev_url: https://github.com/renozao/NMF
+  doc_url: https://cran.r-project.org/package=NMF
+  license: GPL-2.0-or-later
+  license_family: GPL3
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2'
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+  summary: Framework to perform Non-negative Matrix Factorization (NMF).
+  description: |
+    Provides a framework to perform Non-negative Matrix Factorization (NMF). The package
+    implements a set of already published algorithms and seeding methods, and provides a
+    framework to test, develop and plug new/custom algorithms. Most of the built-in algorithms
+    have been optimized in C++, and the main interface function provides an easy way of
+    performing parallel computations on multicore machines.
+
+extra:
+  skip-lints:
+    - in_other_channels
+  recipe-maintainers:
+    - tfenne
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64


### PR DESCRIPTION
NMF is stuck at 0.21.0 (2018) on both the r and conda-forge channels because it added an Imports dependency on Biobase, a Bioconductor package neither channel carries nor permits. bioconda already hosts bioconductor-biobase, so build against that instead.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
