### PR TITLE
Update pyeuk to 0.8.1

### DIFF
--- a/recipes/pyeuk/meta.yaml
+++ b/recipes/pyeuk/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pyeuk" %}
-{% set version = "0.7.0" %}
+{% set version = "0.8.1" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/spond/pyeuk/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 4184570bdff8622f9ad8906940547932e64b21753745c72764202c49fcdf7275
+  sha256: b58a11ce3c23d39f47ce598e71d6f9dad064541e9b0cbca405c5be99fdca7b20
 
 build:
   number: 0


### PR DESCRIPTION
Update `pyeuk` to **0.8.1** (correctness bugfix release; spond/pyeuk#30 merged, tag `v0.8.1`).

Straight bump from the 0.7.0 recipe on `master` — version + sha256 only, no dependency or build changes. Supersedes the BiocondaBot autobump #68884 (0.8.0), which was never merged; going directly to 0.8.1.

- `sha256` verified against `https://github.com/spond/pyeuk/archive/refs/tags/v0.8.1.tar.gz`.
- 0.8.1 is a fixes-only release (genetic-distance heuristic, indel normalization, sheet routing, CLI flags, etc.); dependency set is unchanged from 0.7.0/0.8.0.

---
* [x] This PR bumps an existing recipe (version + sha256).
* [x] I am the recipe maintainer (`nekrut`).
