### PR TITLE
Update circleseeker to 1.6.1

### DIFF
--- a/recipes/circleseeker/meta.yaml
+++ b/recipes/circleseeker/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "circleseeker" %}
-{% set version = "1.5.1" %}
+{% set version = "1.6.1" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://github.com/leoxqy/CircleSeeker/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 3e8c8344d58fc4d0af7f02d6b39d0abd373adaffc968336089b30a5851bcc648
+  url: https://github.com/YaoxinBio/CircleSeeker/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 49703d6728829718f3c48cc808279c387e23624dece27912bff33a9eff7aa38e
 
 build:
   noarch: python
@@ -15,7 +15,6 @@ build:
   script: {{ PYTHON }} -m pip install . -vv
   entry_points:
     - circleseeker = circleseeker.cli:main
-    - CircleSeeker = circleseeker.cli:main
   run_exports:
     - {{ pin_subpackage(name, max_pin="x") }}
 
@@ -56,13 +55,12 @@ test:
     - circleseeker.external
   commands:
     - circleseeker --help
-    - CircleSeeker --help
     - python -c "import circleseeker; print(circleseeker.__version__)"
     - python -c "from circleseeker.modules import ecc_summary; print('Module test passed')"
     - python -m pip check
 
 about:
-  home: https://github.com/leoxqy/CircleSeeker
+  home: https://github.com/YaoxinBio/CircleSeeker
   license: GPL-3.0-only
   license_family: GPL
   license_file: LICENSE
@@ -81,9 +79,9 @@ about:
     - Detailed HTML reports and comprehensive output formats
     - Modular architecture with 16 processing steps
 
-  doc_url: https://github.com/leoxqy/CircleSeeker#readme
-  dev_url: https://github.com/leoxqy/CircleSeeker
+  doc_url: https://github.com/YaoxinBio/CircleSeeker#readme
+  dev_url: https://github.com/YaoxinBio/CircleSeeker
 
 extra:
   recipe-maintainers:
-    - leoxqy
+    - YaoxinBio


### PR DESCRIPTION
Updates `circleseeker` from 1.5.1 to 1.6.1.

### Source moved

The upstream repository is now `YaoxinBio/CircleSeeker`; the previous account is
being retired, so `url`, `home`, `doc_url`, `dev_url` and the maintainer entry
all move with it. The tags are preserved at the new location.

### Entry point removed

`CircleSeeker` (capitalised) is gone upstream; only `circleseeker` remains. Two
console scripts differing solely in case install to the same path on
case-insensitive filesystems and break uninstall, so the recipe drops both the
entry point and its `--help` test.

### What changed upstream

1.6.1 makes results reproducible: two runs of the same code on the same input
now produce byte-identical output. Previously the strand reported for an
inferred UeccDNA and the segment order of an inferred multi-segment CeccDNA both
followed set iteration over strings, which is seeded per process. It also
removes the per-item pandas overhead that stalled large samples.

`networkx` moves to `>=3.2` as part of that fix: earlier versions chose
`cycle_basis`'s root with `set(G.nodes()).pop()`, which reintroduces the same
nondeterminism.

1.6.0 was withdrawn before release and never published.

---

* [x] Recipe passes `bioconda-utils lint` conventions: version bumped, build
      number reset to 0, checksum updated.
* [x] `sha256` verified against the released tarball.
* [x] Noarch python package; no dependency changes other than the `networkx`
      floor.
