### PR TITLE
Update / downgrade shovill version 1.4.0

### DIFF
--- a/recipes/shovill/1.4.0/build.sh
+++ b/recipes/shovill/1.4.0/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+mkdir -p $PREFIX/bin
+cp -r * $PREFIX

--- a/recipes/shovill/1.4.0/meta.yaml
+++ b/recipes/shovill/1.4.0/meta.yaml
@@ -1,0 +1,55 @@
+{% set name = "shovill" %}
+{% set version = "1.4.0" %}
+{% set sha256 = "bfbbe76711c0da605705ae697b4b43ef206911fb5c28e988684fc2e86fc27308" %}
+{% set user = "tseemann" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+build:
+  number: 0
+  noarch: generic
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x") }}
+
+source:
+  url: https://github.com/{{ user }}/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+requirements:
+  run:
+    - perl >=5.32.0
+    - perl-file-spec
+    - perl-findbin
+    - spades >=3.14
+    - skesa >=2.5
+    - megahit >=1.2.9
+    - velvet >=1.2.10
+    - lighter >=1.1
+    - bwa >=0.7.17
+    - kmc >=3.2
+    - flash >=1.2
+    - pilon >=1.22
+    - samclip >=0.4
+    - trimmomatic >=0.36
+    - samtools >=1.10
+    - seqkit
+    - csvtk
+    - pigz
+
+test:
+  commands:
+    - {{ name }} --version | grep -F '{{ version }}'
+    - {{ name }} --check
+
+about:
+  home: https://github.com/{{ user }}/{{ name }}
+  license: GPL2
+  license_file: LICENSE
+  summary: Microbial assembly pipeline for Illumina paired-end reads
+
+extra:
+  identifiers:
+    - biotools:{{ name }}
+    - usegalaxy-eu:{{ name }}

--- a/recipes/shovill/1.4.0/meta.yaml
+++ b/recipes/shovill/1.4.0/meta.yaml
@@ -35,6 +35,7 @@ requirements:
     - trimmomatic >=0.36
     - samtools >=1.10
     - seqkit
+    - seqtk
     - csvtk
     - pigz
 


### PR DESCRIPTION
After release of shovill v1.4.1 the latest SPAdes de-novo assembler is no longer supported because SOME users experiences issues, in fact shovill actively shuts down if it detects SPADes < v4. Since this check is not yet added in the tagged v1.4.0, I've created a special version, which can enable users to run the semi-latest shovill with the latest SPAdes. 

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
