### PR TITLE
Fix kallisto "Illegal instruction" on CPUs without AVX2/AVX-512

### DIFF
--- a/recipes/kallisto/build.sh
+++ b/recipes/kallisto/build.sh
@@ -15,7 +15,9 @@ case $(uname -m) in
 	export CXXFLAGS="${CXXFLAGS} -march=armv8.4-a"
 	;;
     x86_64)
-	export CXXFLAGS="${CXXFLAGS} -march=x86-64-v3"
+	# removed: -march=x86-64-v3 required AVX2 and defeated the
+	# -DENABLE_AVX2=OFF -DCOMPILATION_ARCH=OFF passed to bifrost
+	# below via ARCH_OPTS. See bioconda/bioconda-recipes#42633.
 	;;
 esac
 

--- a/recipes/kallisto/meta.yaml
+++ b/recipes/kallisto/meta.yaml
@@ -21,6 +21,7 @@ requirements:
     - make
     - cmake <4
     - {{ compiler('cxx') }}
+    - {{ stdlib("c") }}
     - pkg-config
     - autoconf
     - automake

--- a/recipes/kallisto/meta.yaml
+++ b/recipes/kallisto/meta.yaml
@@ -12,7 +12,7 @@ source:
     - patches/osx.patch  # [osx]
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage('kallisto', max_pin="x.x") }}
 


### PR DESCRIPTION
Fixes #42633.

`build.sh` set `-march=x86-64-v3` (requires AVX2) in CXXFLAGS on x86_64, silently overriding the `-DENABLE_AVX2=OFF -DCOMPILATION_ARCH=OFF` already passed to bundled bifrost via ARCH_OPTS.
That's why the SIGILL in `kallisto` persisted even after those flags were added following upstream's guidance (pachterlab/kallisto#431).

~Draft until~ verified via CI-built artifacts on real non-AVX2 hardware. ~Will mark ready for review once confirmed.~