### PR TITLE
Add virsorter2-pyhmmeracc

### DIFF
--- a/recipes/virsorter2-pyhmmeracc/meta.yaml
+++ b/recipes/virsorter2-pyhmmeracc/meta.yaml
@@ -44,10 +44,10 @@ test:
     - virsorter run --help
     - virsorter train-feature --help
     - virsorter train-model --help
-    - test -f "$SP_DIR/virsorter/rules/extract-feature.smk"
-    - test -f "$SP_DIR/virsorter/scripts/pyhmmersearch.py"
-    - test -f "$SP_DIR/virsorter/scripts/selectbesthit.py"
-    - test -f "$SP_DIR/virsorter/envs/vs2.yaml"
+    - python -c "from pathlib import Path; import virsorter; assert (Path(virsorter.__file__).parent / 'rules/extract-feature.smk').is_file()"
+    - python -c "from pathlib import Path; import virsorter; assert (Path(virsorter.__file__).parent / 'scripts/pyhmmersearch.py').is_file()"
+    - python -c "from pathlib import Path; import virsorter; assert (Path(virsorter.__file__).parent / 'scripts/selectbesthit.py').is_file()"
+    - python -c "from pathlib import Path; import virsorter; assert (Path(virsorter.__file__).parent / 'envs/vs2.yaml').is_file()"
 
 about:
   home: "https://github.com/liusihang/VirSorter2-pyhmmerAcc"

--- a/recipes/virsorter2-pyhmmeracc/meta.yaml
+++ b/recipes/virsorter2-pyhmmeracc/meta.yaml
@@ -1,0 +1,64 @@
+{% set name = "virsorter2-pyhmmeracc" %}
+{% set version = "2.2.4.2" %}
+{% set sha256 = "14737017cf6a04c6c4741c191045270141d13e2e98723f86b1a6186ae0fdd716" %}
+
+package:
+  name: "{{ name }}"
+  version: "{{ version }}"
+
+source:
+  url: "https://github.com/liusihang/VirSorter2-pyhmmerAcc/archive/refs/tags/v{{ version }}.tar.gz"
+  sha256: "{{ sha256 }}"
+
+build:
+  number: 0
+  noarch: python
+  entry_points:
+    - virsorter=virsorter.virsorter:cli
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x.x") }}
+  script: "{{ PYTHON }} -m pip install . --no-deps --no-build-isolation --no-cache-dir -vvv"
+
+requirements:
+  host:
+    - python >=3.8,<3.11
+    - pip
+    - setuptools
+    - wheel
+  run:
+    - python >=3.8,<3.11
+    - ruamel.yaml =0.16
+    - snakemake-minimal >=5.18,<=5.26
+    - click >=7
+    - git
+    - cookiecutter
+    - mamba <2
+    - conda-package-handling <=1.9
+
+test:
+  imports:
+    - virsorter
+  commands:
+    - virsorter --version
+    - virsorter setup --help
+    - virsorter run --help
+    - virsorter train-feature --help
+    - virsorter train-model --help
+    - test -f "$SP_DIR/virsorter/rules/extract-feature.smk"
+    - test -f "$SP_DIR/virsorter/scripts/pyhmmersearch.py"
+    - test -f "$SP_DIR/virsorter/scripts/selectbesthit.py"
+    - test -f "$SP_DIR/virsorter/envs/vs2.yaml"
+
+about:
+  home: "https://github.com/liusihang/VirSorter2-pyhmmerAcc"
+  dev_url: "https://github.com/liusihang/VirSorter2-pyhmmerAcc"
+  license: "GPL-2.0-only"
+  license_family: "GPL"
+  license_file: "LICENSE"
+  summary: "VirSorter2 with PyHMMER-accelerated feature extraction."
+
+extra:
+  recipe-maintainers:
+    - liusihang
+  container:
+    extended-base: true


### PR DESCRIPTION
Adds the tagged `virsorter2-pyhmmeracc` 2.2.4.2 release as a separate package. ViOTUcluster's YAML installation already pins this PyHMMER-accelerated implementation, so packaging it explicitly preserves the same VirSorter behavior in the Bioconda single-environment installation without downloading a Git repository at install time.

The recipe uses the public `v2.2.4.2` release tarball and SHA256, is `noarch: python`, exports a minor-version compatibility pin, and follows the existing Bioconda VirSorter2 runtime dependency contract.

Validation performed on Linux:

- complete `conda build` and recipe test: PASS
- import plus all five VirSorter CLI checks: PASS, version 2.2.4.2
- packaged Snakemake rule, PyHMMER scripts, selection script, and environment definition: present
- downstream ViOTUcluster clean mamba installation and real mini-data pipeline through viral prediction, vRhyme binning, dRep, and summary: PASS

----

This PR follows the Bioconda recipe checklist: stable tagged source, SHA256, build number 0, `noarch: python`, runtime-only tests, license metadata, `run_exports`, and a listed maintainer.
