### PR TITLE
Add cellme

### DIFF
--- a/recipes/cellme/meta.yaml
+++ b/recipes/cellme/meta.yaml
@@ -1,0 +1,53 @@
+{% set name = "cellme" %}
+{% set version = "1.2.0" %}
+{% set python_min = "3.12" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 7c670ad9bbcd8148d0ad672dec5eef1d9ae96db91c62ce9c7f3840c15637394d
+
+build:
+  noarch: python
+  number: 0
+  entry_points:
+    - cellme = cellme.main:run
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python {{ python_min }}
+    - hatchling
+    - pip
+  run:
+    - python >={{ python_min }}
+    - defopt >=6.4,<8.0
+    - liftover >=1.3
+    - pysam >=0.23
+    - rapidfuzz >=3.14.5
+    - requests >=2.32
+
+test:
+  imports:
+    - cellme
+  commands:
+    - pip check
+    - cellme --help
+  requires:
+    - pip
+    - python {{ python_min }}
+
+about:
+  home: https://github.com/clintval/cellme
+  summary: Convert a human cell line identifier into a truth-track VCF of its known mutations.
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  dev_url: https://github.com/clintval/cellme
+
+extra:
+  recipe-maintainers:
+    - clintval

--- a/recipes/cellme/meta.yaml
+++ b/recipes/cellme/meta.yaml
@@ -13,6 +13,8 @@ source:
 build:
   noarch: python
   number: 0
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x") }}
   entry_points:
     - cellme = cellme.main:run
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation


### PR DESCRIPTION
Adds a new recipe for [cellme](https://github.com/clintval/cellme) ([PyPI](https://pypi.org/project/cellme/)), a Python CLI that converts a human cell-line identifier into a truth-track VCF of that line's known CCLE somatic mutations (resolved via cBioPortal, optionally lifted GRCh37 -> GRCh38).

- Pure Python, built as `noarch: python`.
- All runtime dependencies are already packaged: `defopt`, `rapidfuzz`, `requests` (conda-forge); `liftover`, `pysam` (bioconda).
- Tests: `imports: cellme`, `pip check`, and `cellme --help`.

---

- [x] This PR adds a new recipe.
- [x] The recipe is `noarch: python` and pins `python >={{ python_min }}`.
- [x] All dependencies are available in the bioconda/conda-forge channels.
- [x] The license (MIT) is packaged via `license_file`.
