### PR TITLE
cctyper: allow prodigal 2.6.3 (fixes install on linux-aarch64)

### DIFF
--- a/recipes/cctyper/meta.yaml
+++ b/recipes/cctyper/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 1
+  number: 2
   run_exports:
     - {{ pin_subpackage(name, max_pin="x.x") }}
 
@@ -33,7 +33,7 @@ requirements:
     - multiprocess >=0.70.14,<=0.70.15
     - numpy >=1.16,<=1.24.3
     - pandas >=1.3,<=2.0.3
-    - prodigal >=2.0,<=2.6.2
+    - prodigal >=2.0,<2.7
     - libxgboost >=1.7,<2
     - py-xgboost >=1.4,<2
     - scikit-learn >=1.1.3,<=1.3.0

--- a/recipes/cctyper/meta.yaml
+++ b/recipes/cctyper/meta.yaml
@@ -2,7 +2,7 @@
 {% set version = "1.8.0" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:
@@ -10,19 +10,19 @@ source:
   sha256: 73a4bc661c35e88000d3141d571901cc617d9a4b5517667fcf3bc3e6afc3bffa
 
 build:
-  noarch: python
   number: 2
+  noarch: python
   run_exports:
-    - {{ pin_subpackage(name, max_pin="x.x") }}
+    - {{ pin_subpackage(name, max_pin="x") }}
 
 requirements:
   host:
     - python >=3.8,<3.9.0a0
     - pip
-    - setuptools
-
+    - setuptools <82
   run:
     - python >=3.8
+    - setuptools <82
     - biopython >=1.78,<=1.79
     - blast >=2.5,<3
     - cairosvg
@@ -47,12 +47,12 @@ test:
     - cctyper --help
 
 about:
-  home: https://github.com/Russel88/CRISPRCasTyper
-  dev_url: https://github.com/Russel88/CRISPRCasTyper
-  summary: 'CRISPRCasTyper: Automatic detection and subtyping of CRISPR-Cas operons'
+  home: "https://github.com/Russel88/CRISPRCasTyper"
+  dev_url: "https://github.com/Russel88/CRISPRCasTyper"
+  summary: 'CRISPRCasTyper: Automatic detection and subtyping of CRISPR-Cas operons.'
   license: MIT
+  license_family: MIT
   license_file: LICENSE
-
 
 extra:
   identifiers:


### PR DESCRIPTION
`cctyper` cannot be installed on `linux-aarch64`:

```
$ micromamba install -c conda-forge -c bioconda cctyper
└─ cctyper 1.8.0 would require
   └─ prodigal >=2.0,<=2.6.2 , which does not exist (perhaps a missing channel).
```

The cause is the version ceiling, not a missing ARM build. `prodigal` 2.6.2 was built for `linux-64` and `osx-64` only; 2.6.3 added `linux-aarch64` and `osx-arm64`:

| version | subdirs |
|---|---|
| 2.6.2 | linux-64, osx-64 |
| 2.6.3 | linux-64, **linux-aarch64**, osx-64, osx-arm64 |

So `<=2.6.2` excludes the only ARM-capable prodigal.

Every other runtime dependency already resolves on `linux-aarch64` — `minced` and `cairosvg` are noarch, and `blast` and `hmmer` have aarch64 builds. Removing the ceiling is sufficient:

```
$ docker run --rm mambaorg/micromamba:1.5-jammy \
    micromamba create -y -n t --dry-run -c conda-forge -c bioconda \
    python=3.8 'prodigal>=2.0' minced cairosvg 'hmmer>=3.0,<4' 'blast>=2.5,<3'
Total download: 443MB
Dry run. Not executing the transaction.
```

This relaxes the pin to `>=2.0,<2.7` and bumps the build number.

Separately, and not addressed here: this recipe is on 1.8.0 while upstream is at 1.9.0, which requires Python >=3.10 and has replaced `prodigal`/`minced`/`blast`/`cairosvg` with `pyrodigal-gv`, `diced`, `pyhmmer` and `drawsvg`. A 1.9.0 recipe would need a `diced` recipe first, which does not exist in bioconda or conda-forge. Happy to open that separately if it would be useful.
