### PR TITLE
Fix architectures for taxutils 1.1.1

### DIFF
--- a/recipes/taxutils/meta.yaml
+++ b/recipes/taxutils/meta.yaml
@@ -10,13 +10,16 @@ source:
   sha256: 093f5f5d0387c9b5ca55ec09bc7ee1b2973c3d28bc6330bcd341be5d6b459a82
 
 build:
-  noarch: python
   number: 0
   script: "{{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vvv"
   run_exports:
     - {{ pin_subpackage(name, max_pin="x") }}
 
 requirements:
+  build:
+    - {{ compiler("rust") }}
+    - {{ compiler("c") }}
+    - {{ stdlib("c") }}
   host:
     - python >=3.10
     - pip


### PR DESCRIPTION
Add the Rust and C build toolchain required by taxutils 1.1.1.