### PR TITLE
Update acidplyr to 0.1.1

### DIFF
--- a/recipes/acidplyr/meta.yaml
+++ b/recipes/acidplyr/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.1.0" %}
+{% set version = "0.1.1" %}
 {% set github = "https://github.com/acidgenomics/py-acidplyr" %}
 
 package:
@@ -6,8 +6,8 @@ package:
   version: "{{ version }}"
 
 source:
-  url: "{{ github }}/archive/v{{ version }}.tar.gz"
-  sha256: 74da666e294702fbfd0bd94940342dc5d04e80173095a3ec93fec44b35bb514f
+  url: "https://pypi.io/packages/source/a/acidgenomics-acidplyr/acidgenomics_acidplyr-{{ version }}.tar.gz"
+  sha256: c802b1f3e69c4fc5a84d159c430e064a6638d776d70b4e2a87e0b336c32208c2
 
 build:
   number: 0


### PR DESCRIPTION
- Version 0.1.0 -> 0.1.1
- Source moved from the GitHub release tarball to the PyPI sdist
  (`acidgenomics-acidplyr`, the package's new PyPI distribution name; the
  conda package name and the `acidplyr` import name are unchanged)