### PR TITLE
Add scicone 1.0.0

### DIFF
--- a/recipes/scicone/build.sh
+++ b/recipes/scicone/build.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -euxo pipefail
+
+# ---------------------------------------------------------------------------
+# C++ executables
+# ---------------------------------------------------------------------------
+cmake -S scicone -B build \
+    ${CMAKE_ARGS:-} \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+    -DCMAKE_PREFIX_PATH="${PREFIX}"
+
+cmake --build build -j "${CPU_COUNT}"
+
+# The unit tests resolve their input data relative to the source tree, so this
+# is the only place they can run: by the time the test phase runs, the source
+# is gone. The argument disables the (slow) reproducibility test.
+./build/scicone-tests 0
+
+cmake --install build
+
+# ---------------------------------------------------------------------------
+# Python package
+# ---------------------------------------------------------------------------
+# The source tree carries prebuilt binaries for people installing with pip.
+# This package uses the ones just built into $PREFIX/bin, so drop them rather
+# than vendoring a second, foreign copy into site-packages. A stale setuptools
+# build/ directory would put them back, so that goes too.
+rm -rf pyscicone/scicone/bin pyscicone/build pyscicone/scicone.egg-info
+
+cd pyscicone
+$PYTHON -m pip install . --no-deps --no-build-isolation -vv
+cd ..
+
+# Vendored binaries have slipped through before: they are several megabytes of
+# executables built somewhere else, and one stale directory is enough to bring
+# them back. Fail the build rather than ship them.
+# Located without importing the package: its dependencies are run-time only and
+# are not present in the build environment.
+site_packages=$($PYTHON -c "import sysconfig; print(sysconfig.get_paths()['purelib'])")
+vendored="${site_packages}/scicone/bin"
+if [ -e "${vendored}" ]; then
+    echo "ERROR: prebuilt binaries were vendored into the Python package:" >&2
+    ls -la "${vendored}" >&2
+    exit 1
+fi

--- a/recipes/scicone/meta.yaml
+++ b/recipes/scicone/meta.yaml
@@ -1,0 +1,79 @@
+{% set name = "scicone" %}
+{% set version = "1.0.0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/cbg-ethz/SCICoNE/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: b98b819a1b7b7b5052f85e434e4adcb8c5f56f44e9f4b8f0342b2d50e4aacd9f
+
+build:
+  number: 0
+  skip: True  # [win]
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x") }}
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - {{ stdlib('c') }}
+    - cmake >=3.16
+    - make
+  host:
+    - python
+    - pip
+    - setuptools
+    - libboost-headers >=1.47
+    - nlopt
+    - llvm-openmp  # [osx]
+  run:
+    - python
+    - nlopt
+    - numpy
+    - scipy
+    - pandas
+    - matplotlib-base
+    - seaborn
+    - h5py
+    - python-graphviz
+    - graphviz
+    - phenograph
+    - pybiomart
+
+test:
+  imports:
+    - scicone
+  commands:
+    # A miniature end-to-end run: simulate a counts matrix, then segment it.
+    - scicone-simulation --n_cells=20 --n_bins=200 --n_regions=5 --n_nodes=3 --n_reads=10000 --postfix=condatest --seed=42
+    - scicone-breakpoint_detection --d_matrix_file=3nodes_5regions_10000reads_condatest_d_mat.csv --n_bins=200 --n_cells=20 --window_size=10 --threshold=3.0 --postfix=condatest
+    - test -s condatest_segmented_region_sizes.txt
+    # scicone-inference takes no --help; it reports the first missing required
+    # argument instead, which is enough to show that it loads and runs.
+    - scicone-inference 2>&1 | grep -q "region sizes file is not provided"
+    - test -x ${PREFIX}/bin/scicone-score
+    # The Python package must find the executables it just got installed with.
+    - python -c "from scicone import SCICoNE; SCICoNE()"
+
+about:
+  home: https://github.com/cbg-ethz/SCICoNE
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  license_file: LICENSE
+  summary: Single-cell copy number calling and event history reconstruction
+  description: |
+    SCICoNE is a statistical model and MCMC algorithm tailored to single-cell
+    copy number profiling from shallow whole-genome DNA sequencing data. It
+    reconstructs the history of copy number events in the tumour and uses these
+    evolutionary relationships to identify the copy number profiles of the
+    individual cells. This package provides the command line executables
+    (prefixed with `scicone-`) and the `scicone` Python interface to them.
+  dev_url: https://github.com/cbg-ethz/SCICoNE
+  doc_url: https://github.com/cbg-ethz/SCICoNE/blob/master/docs/tutorial.md
+
+extra:
+  recipe-maintainers:
+    - pedrofale


### PR DESCRIPTION
Adds [SCICoNE](https://github.com/cbg-ethz/SCICoNE) — single-cell copy number calling and event history reconstruction, a statistical model and MCMC algorithm for single-cell copy number profiling from shallow whole-genome sequencing.

I am the upstream maintainer, and I am listed as the recipe maintainer.

The package provides both the command line executables and the Python interface that drives them:

- `scicone-simulation`, `scicone-breakpoint_detection`, `scicone-inference`, `scicone-score`
- the `scicone` Python package, which locates those executables on `PATH`

The executables carry a `scicone-` prefix because upstream names them `inference`, `score` and `simulation`, which would collide in a shared `bin/`. Upstream was changed to build and install them under the prefixed names for this release, so the recipe does not rename anything itself.

### Testing

Built locally with `conda build` on linux-64 from this exact source URL and checksum, and the resulting package installed into a clean environment, where the full upstream tutorial runs end to end: simulate a counts matrix → detect breakpoints → segment → infer a tree, plus the Python API driving the same executables.

The recipe's own test section runs a miniature version of that pipeline rather than only checking that the files exist, since none of the executables accept `--help`.

### Notes for review

- `build.sh` runs the upstream C++ unit tests during the build. They resolve their input data relative to the source tree, so the build phase is the only place they can run; the test binary is deliberately not installed for the same reason.
- `build.sh` removes the prebuilt binaries that the source tarball carries for pip users, and fails the build if any of them end up inside `site-packages`. Without that, roughly 19 MB of unrelated executables are vendored into the package.
- Only Boost's headers are needed — `libboost-headers` — as the code uses Boost.Random's header-only distributions.
- I have not been able to test the osx build. If it fails under clang I will follow up on this branch.