### PR TITLE
Update commec to 2.1.0

### DIFF
--- a/recipes/commec/meta.yaml
+++ b/recipes/commec/meta.yaml
@@ -15,13 +15,9 @@ build:
   noarch: python
   script: "{{ PYTHON }} -m pip install . --no-deps --no-build-isolation --no-cache-dir -vvv"
   run_exports:
-    - {{ pin_subpackage('commec', max_pin="x.x.x") }}
+    - {{ pin_subpackage('commec', max_pin="x") }}
 
 requirements:
-  build:
-    - python >=3.10
-    - pip
-    - setuptools
   host:
     - python >=3.10
     - pip
@@ -60,6 +56,7 @@ about:
   home: https://commec.ibbis.bio
   license: MIT
   license_family: MIT
+  license_file: LICENSE
   doc_url: https://github.com/ibbis-bio/common-mechanism/wiki
   summary: "commec: a free, open-source, globally available tool for DNA synthesis screening"
   dev_url: https://github.com/ibbis-bio/common-mechanism

--- a/recipes/commec/meta.yaml
+++ b/recipes/commec/meta.yaml
@@ -57,11 +57,11 @@ test:
     - commec gui --help
 
 about:
-  home: https://github.com/ibbis-bio/common-mechanism
+  home: https://commec.ibbis.bio
   license: MIT
   license_family: MIT
   doc_url: https://github.com/ibbis-bio/common-mechanism/wiki
-  summary: "commec: a free, open-source, globally available tool for DNA sequence screening"
+  summary: "commec: a free, open-source, globally available tool for DNA synthesis screening"
   dev_url: https://github.com/ibbis-bio/common-mechanism
 
 extra:

--- a/recipes/commec/meta.yaml
+++ b/recipes/commec/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "commec" %}
-{% set version = "2.0.0" %}
-{% set sha256 = "1f8ab8e1c1cee5918dbcd83b2a86642c0f0945cabe078246a42cc18637b6c056" %}
+{% set version = "2.1.0" %}
+{% set sha256 = "e4657ae7ce1338c473a649a33c993fe81f79afb403a22a639c8b13558e7be55d" %}
 
 package:
   name: "{{ name }}"
   version: "{{ version }}"
 
 source:
-  url: https://github.com/ibbis-screening/common-mechanism/archive/refs/tags/v{{version}}.tar.gz
+  url: https://github.com/ibbis-bio/common-mechanism/archive/refs/tags/v{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:
@@ -34,28 +34,35 @@ requirements:
     - pandas
     - pyyaml
     - pycountry
+    - flask
+    - werkzeug
+    - openpyxl
+    - xlrd
+    - psutil
     # Runtime non-Python dependencies
     - blast >=2.17
     - hmmer
     - infernal
-    - wget
-    - yaml
+    - mkcert
     - tar
     - zstd
 
 test:
   commands:
+    - commec --version
+    - commec setup --help
     - commec screen --help
     - commec flag --help
     - commec list --help
+    - commec gui --help
 
 about:
-  home: https://github.com/ibbis-screening/common-mechanism
+  home: https://github.com/ibbis-bio/common-mechanism
   license: MIT
   license_family: MIT
-  doc_url: https://github.com/ibbis-screening/common-mechanism/wiki
+  doc_url: https://github.com/ibbis-bio/common-mechanism/wiki
   summary: "commec: a free, open-source, globally available tool for DNA sequence screening"
-  dev_url: https://github.com/ibbis-screening/common-mechanism
+  dev_url: https://github.com/ibbis-bio/common-mechanism
 
 extra:
   identifiers:


### PR DESCRIPTION
Updates commec from 2.0.0 to 2.1.0.

----

- Adds runtime dependencies for the new `gui` subcommand (web kiosk server): flask, werkzeug, openpyxl, xlrd, psutil, mkcert. Removed wget and yaml, which are stale in v2.x.x. These requirements are synced with upstream environment.yaml. Python version is pinned as declared in pyproject.toml.

- Subcommands `setup` and `gui` were added to the test block.

- Also updates the home and source URL to the `ibbis-bio` org. The incorrect URL is why autobump reported NoRecognizedSourceUrl for this recipe. With the URL fixed, autobump detects releases correctly and can be used to open PRs from the next release.

