### PR TITLE
Update metahict to 1.2.0

### DIFF
--- a/recipes/metahict/build.sh
+++ b/recipes/metahict/build.sh
@@ -8,6 +8,8 @@ install -m 0644 LICENSE "${PREFIX}/share/metahict/LICENSE"
 install -m 0644 README.md "${PREFIX}/share/metahict/README.md"
 install -m 0644 metahict_manager.py \
   "${PREFIX}/share/metahict/metahict_manager.py"
+install -m 0755 metahict \
+  "${PREFIX}/share/metahict/metahict"
 
 cp -R docs "${PREFIX}/share/metahict/"
 cp -R images "${PREFIX}/share/metahict/"

--- a/recipes/metahict/meta.yaml
+++ b/recipes/metahict/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "metahict" %}
-{% set version = "1.1.0" %}
+{% set version = "1.2.0" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/dyxstat/METAHICT/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: d9839874b45736bb1df91911c012eaea67a7af58dcfbc7f00e0195e992ba6c16
+  sha256: 87f9737745d16acfab61fd6739527971018a67f3860651601a2b519a3fadf90a
 
 build:
   number: 0
@@ -36,6 +36,8 @@ test:
     - metahict --help
     - metahict-nextflow -help
     - test -s "${PREFIX}/share/metahict/nextflow/main_dsl2.nf"
+    - test -x "${PREFIX}/share/metahict/metahict"
+    - ${PREFIX}/share/metahict/metahict --version
 
 about:
   home: https://github.com/dyxstat/METAHICT

--- a/recipes/metahict/run_test.sh
+++ b/recipes/metahict/run_test.sh
@@ -2,37 +2,5 @@
 set -euo pipefail
 
 installed_root="${PREFIX}/share/metahict"
-test_root="$(mktemp -d "${TMPDIR:-/tmp}/metahict-bioconda-test.XXXXXX")"
-trap 'rm -rf "${test_root}"' EXIT
 
-dummy_db="${test_root}/dummy_db"
-mkdir -p \
-  "${dummy_db}/checkm_db" \
-  "${dummy_db}/gtdbtk_db" \
-  "${dummy_db}/genomad_db" \
-  "${test_root}/reports"
-touch "${dummy_db}/checkm2.dmnd"
-stub_samplesheet="$(python "${installed_root}/nextflow/ci/create_stub_inputs.py" \
-  --output-dir "${test_root}/stub_inputs")"
-
-metahict-nextflow \
-  -profile stub \
-  -c "${installed_root}/nextflow/nextflow.config" \
-  -c "${installed_root}/nextflow/ci/stub_resources.config" \
-  --samplesheet "${stub_samplesheet}" \
-  --out_root "${test_root}/results" \
-  --report_dir "${test_root}/reports" \
-  -work-dir "${test_root}/work" \
-  --checkm_db "${dummy_db}/checkm_db" \
-  --checkm2_db "${dummy_db}/checkm2.dmnd" \
-  --gtdbtk_db "${dummy_db}/gtdbtk_db" \
-  --genomad_db "${dummy_db}/genomad_db" \
-  --threads 2 \
-  --clean true \
-  --chain true \
-  -stub-run \
-  -ansi-log false
-
-python "${installed_root}/nextflow/bin/check_expected_outputs.py" \
-  --root "${test_root}/results" \
-  --manifest "${installed_root}/nextflow/tests/expected/workflow_stub_outputs.tsv"
+"${installed_root}/metahict" test workflow


### PR DESCRIPTION
Describe your pull request here

This updates METAHICT from 1.1.0 to 1.2.0.

The release includes updated workflow behavior, configurable reassembly
parameters, and revised workflow tests.

The recipe also corrects the installed layout by placing the internal METAHICT
launcher at `$PREFIX/share/metahict/metahict`, where the Nextflow local profile
expects it. Regression tests verify both the user-facing command and the
internal launcher. The complete Nextflow graph is also executed in stub mode
by `run_test.sh`.

----

Please read the [guidelines for Bioconda recipes](https://bioconda.github.io/contributor/guidelines.html) before opening a pull request (PR).

### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
