### PR TITLE
kma: 1.6.15

### DIFF
--- a/recipes/kma/meta.yaml
+++ b/recipes/kma/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "kma" %}
-{% set version = "1.6.13" %}
-{% set sha256 = "8f4b51bbb941fbcb11d01057c38a1624b2eb11385256429db29d1617aeac6a8b" %}
+{% set version = "1.6.15" %}
+{% set sha256 = "46bd50fb49cce4d070a06fdbbaac50319e3418353a08522738a1838d30068650" %}
 
 package:
   name: {{ name }}


### PR DESCRIPTION
Bump KMA to 1.6.15.

- Updated version to 1.6.15
- Updated sha256
- Build number stays at 0 (new upstream version)

Upstream tag: https://bitbucket.org/genomicepidemiology/kma/commits/tag/1.6.15

Note: 1.6.14 was tagged upstream but never packaged here, so this goes 1.6.13 -> 1.6.15.

Verified locally before opening: tarball sha256 reproducible across two downloads, source builds cleanly, all four binaries (kma, kma_index, kma_shm, kma_update) produced, and all four recipe test commands pass. `kma -v` reports KMA-1.6.15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)