### PR TITLE
Add vepyr 0.6.0

### DIFF
--- a/recipes/vepyr/build.sh
+++ b/recipes/vepyr/build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euxo pipefail
+
+# Use conda's Rust compiler instead of the upstream development toolchain pin.
+rm -f rust-toolchain.toml
+
+# Preserve compiler activation flags; upstream does not set target-cpu flags.
+export CARGO_PROFILE_RELEASE_DEBUG=false
+export CARGO_PROFILE_RELEASE_STRIP=symbols
+export CARGO_BUILD_JOBS="${CPU_COUNT}"
+export CARGO_NET_GIT_FETCH_WITH_CLI=true
+export CARGO_NET_RETRY=5
+
+# Include licenses for the Rust dependencies linked into the extension.
+cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
+
+"${PYTHON}" -m pip install . -vv --no-deps --no-build-isolation \
+    --config-settings=build-args=--locked

--- a/recipes/vepyr/build.sh
+++ b/recipes/vepyr/build.sh
@@ -10,7 +10,6 @@ export CARGO_BUILD_JOBS="${CPU_COUNT}"
 export CARGO_NET_GIT_FETCH_WITH_CLI=true
 export CARGO_NET_RETRY=5
 
-# Include licenses for the Rust dependencies linked into the extension.
 cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
 
 "${PYTHON}" -m pip install . -vv --no-deps --no-build-isolation \

--- a/recipes/vepyr/build.sh
+++ b/recipes/vepyr/build.sh
@@ -4,7 +4,6 @@ set -euxo pipefail
 # Use conda's Rust compiler instead of the upstream development toolchain pin.
 rm -f rust-toolchain.toml
 
-# Preserve compiler activation flags; upstream does not set target-cpu flags.
 export CARGO_PROFILE_RELEASE_DEBUG=false
 export CARGO_PROFILE_RELEASE_STRIP=symbols
 export CARGO_BUILD_JOBS="${CPU_COUNT}"

--- a/recipes/vepyr/meta.yaml
+++ b/recipes/vepyr/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "vepyr" %}
-{% set version = "0.5.0" %}
+{% set version = "0.6.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 1afe1824512e211f084e298fc86fa964e9516bcc87086ea02dde4a045237d538
+  sha256: 7a28e6bc6f25d550e46765df0a94a7ca27a4a3d3e77ca778da0940d0c7a7a7ad
 
 build:
   number: 0
@@ -44,6 +44,8 @@ test:
     - vepyr._core
   commands:
     - pip check
+    - vepyr --version
+    - vepyr annotate --help
     - python -c "import vepyr; assert vepyr.__version__ == '{{ version }}'; targets = vepyr.supported_vep_targets(); assert targets; assert all(t.get('vepyr_version') == '{{ version }}' for t in targets); assert {t.get('cache_version') for t in targets} == {'115', '116'}; print('compiled VEP targets passed')"
     # Mulled tests have only runtime dependencies and no test files. Keep this
     # self-contained and bracket-free: mulled can strip brackets as selectors.
@@ -70,7 +72,7 @@ about:
   dev_url: https://github.com/biodatageeks/vepyr
 
 extra:
-  # Matches the Unix platforms exercised by the upstream 0.5.0 wheel builds.
+  # Matches the Unix platforms exercised by the upstream 0.6.0 wheel builds.
   additional-platforms:
     - osx-arm64
   recipe-maintainers:

--- a/recipes/vepyr/meta.yaml
+++ b/recipes/vepyr/meta.yaml
@@ -1,0 +1,77 @@
+{% set name = "vepyr" %}
+{% set version = "0.5.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 1afe1824512e211f084e298fc86fa964e9516bcc87086ea02dde4a045237d538
+
+build:
+  number: 0
+  skip: true  # [py < 310]
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x.x") }}
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - {{ stdlib('c') }}
+    - {{ compiler('rust') }}
+    - cargo-bundle-licenses
+    - cmake
+    - make
+    - pkg-config
+    # Cargo.lock pins the bio-functions, bio-formats, noodles and opendal git sources.
+    - git
+    - cross-python_{{ target_platform }}  # [build_platform != target_platform]
+  host:
+    - python
+    - pip
+    - maturin >=1.0,<2.0
+  run:
+    - python
+    - pyarrow >=18.0
+    - polars >=1.37.1
+    - tqdm >=4.60
+
+test:
+  imports:
+    - vepyr
+    - vepyr._core
+  commands:
+    - pip check
+    - python -c "import vepyr; assert vepyr.__version__ == '{{ version }}'; targets = vepyr.supported_vep_targets(); assert targets; assert all(t.get('vepyr_version') == '{{ version }}' for t in targets); assert {t.get('cache_version') for t in targets} == {'115', '116'}; print('compiled VEP targets passed')"
+    # Mulled tests have only runtime dependencies and no test files. Keep this
+    # self-contained and bracket-free: mulled can strip brackets as selectors.
+    # A VCF without contig headers makes the Rust provider scan the records.
+    - python -c "import tempfile; from pathlib import Path; from vepyr._core import vcf_contigs; tmp = tempfile.TemporaryDirectory(); vcf = Path(tmp.name) / 'smoke.vcf'; vcf.write_text('##fileformat=VCFv4.2\n#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n1\t101\t.\tA\tG\t.\tPASS\t.\n2\t202\t.\tC\tT\t.\tPASS\t.\n'); contigs = tuple(sorted(vcf_contigs(str(vcf)))); assert contigs == ('1', '2'), contigs; tmp.cleanup(); print('native VCF scan passed')"
+  requires:
+    - pip
+
+about:
+  home: https://github.com/biodatageeks/vepyr
+  license: Apache-2.0
+  license_family: Apache
+  license_file:
+    - LICENSE
+    - THIRDPARTY.yml
+  summary: 'Rust-powered Ensembl VEP variant annotation for Python'
+  description: |
+    vepyr (VEP Yielding Performant Results) is a Python interface to a Rust
+    reimplementation of Ensembl's Variant Effect Predictor, built on Apache
+    Arrow and DataFusion. It converts Ensembl VEP caches to Parquet and
+    annotates variants through a streaming engine, returning Polars LazyFrames
+    or annotated VCF files.
+  doc_url: https://biodatageeks.org/vepyr/
+  dev_url: https://github.com/biodatageeks/vepyr
+
+extra:
+  # Matches the Unix platforms exercised by the upstream 0.5.0 wheel builds.
+  additional-platforms:
+    - osx-arm64
+  recipe-maintainers:
+    - mwiewior


### PR DESCRIPTION
Adds [vepyr](https://github.com/biodatageeks/vepyr) 0.6.0 to Bioconda.

**vepyr** (VEP Yielding Performant Results) is a Python library for predicting the functional consequences of genetic variants. It reimplements Ensembl's Variant Effect Predictor in Rust, uses Ensembl VEP caches, and returns annotations as Polars LazyFrames or annotated VCF files.

The recipe follows the source-build approach from #67602 (polars-bio): builds the PyPI sdist with conda compilers and maturin, uses the released Cargo.lock with `--locked`, bundles Rust dependency licenses, and enables `osx-arm64` alongside the default Linux/macOS x86-64 builds. The development Rust toolchain pin is removed from the extracted source while conda compiler activation flags are preserved. Runtime bounds match the released PKG-INFO: Python >=3.10, PyArrow >=18.0, Polars >=1.37.1, and tqdm >=4.60. DataFusion is compiled into the extension and does not require the Python datafusion package.

Tests check imports, dependency compatibility, matching Python/native release versions, VEP 115/116 compatibility records, and a native DataFusion scan of a small generated VCF. Functional tests are inline and bracket-free so they can run in the mulled container without additional files or downloaded VEP caches. The 0.x API uses minor-version run_exports.

Validation:

- Bioconda lint: all checks OK.
- Source SHA-256 verified against the downloaded 0.6.0 sdist by hashing the archive; dependency bounds checked against its PKG-INFO.
- The 0.6.0 sdist was confirmed to ship `src/vepyr/cli.py`, `src/vepyr/__main__.py` and the `[project.scripts] vepyr = "vepyr.cli:main"` entry, so the built package provides a `vepyr` executable.
- All five recipe test commands passed against the published 0.6.0 wheel in an isolated Python 3.12 environment: `pip check`, `vepyr --version`, `vepyr annotate --help`, the compiled VEP 115/116 targets assertion, and the native DataFusion VCF scan.

CI is green on commit `ea0e8cb4`: [Lint](https://github.com/bioconda/bioconda-recipes/actions/runs/34221966832/job/102046949094), [Linux x86-64](https://github.com/bioconda/bioconda-recipes/actions/runs/34221966832/job/102047424221), [macOS x86-64](https://github.com/bioconda/bioconda-recipes/actions/runs/34221966832/job/102079117948), and [macOS arm64](https://app.circleci.com/workflow/a86842ff-735e-475e-bdc2-e0616f09615d). All 12 packages (Python 3.10, 3.11, 3.12, and 3.13 on each of linux-64, osx-64, and osx-arm64) built and passed their recipe tests, and Linux container images were built for all four Python variants. No recipe changes were needed during CI.

Changes since the earlier 0.5.0 revision of this PR: `version` and `sha256` bumped to the released 0.6.0 sdist, and `vepyr --version` / `vepyr annotate --help` added to the test commands. 0.6.0 is the first release exposing a console script, which a downstream nf-core module invokes; a 0.5.0 package would install no executable for it to call.
