### PR TITLE
Update oxo-flow-cli to 0.18.1 and pin rust 1.98.0 (MSRV)

### DIFF
--- a/recipes/oxo-flow-cli/build.sh
+++ b/recipes/oxo-flow-cli/build.sh
@@ -7,6 +7,14 @@ set -x
 # on macOS. Point CARGO_HOME at an absolute path instead.
 export CARGO_HOME="${BUILD_PREFIX}/.cargo"
 
+# rustc's default linker on macOS is the system `cc`, which resolves its
+# toolchain through xcodebuild. bioconda's CI installs the MacOSX11.3 SDK
+# under Xcode 15.4, which refuses SDKs below 13.0 ("cannot be located"),
+# so linking via `cc` fails with exit status 72. Use the conda clang as
+# the Rust linker instead; it does not consult xcodebuild.
+export CARGO_TARGET_AARCH64_APPLE_DARWIN_LINKER="${CC}"
+export CARGO_TARGET_X86_64_APPLE_DARWIN_LINKER="${CC}"
+
 cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
 
 cargo install --no-track --locked --verbose --root "${PREFIX}" --path crates/oxo-flow-cli

--- a/recipes/oxo-flow-cli/build.sh
+++ b/recipes/oxo-flow-cli/build.sh
@@ -2,6 +2,11 @@
 
 set -x
 
+# HOME is not passed to conda-build, so cargo's default "${HOME}/.cargo"
+# resolves to a non-absolute "UNKNOWN" path and cargo-bundle-licenses panics
+# on macOS. Point CARGO_HOME at an absolute path instead.
+export CARGO_HOME="${BUILD_PREFIX}/.cargo"
+
 cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
 
 cargo install --no-track --locked --verbose --root "${PREFIX}" --path crates/oxo-flow-cli

--- a/recipes/oxo-flow-cli/conda_build_config.yaml
+++ b/recipes/oxo-flow-cli/conda_build_config.yaml
@@ -1,0 +1,5 @@
+# oxo-flow 0.17.0+ requires rustc >= 1.98.0 (rust-version in Cargo.toml).
+# The global default resolves to an older rustc, which fails the crate's
+# MSRV check during cargo install.
+rust_compiler_version:
+  - 1.98.0

--- a/recipes/oxo-flow-cli/conda_build_config.yaml
+++ b/recipes/oxo-flow-cli/conda_build_config.yaml
@@ -1,7 +1,0 @@
-# oxo-flow 0.17.0+ requires rustc >= 1.98.0 (rust-version in Cargo.toml).
-# The global default resolves to an older rustc, which fails the crate's
-# MSRV check during cargo install. 1.98.0 is unavailable on some platforms
-# (its noarch rust-std package was removed from repodata); 1.98.1 is
-# the earliest 1.98.x that resolves on all four platforms.
-rust_compiler_version:
-  - 1.98.1

--- a/recipes/oxo-flow-cli/conda_build_config.yaml
+++ b/recipes/oxo-flow-cli/conda_build_config.yaml
@@ -1,5 +1,7 @@
 # oxo-flow 0.17.0+ requires rustc >= 1.98.0 (rust-version in Cargo.toml).
 # The global default resolves to an older rustc, which fails the crate's
-# MSRV check during cargo install.
+# MSRV check during cargo install. 1.98.0 is unavailable on some platforms
+# (its noarch rust-std package was removed from repodata); 1.98.1 is
+# the earliest 1.98.x that resolves on all four platforms.
 rust_compiler_version:
-  - 1.98.0
+  - 1.98.1

--- a/recipes/oxo-flow-cli/meta.yaml
+++ b/recipes/oxo-flow-cli/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "oxo-flow-cli" %}
 {% set version = "0.17.2" %}
-{% set sha256 = "e855d5689935be703228d2681aa40e8d856ecd740d27bcf5f4e4076f97657dab" %}
+{% set sha256 = "ce946d7bb2d450b9d0bc681919df43338f20a6935f11f37e8e247c34e4f77b78" %}
 
 package:
   name: {{ name|lower }}

--- a/recipes/oxo-flow-cli/meta.yaml
+++ b/recipes/oxo-flow-cli/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "oxo-flow-cli" %}
-{% set version = "0.17.0" %}
-{% set sha256 = "c97239ee53c9cd090d91199f12f9b0fac3863e0a816f16ecfe839966331ed449" %}
+{% set version = "0.17.1" %}
+{% set sha256 = "a388b49e14e1f0d4fba29085216321ead946b12ace230bfc3171c2a67d7a2727" %}
 
 package:
   name: {{ name|lower }}

--- a/recipes/oxo-flow-cli/meta.yaml
+++ b/recipes/oxo-flow-cli/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "oxo-flow-cli" %}
-{% set version = "0.17.1" %}
-{% set sha256 = "a388b49e14e1f0d4fba29085216321ead946b12ace230bfc3171c2a67d7a2727" %}
+{% set version = "0.17.2" %}
+{% set sha256 = "e855d5689935be703228d2681aa40e8d856ecd740d27bcf5f4e4076f97657dab" %}
 
 package:
   name: {{ name|lower }}

--- a/recipes/oxo-flow-cli/meta.yaml
+++ b/recipes/oxo-flow-cli/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "oxo-flow-cli" %}
-{% set version = "0.15.0" %}
-{% set sha256 = "2128010d1c3863e12fb4872a81e1fd33c788e6a747926c49bfe6828dab58a63e" %}
+{% set version = "0.16.0" %}
+{% set sha256 = "7d7bc77692f94af2021ec8c0ce0830e353cdd757343261ef17e258fa105000f3" %}
 
 package:
   name: {{ name|lower }}

--- a/recipes/oxo-flow-cli/meta.yaml
+++ b/recipes/oxo-flow-cli/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "oxo-flow-cli" %}
-{% set version = "0.16.0" %}
-{% set sha256 = "7d7bc77692f94af2021ec8c0ce0830e353cdd757343261ef17e258fa105000f3" %}
+{% set version = "0.17.0" %}
+{% set sha256 = "c97239ee53c9cd090d91199f12f9b0fac3863e0a816f16ecfe839966331ed449" %}
 
 package:
   name: {{ name|lower }}

--- a/recipes/oxo-flow-cli/meta.yaml
+++ b/recipes/oxo-flow-cli/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "oxo-flow-cli" %}
-{% set version = "0.18.0" %}
-{% set sha256 = "def8e5eb9c81942ecef23b784e3daff5228fd68d1c4b7d732d91fb171be62b9e" %}
+{% set version = "0.18.1" %}
+{% set sha256 = "6ae1689435cd03d844043cf72affdf4f4ec2d7f376815d26c774d58b51777b4c" %}
 
 package:
   name: {{ name|lower }}

--- a/recipes/oxo-flow-cli/meta.yaml
+++ b/recipes/oxo-flow-cli/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "oxo-flow-cli" %}
-{% set version = "0.17.2" %}
-{% set sha256 = "ce946d7bb2d450b9d0bc681919df43338f20a6935f11f37e8e247c34e4f77b78" %}
+{% set version = "0.18.0" %}
+{% set sha256 = "def8e5eb9c81942ecef23b784e3daff5228fd68d1c4b7d732d91fb171be62b9e" %}
 
 package:
   name: {{ name|lower }}

--- a/recipes/oxo-flow-cli/meta.yaml
+++ b/recipes/oxo-flow-cli/meta.yaml
@@ -50,3 +50,9 @@ extra:
     - osx-arm64
   recipe-maintainers:
     - ShixiangWang
+  skip-lints:
+    # The rust_osx-arm64 / rust_linux-aarch64 metapackages that
+    # {{ compiler('rust') }} resolves to top out at 1.97.1 in repodata
+    # (the 1.98.x metapackage builds are missing on conda-forge), so the
+    # raw rust package is pinned instead to meet the crate MSRV (1.98.0).
+    - should_use_compilers

--- a/recipes/oxo-flow-cli/meta.yaml
+++ b/recipes/oxo-flow-cli/meta.yaml
@@ -20,7 +20,11 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ stdlib('c') }}
-    - {{ compiler('rust') }}
+    # Pin the raw rust compiler: oxo-flow 0.17.0+ requires rustc >= 1.98.0
+    # (rust-version in Cargo.toml), but the rust_* metapackages that
+    # {{ compiler('rust') }} resolves to top out at 1.97.1 in repodata
+    # (the 1.98.x metapackage builds are missing on conda-forge).
+    - rust >=1.98.0
     - cargo-bundle-licenses
 
 test:


### PR DESCRIPTION
Supersedes the autobump PR #68566, adding the fix for its failing build.

### Root cause of the #68566 failure

oxo-flow 0.17.0+ sets `rust-version = "1.98.0"` in its workspace `Cargo.toml`. Cargo enforces this MSRV at build time, so the build fails with:

```
rustc 1.97.1 is not supported by the following package:
oxo-flow-web@0.18.1 requires rustc 1.98.0
```

The conda build environment resolves `rust 1.97.1` from the global pin, which is why 0.16.0 built fine and every rebump since 0.17.0 has failed.

### Fix

Depend on the raw `rust >=1.98.0` package in `build:` requirements instead of `{{ compiler('rust') }}`. The raw package is available at 1.98.1 on all four supported platforms and satisfies the crate MSRV. Because bioconda's `should_use_compilers` lint flags a direct `rust` requirement, the deviation is declared via `skip-lints: should_use_compilers` (same as the `fqgrep` recipe).

`build.sh` exports `CARGO_HOME="${BUILD_PREFIX}/.cargo"` (as `fqgrep` does): conda-build does not pass `HOME` into the build, so cargo resolves its registry dir from a non-absolute `"UNKNOWN"` home and `cargo-bundle-licenses` panicked with `is not absolute` on osx-arm64.

`build.sh` also exports `CARGO_TARGET_*_APPLE_DARWIN_LINKER="${CC}"`: bioconda's CI sets `MACOSX_SDK_VERSION=11.3` and installs the downloaded `MacOSX11.3.sdk` under Xcode 15.4, which refuses SDKs below 13.0. rustc's default linker (the system `cc`) resolves its toolchain through `xcodebuild` and fails with exit status 72 (`error: linking with 'cc' failed`); the conda clang does not consult `xcodebuild` and links fine.

Two CI-proven reasons for bypassing the compiler metapackage:

1. `1.98.0` itself is unsatisfiable on linux-aarch64 and osx-arm64 — the `rust_linux-aarch64`/`rust_osx-arm64` 1.98.0 metapackage builds are not resolvable from conda-forge repodata (caught by the first CI run).
2. The `rust_osx-arm64` / `rust_linux-aarch64` metapackages (what `{{ compiler('rust') }}` resolves to on those platforms) top out at 1.97.1 in repodata — no 1.98.x metapackage build exists (caught by the second CI run with a `rust_compiler_version: 1.98.1` pin, now removed).

The raw `rust` 1.98.1 compiler package pulls its matching noarch `rust-std-*` 1.98.1 target package, which is present for all four platforms.

The version bump itself is taken unchanged from the autobump branch (`bump/oxo_flow_cli`, commit aea7abd0). `rust-toolchain.toml` in the source tarball is inert in conda builds since the conda rust package is not rustup.

Once this PR is merged, the autobump PR #68566 should be closed as superseded.

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/bioconda/bioconda-recipes/blob/master/CONTRIBUTING.md).
- [x] This PR updates an existing recipe.




