### PR TITLE
Update whittle to 0.2.0

### DIFF
--- a/recipes/whittle/meta.yaml
+++ b/recipes/whittle/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "whittle" %}
-{% set version = "0.1.1" %}
+{% set version = "0.2.0" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/erdikilic/{{ name }}/archive/{{ version }}.tar.gz
-  sha256: 35f2c783c3ee1ea75f629d76d5bbd8297429ee28c53d5f9e7026f13d37c7ca88
+  sha256: 3814dd773e4d1be7a91ae8c865e3e88ad14b5f52efbd7b792bd4f8952ef4aeed
 
 build:
   number: 0


### PR DESCRIPTION
Updates `whittle` from 0.1.1 to 0.2.0.

This supersedes #68816. That PR was generated by autobump a minute or two before the upstream 0.2.0 tag was recreated, so it pins the checksum of the earlier tarball and its source download fails. The checksum here is the current one:

```
$ curl -sL https://github.com/erdikilic/whittle/archive/0.2.0.tar.gz | sha256sum
3814dd773e4d1be7a91ae8c865e3e88ad14b5f52efbd7b792bd4f8952ef4aeed
```

Nothing else in the recipe changes: the build script, requirements and tests are unchanged, and the build number stays 0 for the new version.

I am the recipe maintainer (@erdikilic) and the upstream author.