### PR TITLE
Update goalie to 0.2.1

### DIFF
--- a/recipes/goalie/meta.yaml
+++ b/recipes/goalie/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.2.0" %}
+{% set version = "0.2.1" %}
 {% set github = "https://github.com/acidgenomics/py-goalie" %}
 
 package:
@@ -6,8 +6,8 @@ package:
   version: "{{ version }}"
 
 source:
-  url: "{{ github }}/archive/v{{ version }}.tar.gz"
-  sha256: 50b6e67db41943e3ac54787603604e6bc13905403579a7a350ad0130a502e241
+  url: "https://pypi.io/packages/source/a/acidgenomics-goalie/acidgenomics_goalie-{{ version }}.tar.gz"
+  sha256: 0cc44fb25a8b9e7e11dfcffcf1d55d4954ba1da1952ec52e46f0f9d6ada4c2b8
 
 build:
   number: 0


### PR DESCRIPTION
- Version 0.2.0 -> 0.2.1
- Source moved from the GitHub release tarball to the PyPI sdist
  (`acidgenomics-goalie`, the package's new PyPI distribution name; the
  conda package name and the `goalie` import name are unchanged)