### PR TITLE
Update sativa-epang to 0.9.3.6

### DIFF
--- a/recipes/sativa-epang/meta.yaml
+++ b/recipes/sativa-epang/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "sativa-epang" %}
-{% set version = "0.9.3.4" %}
-{% set sha256 = "0be51d27c2b230fe8630c1981f96c18d77808332b5c6a06efddace9ec771ac78" %}
+{% set version = "0.9.3.6" %}
+{% set sha256 = "4a300bd587378381f8299aa594ec14c5e170dd4d6542c739a70b7fc047aec6b9" %}
 
 package:
   name: {{ name|lower }}
@@ -66,9 +66,11 @@ about:
     The command is `sativa-epang`; the `sativa` package provides unmodified SATIVA as
     `sativa.py`, and the two can be installed side by side.
   doc_url: https://github.com/Aaramis/sativa-epang/blob/epa-ng/CHANGES-epa-ng.md
+  dev_url: https://github.com/Aaramis/sativa-epang
 
 extra:
   identifiers:
+    - doi:10.5281/zenodo.22660415
     - doi:10.1093/nar/gkw396
     - doi:10.1093/sysbio/syy054
   recipe-maintainers:


### PR DESCRIPTION
Version bump, plus two metadata additions.

`0.9.3.6` fixes three things the nf-core/taxmarker team hit while building modules against the tool: a stale internal version string with no way to query it (there is now a `-version` flag), a silent GTR+G fallback when `-reftree` was given without `-refmodel` (now an error), and a log line naming the wrong placement engine.

Also adds the software's own Zenodo DOI to `extra: identifiers:` alongside the two upstream papers, and a `dev_url`.