### PR TITLE
Update muat to 0.1.31

### DIFF
--- a/recipes/muat/meta.yaml
+++ b/recipes/muat/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "muat" %}
-{% set version = "0.1.28" %}
+{% set version = "0.1.31" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,8 @@ package:
 
 source:
   url: https://github.com/primasanjaya/muat/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 378d1b558bbb1b3097913ea5dcc2cc4b0313cce87ef33e6010f6e820519e7b26
+  sha256: c29b7989d8a0ae4d99cfb58362caccc0ca00bbfab4d72971049247c57a3b0754
+
 
 build:
   number: 0


### PR DESCRIPTION
**Fixes**
- `muat reproduce a1_d1_hfmatch` was previously non-functional for anyone outside this repo's own filesystem: the split file pinning the exact 2,587-sample train/val partition was never shipped in the package. Now included as `muat/pkg_reproduce/splits/a1_train_full.tsv` + `a1_val.tsv` (sample IDs and tumour-type labels only — no mutation calls or other genomic data; requires separate PCAWG DACO access to the underlying data itself).

**Documentation**
- `experiments.json`: added the completed `b1` GEL SPE portability result (a0 and a1_d1_hfmatch checkpoints, 3 repeats each inside GEL, both bit-identical), replacing the never-run `a5` placeholder.
- Added `a1_d1_hfmatch_all_repeats` checkpoint-archive asset entry.

**Data availability**
All reproducibility checkpoints and preprocessed data, including this release's new `a1_ckpt_hfmatch.zip` checkpoint archive and the `a1_train_full.tsv`/`a1_val.tsv` split lists, are archived on Zenodo: https://doi.org/10.5281/zenodo.21873079 (record 22703149).