### PR TITLE
Update vcf-reformatter to 0.7.5

### DIFF
--- a/recipes/vcf-reformatter/meta.yaml
+++ b/recipes/vcf-reformatter/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "vcf-reformatter" %}
-{% set version = "0.3.0" %}
+{% set version = "0.7.5" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/flalom/vcf-reformatter/archive/v{{ version }}.tar.gz
-  sha256: 7f8f24651a932a062130f2c65d34ea3ec6c50d21fc04167316172404bb999873 
+  sha256: f72cefa00ada99fd005544bc5a03a6923ebb2859906d8649b4095583c3da6890
 
 build:
   number: 0
@@ -17,6 +17,7 @@ build:
 requirements:
   build:
     - {{ compiler('rust') }}
+    - {{ stdlib('c') }}
     - cargo-bundle-licenses
 
 test:


### PR DESCRIPTION
Updates vcf-reformatter 0.3.0 → 0.7.5.

Supersedes #69185 (autobump), which carries the correct version and sha256 but fails `compiler_needs_stdlib_c`. That lint postdates the 0.3.0 recipe, so the recipe was already non-compliant; this PR adds the missing `{{ stdlib('c') }}` alongside the bump.

sha256 verified against the v0.7.5 tag tarball.

I am the recipe maintainer (@flalom) and have no write access, so I could not push the fix to the autobump branch.