### PR TITLE
Update cellosaurus to 0.2.1

### DIFF
--- a/recipes/cellosaurus/meta.yaml
+++ b/recipes/cellosaurus/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.2.0" %}
+{% set version = "0.2.1" %}
 {% set github = "https://github.com/acidgenomics/py-cellosaurus" %}
 
 package:
@@ -6,8 +6,8 @@ package:
   version: "{{ version }}"
 
 source:
-  url: "{{ github }}/archive/v{{ version }}.tar.gz"
-  sha256: 8a60050a8ed35fb52b1453ec2205c9a6328eb175a0c3b525b165cad0de69850b
+  url: "https://pypi.io/packages/source/a/acidgenomics-cellosaurus/acidgenomics_cellosaurus-{{ version }}.tar.gz"
+  sha256: dc4804a94db2e951c999b49da7a98c8220f8b458485fd1350e0219601f2d3827
 
 build:
   number: 0


### PR DESCRIPTION
- Version 0.2.0 -> 0.2.1
- Source moved from the GitHub release tarball to the PyPI sdist
  (`acidgenomics-cellosaurus`, the package's new PyPI distribution name; the
  conda package name and the `cellosaurus` import name are unchanged)