### PR TITLE
New recipe builds for csuite tools (pin cblaster<=1.4.0)

### DIFF
--- a/recipes/cagecleaner/meta.yaml
+++ b/recipes/cagecleaner/meta.yaml
@@ -26,7 +26,7 @@ requirements:
   run:
     - python >=3.12
     - biopython
-    - cblaster >=1.4
+    - cblaster <=1.4.0
     - pandas <3.0.0
     - scipy <=1.14.1
     - ncbi-datasets-cli

--- a/recipes/cagecleaner/meta.yaml
+++ b/recipes/cagecleaner/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: cc452fd5d8fcbb075de870e68c301c861e60f3d94074e62b77f90764f867086a
 
 build:
-  number: 0
+  number: 1
   noarch: python
   entry_points:
     - cagecleaner = cagecleaner.main:main

--- a/recipes/cfoldseeker/meta.yaml
+++ b/recipes/cfoldseeker/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 79e867556dae491b8585a62303bd84f37cea745e2aed6c98afca352e58c93d8b
 
 build:
-  number: 1
+  number: 2
   noarch: python
   entry_points:
     - cfoldseeker = cfoldseeker.main:main

--- a/recipes/cfoldseeker/meta.yaml
+++ b/recipes/cfoldseeker/meta.yaml
@@ -28,7 +28,7 @@ requirements:
   run:
     - python >=3.12
     - biopython
-    - cblaster >=1.4.0
+    - cblaster <=1.4.0
     - polars >=1.0.0
     - foldseek
     - networkx

--- a/recipes/csuite/meta.yaml
+++ b/recipes/csuite/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 3f80fcffacb57b55c4f6c228790eabb77d27078444a5c06bbfc8c7407d8c3e33
 
 build:
-  number: 0
+  number: 1
   noarch: python
   entry_points:
     - csuite = csuite.main:main

--- a/recipes/csuite/meta.yaml
+++ b/recipes/csuite/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - setuptools
   run:
     - python >=3.12
-    - cblaster >=1.4.0
+    - cblaster <=1.4.0
     - cagecleaner >=1.5.2
     - cfoldseeker >=0.2.0
 


### PR DESCRIPTION
This PR updates the recipes for CAGEcleaner, cfoldseeker and csuite, pinning the version of the key dependency cblaster to a maximum version to avoid breaking changes introduced in newer cblaster versions.