### PR TITLE
Update pipette to 0.2.1

### DIFF
--- a/recipes/pipette/meta.yaml
+++ b/recipes/pipette/meta.yaml
@@ -6,11 +6,11 @@ package:
   version: "{{ version }}"
 
 source:
-  url: "{{ github }}/archive/v{{ version }}.tar.gz"
-  sha256: f924eef0264190a4ecb0388998553d0c9087298b5f4d184a3fd2875b911b6c4c
+  url: "https://pypi.io/packages/source/a/acidgenomics-pipette/acidgenomics_pipette-{{ version }}.tar.gz"
+  sha256: c486926176c639815e2e79800134b3c3dc78b50deeaedfcf70d91a888a326432
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: "{{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv"
   run_exports:


### PR DESCRIPTION
- Version 0.2.0 -> 0.2.1
- Source moved from the GitHub release tarball to the PyPI sdist
  (`acidgenomics-pipette`, the package's new PyPI distribution name; the
  conda package name and the `pipette` import name are unchanged)