### PR TITLE
Update molamola to v0.6.0

### DIFF
--- a/recipes/molamola/meta.yaml
+++ b/recipes/molamola/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "molamola" %}
-{% set version = "0.5.0" %}
+{% set version = "0.5.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 0e3175b1122a37958775523244bb040e82877f5bdb6b0f803b44f6cee9ccb0cf
+  sha256: bc87271a9c55a496f5bd4a7eab393b75841e25c82ea04f2ff02371bb1559f3c6
 
 build:
   number: 0

--- a/recipes/molamola/meta.yaml
+++ b/recipes/molamola/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "molamola" %}
-{% set version = "0.5.1" %}
+{% set version = "0.6.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: bc87271a9c55a496f5bd4a7eab393b75841e25c82ea04f2ff02371bb1559f3c6
+  sha256: d67fe27266cfd3c3914488d47078f04582fa61239027fa308fb4b41ecb4a8d06
 
 build:
   number: 0
@@ -53,13 +53,11 @@ about:
     * VCF with ``##INFO=<ID=SVTYPE,...>``: a circos + linear
       cytoband SV report (Sniffles2 / cuteSV / SVIM / pbsv /
       NanoVar).
-    * VCF with ``##INFO=<ID=CSQ,...>`` + ``##FORMAT=<ID=PS,...>``:
-      per-gene phased-haplotype panels for compound-het workup
-      from phased + VEP-annotated small-variant VCFs.
     * Mosdepth ``regions.bed.gz`` (via ``--mosdepth``): a
-      karyotype coverage report -- genome-wide CN scatter +
-      rolling-median smooth, with an optional BAF panel beneath
-      when paired with a small-variant VCF.
+      karyotype coverage report -- genome-wide log2 relative
+      depth, with an optional BAF panel beneath when paired with
+      a small-variant VCF, haplotype-resolved when that VCF is
+      phased.
   license: MIT
   license_family: MIT
   license_file: LICENSE


### PR DESCRIPTION
## Summary

Updates molamola from v0.5.0 (current in bioconda) to **v0.6.0**.

This PR was originally opened for v0.5.1. That release did not merge before
v0.6.0 was cut, so the branch has been **retargeted in place** rather than
opening a second, competing PR. v0.5.1 is superseded — its only change (a
colour-vision-safe VAF palette) is included in v0.6.0.

PyPI sdist: <https://pypi.org/project/molamola/0.6.0/>

## What changed since v0.5.0

- **v0.5.1** — VAF class colours reworked for colour-vision deficiency.
- **v0.6.0** — compound-het mode removed; molamola is now a cytogenetics tool
  covering SV reports and karyotype coverage only. The circos gained SV density
  rings and a legend, and the density scale was reworked.

## Notes for reviewers

- **The package is now much smaller.** Removing compound-het mode also removed
  its bundled ClinVar (12 MB) and MANE Select (1.8 MB) references, so the
  bundled data inside `molamola/data/` drops from ~28.5 MB to ~14.7 MB. Only
  cytobands, karyotype exclusion masks and GC tables remain. Earlier reviews
  raised the bundled-data-in-noarch question; this substantially reduces it.
- **`recipe/meta.yaml` changes are version, sha256, and the `about:
  description`** — the description no longer advertises the removed mode.
- Dependencies, entry point, `run_exports` and the test section are unchanged.
- Still pure-Python `noarch`; `matplotlib-base` rather than `matplotlib` since
  molamola never opens a GUI.
- The sha256 was verified against the bytes PyPI actually serves, not just the
  locally built artefact.

## Breaking change note

v0.6.0 removes a user-facing mode. Anyone relying on the phased-haplotype gene
panels should pin `molamola=0.5.1`; the CLI tells them so by name when it sees
a phased + VEP-annotated VCF, rather than failing with a generic error.
