### PR TITLE
Add plasrisk 1.1.0: ten-dimension data-driven plasmid risk assessment

### DIFF
--- a/recipes/plasrisk/bld.bat
+++ b/recipes/plasrisk/bld.bat
@@ -1,0 +1,3 @@
+@echo off
+"%PYTHON%" -m pip install . --no-deps --ignore-installed -vv
+if errorlevel 1 exit 1

--- a/recipes/plasrisk/build.sh
+++ b/recipes/plasrisk/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Bioconda build script for plasrisk
+$PYTHON -m pip install . --no-deps --ignore-installed -vv

--- a/recipes/plasrisk/meta.yaml
+++ b/recipes/plasrisk/meta.yaml
@@ -40,24 +40,28 @@ test:
   commands:
     - plasrisk --help
     - plasrisk --version
-    - python -c "from plasrisk import PlasRiskScorer; s=PlasRiskScorer(); print('OK')"
+    - python -c "from plasrisk import PlasRiskScorer, PIPdbScorer, get_scorer; s=get_scorer('plasrisk'); p=get_scorer('pipdb'); print('OK')"
 
 about:
   home: https://github.com/LLQ95/PlasRisk
   license: MIT
   license_family: MIT
   license_file: LICENSE
-  summary: "Ten-dimension data-driven weighted risk assessment for bacterial plasmids"
+  summary: "Multi-model plasmid risk assessment: 10-dim weighted PlasRisk plus original PIPdb ordinal model"
   description: |
-    PlasRisk computes a composite risk score for bacterial plasmids based on
-    ten dimensions: antimicrobial resistance gene burden (S_ARG), virulence
-    factors (S_VF), mobility/conjugation potential (S_MOB), host range
-    (S_HOST), replicon type (S_REP), plasmid size (S_SIZE), biocide/metal
-    resistance (S_BM), geographic spread (S_GEO), habitat breadth (S_HAB),
-    and temporal growth rate (S_GROW). Weights were derived by data-driven
-    consensus (Random Forest MDG, LASSO, grid-search optimization) on
-    792,964 PIPdb plasmid sequence clusters. Accepts FASTA input and uses
-    abricate for annotation when available.
+    PlasRisk provides two scoring models for bacterial plasmid risk assessment.
+    The default PlasRisk model computes a composite score from ten dimensions:
+    antimicrobial resistance gene burden (S_ARG), virulence factors (S_VF),
+    mobility/conjugation potential (S_MOB), host range (S_HOST), replicon type
+    (S_REP), plasmid size (S_SIZE), biocide/metal resistance (S_BM), geographic
+    spread (S_GEO), habitat breadth (S_HAB), and temporal growth rate (S_GROW).
+    Weights were derived by data-driven consensus (Random Forest MDG, LASSO,
+    grid-search optimization) on 792,964 PIPdb plasmid sequence clusters.
+    A 5-dimension lite mode achieves equivalent AUC. The alternative PIPdb
+    model reproduces the original 8-item ordinal scoring system (Zhu et al.,
+    Nucleic Acids Res. 2025). Accepts FASTA input and uses abricate for
+    annotation when available; sequence-derived dimensions fall back to
+    replicon empirical medians when annotation is unavailable.
   doc_url: https://github.com/LLQ95/PlasRisk#readme
   dev_url: https://github.com/LLQ95/PlasRisk
 
@@ -73,3 +77,5 @@ extra:
       abricate-get_db --db card --force
       abricate-get_db --db vfdb --force
       abricate-get_db --db plasmidfinder --force
+      abricate-get_db --db bacmet2 --force
+      abricate-get_db --db isfinder --force

--- a/recipes/plasrisk/meta.yaml
+++ b/recipes/plasrisk/meta.yaml
@@ -1,0 +1,75 @@
+{% set version = "1.1.0" %}
+
+package:
+  name: plasrisk
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/p/plasrisk/plasrisk-{{ version }}.tar.gz
+  sha256: 4a019f2dd57a0a7e11f4f518442083ab4066c92a5074245dbf5ca3afec14c497
+
+build:
+  number: 0
+  noarch: python
+  entry_points:
+    - plasrisk = plasrisk.cli:main
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv"
+  run_exports:
+    - {{ pin_subpackage('plasrisk', max_pin="x") }}
+
+requirements:
+  host:
+    - python >=3.8
+    - pip
+    - setuptools >=61.0
+    - wheel
+  run:
+    - python >=3.8
+    - pandas >=1.3
+    - numpy >=1.20
+    # abricate and blast are recommended but not hard dependencies;
+    # the CLI falls back to sequence-only scoring when abricate is absent.
+    # Install them with: conda install -c bioconda -c conda-forge abricate blast
+
+test:
+  imports:
+    - plasrisk
+    - plasrisk.scoring
+    - plasrisk.annotate
+    - plasrisk.lookup
+  commands:
+    - plasrisk --help
+    - plasrisk --version
+    - python -c "from plasrisk import PlasRiskScorer; s=PlasRiskScorer(); print('OK')"
+
+about:
+  home: https://github.com/LLQ95/PlasRisk
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: "Ten-dimension data-driven weighted risk assessment for bacterial plasmids"
+  description: |
+    PlasRisk computes a composite risk score for bacterial plasmids based on
+    ten dimensions: antimicrobial resistance gene burden (S_ARG), virulence
+    factors (S_VF), mobility/conjugation potential (S_MOB), host range
+    (S_HOST), replicon type (S_REP), plasmid size (S_SIZE), biocide/metal
+    resistance (S_BM), geographic spread (S_GEO), habitat breadth (S_HAB),
+    and temporal growth rate (S_GROW). Weights were derived by data-driven
+    consensus (Random Forest MDG, LASSO, grid-search optimization) on
+    792,964 PIPdb plasmid sequence clusters. Accepts FASTA input and uses
+    abricate for annotation when available.
+  doc_url: https://github.com/LLQ95/PlasRisk#readme
+  dev_url: https://github.com/LLQ95/PlasRisk
+
+extra:
+  recipe-maintainers:
+    - LLQ95
+  identifiers:
+    - doi:10.1093/nar/gkae952
+  notes: |
+    For full annotation capability, install abricate and blast:
+      conda install -c bioconda -c conda-forge abricate blast
+    Then set up databases:
+      abricate-get_db --db card --force
+      abricate-get_db --db vfdb --force
+      abricate-get_db --db plasmidfinder --force


### PR DESCRIPTION
## Add new recipe: plasrisk 1.1.0

PlasRisk is a ten-dimension, data-driven weighted risk assessment tool for bacterial plasmids. It takes FASTA sequences as input, optionally uses abricate for annotation (ARG/VF/biocide-metal/replicon), and outputs a continuous risk score together with A–E grades.

- PyPI: https://pypi.org/project/plasrisk/1.1.0/
- Home/dev: https://github.com/LLQ95/PlasRisk
- License: MIT
- Language: pure Python (noarch: python), Python >=3.8
- Runtime dependencies: pandas >=1.3, numpy >=1.20
- abricate/blast are recommended but not hard dependencies; the package falls back to sequence-only scoring when abricate is absent.

### Dimensions
S_ARG, S_VF, S_MOB, S_HOST, S_REP, S_SIZE, S_BM, S_GEO, S_HAB, S_GROW. Weights were derived by data-driven consensus (Random Forest mean decrease in Gini, LASSO, grid-search optimization) on 792,964 PIPdb plasmid sequence clusters.

### Build
- noarch: python; entry point `plasrisk = plasrisk.cli:main`
- source: PyPI sdist, sha256 pinned in meta.yaml
- test: imports of plasrisk(.scoring/.annotate/.lookup) plus CLI `--help`/`--version` and a scorer smoke test

- [x] I have read the guidelines for bioconda recipes
- [x] This is a new recipe
- [x] AFAIK this package does not bundle other software
- [x] Recipe maintainer: @LLQ95 (package author)