### PR TITLE
Bump jaeger-bio to 1.26.5

### DIFF
--- a/recipes/jaeger-bio/meta.yaml
+++ b/recipes/jaeger-bio/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "jaeger-bio" %}
-{% set version = "1.26.4" %}
+{% set version = "1.26.5" %}
 
 package:
   name: "{{ name|lower }}"
@@ -8,7 +8,7 @@ package:
 source:
   url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name | replace('-', '_') }}-{{ version }}.tar.gz"
   # NOTE: update sha256 after releasing to PyPI
-  sha256: 262a896fd7254f30461155ab0157f75a350c3f2b9f7ad38c082273981af32dd7
+  sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 
 build:
   number: 0

--- a/recipes/jaeger-bio/meta.yaml
+++ b/recipes/jaeger-bio/meta.yaml
@@ -8,7 +8,7 @@ package:
 source:
   url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name | replace('-', '_') }}-{{ version }}.tar.gz"
   # NOTE: update sha256 after releasing to PyPI
-  sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+  sha256: 3ce9f84ebe765ef5a0b0002dd1f63dcc681f4761f52222b776fcf4edebfaf2e9
 
 build:
   number: 0


### PR DESCRIPTION
Update jaeger-bio to version 1.26.5.                                                                                                                                                                                                                    Release: https://github.com/Yasas1994/Jaeger/releases/tag/v1.26.5 