### PR TITLE
Update replidec

### DIFF
--- a/recipes/replidec/meta.yaml
+++ b/recipes/replidec/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "replidec" %}
-{% set version = "0.3.5" %}
+{% set version = "0.3.6" %}
 
 package:
   name: "{{ name|lower }}"
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/replidec-{{ version }}.tar.gz
-  sha256: c84212d3000e399d203f0a87e91381aa6b39482b44d53b069fbb0754a88ddfde
+  sha256: 346f59fdecdd43cb1d01c7fb6ad895a7e0f0e78e66b228a924a4ed3e9087a507
 
 build:
   number: 0


### PR DESCRIPTION
Describe your pull request here
Update Replidec 
Update Traning database.
DB update:The updated RepliDec training database comprises 926 curated phage genomes from the PHACTS database and verified RefSeq records. Temperate and virulent phages were balanced at a 1:1 ratio, while duplicate genomes and sequences sharing ≥95% ANI with the Mavrich test dataset were removed to minimize data leakage. These genomes yielded 39,016 predicted proteins, which were clustered to construct the protein-feature database used by the Naive Bayes classifier. Overall, the updated database is smaller but more balanced, reliable, and suitable for independent performance evaluation.
----

@BiocondaBot please add label