### PR TITLE
Update rastqc and rastqc-nanopore to 0.2.0

### DIFF
--- a/recipes/rastqc-nanopore/meta.yaml
+++ b/recipes/rastqc-nanopore/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "rastqc-nanopore" %}
-{% set version = "0.1.0" %}
+{% set version = "0.2.0" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/Huang-lab/RastQC/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 8f1417836958637602e17e1c17ced3e4a05bcbe7d013dd6cc34ed0dc341136d1
+  sha256: ceda2350f81218dc878652b467e9d0f27807d9001cd802f371088e20b9a5fd41
 
 build:
   number: 0
@@ -16,6 +16,8 @@ build:
 
 requirements:
   build:
+    # Cargo.toml declares rust-version = 1.85; cargo will refuse to build on
+    # anything older, with a clear message.
     - {{ compiler('rust') }}
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}

--- a/recipes/rastqc/meta.yaml
+++ b/recipes/rastqc/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "rastqc" %}
-{% set version = "0.1.0" %}
+{% set version = "0.2.0" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/Huang-lab/RastQC/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 8f1417836958637602e17e1c17ced3e4a05bcbe7d013dd6cc34ed0dc341136d1
+  sha256: ceda2350f81218dc878652b467e9d0f27807d9001cd802f371088e20b9a5fd41
 
 build:
   number: 0
@@ -16,6 +16,8 @@ build:
 
 requirements:
   build:
+    # Cargo.toml declares rust-version = 1.85; cargo will refuse to build on
+    # anything older, with a clear message.
     - {{ compiler('rust') }}
     - {{ compiler('c') }}
     - {{ stdlib('c') }}
@@ -36,8 +38,9 @@ about:
   description: |
     RastQC is a drop-in replacement for FastQC written in Rust. It implements
     all 12 FastQC modules with matching algorithms and output formats (HTML,
-    fastqc_data.txt, ZIP, native MultiQC JSON). The streaming parallel
-    pipeline runs 2-3x faster than FastQC on real sequencing data. For Oxford
+    fastqc_data.txt, ZIP, native MultiQC JSON). On a real 18.7M-read NextSeq
+    run it is 2.9x faster than Falco on one core and 4.7x on four, and its
+    output is byte-identical at any thread count. For Oxford
     Nanopore data (Fast5 + POD5 readers and long-read modules), install the
     sibling package `rastqc-nanopore`.
   dev_url: https://github.com/Huang-lab/RastQC


### PR DESCRIPTION
Bumps the two sibling RastQC packages from 0.1.0 to 0.2.0. Opened by the
upstream author / recipe maintainer.

Both packages build from the same upstream tag (`rastqc` is the core
short-read build, `rastqc-nanopore` adds the Fast5/POD5 readers), so they
are bumped together. Upstream v0.2.0 is a performance, memory and
reproducibility release — [release notes](https://github.com/Huang-lab/RastQC/releases/tag/v0.2.0).

### What changed in the recipes

Only `version` and `sha256`, plus a comment noting the new MSRV and a
refreshed `about.description` for the core package. `build.sh`, `LICENSE`,
`run_exports`, `extra.additional-platforms` and the `hdf5`/`libarrow` pins
are all untouched.

### Notes for review

* **Build inputs are unchanged.** The dependency of note added upstream is a
  pure-Rust zlib backend (`flate2`'s `zlib-rs`), so no C zlib and no cmake
  is pulled in. The nanopore variant's `hdf5 >=1.10,<1.13` and `libarrow`
  pins still apply as-is, and its `H5pubconf.h` workaround in `build.sh` is
  still needed (upstream is still on `hdf5` 0.8).
* **MSRV is now 1.85.** Upstream declared `rust-version = 1.70` while its
  dependencies already required newer; that is corrected in 0.2.0.
  conda-forge's `rust` compiler satisfies it. `cargo` fails with a clear
  message rather than a confusing compile error if it ever does not.
* **`run_exports` is already present** in both recipes as
  `{{ pin_subpackage(name, max_pin='x.x') }}`, which is the documented form
  for 0.x.x versioning — so the 0.1.x → 0.2.x pin move is intended.
* **Verified the tag builds with this recipe's exact invocation.** From the
  v0.2.0 tarball, `cargo install --no-track --locked --root <prefix> --path .
  --bin rastqc` succeeds and the binary reports `rastqc 0.2.0`, so the
  lockfile in the tag resolves under `--locked`.

Merging this also produces the 0.2.0 BioContainer, which is what
[Huang-lab/RastQC#11](https://github.com/Huang-lab/RastQC/issues/11) asked
for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
