### PR TITLE
Update locityper dependencies

### DIFF
--- a/recipes/locityper/meta.yaml
+++ b/recipes/locityper/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 6998d0918c1c45b4f0fb675c1d92f5793bba2c0da6b5b8cb6538f3d0827cd1b0
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage(name, max_pin="x") }}
 
@@ -36,10 +36,10 @@ requirements:
     - python
     - libgomp  # [linux]
     - llvm-openmp  # [osx]
-    - samtools >=1.19
+    - samtools >=1.23
     - kmer-jellyfish >=1.0
-    - minimap2 >=2.26
-    - strobealign >=0.17
+    - minimap2 >=2.30
+    - strobealign >=0.18
     - pysam
 
 test:


### PR DESCRIPTION
Update dependencies for Locityper in `meta.yaml`. Most importantly, update Strobealign to `v0.18.0`