### PR TITLE
Update dotmatch and assaycode to 0.4.0

### DIFF
--- a/recipes/assaycode/meta.yaml
+++ b/recipes/assaycode/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.2.2" %}
+{% set version = "0.4.0" %}
 
 package:
   name: assaycode

--- a/recipes/dotmatch/build.sh
+++ b/recipes/dotmatch/build.sh
@@ -7,6 +7,13 @@ if [[ "$(uname -s)" == "Darwin" && "$(uname -m)" == "x86_64" ]]; then
   sed -i.bak '/CFLAGS += -mavx2/d; /CXXFLAGS += -mavx2/d' Makefile
 fi
 
+# Keep the setuptools-built macOS binaries on the same deployment target as the
+# Conda Python interpreter so conda-build's llvm-otool relocation step does not
+# abort on a mismatched Mach-O produced under the older toolchain default.
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  export MACOSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-11.0}"
+fi
+
 make \
   DOTMATCH_VERSION="${PKG_VERSION}" \
   CC="${CC}" \
@@ -27,6 +34,12 @@ install -m 644 LICENSE "${PREFIX}/share/${PKG_NAME}/LICENSE"
 
 if [[ "$(uname -s)" == "Darwin" ]]; then
   install -m 755 libdotmatch.dylib "${PREFIX}/lib/libdotmatch.dylib"
+  # Prefer the Makefile-built shared library inside the Python package as well.
+  # The setuptools copy has tripped conda-build's osx-64 llvm-otool relocation.
+  PKG_DIR="$("${PYTHON}" -c 'import pathlib, sysconfig; print(pathlib.Path(sysconfig.get_paths()["purelib"]) / "dotmatch")')"
+  if [[ -d "${PKG_DIR}" ]]; then
+    install -m 755 libdotmatch.dylib "${PKG_DIR}/libdotmatch.dylib"
+  fi
 else
   install -m 755 libdotmatch.so "${PREFIX}/lib/libdotmatch.so"
 fi

--- a/recipes/dotmatch/build.sh
+++ b/recipes/dotmatch/build.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Bioconda sets -march=core2 on osx-64, which conflicts with DotMatch's Makefile
+# unconditionally appending -mavx2 for x86_64 and can abort clang during qdalign.c.
+if [[ "$(uname -s)" == "Darwin" && "$(uname -m)" == "x86_64" ]]; then
+  sed -i.bak '/CFLAGS += -mavx2/d; /CXXFLAGS += -mavx2/d' Makefile
+fi
+
 make \
   DOTMATCH_VERSION="${PKG_VERSION}" \
   CC="${CC}" \

--- a/recipes/dotmatch/meta.yaml
+++ b/recipes/dotmatch/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "dotmatch" %}
-{% set version = "0.2.2" %}
-{% set sha256 = "52536b70e379f1aa09d891b3e44c7f67b02875086826f55fabe25f3bcfab89b9" %}
+{% set version = "0.4.0" %}
+{% set sha256 = "618231404db7b4310241afd48dc6a14cd33c4b2cfaa68abc7d4fbc82a8e9a026" %}
 
 package:
   name: {{ name }}
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 0
   skip: True  # [win or py<39]
   run_exports:
     - {{ pin_subpackage(name, max_pin="x.x") }}
@@ -47,6 +47,8 @@ test:
     - dotmatch assay --help | grep 'dotmatch assay'
     - dotmatch barcode --help | grep 'dotmatch barcode'
     - dotmatch panel --help | grep 'dotmatch panel'
+    - dotmatch agent tools --json | grep 'prepare_assay'
+    - dotmatch agent tools --json | grep 'handoff_assay'
     - test -f "${PREFIX}/include/qdalign.h"
     - test -f "${PREFIX}/lib/libdotmatch.a"
     - test -f "${PREFIX}/lib/libdotmatch.so" || test -f "${PREFIX}/lib/libdotmatch.dylib"
@@ -79,6 +81,10 @@ test:
     - test -f panel_out/barcodes.tsv
     - test -f panel_out/design_report.json
     - chmod -R a+rwX panel_out
+    - mkdir exported-skill
+    - dotmatch agent export-skill --target exported-skill
+    - test -f exported-skill/SKILL.md
+    - test -f exported-skill/agents/openai.yaml
 
 about:
   home: "https://dnncha.github.io/dotmatch"

--- a/recipes/dotmatch/meta.yaml
+++ b/recipes/dotmatch/meta.yaml
@@ -85,6 +85,7 @@ test:
     - dotmatch agent export-skill --target exported-skill
     - test -f exported-skill/SKILL.md
     - test -f exported-skill/agents/openai.yaml
+    - chmod -R a+rwX exported-skill
 
 about:
   home: "https://dnncha.github.io/dotmatch"


### PR DESCRIPTION
Updates `dotmatch` and its `assaycode` compatibility metapackage from 0.2.2 to the public 0.4.0 release.

The immutable source archive SHA-256 is `618231404db7b4310241afd48dc6a14cd33c4b2cfaa68abc7d4fbc82a8e9a026`. The recipe retains the existing architecture opt-ins and adds smoke coverage for the structured local agent-tool manifest and exported Codex skill.

Upstream release: https://github.com/dnncha/dotmatch/releases/tag/v0.4.0
PyPI: https://pypi.org/project/dotmatch/0.4.0/
Zenodo: https://doi.org/10.5281/zenodo.22214073