### PR TITLE
Update fastga to a post-1.5 commit so it can read current FASTAN .1ano files

### DIFF
--- a/recipes/fastga/build.sh
+++ b/recipes/fastga/build.sh
@@ -4,7 +4,13 @@ mkdir -p ${PREFIX}/bin
 
 export CFLAGS="${CFLAGS} -O3 -I$PREFIX/include -L$PREFIX/lib -pthread"
 
-make -j"${CPU_COUNT}" CC="${CC}" CFLAGS="${CFLAGS}"
+# LDFLAGS is folded into CFLAGS on purpose. The Makefile never references $(LDFLAGS) -- every rule
+# compiles and links in one step as `$(CC) $(CFLAGS) -o prog prog.c ... -lm -lz` -- so conda's
+# linker flags reach the linker only by this route. On osx that includes
+# -headerpad_max_install_names, without which conda-build's relocation step fails at:
+#   install_name_tool: changing install names or rpaths can't be redone for ... bin/ALNshow
+#   because larger updated load commands do not fit
+make -j"${CPU_COUNT}" CC="${CC}" CFLAGS="${CFLAGS} ${LDFLAGS}"
 
 install -v -m 0755 FastGA \
     FAtoGDB GIXmake ALNtoPAF ALNtoPSL \

--- a/recipes/fastga/meta.yaml
+++ b/recipes/fastga/meta.yaml
@@ -1,13 +1,19 @@
+{% set commit = "178afcbba2f79abc1686e3bd2b8a916969467e83" %}
+
 package:
   name: fastga
-  version: 1.5
+  version: 1.5.20260729
 
 source:
-  url: https://github.com/thegenemyers/FASTGA/archive/refs/tags/v1.5.tar.gz
-  sha256: c12e8f54ff69f76e872a8878a5a2e68c4a7bce18f91e246d2e06b21871477a0e
+  # Post-v1.5 commit, not a tag: the v1.5 tarball cannot read the .1ano files that
+  # current FASTAN writes. See the PR description -- upstream changed the ANO record
+  # definition in 0a4a4db ("ANO file definition change", 2026-04-23), three months
+  # after v1.5 was tagged, and there has been no release since.
+  url: https://github.com/thegenemyers/FASTGA/archive/{{ commit }}.tar.gz
+  sha256: 9bb7b506f4c6445819119ab41ad2bbbed25e20a4f6286d6d1c6a5c77ff1eddf0
 
 build:
-  number: 1
+  number: 0
   run_exports:
     - {{ pin_subpackage('fastga', max_pin="x") }}
 


### PR DESCRIPTION
fastga 1.5 and fastan 0.8 are both in the channel and cannot be used together:

  FAtoGDB up.fa gdb              (fastga 1.5)  ok
  FasTAN -m -p -oscan gdb        (fastan 0.8)  ok, writes scan.1ano
  ANOtoBED scan.1ano             (fastga 1.5)  Failed to open .1ano file

Upstream changed the ano schema after tagging v1.5, in 0a4a4db ("ANO file definition change", 2026-04-23); v1.5 was tagged 2026-01-07 and nothing has been released since. The M record was redefined and a P record added:

  v1.5   O M 2 3 INT 8 INT_LIST   (no P record)
  main   O M 3 3 INT 3 INT 3 INT  + D P 1 8 INT_LIST

FASTAN 0.8's own ANO.c carries the new definition, byte-identical to FastGA main, so its output is unreadable by the ANOtoBED in fastga 1.5 -- and the failure is at file-open, giving no hint that the cause is a version mismatch.

Reproduced against the biocontainer, a local v1.5 build, and the schema diff. The GDB is irrelevant; ANOtoBED does not read it.

Pins 178afcbba2f79abc1686e3bd2b8a916969467e83 (current main), which also carries a later fix making plist[] dynamically allocated. Verified from that tarball that all 24 binaries the recipe tests still build, and that its ANOtoBED reads a fastan 0.8 .1ano (77 BED rows). sha256 is stable across repeated downloads.

Version becomes 1.5.20260729 rather than 1.5 with a build bump, because this is a file-format change and reusing the version would alter what .1ano means under an unchanged version. Happy to switch to 1.5 + build 2 if preferred.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
