### PR TITLE
Update tesseract-assembler to 1.2.5

### DIFF
--- a/recipes/tesseract-assembler/build.sh
+++ b/recipes/tesseract-assembler/build.sh
@@ -3,10 +3,18 @@
 # the same steps work when building from a local checkout.
 set -euo pipefail
 
-mkdir -p "${PREFIX}/bin"
-
 make -j"${CPU_COUNT:-4}" CXX="${CXX:-g++}"
 
-install -v -m 0755 tesseract-asm "${PREFIX}/bin"
-install -v -m 0755 tesseract-model "${PREFIX}/bin"
-install -v -m 0755 tesseract-klebsiella "${PREFIX}/bin"
+mkdir -p "${PREFIX}/bin"
+install -m 0755 tesseract-asm "${PREFIX}/bin/tesseract-asm"
+install -m 0755 tesseract-model "${PREFIX}/bin/tesseract-model"
+
+# The Klebsiella runner ships too, as `tesseract-klebsiella`. Without it an installed package
+# is the assembler and nothing else: the user still has to find the release page, download a
+# 339 MB model by hand and work out the flags. The script finds the model, checks it and
+# assembles, which is the difference between "installed" and "usable".
+#
+# It resolves the assembler as $(dirname $0)/tesseract-asm, which in an installed tree is the
+# TesserACT sitting beside it -- so the installed copy uses the installed binary, not whatever
+# happens to be on PATH.
+install -m 0755 tesseract-klebsiella "${PREFIX}/bin/tesseract-klebsiella"

--- a/recipes/tesseract-assembler/meta.yaml
+++ b/recipes/tesseract-assembler/meta.yaml
@@ -1,9 +1,9 @@
 {% set name = "tesseract-assembler" %}
-{% set version = "1.2.4" %}
-{% set sha256 = "a7a2dfb86915cc94e00036c88aa28f22c0dc25c50fa5e4d8af9553d1bfc15efa" %}
+{% set version = "1.2.5" %}
+{% set sha256 = "924dde503d37f9b1279864e90aefd708b32bb210aa7c8c32f1da68fde5dceedc" %}
 
 package:
-  name: {{ name }}
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
@@ -35,6 +35,8 @@ requirements:
     - make
   host:
     - zlib
+  run:
+    - zlib
   # --map-polish shells out to one of these. They are not needed to assemble, so they
   # constrain rather than depend: installing the package should not drag in an aligner.
   run_constrained:
@@ -62,11 +64,11 @@ test:
     - python
 
 about:
-  home: "https://github.com/iowa69/TesserACT"
+  home: https://github.com/iowa69/TesserACT
   license: MIT
   license_family: MIT
   license_file: LICENSE
-  summary: "De novo short-read assembler for bacterial isolates, with optional genus models."
+  summary: De novo short-read assembler for bacterial isolates, with optional genus models
   description: |
     TesserACT assembles bacterial isolates from paired-end Illumina reads. It builds a de
     Bruijn graph over a ladder of k-mer sizes, simplifies it, resolves repeats with
@@ -84,12 +86,9 @@ about:
     With a model carrying a plasmid panel it also labels every contig chromosomal, plasmid
     or unknown, groups the contigs of one plasmid, and marks contigs whose two ends join as
     complete replicons. Pre-built Klebsiella models are attached to the GitHub releases.
-  doc_url: "https://github.com/iowa69/TesserACT#readme"
-  dev_url: "https://github.com/iowa69/TesserACT"
+  doc_url: https://github.com/iowa69/TesserACT#readme
+  dev_url: https://github.com/iowa69/TesserACT
 
 extra:
   recipe-maintainers:
     - iowa69
-  additional-platforms:
-    - linux-aarch64
-    - osx-arm64


### PR DESCRIPTION
Two fixes since 1.2.4, both found by auditing rather than by anything failing.

**`install.sh` shipped two commands while this package shipped three.** A source install left the user without `tesseract-klebsiella`, the command that fetches and verifies the model — so the two install routes disagreed about what the tool is.

**`assignReplicons` read the coverage vector by contig index without checking the two were the same length.** The invariant holds today, but the failure mode if it stopped would be a garbage depth ratio feeding the replicon classifier — a contig labelled chromosome or plasmid on the strength of an out-of-bounds read, silently, in a field read clinically. It now refuses and leaves everything unassigned instead.

### Testing

Built from the 1.2.5 release tarball with the `c_stdlib` pin CI supplies: package test passes, the functional test assembles a 6 kb genome to a single contig of the right length, and the help lists every flag a pipeline may depend on.

Separately, the assembler was rebuilt under AddressSanitizer and UBSan and run on a real clinical isolate with a genus model — no findings, and byte-identical output to the normal build.

Linux-64 only here; I will follow whatever your CI reports for osx.