### PR TITLE
nanoplot: pin plotly <7 and require nanoget >=1.19.6

### DIFF
--- a/recipes/nanoplot/meta.yaml
+++ b/recipes/nanoplot/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 1cffcb73cece29f59af87d9da496e4447875ce7a7d5e5d2490014c9f83956ef0
 
 build:
-  number: 0
+  number: 1
   noarch: python
   entry_points:
     - NanoPlot = nanoplot.NanoPlot:main
@@ -35,8 +35,8 @@ requirements:
     - scipy
     - python-dateutil
     - libpng
-    - nanoget >=1.19.1
-    - plotly >=6.1.1
+    - nanoget >=1.19.6
+    - plotly >=6.1.1,<7
     - pyarrow
     - python-kaleido >=1.0.0
 


### PR DESCRIPTION
plotly 7 removed `figure_factory.create_2d_density`, which NanoPlot calls, so installing nanoplot from bioconda currently produces an environment that fails at plot time:

```
AttributeError: module 'plotly.figure_factory' has no attribute 'create_2d_density'
```

Upstream pinned `plotly<7` for PyPI in 1.47.4, and the published sdist for 1.48.0 declares `plotly<7,>=6.1.1`, but the recipe still said `plotly >=6.1.1` — so the conda package resolves to plotly 7.0.0. The published `1.48.0 pyhdfd78af_0` metadata shows it:

```
depends: ... nanoget >=1.19.1, plotly >=6.1.1, ...
```

`nanoget` had drifted too: NanoPlot 1.48.0 requires `>=1.19.6` (for the dorado `barcode_arrangement` workaround) while the recipe allowed `>=1.19.1`.

Same version, so the build number is bumped to 1.

Reported downstream in wdecoster/NanoPlot#442. I maintain NanoPlot.

---

* [x] This PR only affects a recipe I maintain
* [x] The recipe builds the same version; only run requirements and the build number change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0127Lv9RkKNVWZ12Rr3ehCtt