### PR TITLE
Disco: add iterator patch

### DIFF
--- a/recipes/disco/0005-overlapgraph-erase-iterator-invalidation.patch
+++ b/recipes/disco/0005-overlapgraph-erase-iterator-invalidation.patch
@@ -1,0 +1,11 @@
+--- a/src/SimplifyGraph/src/OverlapGraph.cpp
++++ b/src/SimplifyGraph/src/OverlapGraph.cpp
+@@ -347,7 +347,7 @@
+ 		if(it->second->empty())
+ 		{
+ 			delete it->second;
+-			m_graph->erase(it);
++			it = m_graph->erase(it);
+ 		}
+ 		else
+ 			it++;

--- a/recipes/disco/meta.yaml
+++ b/recipes/disco/meta.yaml
@@ -16,7 +16,7 @@ source:
     - 0004-cs2-parser-pr_type-buffer-size.patch
 
 build:
-  number: 1
+  number: 2
   run_exports:
     - {{ pin_subpackage('disco', max_pin="x") }}
 


### PR DESCRIPTION
`fullsimplify` segfaults on basically any real input:

```
#0  std::_Rb_tree_increment(std::_Rb_tree_node_base*) from libstdc++.so.6
#2  OverlapGraph::contractCompositeEdgesPar () at ../src/OverlapGraph.cpp:353
```

The cause is:

```cpp
while(it!=m_graph->end())
{
    if(it->second->empty())
    {
        delete it->second;
        m_graph->erase(it);   // invalidates it
    }
    else
        it++;                 // ...and we keep using it
}
```

`map::erase(it)` invalidates `it` and the loop carries on dereferencing it. The same loop appears
four times - lines 350, 691, 1353, 1621. This PR fixes this with `it = m_graph->erase(it);` at each site; `erase`
has returned the next iterator since C++11, and this already builds with `-std=c++11`.


### General instructions

* If this PR adds or updates a recipe, use "Add" or "Update" appropriately as the first word in its title.
* New recipes not directly relevant to the biological sciences need to be submitted to the [conda-forge channel](https://conda-forge.org/docs/) instead of Bioconda.
* PRs require reviews prior to being merged. Once your PR is passing tests and ready to be merged, please issue the `@BiocondaBot please add label` command.
* Please post questions [on Gitter](https://gitter.im/bioconda/Lobby) or ping `@bioconda/core` in a comment.

### Instructions for avoiding API, ABI, and CLI breakage issues
Conda is able to record and lock (a.k.a. pin) dependency versions used at build time of other recipes.
This way, one can avoid that expectations of a downstream recipe with regards to API, ABI, or CLI are violated by later changes in the recipe.
If not already present in the meta.yaml, make sure to specify `run_exports` (see [here](https://bioconda.github.io/contributor/linting.html#missing-run-exports) for the rationale and comprehensive explanation).
Add a `run_exports` section like this:

```yaml
build:
  run_exports:
    - ...

```

with `...` being one of:

| Case                             | run_exports statement                                               |
| -------------------------------- | ------------------------------------------------------------------- |
| semantic versioning              | `{{ pin_subpackage("myrecipe", max_pin="x") }}`     |
| semantic versioning (0.x.x)      | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}`   |
| known breakage in minor versions | `{{ pin_subpackage("myrecipe", max_pin="x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| known breakage in patch versions | `{{ pin_subpackage("myrecipe", max_pin="x.x.x") }}` (in such a case, please add a note that shortly mentions your evidence for that) |
| calendar versioning              | `{{ pin_subpackage("myrecipe", max_pin=None) }}`    |

while replacing `"myrecipe"` with either `name` if a `name|lower` variable is defined in your recipe or with the lowercase name of the package in quotes.

### Bot commands for PR management

<details>
  <summary>Please use the following BiocondaBot commands:</summary>

Everyone has access to the following BiocondaBot commands, which can be given in a comment:

<table>
  <tr>
    <td><code>@BiocondaBot please add label</code></td>
    <td>Add the <code>please review & merge</code> label.</td>
  </tr>
  <tr>
    <td><code>@BiocondaBot please fetch artifacts</code></td>
    <td>Post links to CI-built packages/containers. <br />You can use this to test packages locally.</td>
  </tr>
</table>

Note that the <code>@BiocondaBot please merge</code> command is now depreciated. Please just squash and merge instead.

Also, the bot watches for comments from non-members that include `@bioconda/<team>` and will automatically re-post them to notify the addressed `<team>`.

</details>
