### PR TITLE
Update syntactic to 0.1.1

### DIFF
--- a/recipes/syntactic/meta.yaml
+++ b/recipes/syntactic/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.1.0" %}
+{% set version = "0.1.1" %}
 {% set github = "https://github.com/acidgenomics/py-syntactic" %}
 
 package:
@@ -6,8 +6,8 @@ package:
   version: "{{ version }}"
 
 source:
-  url: "{{ github }}/archive/v{{ version }}.tar.gz"
-  sha256: be277baa1a3a89a4d2c6e7f9148a629eec3e76f1224554819db184f374da2522
+  url: "https://pypi.io/packages/source/a/acidgenomics-syntactic/acidgenomics_syntactic-{{ version }}.tar.gz"
+  sha256: fed1ac2fe4bf1f2b73147799aba8ef6ca81462fc6160f01e01ad3ea42e3fcd35
 
 build:
   number: 0


### PR DESCRIPTION
- Version 0.1.0 -> 0.1.1
- Source moved from the GitHub release tarball to the PyPI sdist
  (`acidgenomics-syntactic`, the package's new PyPI distribution name; the
  conda package name and the `syntactic` import name are unchanged)