### PR TITLE
Add gravlax 0.1.6

### DIFF
--- a/recipes/gravlax/meta.yaml
+++ b/recipes/gravlax/meta.yaml
@@ -1,0 +1,72 @@
+{% set name = "gravlax" %}
+{% set version = "0.1.5" %}
+{% set sha256 = "f77773250eaa0b7793655ec27b6b22c49a8471933cc29fe692f79528aa466c12" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/COMBINE-lab/gravlax/releases/download/v{{ version }}/gravlax-{{ version }}-source.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x.x") }}
+  script:
+    - cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
+    - export CARGO_TARGET_X86_64_APPLE_DARWIN_LINKER="${CC}"  # [osx and x86_64]
+    - export CARGO_TARGET_AARCH64_APPLE_DARWIN_LINKER="${CC}"  # [osx and arm64]
+    - cargo install --locked --offline --no-track --path crates/aie --root "${PREFIX}"
+    - '"${STRIP}" "${PREFIX}/bin/aie"'
+    - mkdir -p "${PREFIX}/share/bash-completion/completions"
+    - mkdir -p "${PREFIX}/share/zsh/site-functions"
+    - mkdir -p "${PREFIX}/share/fish/vendor_completions.d"
+    - '"${PREFIX}/bin/aie" completions bash > "${PREFIX}/share/bash-completion/completions/aie"'
+    - '"${PREFIX}/bin/aie" completions zsh > "${PREFIX}/share/zsh/site-functions/_aie"'
+    - '"${PREFIX}/bin/aie" completions fish > "${PREFIX}/share/fish/vendor_completions.d/aie.fish"'
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ stdlib('c') }}
+    # Rust 1.98 is newer than the compiler activation package on the main
+    # conda-forge channel, so use the native Rust package directly.
+    - rust >=1.98,<2
+    - cargo-bundle-licenses
+
+test:
+  commands:
+    - aie --version
+    - aie --help
+    - aie doctor --help
+    - 'aie completions bash > /dev/null'
+    - test -s "${PREFIX}/share/bash-completion/completions/aie"
+    - test -s "${PREFIX}/share/zsh/site-functions/_aie"
+    - test -s "${PREFIX}/share/fish/vendor_completions.d/aie.fish"
+
+about:
+  home: https://github.com/COMBINE-lab/gravlax
+  summary: Annotation-independent molecular-evidence archives for single-cell RNA-seq
+  description: >-
+    Gravlax stores compact molecule-resolved alignment evidence once and replays
+    annotations and indexed biological queries without realignment.
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file:
+    - LICENSE
+    - THIRDPARTY.yml
+  doc_url: https://combine-lab.github.io/gravlax/
+  dev_url: https://github.com/COMBINE-lab/gravlax
+
+extra:
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64
+  skip-lints:
+    # The Rust compiler activation package on the main conda-forge channel is
+    # older than Gravlax's minimum Rust version. The native package is current.
+    - should_use_compilers
+  recipe-maintainers:
+    - rob-p

--- a/recipes/gravlax/meta.yaml
+++ b/recipes/gravlax/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "gravlax" %}
-{% set version = "0.1.5" %}
-{% set sha256 = "f77773250eaa0b7793655ec27b6b22c49a8471933cc29fe692f79528aa466c12" %}
+{% set version = "0.1.6" %}
+{% set sha256 = "3cecbda6a80ebfd4f1a8e9a0719c662b04c37aeb1efbe91a3925a3de8fc789bd" %}
 
 package:
   name: {{ name }}
@@ -31,9 +31,8 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ stdlib('c') }}
-    # Rust 1.98 is newer than the compiler activation package on the main
-    # conda-forge channel, so use the native Rust package directly.
-    - rust >=1.98,<2
+    # Gravlax's minimum supported Rust version is 1.89.
+    - {{ compiler('rust') }}
     - cargo-bundle-licenses
 
 test:
@@ -64,9 +63,5 @@ extra:
   additional-platforms:
     - linux-aarch64
     - osx-arm64
-  skip-lints:
-    # The Rust compiler activation package on the main conda-forge channel is
-    # older than Gravlax's minimum Rust version. The native package is current.
-    - should_use_compilers
   recipe-maintainers:
     - rob-p


### PR DESCRIPTION
Adds the initial Bioconda recipe for Gravlax 0.1.6.

- Builds the `aie` CLI from the immutable release source archive using vendored Cargo dependencies in locked, offline mode.
- Installs Bash, Zsh, and Fish completions and records third-party licenses.
- Adds same-minor run exports for the 0.x CLI and native linux-aarch64/osx-arm64 builds.
- Uses the standard `compiler("rust")` activation package. Gravlax 0.1.6 corrects its tested MSRV to Rust 1.89, so the temporary direct-Rust dependency and `should_use_compilers` exception are no longer needed.
- Retains target-specific Cargo linker selection for both Intel and Apple Silicon macOS builds.

Validation:
- The immutable v0.1.6 source asset matches its published SHA256SUMS entry: `3cecbda6a80ebfd4f1a8e9a0719c662b04c37aeb1efbe91a3925a3de8fc789bd`.
- The submitted file matches the recipe generated by the v0.1.6 renderer byte-for-byte.
- The upstream v0.1.6 release passed full Rust 1.89 tests and strict Clippy, Python 3.10-3.13, Linux musl, Windows, macOS, container, source-distribution, and documentation gates.
- The prior recipe revision passed Bioconda Linux, OSX-64, linux-aarch64, and osx-arm64 builds/tests; this updated revision lets Bioconda CI revalidate the final 0.1.6 bytes and standard compiler activation.