### PR TITLE
Update kegalign-full to 0.3.0

### DIFF
--- a/recipes/kegalign-full/meta.yaml
+++ b/recipes/kegalign-full/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.2.2.14" %}
+{% set version = "0.3.0" %}
 
 package:
   name: kegalign-full


### PR DESCRIPTION
Tracks the conda-forge [kegalign 0.3.0](https://github.com/conda-forge/kegalign-feedstock/pull/25) release. The recipe pins `kegalign ={{ version }}`, so this is a version bump only — no other changes.

Upstream release: https://github.com/galaxyproject/KegAlign/releases/tag/v0.3.0

0.3.0 fixes a GPU seed-buffer overflow that crashed `14of22` jobs on usegalaxy.org, plus four further defects found reviewing the surrounding code (duplicate segments, out-of-range entropy counters, `exit()` from worker threads, unbounded `--seed` patterns). Two change output, hence the minor bump. Verified on 4× A100 against `lastz --nogapped`: HSP sets byte-identical at `step=1` and `step=2`.

The version scheme moves from a four-component counter to plain semver. Ordering is unaffected — conda compares element-wise and `0.3.0 > 0.2.2.14` at the second element.

`kegalign 0.3.0` is confirmed present in conda-forge `repodata.json` before filing, so the pin resolves.