### PR TITLE
gfviewer: update to 2.0.3; PyPI sdist source; add numpy, pillow, pyyaml to run deps

### DIFF
--- a/recipes/gfviewer/meta.yaml
+++ b/recipes/gfviewer/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: gfviewer
-  version: "2.0.2"
+  version: "2.0.3"
 
 source:
-  url: https://github.com/sakshar/GFViewer/archive/refs/tags/v2.0.2.tar.gz
-  sha256: 924d022dbed6556fa2a86aad4359b59ee14d9b772a80fe6f19d8c3529a28805c
+  url: https://pypi.io/packages/source/g/gfviewer/gfviewer-2.0.3.tar.gz
+  sha256: 1c646919278d517618e09ae4521b4686096b8033c99ba0b03fb37be6ba6e2c13
 
 build:
   noarch: python
@@ -15,33 +15,41 @@ build:
 
 requirements:
   host:
-    - python >=3.8,<3.13  # Restrict Python version
+    - python >=3.8,<3.13
     - pip
-    - setuptools
+    - setuptools >=64
     - wheel
   run:
-    - python >=3.8,<3.13  # Restrict Python version
+    - python >=3.8,<3.13
     - biopython
     - pandas
+    - numpy
     - matplotlib-base
+    - pillow
     - reportlab
     - pypdf2
     - openpyxl
+    - pyyaml
 
 test:
   imports:
     - gfviewer
   commands:
     - gfviewer --help
+    - gfviewer --version
 
 about:
   home: https://github.com/sakshar/GFViewer
   license: MIT
   license_file: LICENSE
-  summary: "A bioinformatics tool for visualizing the localization of multi-gene families across the genome of a given organism."
+  summary: "Visualize and quantify the localization of multigene families across chromosomes."
   description: |
-    This tool is designed for processing genomic data, visualizing chromosomes,
-    and localizing multi-gene families using Biopython and Matplotlib.
+    GFViewer draws round-capped chromosome ideograms with each gene family in
+    its own colour and computes localization statistics (sub-telomeric bias,
+    tandem arrays, 1-D Ripley's K/L, chromosome enrichment, multigene-family
+    hotspots, family-proximity clustering, ...). Reads annotation tables, BED,
+    GFF3 and GTF. Provides the `gfviewer` command-line tool.
+  dev_url: https://github.com/sakshar/GFViewer
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Update `gfviewer` 2.0.2 → 2.0.3. I am the recipe maintainer (`sakshar`).

## Source

Switched `source.url` from the GitHub auto-generated tag tarball to the immutable
PyPI sdist, since GitHub archive tarballs are not byte-stable:

- `url: https://pypi.io/packages/source/g/gfviewer/gfviewer-2.0.3.tar.gz`
- `sha256: 1c646919278d517618e09ae4521b4686096b8033c99ba0b03fb37be6ba6e2c13`

```bash
curl -sL https://pypi.io/packages/source/g/gfviewer/gfviewer-2.0.3.tar.gz | sha256sum
# 1c646919278d517618e09ae4521b4686096b8033c99ba0b03fb37be6ba6e2c13
```

## Dependency fixes (`requirements.run`)

The recipe was missing three runtime deps that are in the project's
`pyproject.toml` and imported unconditionally:

- **`numpy`** — imported directly by `gfviewer.analytics`
- **`pillow`** — excluded by `matplotlib-base`, but required for `gfviewer -f jpg` / `-f tiff` export
- **`pyyaml`** — used by `--style` / `--save-style` for YAML style files

## Other recipe updates

- Added a `run_exports` section (`{{ pin_subpackage("gfviewer", max_pin="x") }}`) per the linting guidelines.
- `requirements.host`: added `setuptools >=64` and `wheel`.
- `test.commands`: added `gfviewer --version`.
- Refreshed `about.summary` / `about.description`, added `dev_url`.
- `build.number` reset to `0` for the new version.

Still `noarch: python`, CLI only (`gfviewer` command); the Flask web portal is an
optional `pip` extra and not part of the conda package.
