### PR TITLE
Bump/deepdetails

### DIFF
--- a/recipes/deepdetails/meta.yaml
+++ b/recipes/deepdetails/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "deepdetails" %}
-{% set version = "1.0.0rc1" %}
+{% set version = "1.0.0rc2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/deepdetails-{{ version }}.tar.gz
-  sha256: b442a84cabd097c71215c71bf8341165077d74fb1c854f259c4f442fb6a293dc
+  sha256: 5f8f35d4e4f73eb92a07a0a9ee9ceccb479a3daf6cb79cb3d9476a83e6dd8d7a
 
 build:
   entry_points:


### PR DESCRIPTION
Update [`deepdetails`](https://bioconda.github.io/recipes/deepdetails/README.html): **1.0.0rc1** → **1.0.0rc2**.

Adds `seaborn-base` to `run:` so the recipe matches the new PyPI dependency in 1.0.0rc2. Without it, Linux Tests fail `pip check` (`deepdetails` requires `seaborn`).

This supersedes https://github.com/bioconda/bioconda-recipes/pull/69181 (autobump). That PR only bumped version/sha256; I cannot push to `bioconda/bump/deepdetails`.

`run_exports` is already present:

```yaml
build:
  run_exports:
    - {{ pin_subpackage('deepdetails', max_pin="x") }}