### PR TITLE
 Add genescopefk v1.0.0

### DIFF
--- a/recipes/genescopefk/build.sh
+++ b/recipes/genescopefk/build.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+R -e 'install.packages(".", repos=NULL, type="source")'
+
+mkdir -p $PREFIX/bin
+cp GeneScopeFK.R $PREFIX/bin/GeneScopeFK.R
+chmod +x $PREFIX/bin/GeneScopeFK.R

--- a/recipes/genescopefk/meta.yaml
+++ b/recipes/genescopefk/meta.yaml
@@ -1,0 +1,40 @@
+{% set version = "1.0.0" %}
+
+package:
+  name: genescopefk
+  version: {{ version }}
+
+source:
+  url: https://github.com/thegenemyers/GENESCOPE.FK/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: f4d4754814e36039ea26b3f337f5b5980dfe880b84b05de0bf8a93bb22ddcb80
+
+build:
+  number: 0
+  noarch: generic
+  run_exports:
+    - {{ pin_subpackage('genescopefk', max_pin="x.x") }}
+
+requirements:
+  host:
+    - r-base
+    - r-minpack.lm
+    - r-argparse
+  run:
+    - r-base
+    - r-minpack.lm
+    - python >=3.6
+    - r-argparse
+    - fonts-conda-ecosystem
+
+test:
+  commands:
+    - GeneScopeFK.R --help
+
+about:
+  home: https://github.com/thegenemyers/GENESCOPE.FK
+  license: Apache-2.0
+  summary: "A derivative of GenomeScope2.0 modified to work with FastK"
+
+extra:
+  container:
+    extended-base: True

--- a/recipes/genescopefk/meta.yaml
+++ b/recipes/genescopefk/meta.yaml
@@ -22,13 +22,11 @@ requirements:
   run:
     - r-base
     - r-minpack.lm
-    - python >=3.6
     - r-argparse
-    - fonts-conda-ecosystem
 
 test:
   commands:
-    - GeneScopeFK.R --help
+    - GeneScopeFK.R --version
 
 about:
   home: https://github.com/thegenemyers/GENESCOPE.FK


### PR DESCRIPTION
This PR adds a recipe for GeneScopeFK (https://github.com/thegenemyers/GENESCOPE.FK), an implementation of GenomeScope2.0 capable of taking FastK results as input. This recipe is adapted from the GenomeScope2 recipe.



<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
