### PR TITLE
Update lightpanda to 0.4.0

### DIFF
--- a/recipes/lightpanda/meta.yaml
+++ b/recipes/lightpanda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "lightpanda" %}
-{% set version = "0.3.7" %}
+{% set version = "0.4.0" %}
 
 package:
   name: {{ name }}
@@ -7,13 +7,13 @@ package:
 
 source:
   - url: https://github.com/lightpanda-io/browser/releases/download/{{ version }}/lightpanda-x86_64-linux  # [linux and x86_64]
-    sha256: 895339b02205171a181dde743ae0068bb4564884076feac8482baca9c212aa5a  # [linux and x86_64]
+    sha256: bfcf9bd7e80939b87232aa114a49d8f397f51af0c2632d9fc58d4a6d4386624f  # [linux and x86_64]
   - url: https://github.com/lightpanda-io/browser/releases/download/{{ version }}/lightpanda-aarch64-linux  # [linux and aarch64]
-    sha256: 4c0ecb28b4fcfb6d5bce82ec86e15fc6cde89cea168cf3840494f0ee26755852  # [linux and aarch64]
+    sha256: 5e3b54deed642ffeb2b8f24a1931e54c51161f44d9d728135da3d4863cb722fb  # [linux and aarch64]
   - url: https://github.com/lightpanda-io/browser/releases/download/{{ version }}/lightpanda-x86_64-macos  # [osx and x86_64]
-    sha256: 5e118b6e91c2cccb1ce7f0d34fc39dab262b947e4dea29a90b1a75b9399d7862  # [osx and x86_64]
+    sha256: fe50a51d4983dd1b93d410c5ac176bb14b7e57da940a5a0eb381a69f18bc57bd  # [osx and x86_64]
   - url: https://github.com/lightpanda-io/browser/releases/download/{{ version }}/lightpanda-aarch64-macos  # [osx and arm64]
-    sha256: ae99542d81af23087296ec037abb0d57a57002502f5ff4c1b0b05dfa484b79b8  # [osx and arm64]
+    sha256: 840547bb7b98743a3e32618a4d120ac4a75e7c3c2d227ecf5ce8d508ddc118b7  # [osx and arm64]
   - url: https://raw.githubusercontent.com/lightpanda-io/browser/refs/tags/{{ version }}/LICENSE
     sha256: 8486a10c4393cee1c25392769ddd3b2d6c242d6ec7928e1414efff7dfb2f07ef
 


### PR DESCRIPTION
## Description

This PR updates the `lightpanda` package in Bioconda from `0.3.7` to `0.4.0`, the latest upstream stable release (2026-08-31).

Changes:

- bumps `version` from `0.3.7` to `0.4.0`;
- updates the SHA256 checksums of the four per-platform official release binaries:
  - `linux-64` (`lightpanda-x86_64-linux`)
  - `linux-aarch64` (`lightpanda-aarch64-linux`)
  - `osx-64` (`lightpanda-x86_64-macos`)
  - `osx-arm64` (`lightpanda-aarch64-macos`)

The checksums were verified against the GitHub release asset digests. The `LICENSE` is unchanged, the `run_exports` pin and all other recipe fields are kept as-is. No build-number change is needed since this is a new version (reset to 0).