### PR TITLE
Update acidgenomes to 0.2.1

### DIFF
--- a/recipes/acidgenomes/meta.yaml
+++ b/recipes/acidgenomes/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.2.0" %}
+{% set version = "0.2.1" %}
 {% set github = "https://github.com/acidgenomics/py-acidgenomes" %}
 
 package:
@@ -6,8 +6,8 @@ package:
   version: "{{ version }}"
 
 source:
-  url: "{{ github }}/archive/v{{ version }}.tar.gz"
-  sha256: 8441733e1161f9c1a4d09ae074133e234074896f6a0bb33d1ecc09e780a0018d
+  url: "https://pypi.io/packages/source/a/acidgenomics-acidgenomes/acidgenomics_acidgenomes-{{ version }}.tar.gz"
+  sha256: d414fd8a8f789ae3603d21c043938865c20e076170fe791df063fb2bc833c789
 
 build:
   number: 0


### PR DESCRIPTION
- Version 0.2.0 -> 0.2.1
- Source moved from the GitHub release tarball to the PyPI sdist
  (`acidgenomics-acidgenomes`, the package's new PyPI distribution name; the
  conda package name and the `acidgenomes` import name are unchanged)