### PR TITLE
Add sniffcell and sniffcell-lite 0.9.7

### DIFF
--- a/recipes/sniffcell-lite/meta.yaml
+++ b/recipes/sniffcell-lite/meta.yaml
@@ -1,0 +1,59 @@
+{% set name = "sniffcell-lite" %}
+{% set version = "0.9.7" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/s/{{ name }}/sniffcell_lite-{{ version }}.tar.gz
+  sha256: b94f7c4871bc9b2e6b2f7d43a6165e777e19ecfa29ed19882dc874bb0f376678
+
+build:
+  number: 0
+  noarch: python
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x.x") }}
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  entry_points:
+    - sniffcell-lite = sniffcell.main:main
+
+requirements:
+  host:
+    - python >=3.10
+    - pip
+    - setuptools >=64
+    - wheel
+  run:
+    - python >=3.10
+    - pysam >=0.21.0
+    - numpy >=2.2.0
+    - pandas >=2.3.0
+    - scipy
+    - tqdm
+    - matplotlib-base
+  run_constrained:
+    # Both distributions install the same sniffcell Python namespace.
+    - sniffcell <0a0
+
+test:
+  imports:
+    - sniffcell
+    - sniffcell.main
+  commands:
+    - sniffcell-lite --help
+    - sniffcell-lite find --help
+    - sniffcell-lite anno --help
+    - sniffcell-lite report --help
+
+about:
+  home: https://github.com/Fu-Yilei/SniffCell-lite
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: SniffCell Lite annotates variants using targeted long-read methylation evidence and ctDMR signals.
+  dev_url: https://github.com/Fu-Yilei/SniffCell-lite
+
+extra:
+  recipe-maintainers:
+    - Fu-Yilei

--- a/recipes/sniffcell/meta.yaml
+++ b/recipes/sniffcell/meta.yaml
@@ -1,0 +1,66 @@
+{% set name = "sniffcell" %}
+{% set version = "0.9.7" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/s/{{ name }}/sniffcell-{{ version }}.tar.gz
+  sha256: c22dde9e12c01261b159a75de174fadac0dbd1c6bd5b965cebc2b677f64ed8bd
+
+build:
+  number: 0
+  noarch: python
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x.x") }}
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  entry_points:
+    - sniffcell = sniffcell.main:main
+    - sniffcell-discover-sv = sniffcell.sv_discovery:main
+    - sniffcell-check-discover = sniffcell.discover.envcheck:main
+
+requirements:
+  host:
+    - python >=3.10
+    - pip
+    - setuptools >=64
+    - wheel
+  run:
+    - python >=3.10
+    - pysam >=0.21.0
+    - numpy >=2.2.0
+    - pandas >=2.3.0
+    - scipy
+    - tqdm
+    - matplotlib-base
+    - scikit-learn
+  run_constrained:
+    # Both distributions install the same sniffcell Python namespace.
+    - sniffcell-lite <0a0
+
+test:
+  imports:
+    - sniffcell
+    - sniffcell.main
+  commands:
+    - sniffcell --help
+    - sniffcell find --help
+    - sniffcell anno --help
+    - sniffcell report --help
+    - sniffcell deconv --help
+    - sniffcell discover --help
+    - sniffcell-discover-sv --help
+    - sniffcell-check-discover --help
+
+about:
+  home: https://github.com/Fu-Yilei/SniffCell
+  license: Apache-2.0
+  license_family: APACHE
+  license_file: LICENSE
+  summary: SniffCell annotates structural variants using long-read methylation evidence and ctDMR signals.
+  dev_url: https://github.com/Fu-Yilei/SniffCell
+
+extra:
+  recipe-maintainers:
+    - Fu-Yilei


### PR DESCRIPTION
Adds `sniffcell` and `sniffcell-lite` 0.9.7, two bioinformatics packages that use long-read DNA methylation and cell-type-specific DMRs to assign variants to cell types. Full SniffCell provides deconvolution, discovery orchestration, annotation, and reporting; lite annotates existing variants from their supporting reads.

Both recipes use verified PyPI source distributions, noarch Python builds, declared core dependencies, CLI/import smoke tests, and run exports pinned at the minor version for these 0.x releases. Optional external discovery callers and reference data are not bundled. Reciprocal `run_constrained` entries prevent co-installation because both distributions install the `sniffcell` Python namespace.

Upstream recipe copies are maintained separately:
- https://github.com/Fu-Yilei/SniffCell/tree/main/bioconda/recipes/sniffcell
- https://github.com/Fu-Yilei/SniffCell-lite/tree/main/bioconda/recipes/sniffcell-lite

Validation: downloaded and verified both source SHA-256 hashes, rendered and parsed both recipes, installed the source distributions in an isolated Python environment, and passed all listed import and CLI help checks. Full SniffCell's upstream suite passed 255 tests. Full Conda builds and Bioconda lint are pending CI.

SniffCell 0.9.7 ships Apache-2.0 licensing; SniffCell-lite 0.9.7 ships MIT licensing, as recorded in their respective source archives.
