### PR TITLE
Update genomicranges to 0.9.0

### DIFF
--- a/recipes/genomicranges/meta.yaml
+++ b/recipes/genomicranges/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "genomicranges" %}
-{% set version = "0.8.5" %}
+{% set version = "0.9.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: a493956ec5a72b1a63f6b3e2f56a64a7b6938fa06fd0119fffe4bcb75e86c3eb
+  sha256: b5f538b56f58ad246818192b9350740f601155e716b75c4cb7d72ee44f836de4
 
 build:
   noarch: python
@@ -19,14 +19,14 @@ build:
 requirements:
   host:
     - python
-    - setuptools >=46.1.0
-    - setuptools-scm >=5
+    - hatchling
+    - hatch-vcs
     - pip
   run:
     - python
     - numpy
-    - biocutils >=0.3.3
-    - biocframe >=0.7.1
+    - biocutils >=0.4.0
+    - biocframe >=0.8.0
     - iranges >=0.7.2
     - compressed-lists >=0.4.3
 


### PR DESCRIPTION
- Version 0.8.5 → 0.9.0
- Add `hatchling` and `hatch-vcs` host requirements required by the 0.9.0 build backend.
- Update runtime minimum versions to match upstream metadata.