### PR TITLE
Update LongAIRR to fix missing runtime dependency

### DIFF
--- a/recipes/longairr/meta.yaml
+++ b/recipes/longairr/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 10045d1688e6a5d78720863d26ece56e118540451ce686aa503c3b16ff6ad687
 
 build:
-  number: 0
+  number: 1
   noarch: generic
   run_exports:
     - {{ pin_subpackage(name, max_pin="x") }}
@@ -35,6 +35,7 @@ requirements:
     - pysam 0.22.*
     - pyyaml 6.0.2.*
     - pyarrow 17.0.0.*
+    - python-kaleido 0.2.1.*
     - airr 1.5.1.*
     - changeo 1.3.3.*
     - bash
@@ -58,6 +59,7 @@ test:
     - longairr airr --help
     - longairr report --help
     - longairr-setup --help
+    - NanoPlot --help
     - test -f "$PREFIX/share/longairr/README.md"
     - test -f "$PREFIX/share/longairr/docs/images_design/images/longairr_logo_small.png"
     - test -f "$PREFIX/share/longairr/docs/images_design/images/longairr_profiling_overview.png"


### PR DESCRIPTION
The currently published LongAIRR 1.1.0 build installs successfully but is not fully functional: the NanoPlot-based plotting step cannot export figures because `python-kaleido` is missing from the runtime dependencies.

This update adds the tested `python-kaleido 0.2.1.*` dependency, which also installs the required `kaleido-core` package and restores Plotly image export.

Changes:
- Add `python-kaleido 0.2.1.*` as a runtime dependency
- Add `NanoPlot --help` to the recipe tests
- Increment the build number from 0 to 1

The LongAIRR source and version remain unchanged; the build-number increment rebuilds version 1.1.0 with the corrected runtime dependencies.

Local checks completed successfully.

----