### PR TITLE
Update cutesv dependency on pyvcf3

### DIFF
--- a/recipes/cutesv/meta.yaml
+++ b/recipes/cutesv/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: e84292be5b9329fdb6ab9bf1c9b678506b33a70694abba7099aafe919183bb3b
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install --no-deps --no-build-isolation --no-cache-dir -vvv .
   run_exports:
@@ -26,7 +26,7 @@ requirements:
     - numpy
     - pysam >=0.15.0
     - python >=3
-    - pyvcf
+    - pyvcf3
     - scikit-learn
     - scipy
 


### PR DESCRIPTION
The cutesv recipe currently declares the legacy `pyvcf` package.
This package fails with newer Python packaging toolchains, whereas
`pyvcf3` provides the same `vcf` import used by [cuteSV](https://github.com/tjiangHIT/cuteSV/blob/master/setup.py)

This PR:
- replaces the runtime dependency `pyvcf` with `pyvcf3`;
- increments the recipe build number;
- leaves the upstream cuteSV version unchanged.

The issue was encountered while creating a clean environment for an
ONT structural-variant benchmarking pipeline.

Related: #64565, where @thanhleviet identifies the same dependency discrepancy in the
separate cuteSV-Trio recipe. This PR updates the existing cutesv recipe.
