### PR TITLE
Update egt to v0.2.6

### DIFF
--- a/recipes/egt/meta.yaml
+++ b/recipes/egt/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "egt" %}
-{% set version = "0.2.5" %}
+{% set version = "0.2.6" %}
 
 package:
   name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://files.pythonhosted.org/packages/2c/26/9737d2fd448bd912ba033fd74c91f249a2061792c6da45fda7037c54f6ef/egt-{{ version }}.tar.gz
-  sha256: 019375814c2e1e024e416ae2d3b5cc89c31268b33c635ab4d6bcc2932a0798f7
+  url: https://files.pythonhosted.org/packages/8b/6c/78657de1115563d0e08150265d330762a1f90704c170f09fd1eefde9e3d8/egt-{{ version }}.tar.gz
+  sha256: e62b9f9d00d148f0fd1f2ff28a99879c227a438d82abc31bdfcea0596b2612a5
 
 build:
   number: 0


### PR DESCRIPTION
Version bump 0.2.5 → 0.2.6.

The PyPI sdist URL and SHA-256 were verified against the published artifact. Runtime dependencies and the `egt = egt.cli:main` entry point are unchanged, so no requirements or entry-point edits are needed. The build number remains 0 for the new upstream version.

Upstream release: https://github.com/conchoecia/egt/releases/tag/v0.2.6

Recipe maintainer: conchoecia
