### PR TITLE
Update MobiOrigin to 0.1.6

### DIFF
--- a/recipes/mobiorigin/meta.yaml
+++ b/recipes/mobiorigin/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "mobiorigin" %}
-{% set version = "0.1.5" %}
-{% set sha256 = "74572b0a279ca12c3983182b167a292bc0bfbea4a35b7799400068e29b93a667" %}
+{% set version = "0.1.6" %}
+{% set sha256 = "c3cf5547465d32c036e89476ee8be6c25c583af0284173b8eb213f0c56a73857" %}
 
 package:
   name: {{ name }}


### PR DESCRIPTION
Update MobiOrigin from 0.1.5 to 0.1.6.

The source SHA-256 was verified against the public PyPI source distribution.

This release improves compressed FASTA handling, runtime diagnostics, WSL temporary-storage safety, AMRFinderPlus retry behavior, workflow progress reporting, normalized annotation tables, evidence-tier descriptions, and origin-stratified annotation visualization.

The frozen models, prediction features, ensemble weights, decision threshold, annotation thresholds, database content, and scientific prediction semantics remain unchanged.