### PR TITLE
Add gene-tidy

### DIFF
--- a/recipes/gene-tidy/meta.yaml
+++ b/recipes/gene-tidy/meta.yaml
@@ -1,0 +1,63 @@
+{% set name = "gene-tidy" %}
+{% set version = "0.2.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/gene_tidy-{{ version }}.tar.gz
+  sha256: 49a665f004ad3f88c8d912bec8876f082f1c2466b76c26dbfb56ded82cd91591
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --no-cache-dir -vvv
+  entry_points:
+    - gene-tidy = gene_tidy.cli:app
+  run_exports:
+    - {{ pin_subpackage("gene-tidy", max_pin="x.x") }}
+
+requirements:
+  host:
+    - python >=3.10
+    - pip
+    - setuptools >=64
+    - wheel
+  run:
+    - python >=3.10
+    - pandas >=1.5
+    - openpyxl >=3.0
+    - typer >=0.9
+
+test:
+  imports:
+    - gene_tidy
+  commands:
+    - gene-tidy --help
+    - gene-tidy --version
+    - python -c "import gene_tidy; assert gene_tidy.hgnc_version_info()['hgnc_release']"
+
+about:
+  home: https://github.com/MargoSolo/gene-tidy
+  summary: 'No-code cleaning of messy gene/protein identifier tables, fully offline, with explicit ambiguity handling.'
+  description: |
+    gene-tidy cleans messy human gene/protein identifier tables (TXT/CSV/TSV/XLSX)
+    by mapping them to current HGNC approved symbols plus Ensembl, UniProt, Entrez
+    and RefSeq cross-references. It runs fully offline against a bundled static
+    HGNC complete set, recovers Excel date-corrupted gene symbols (SEPT2 -> "2-Sep",
+    MARCH1 -> "1-Mar"), and never guesses silently: one-to-many and uncertain
+    mappings are flagged for manual review rather than resolved, and no input row
+    is ever dropped. Every run records the gene-tidy version and the exact HGNC
+    release used, and emits a paste-ready methods paragraph.
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  doc_url: https://github.com/MargoSolo/gene-tidy#readme
+  dev_url: https://github.com/MargoSolo/gene-tidy
+
+extra:
+  recipe-maintainers:
+    - MargoSolo
+  identifiers:
+    - doi:10.5281/zenodo.22285392

--- a/recipes/gene-tidy/meta.yaml
+++ b/recipes/gene-tidy/meta.yaml
@@ -13,8 +13,6 @@ build:
   noarch: python
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --no-cache-dir -vvv
-  entry_points:
-    - gene-tidy = gene_tidy.cli:app
   run_exports:
     - {{ pin_subpackage("gene-tidy", max_pin="x.x") }}
 


### PR DESCRIPTION
Adds a recipe for [gene-tidy](https://github.com/MargoSolo/gene-tidy), a tool for cleaning messy human gene/protein identifier tables.

It takes a TXT/CSV/TSV/XLSX table, detects the identifier column and the type of each value (approved symbol, alias, previous symbol, Ensembl gene, UniProt, Entrez, RefSeq, HGNC ID), and maps everything to current HGNC approved symbols with cross-references. Two behaviours are the point of it: Excel date-corrupted symbols are recovered where unambiguous and **flagged rather than guessed** where not (`Sep-7` → `SEPTIN7`, but `2-Sep` → `SEPTIN2`/`SEPTIN6` goes to manual review), and no input row is ever dropped — clean, ambiguous and failed rows always reconcile to the input count. Every run records the tool version and the exact HGNC release used.

I am the author and the recipe maintainer.

### Notes for the reviewer

* **`noarch: python`**, pure Python, no compiled extensions. `run_exports` uses `max_pin="x.x"` per the pre-1.0 case in the PR template.
* **Package size (~1.4 MB) is mostly vendored data**, and that is deliberate rather than sloppy: the HGNC complete set (44,997 Approved records) is bundled as a gzipped TSV so resolution works with no network access and no API keys, and so a result is reproducible years later. The exact release and its SHA-256 are recorded in the package and printed on every run. Bundle refreshes are minor version bumps, never patches, since new nomenclature can change a mapping.
* **Upstream is tested**: 117 tests run offline on Python 3.10–3.13 across Linux, macOS and Windows in CI, including a job that unpacks the built sdist and runs the suite from inside it.
* The recipe's `test:` section keeps to import and CLI smoke tests, plus one check that the bundled HGNC data is actually present in the installed package.
* License MIT; `LICENSE` is present in the sdist. The bundled HGNC data is CC0 and redistributable, attributed in the upstream README.
* Relevance to bioconda rather than conda-forge: the domain is gene nomenclature, and the audience is people cleaning supplementary tables and expression matrices before analysis.
