### PR TITLE
Update panmap recipe maintainers

### DIFF
--- a/recipes/panmap/meta.yaml
+++ b/recipes/panmap/meta.yaml
@@ -71,6 +71,7 @@ about:
 extra:
   recipe-maintainers:
     - amkram
+    - AlanZhangUCSC
   additional-platforms:
     - linux-aarch64
     - osx-arm64


### PR DESCRIPTION
Adds @AlanZhangUCSC to `extra.recipe-maintainers` for panmap. Metadata-only change, no rebuild needed.

Independent of #68983 (different hunk of `meta.yaml`); merges cleanly in either order.