### PR TITLE
Add hipstr-mt

### DIFF
--- a/recipes/hipstr-mt/build.sh
+++ b/recipes/hipstr-mt/build.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+# The vendored htslib and cephes Makefiles both hardcode `CC = gcc`, and a
+# makefile assignment beats the environment in GNU Make, so neither picks up
+# conda's target-prefixed compiler on its own. Give them a `gcc` to find.
+ln -sf "${CC}" "${BUILD_PREFIX}/bin/gcc"
+
+# Same two sub-builds, for headers and libraries: CPATH and LIBRARY_PATH are
+# read by the compiler itself rather than passed as flags, so they survive a
+# sub-make that would otherwise drop CPPFLAGS/LDFLAGS.
+export CPATH="${PREFIX}/include:${CPATH:-}"
+export LIBRARY_PATH="${PREFIX}/lib:${LIBRARY_PATH:-}"
+
+make -j"${CPU_COUNT}" HipSTR-MT
+
+install -d "${PREFIX}/bin"
+install -m 755 HipSTR-MT "${PREFIX}/bin/HipSTR-MT"

--- a/recipes/hipstr-mt/conda_build_config.yaml
+++ b/recipes/hipstr-mt/conda_build_config.yaml
@@ -1,8 +1,0 @@
-# src/mathops.cpp vectorizes its exp() reduction through glibc's libmvec, via
-# `#pragma omp simd` and -fopenmp-simd. GCC emits the vector-exp calls
-# (_ZGVbN2v_exp, _ZGVdN4v_exp, _ZGVeN8v_exp) whenever that flag is on, and
-# libmvec only exists in glibc 2.22 and later -- the default 2.17 sysroot has
-# no libmvec at all, so the link fails on those undefined symbols. 2.28 is the
-# earliest sysroot conda-forge ships that provides it.
-c_stdlib_version:  # [linux]
-  - "2.28"         # [linux]

--- a/recipes/hipstr-mt/conda_build_config.yaml
+++ b/recipes/hipstr-mt/conda_build_config.yaml
@@ -1,0 +1,8 @@
+# src/mathops.cpp vectorizes its exp() reduction through glibc's libmvec, via
+# `#pragma omp simd` and -fopenmp-simd. GCC emits the vector-exp calls
+# (_ZGVbN2v_exp, _ZGVdN4v_exp, _ZGVeN8v_exp) whenever that flag is on, and
+# libmvec only exists in glibc 2.22 and later -- the default 2.17 sysroot has
+# no libmvec at all, so the link fails on those undefined symbols. 2.28 is the
+# earliest sysroot conda-forge ships that provides it.
+c_stdlib_version:  # [linux]
+  - "2.28"         # [linux]

--- a/recipes/hipstr-mt/meta.yaml
+++ b/recipes/hipstr-mt/meta.yaml
@@ -1,0 +1,67 @@
+{% set version = "0.6.6" %}
+
+package:
+  name: hipstr-mt
+  version: {{ version }}
+
+source:
+  url: https://github.com/TurakhiaLab/HipSTR-MT/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 45cca0445217662c1c625159048d29f9acabf0a762c3ab713d6cd252a1c9f4a2
+
+build:
+  number: 0
+  # ISA dispatch (src/mathops.cpp's target_clones) is decided at runtime via
+  # cpuid, but the build itself assumes x86_64 (SSE2/AVX intrinsics are used
+  # directly elsewhere) and Linux (/proc/self/status, sched_getaffinity).
+  skip: True  # [not (linux and x86_64)]
+  run_exports:
+    - {{ pin_subpackage('hipstr-mt', max_pin="x.x") }}
+
+requirements:
+  build:
+    # The C compiler is needed for the vendored htslib, cephes, libdeflate and
+    # mimalloc; the C++ one for HipSTR-MT itself.
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - {{ stdlib('c') }}
+    - make
+    - cmake >=3.18
+  host:
+    - zlib
+    - bzip2
+    - xz
+    - libcurl
+    - openssl
+  run:
+    - zlib
+    - bzip2
+    - xz
+    - libcurl
+    - openssl
+
+test:
+  commands:
+    - HipSTR-MT --help
+    - HipSTR-MT --version
+
+about:
+  home: https://github.com/TurakhiaLab/HipSTR-MT
+  license: GPL-2.0-only
+  license_family: GPL
+  license_file: LICENSE
+  summary: "Multi-threaded fork of HipSTR, a haplotype-based STR genotyper for Illumina sequencing data"
+  description: |
+    HipSTR-MT adds thread-level parallelization (--threads), additional
+    vectorization, and memory optimizations to HipSTR, the haplotype-based
+    short tandem repeat (STR) genotyping tool originally developed by
+    Thomas Willems et al. It produces the same genotype calls as upstream
+    HipSTR at any thread count, while running substantially faster on
+    multi-core machines.
+  doc_url: https://github.com/TurakhiaLab/HipSTR-MT/blob/v{{ version }}/README.md
+  dev_url: https://github.com/TurakhiaLab/HipSTR-MT
+
+extra:
+  recipe-maintainers:
+    - JGalil
+  identifiers:
+    - doi:10.5281/zenodo.22650334

--- a/recipes/hipstr-mt/meta.yaml
+++ b/recipes/hipstr-mt/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.6.6" %}
+{% set version = "0.6.7" %}
 
 package:
   name: hipstr-mt
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/TurakhiaLab/HipSTR-MT/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 45cca0445217662c1c625159048d29f9acabf0a762c3ab713d6cd252a1c9f4a2
+  sha256: 140522b0facccd4fa2df9651636dfc77b0c276561c8ae5d72ba6b75c40e34add
 
 build:
   number: 0

--- a/recipes/hipstr-mt/meta.yaml
+++ b/recipes/hipstr-mt/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.6.7" %}
+{% set version = "0.6.8" %}
 
 package:
   name: hipstr-mt
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/TurakhiaLab/HipSTR-MT/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 140522b0facccd4fa2df9651636dfc77b0c276561c8ae5d72ba6b75c40e34add
+  sha256: 7b1f8f1eafd2809c55fe12a7238d52128917a08eaaf98b11bfd3471c4eba8380
 
 build:
   number: 0


### PR DESCRIPTION
Adds a recipe for [HipSTR-MT](https://github.com/TurakhiaLab/HipSTR-MT) v0.6.6, a performance fork of HipSTR (already packaged here as `hipstr`) that adds thread-level parallelization via a `--threads` flag, plus vectorization and memory optimizations. It produces genotype-identical output to upstream HipSTR at any thread count.

The upstream project is GPL-2.0-only and archived on Zenodo (`doi:10.5281/zenodo.22650334`).

Notes for reviewers:

- **Linux/x86_64 only.** The build uses SSE/AVX intrinsics directly and reads `/proc/self/status` and `sched_getaffinity`, which have no fallback path. The recipe skips other platforms rather than failing on them.
- **`build.sh` mirrors the existing `hipstr` recipe's workarounds.** The vendored htslib and cephes Makefiles hardcode `CC = gcc`, which beats the environment in GNU Make, so `${CC}` is symlinked to `gcc`; `CPATH`/`LIBRARY_PATH` cover the same two sub-builds for headers and libraries.
- **libcurl and openssl are in `host`** (unlike the `hipstr` recipe): this fork vendors htslib 1.24, whose default build config compiles in libcurl-backed remote-file support.
- Everything under `lib/` (htslib, mimalloc, libdeflate, Taskflow, cephes) is vendored in the source tarball and built from it; no system htslib is used.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)